### PR TITLE
Release/all 0.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,19 @@ jobs:
             - run: npm run lint
             - run: npm run build
             - run: npm test
+  publish-release:
+    executor:
+      name: node/default
+    steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - run: npm run publish:latest
 workflows:
     build-and-test:
       jobs:
         - build-and-test
+        - publish-release:
+            filters:
+              branches:
+                only: master

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,11 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.0"
+  "version": "independent",
+  "command": {
+    "version": {
+      "allowBranch": "release/*",
+      "message": "chore(release):"
+    }
+  }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -5,8 +5,11 @@
   "version": "independent",
   "command": {
     "version": {
-      "allowBranch": "release/*",
       "message": "chore(release):"
+    },
+    "publish": {
+      "message": "chore(release):",
+      "conventionalCommits": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,8 @@
     "bootstrap": "npm install && lerna bootstrap --hoist",
     "test": "lerna run test",
     "build": "lerna run build",
-    "release:pre": "lerna version --no-push --conventional-commits --conventional-prerelease",
-    "release:graduate": "lerna version --no-push --conventional-commits --conventional-graduate",
-    "release": "lerna version --no-push --conventional-commits",
-    "publish:next": "lerna publish from-package --dist-tag next",
+    "publish:next": "lerna publish --no-push --conventional-prerelease --dist-tag next",
+    "publish:latest": "lerna publish --allow-branch master --conventional-graduate --create-release github --yes",
     "lint": "lerna run lint",
     "clean": "rm -rf ./lib"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
     "bootstrap": "npm install && lerna bootstrap --hoist",
     "test": "lerna run test",
     "build": "lerna run build",
-    "prepublishOnly": "npm run build",
+    "release:pre": "lerna version --no-push --conventional-commits --conventional-prerelease",
+    "release:graduate": "lerna version --no-push --conventional-commits --conventional-graduate",
+    "release": "lerna version --no-push --conventional-commits",
+    "publish:next": "lerna publish from-package --dist-tag next",
     "lint": "lerna run lint",
     "clean": "rm -rf ./lib"
   },

--- a/packages/3id-did-resolver/CHANGELOG.md
+++ b/packages/3id-did-resolver/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0-alpha.0 (2020-04-07)
+
+
+### Features
+
+* add account link doctype ([#11](https://github.com/ceramicnetwork/js-ceramic/issues/11)) ([f9778c9](https://github.com/ceramicnetwork/js-ceramic/commit/f9778c90eaf4da2bbecfdc0d9fd6dfa0adbdb2d2))

--- a/packages/3id-did-resolver/package-lock.json
+++ b/packages/3id-did-resolver/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramicnetwork/3id-did-resolver",
-  "version": "0.0.1",
+  "version": "0.1.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/3id-did-resolver/package.json
+++ b/packages/3id-did-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramicnetwork/3id-did-resolver",
-  "version": "0.0.1",
+  "version": "0.1.0-alpha.0",
   "description": "DID Resolver for the 3ID method",
   "keywords": [
     "Ceramic",
@@ -26,7 +26,6 @@
     "lint": "./node_modules/.bin/eslint ./src --ext .js,.jsx,.ts,.tsx",
     "clean": "rm -rf ./lib"
   },
-  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.8.4",

--- a/packages/ceramic-cli/CHANGELOG.md
+++ b/packages/ceramic-cli/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0-alpha.0 (2020-04-07)
+
+
+### Features
+
+* **ceramic-cli:** Implement CeramicDaemon ([cfe56aa](https://github.com/ceramicnetwork/js-ceramic/commit/cfe56aa9b0761f7870981f9f957e56da66382029))
+* **cli:** implemented most commands ([16c860e](https://github.com/ceramicnetwork/js-ceramic/commit/16c860e18784ee6a61701f99059ac927b0b19c2e))
+* **cli:** implemented watch command ([7c20e6a](https://github.com/ceramicnetwork/js-ceramic/commit/7c20e6a4762f6fcc41d5394d36e2c73951bf8dd5))
+* **cli:** Proper error handling ([acbe044](https://github.com/ceramicnetwork/js-ceramic/commit/acbe044f634badd36d079d5125c41ad56163b57e))
+* **cli:** Support signed doctypes ([3d2ad1f](https://github.com/ceramicnetwork/js-ceramic/commit/3d2ad1ff28638d064b6cecd298dc9b9f1b6a432c))
+* add account link doctype ([#11](https://github.com/ceramicnetwork/js-ceramic/issues/11)) ([f9778c9](https://github.com/ceramicnetwork/js-ceramic/commit/f9778c90eaf4da2bbecfdc0d9fd6dfa0adbdb2d2))

--- a/packages/ceramic-cli/package-lock.json
+++ b/packages/ceramic-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramicnetwork/ceramic-cli",
-  "version": "0.0.1",
+  "version": "0.1.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/ceramic-cli/package.json
+++ b/packages/ceramic-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramicnetwork/ceramic-cli",
-  "version": "0.0.1",
+  "version": "0.1.0-alpha.0",
   "description": "Typescript implementation of the Ceramic CLI",
   "keywords": [
     "Ceramic",
@@ -31,8 +31,8 @@
     "clean": "rm -rf ./lib"
   },
   "dependencies": {
-    "@ceramicnetwork/ceramic-core": "^0.0.1",
-    "@ceramicnetwork/ceramic-http-client": "^0.0.1",
+    "@ceramicnetwork/ceramic-core": "^0.1.0-alpha.0",
+    "@ceramicnetwork/ceramic-http-client": "^0.1.0-alpha.0",
     "commander": "^4.1.1",
     "express": "^4.17.1",
     "identity-wallet": "^1.2.0-ceramic.1",

--- a/packages/ceramic-core/CHANGELOG.md
+++ b/packages/ceramic-core/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0-alpha.0 (2020-04-07)
+
+
+### Bug Fixes
+
+* build type check etc. ([89fa279](https://github.com/ceramicnetwork/js-ceramic/commit/89fa2799a496e7fa900b9769db5f85491837cad4))
+* **core:** use correct CID format ([4ca5b8d](https://github.com/ceramicnetwork/js-ceramic/commit/4ca5b8d3d7866b70b8c3ad53d63afb1b5c141d35))
+
+
+### Features
+
+* **cli:** implemented most commands ([16c860e](https://github.com/ceramicnetwork/js-ceramic/commit/16c860e18784ee6a61701f99059ac927b0b19c2e))
+* **core:** add anchor module and refactor doctype update mechanism ([bfc5515](https://github.com/ceramicnetwork/js-ceramic/commit/bfc551525079e288e3ec3e67b9c7bea26449edd4))
+* **core:** implement 3id and tile doctypes ([c1fa90c](https://github.com/ceramicnetwork/js-ceramic/commit/c1fa90c61c8a1ea1dd61fdf23d50e40fc674f14b))
+* add account link doctype ([#11](https://github.com/ceramicnetwork/js-ceramic/issues/11)) ([f9778c9](https://github.com/ceramicnetwork/js-ceramic/commit/f9778c90eaf4da2bbecfdc0d9fd6dfa0adbdb2d2))

--- a/packages/ceramic-core/package.json
+++ b/packages/ceramic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramicnetwork/ceramic-core",
-  "version": "0.0.1",
+  "version": "0.1.0-alpha.0",
   "description": "Typescript implementation of the Ceramic protocol",
   "keywords": [
     "Ceramic",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "3id-blockchain-utils": "^0.3.3",
-    "@ceramicnetwork/3id-did-resolver": "^0.0.1",
+    "@ceramicnetwork/3id-did-resolver": "^0.1.0-alpha.0",
     "@types/lodash.clonedeep": "^4.5.6",
     "cids": "^0.8.0",
     "did-jwt": "^4.0.0",

--- a/packages/ceramic-http-client/CHANGELOG.md
+++ b/packages/ceramic-http-client/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0-alpha.0 (2020-04-07)
+
+
+### Features
+
+* add account link doctype ([#11](https://github.com/ceramicnetwork/js-ceramic/issues/11)) ([f9778c9](https://github.com/ceramicnetwork/js-ceramic/commit/f9778c90eaf4da2bbecfdc0d9fd6dfa0adbdb2d2))

--- a/packages/ceramic-http-client/package-lock.json
+++ b/packages/ceramic-http-client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ceramicnetwork/ceramic-http-client",
-	"version": "0.0.1",
+	"version": "0.1.0-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/ceramic-http-client/package.json
+++ b/packages/ceramic-http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramicnetwork/ceramic-http-client",
-  "version": "0.0.1",
+  "version": "0.1.0-alpha.0",
   "description": "An http client for the ceramic network",
   "keywords": [
     "Ceramic",


### PR DESCRIPTION
Ok, this has been a bit of a pain to set up and I'm not totally happy yet. 
Main problem is if we create the release on a release branch as we have been practicing before with 3box repos it will tag the release in the current branch. When the branch is then merged to master this will cause an issue in most cases since the tags will remain on this branch if the commit hashes changes. 

It seems like the proper way to do releases in lerna is to actually just do the release directly on the master branch. 

Would love some thought @msterle @zachferland @simonovic86 


Btw, @msterle I created a prerelease that you can use 👍 (0.1.0-alpha.0), 0.1.0 has not been released yet.

Also note that we can generate automatic release notes and github releases using lerna.

# Edit

I believe this should now be set up properly. 

Circle should automatically try to deploy when something is merged to master. It will generate release notes, tags, and a release on github. 

It is also possible to create prereleases by running `$ npm run publish:next`

The command to publish a real relese (`$ npm run publish:latest`) should only be possible to run on the master branch.

After this has been merged we should set up a develop branch which we set to default.