### PR TITLE
node-fetch -> cross-fetch

### DIFF
--- a/packages/ceramic-core/package-lock.json
+++ b/packages/ceramic-core/package-lock.json
@@ -1198,50 +1198,53 @@
 			"dev": true
 		},
 		"@ceramicnetwork/3id-did-resolver": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/3id-did-resolver/-/3id-did-resolver-0.1.5.tgz",
-			"integrity": "sha512-cd8D9XfaArpRffkzbjxn03h7Eyjj2cL4IWNqtoQbMoU4yMWSKNjDdEtIPxfLKulosc3p7BwUxBaA7DkeSkkW/Q=="
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/@ceramicnetwork/3id-did-resolver/-/3id-did-resolver-0.1.8.tgz",
+			"integrity": "sha512-gIuJeegXgogC9S5FKc04ExifSSXBA3kEPQUFCxd1gq9BQzv7t1wdZ158aeoeiB2aGmL941X0FTbuqd/BnDWDTg==",
+			"requires": {
+				"@ceramicnetwork/ceramic-common": "0.2.7"
+			}
 		},
 		"@ceramicnetwork/ceramic-common": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-common/-/ceramic-common-0.2.4.tgz",
-			"integrity": "sha512-ud5umkOYSlc6fvkPnQNvCpu7F8AJspGR8aA7twLR0iY/pdSoGQ7tBFE2VYGdukE+p91ZX+plITYunN9pnSmpvg==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-common/-/ceramic-common-0.2.7.tgz",
+			"integrity": "sha512-p8MqGhZHKfUr2Y4e7qh2wbWUhePceeEnXxHgjxLBUTHuSVZRu8NOokXhQ6p6uNjKY8/MpFLSR19zexvR9I1ozw==",
 			"requires": {
 				"@types/lodash.clonedeep": "^4.5.6",
 				"did-resolver": "^2.0.1"
 			}
 		},
 		"@ceramicnetwork/ceramic-doctype-account-link": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-account-link/-/ceramic-doctype-account-link-0.2.4.tgz",
-			"integrity": "sha512-IRogf4tMYChRu0EgrZzUFdsQ3qkCvXs/mjSrV06+IfjNS3BoSHohB6J4zhjZkCpPrPVNAcqxVl1j7N3avzwWfQ==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-account-link/-/ceramic-doctype-account-link-0.2.7.tgz",
+			"integrity": "sha512-xGfWI1JM11mnKOCe4nBj5eGvO6KxB20y6iq8/7cijRQdZE+yLZ9M/Ige3GZ8mc/mkS8NnSon72IUpOydX24Fog==",
 			"requires": {
 				"3id-blockchain-utils": "^0.4.0",
-				"@ceramicnetwork/ceramic-common": "^0.2.4",
+				"@ceramicnetwork/ceramic-common": "0.2.7",
 				"@types/lodash.clonedeep": "^4.5.6",
 				"did-resolver": "^2.0.1"
 			}
 		},
 		"@ceramicnetwork/ceramic-doctype-three-id": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-three-id/-/ceramic-doctype-three-id-0.2.4.tgz",
-			"integrity": "sha512-ovTxWOxmdPYt4M9hVV1jA1vX7gv1CWHU2nqPoN4pnqnp2A8nsijmOGY0FQqk+7QLMEEezcdGt3+qiaFVxuTIgg==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-three-id/-/ceramic-doctype-three-id-0.2.7.tgz",
+			"integrity": "sha512-Iv1vmrJqxACMBqXLcZQNf5OP3EGkO6MppUKmDjhzo5CjOGYnneMNGBjsJCtgBGH2cAfJt++VYI31g+RX3DqxxQ==",
 			"requires": {
 				"3id-blockchain-utils": "^0.4.0",
-				"@ceramicnetwork/3id-did-resolver": "^0.1.5",
-				"@ceramicnetwork/ceramic-common": "^0.2.4",
+				"@ceramicnetwork/3id-did-resolver": "0.1.8",
+				"@ceramicnetwork/ceramic-common": "0.2.7",
 				"@types/lodash.clonedeep": "^4.5.6",
 				"did-jwt": "^4.0.0",
 				"did-resolver": "^2.0.1"
 			}
 		},
 		"@ceramicnetwork/ceramic-doctype-tile": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-tile/-/ceramic-doctype-tile-0.2.4.tgz",
-			"integrity": "sha512-fBGar66fe3RA8nvI0ue+CM2jgfGGSVyJZoH4zC0urV4Nkpvbk+Bv8dy9j1LXoK5HXrw39WdcSYH8FgAgUJq0MQ==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-tile/-/ceramic-doctype-tile-0.2.7.tgz",
+			"integrity": "sha512-6SgSQ58FfQ9U2PvcAIU/nuot/jsHMUPSbsYy8RCXtjJ7Of8f/bxLMJdJ7/G4243bjyX8ORdeUqmcnZNxHNiscA==",
 			"requires": {
 				"3id-blockchain-utils": "^0.4.0",
-				"@ceramicnetwork/ceramic-common": "^0.2.4",
+				"@ceramicnetwork/ceramic-common": "0.2.7",
 				"@types/lodash.clonedeep": "^4.5.6",
 				"did-resolver": "^2.0.1"
 			}
@@ -3157,9 +3160,9 @@
 			"dev": true
 		},
 		"@types/lodash": {
-			"version": "4.14.157",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.157.tgz",
-			"integrity": "sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ=="
+			"version": "4.14.158",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.158.tgz",
+			"integrity": "sha512-InCEXJNTv/59yO4VSfuvNrZHt7eeNtWQEgnieIA+mIC+MOWM9arOWG2eQ8Vhk6NbOre6/BidiXhkZYeDY9U35w=="
 		},
 		"@types/lodash.clonedeep": {
 			"version": "4.5.6",
@@ -4780,6 +4783,14 @@
 				"ripemd160": "^2.0.0",
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
+			}
+		},
+		"cross-fetch": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
+			"integrity": "sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==",
+			"requires": {
+				"node-fetch": "2.6.0"
 			}
 		},
 		"cross-spawn": {
@@ -13438,8 +13449,7 @@
 		"node-fetch": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-			"dev": true
+			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
 		},
 		"node-forge": {
 			"version": "0.9.1",

--- a/packages/ceramic-core/package.json
+++ b/packages/ceramic-core/package.json
@@ -37,6 +37,7 @@
     "@ethersproject/providers": "^5.0.0-beta.144",
     "@ethersproject/random": "^5.0.0-beta.136",
     "cids": "^0.8.0",
+    "cross-fetch": "^3.0.5",
     "did-resolver": "^2.0.1",
     "fast-json-patch": "^3.0.0-1",
     "level-ts": "^1.12.2",

--- a/packages/ceramic-core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/ceramic-core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -1,5 +1,5 @@
 import CID from "cids";
-import fetch from "node-fetch";
+import fetch from "cross-fetch";
 
 import { decode } from "typestub-multihashes";
 import * as providers from "@ethersproject/providers"


### PR DESCRIPTION
so we can call the anchoring service from a browser

executed the tests & ran the cli / daemon + an anchoring node. Seems to work like that ;) node-fetch unfortunately doesn't support isomorphic browser & node fetching, cross-fetch falls back to a whatwg brower fetch when it detects a windows object (think it's also officially used by js-ipfs)