### PR TITLE
Changes for IDX lib

### DIFF
--- a/packages/3id-did-resolver/README.md
+++ b/packages/3id-did-resolver/README.md
@@ -12,7 +12,7 @@ $ npm install @ceramicnetwork/3id-did-resolver
 ### Usage
 
 ```
-import ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
+import { getResolver } from '@ceramicnetwork/3id-did-resolver'
 import { Resolver } from 'did-resolver'
 
 // You need an instance of Ceramic to call getResolver.
@@ -22,8 +22,8 @@ const ceramic = // ...
 
 // getResolver will return an object with a key/value pair of { '3': resolver }
 // where resolver is a function used by the generic did resolver.
-const threeIdResolver = ThreeIdResolver.getResolver(ceramic)
-const didResolver = Resolver(threeIdResolver)
+const threeIdResolver = getResolver(ceramic)
+const didResolver = new Resolver(threeIdResolver)
 
 const doc = await didResolver.resolve('did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74')
 console.log(doc)

--- a/packages/3id-did-resolver/package-lock.json
+++ b/packages/3id-did-resolver/package-lock.json
@@ -1164,6 +1164,34 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@ceramicnetwork/ceramic-common": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-common/-/ceramic-common-0.2.8.tgz",
+      "integrity": "sha512-GAcoxCD0rD9AfkBt5icYhdrrQJKpEptyW6yTubQx/JimDDS3kL+WnrjMiua5pidE7JOszISpLhfUS0sWluJKNA==",
+      "requires": {
+        "@types/json-schema": "^7.0.5",
+        "ajv": "^6.12.3",
+        "did-resolver": "^2.0.1"
+      },
+      "dependencies": {
+        "@types/json-schema": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+          "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
+        },
+        "ajv": {
+          "version": "6.12.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        }
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -2840,8 +2868,7 @@
     "did-resolver": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-2.0.1.tgz",
-      "integrity": "sha512-NomJQaRiu0izKFFerYGrca48YxWtMOtOoqG3JUTLJtET8n2T1i8WlQz500zesnioZWi5RVNsUS/eMQfRWy7bbg==",
-      "dev": true
+      "integrity": "sha512-NomJQaRiu0izKFFerYGrca48YxWtMOtOoqG3JUTLJtET8n2T1i8WlQz500zesnioZWi5RVNsUS/eMQfRWy7bbg=="
     },
     "diff-sequences": {
       "version": "25.2.6",
@@ -3331,14 +3358,12 @@
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
-      "dev": true
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5459,8 +5484,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6220,8 +6244,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -7552,7 +7575,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/packages/3id-did-resolver/package.json
+++ b/packages/3id-did-resolver/package.json
@@ -38,7 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^2.19.0",
     "@typescript-eslint/parser": "^2.19.0",
     "babel-jest": "^25.1.0",
-    "did-resolver": "^2.0.1",
+    "did-resolver": "^2.1.0",
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.8.2",
     "jest": "^25.1.0",

--- a/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
@@ -10,16 +10,17 @@ Object {
     },
   ],
   "id": "did:3:bafyiuh3f97hqef97h",
+  "idx": undefined,
   "publicKey": Array [
     Object {
+      "controller": "did:3:bafyiuh3f97hqef97h",
       "id": "did:3:bafyiuh3f97hqef97h#signingKey",
-      "owner": "did:3:bafyiuh3f97hqef97h",
       "publicKeyHex": "fake signing key",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
+      "controller": "did:3:bafyiuh3f97hqef97h",
       "id": "did:3:bafyiuh3f97hqef97h#encryptionKey",
-      "owner": "did:3:bafyiuh3f97hqef97h",
       "publicKeyBase64": "fake encryption key",
       "type": "Curve25519EncryptionPublicKey",
     },

--- a/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`3ID DID Resolver resolver adds IDX root as service 1`] = `
+Object {
+  "@context": "https://w3id.org/did/v1",
+  "authentication": Array [
+    Object {
+      "publicKey": "did:3:bafyiuh3f97hqef97h#signingKey",
+      "type": "Secp256k1SignatureAuthentication2018",
+    },
+  ],
+  "id": "did:3:bafyiuh3f97hqef97h",
+  "publicKey": Array [
+    Object {
+      "controller": "did:3:bafyiuh3f97hqef97h",
+      "id": "did:3:bafyiuh3f97hqef97h#signingKey",
+      "publicKeyHex": "fake signing key",
+      "type": "Secp256k1VerificationKey2018",
+    },
+    Object {
+      "controller": "did:3:bafyiuh3f97hqef97h",
+      "id": "did:3:bafyiuh3f97hqef97h#encryptionKey",
+      "publicKeyBase64": "fake encryption key",
+      "type": "Curve25519EncryptionPublicKey",
+    },
+  ],
+  "service": Array [
+    Object {
+      "id": "did:3:bafyiuh3f97hqef97h#idx",
+      "serviceEndpoint": "ceramic://rootId",
+      "type": "IdentityIndexRoot",
+    },
+  ],
+}
+`;
+
 exports[`3ID DID Resolver resolver works correctly 1`] = `
 Object {
   "@context": "https://w3id.org/did/v1",
@@ -10,7 +44,6 @@ Object {
     },
   ],
   "id": "did:3:bafyiuh3f97hqef97h",
-  "idx": undefined,
   "publicKey": Array [
     Object {
       "controller": "did:3:bafyiuh3f97hqef97h",

--- a/packages/3id-did-resolver/src/__tests__/index.test.ts
+++ b/packages/3id-did-resolver/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import ThreeIdResolver from '../index'
+import { getResolver } from '../index'
 import { Resolver } from 'did-resolver'
 
 const ceramicMock = {
@@ -6,21 +6,20 @@ const ceramicMock = {
     content: {
       publicKeys: {
         signing: 'fake signing key',
-        encryption: 'fake encryption key'
-      }
-    }
-  })
+        encryption: 'fake encryption key',
+      },
+    },
+  }),
 }
 
 describe('3ID DID Resolver', () => {
-
   it('getResolver works correctly', async () => {
-    const threeIdResolver = ThreeIdResolver.getResolver(ceramicMock)
+    const threeIdResolver = getResolver(ceramicMock)
     expect(Object.keys(threeIdResolver)).toEqual(['3'])
   })
 
   it('resolver works correctly', async () => {
-    const threeIdResolver = ThreeIdResolver.getResolver(ceramicMock)
+    const threeIdResolver = getResolver(ceramicMock)
     const resolver = new Resolver(threeIdResolver)
     const fake3ID = 'did:3:bafyiuh3f97hqef97h'
     expect(await resolver.resolve(fake3ID)).toMatchSnapshot()

--- a/packages/3id-did-resolver/src/__tests__/index.test.ts
+++ b/packages/3id-did-resolver/src/__tests__/index.test.ts
@@ -12,6 +12,18 @@ const ceramicMock = {
   }),
 }
 
+const ceramicMockWithIDX = {
+  loadDocument: async (): Promise<any> => ({
+    content: {
+      publicKeys: {
+        signing: 'fake signing key',
+        encryption: 'fake encryption key',
+      },
+      idx: 'ceramic://rootId',
+    },
+  }),
+}
+
 describe('3ID DID Resolver', () => {
   it('getResolver works correctly', async () => {
     const threeIdResolver = getResolver(ceramicMock)
@@ -20,6 +32,13 @@ describe('3ID DID Resolver', () => {
 
   it('resolver works correctly', async () => {
     const threeIdResolver = getResolver(ceramicMock)
+    const resolver = new Resolver(threeIdResolver)
+    const fake3ID = 'did:3:bafyiuh3f97hqef97h'
+    expect(await resolver.resolve(fake3ID)).toMatchSnapshot()
+  })
+
+  it('resolver adds IDX root as service', async () => {
+    const threeIdResolver = getResolver(ceramicMockWithIDX)
     const resolver = new Resolver(threeIdResolver)
     const fake3ID = 'did:3:bafyiuh3f97hqef97h'
     expect(await resolver.resolve(fake3ID)).toMatchSnapshot()

--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -1,44 +1,61 @@
-import { Doctype } from "@ceramicnetwork/ceramic-common"
-import type { ParsedDID, DIDResolver, DIDDocument } from 'did-resolver'
+import { Doctype } from '@ceramicnetwork/ceramic-common'
+import type { ParsedDID, DIDResolver, DIDDocument, Resolver } from 'did-resolver'
 
 interface Ceramic {
   loadDocument(docId: string): Promise<Doctype>;
 }
 
-interface ResolverRegistry {
+export interface ThreeIDDocument extends DIDDocument {
+  idx?: string;
+}
+
+export type ThreeIDResolver = (
+  did: string,
+  parsed: ParsedDID,
+  resolver: Resolver
+) => Promise<null | ThreeIDDocument>
+
+export interface ResolverRegistry {
+  '3': ThreeIDResolver;
   [index: string]: DIDResolver;
 }
 
-export function wrapDocument (content: any, did: string): DIDDocument {
+export function wrapDocument(content: any, did: string): ThreeIDDocument {
   // this should be generated in a much more dynamic way based on the content of the doc
   // keys should be encoded using multicodec, by looking at the codec bits
   // we can determine the key type.
   return {
     '@context': 'https://w3id.org/did/v1',
     id: did,
-    publicKey: [{
-      id: `${did}#signingKey`,
-      type: 'Secp256k1VerificationKey2018',
-      owner: did,
-      publicKeyHex: content.publicKeys.signing
-    }, {
-      id: `${did}#encryptionKey`,
-      type: 'Curve25519EncryptionPublicKey',
-      owner: did,
-      publicKeyBase64: content.publicKeys.encryption
-    }],
-    authentication: [{
-      type: 'Secp256k1SignatureAuthentication2018',
-      publicKey: `${did}#signingKey`,
-    }]
+    publicKey: [
+      {
+        id: `${did}#signingKey`,
+        type: 'Secp256k1VerificationKey2018',
+        controller: did,
+        publicKeyHex: content.publicKeys.signing,
+      },
+      {
+        id: `${did}#encryptionKey`,
+        type: 'Curve25519EncryptionPublicKey',
+        controller: did,
+        publicKeyBase64: content.publicKeys.encryption,
+      },
+    ],
+    authentication: [
+      {
+        type: 'Secp256k1SignatureAuthentication2018',
+        publicKey: `${did}#signingKey`,
+      },
+    ],
+    idx: content.idx
   }
 }
 
-export default {
-  getResolver: (ceramic: Ceramic): ResolverRegistry => ({
-    '3': async (did: string, parsed: ParsedDID): Promise<DIDDocument | null> => {
+export function getResolver(ceramic: Ceramic): ResolverRegistry {
+  return {
+    '3': async (did: string, parsed: ParsedDID): Promise<ThreeIDDocument | null> => {
       const doctype = await ceramic.loadDocument(`/ceramic/${parsed.id}`)
       return wrapDocument(doctype.content, did)
-    }
-  })
+    },
+  }
 }

--- a/packages/account-template/package.json
+++ b/packages/account-template/package.json
@@ -21,7 +21,7 @@
     "@typescript-eslint/eslint-plugin": "^2.19.0",
     "@typescript-eslint/parser": "^2.19.0",
     "babel-jest": "^25.1.0",
-    "did-resolver": "^2.0.1",
+    "did-resolver": "^2.1.0",
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.8.2",
     "jest": "^25.1.0",

--- a/packages/ceramic-common/package-lock.json
+++ b/packages/ceramic-common/package-lock.json
@@ -4761,9 +4761,9 @@
 			}
 		},
 		"did-resolver": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-2.0.1.tgz",
-			"integrity": "sha512-NomJQaRiu0izKFFerYGrca48YxWtMOtOoqG3JUTLJtET8n2T1i8WlQz500zesnioZWi5RVNsUS/eMQfRWy7bbg=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-2.1.0.tgz",
+			"integrity": "sha512-9skNafNhYB4UHAcQnv5ozCZSITW+m4kNybSuDVNpGeMqppD5DGXrpOrluFjE6TWtinT217wvy/G46IbRDZ1u2A=="
 		},
 		"dids": {
 			"version": "0.1.0",

--- a/packages/ceramic-common/package-lock.json
+++ b/packages/ceramic-common/package-lock.json
@@ -2703,16 +2703,6 @@
 			"integrity": "sha512-Az3QsOt1U/K1pbCQ0TXGELTuTkPLOiFIQf3ILzbOyo0FqgV9SxRnxbxM5QlAveERZMHpZY+7u3Jz2tKyl+yg6g==",
 			"dev": true
 		},
-		"@types/node-fetch": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-			"integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*",
-				"form-data": "^3.0.0"
-			}
-		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -3418,7 +3408,6 @@
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
 			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -4094,8 +4083,7 @@
 		"class-is": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
-			"integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
-			"dev": true
+			"integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -4776,6 +4764,69 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-2.0.1.tgz",
 			"integrity": "sha512-NomJQaRiu0izKFFerYGrca48YxWtMOtOoqG3JUTLJtET8n2T1i8WlQz500zesnioZWi5RVNsUS/eMQfRWy7bbg=="
+		},
+		"dids": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/dids/-/dids-0.1.0.tgz",
+			"integrity": "sha512-kWFiAmpCEoKxywsvOwjl0qM/8hEK3fVkP/VaF4788sIc7mcb1lL+/QANTMXWpw1aIRcV034lQCU7hpn2FG8TAA==",
+			"requires": {
+				"cids": "^1.0.0",
+				"is-circular": "^1.0.2",
+				"rpc-utils": "^0.1.2"
+			},
+			"dependencies": {
+				"cids": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/cids/-/cids-1.0.0.tgz",
+					"integrity": "sha512-HEBCIElSiXlkgZq3dgHJc3eDcnFteFp96N8/1/oqX5lkxBtB66sZ12jqEP3g7Ut++jEk6kIUGifQ1Qrya1jcNQ==",
+					"requires": {
+						"class-is": "^1.1.0",
+						"multibase": "^3.0.0",
+						"multicodec": "^2.0.0",
+						"multihashes": "^3.0.1",
+						"uint8arrays": "^1.0.0"
+					}
+				},
+				"multibase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
+					"integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
+					"requires": {
+						"base-x": "^3.0.8",
+						"web-encoding": "^1.0.2"
+					}
+				},
+				"multicodec": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.0.tgz",
+					"integrity": "sha512-2SLsdTCXqOpUfoSHkTaVzxnjjl5fsSO283Idb9rAYgKGVu188NFP5KncuZ8Ifg8H2gc5GOi2rkuhLumqv9nweQ==",
+					"requires": {
+						"uint8arrays": "1.0.0",
+						"varint": "^5.0.0"
+					},
+					"dependencies": {
+						"uint8arrays": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
+							"integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
+							"requires": {
+								"multibase": "^3.0.0",
+								"web-encoding": "^1.0.2"
+							}
+						}
+					}
+				},
+				"multihashes": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
+					"integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
+					"requires": {
+						"multibase": "^3.0.0",
+						"uint8arrays": "^1.0.0",
+						"varint": "^5.0.0"
+					}
+				}
+			}
 		},
 		"diff": {
 			"version": "4.0.2",
@@ -8055,8 +8106,7 @@
 		"is-circular": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
-			"integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA==",
-			"dev": true
+			"integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
@@ -13364,6 +13414,21 @@
 				"bn.js": "^4.11.1"
 			}
 		},
+		"rpc-utils": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/rpc-utils/-/rpc-utils-0.1.2.tgz",
+			"integrity": "sha512-me5uyHghn47tJ8UbtFuG+8Rr8P2Ct9fltPIiKXihS2W3T23VQXRK8QBQTHGIvypvG4y/wuc2w/O8sjB/z4jlVQ==",
+			"requires": {
+				"nanoid": "^3.1.11"
+			},
+			"dependencies": {
+				"nanoid": {
+					"version": "3.1.12",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+					"integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
+				}
+			}
+		},
 		"rsvp": {
 			"version": "4.8.5",
 			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -13388,8 +13453,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -15049,6 +15113,26 @@
 			"integrity": "sha512-+g3NEp7fJLe9DPa1TArHm9QAA7YciZmWnfAqEaFrBihQ7epOv9i99rjtgb6Iz0wh3WuQDjsCTDfgRoGnmHN81A==",
 			"dev": true
 		},
+		"uint8arrays": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
+			"integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
+			"requires": {
+				"multibase": "^3.0.0",
+				"web-encoding": "^1.0.2"
+			},
+			"dependencies": {
+				"multibase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
+					"integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
+					"requires": {
+						"base-x": "^3.0.8",
+						"web-encoding": "^1.0.2"
+					}
+				}
+			}
+		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -15337,8 +15421,7 @@
 		"varint": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
-			"integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8=",
-			"dev": true
+			"integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
 		},
 		"varint-decoder": {
 			"version": "0.4.0",
@@ -15406,6 +15489,11 @@
 			"requires": {
 				"makeerror": "1.0.x"
 			}
+		},
+		"web-encoding": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.2.tgz",
+			"integrity": "sha512-fe9pqxglgy25Z4Ds+2GwZIrOnLxeozydMj0iV8zx0ZNxE3MPTseF4oXGrrBuH4vSkoDYDXoPRRFY/FEYitEUTA=="
 		},
 		"webcrypto": {
 			"version": "0.1.1",

--- a/packages/ceramic-common/package.json
+++ b/packages/ceramic-common/package.json
@@ -29,8 +29,7 @@
     "@types/json-schema": "^7.0.5",
     "ajv": "^6.12.3",
     "did-resolver": "^2.1.0",
-    "dids": "^0.1.0",
-    "rpc-utils": "^0.1.2"
+    "dids": "^0.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/ceramic-common/package.json
+++ b/packages/ceramic-common/package.json
@@ -28,7 +28,9 @@
   "dependencies": {
     "@types/json-schema": "^7.0.5",
     "ajv": "^6.12.3",
-    "did-resolver": "^2.0.1"
+    "did-resolver": "^2.1.0",
+    "dids": "^0.1.0",
+    "rpc-utils": "^0.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/ceramic-common/src/ceramic-api.ts
+++ b/packages/ceramic-common/src/ceramic-api.ts
@@ -1,3 +1,5 @@
+import { DID } from 'dids'
+import { RPCConnection } from 'rpc-utils'
 import { Doctype, DoctypeHandler, DocOpts, DocParams } from "./doctype"
 
 /**
@@ -23,25 +25,17 @@ export interface PinApi {
     ls(docId?: string): Promise<AsyncIterable<string>>;
 }
 
-// TODO handle errors as well
-export interface JsonRpc2Response {
-    'id': string;
-    'json-rpc': string;
-    'result': object;
-}
-
 /**
  * Describes DID provider instance
  */
-export interface DIDProvider {
-    send(jsonReq: object): JsonRpc2Response;
-}
+export type DIDProvider = RPCConnection
 
 /**
  * Describes Ceramic node API
  */
 export interface CeramicApi {
     pin: PinApi;
+    user?: DID;
 
     /**
      * Register Doctype handler

--- a/packages/ceramic-common/src/ceramic-api.ts
+++ b/packages/ceramic-common/src/ceramic-api.ts
@@ -1,5 +1,4 @@
 import { DID } from 'dids'
-import { RPCConnection } from 'rpc-utils'
 import { Doctype, DoctypeHandler, DocOpts, DocParams } from "./doctype"
 
 /**
@@ -28,7 +27,7 @@ export interface PinApi {
 /**
  * Describes DID provider instance
  */
-export type DIDProvider = RPCConnection
+export { DIDProvider } from 'dids'
 
 /**
  * Describes Ceramic node API

--- a/packages/ceramic-core/package.json
+++ b/packages/ceramic-core/package.json
@@ -39,7 +39,7 @@
     "@textile/powergate-client": "^0.2.0",
     "cids": "^0.8.0",
     "cross-fetch": "^3.0.5",
-    "did-resolver": "^2.0.1",
+    "did-resolver": "^2.1.0",
     "fast-json-patch": "^3.0.0-1",
     "ipfs-http-client": "^45.0.0",
     "level-ts": "^2.0.5",

--- a/packages/ceramic-core/src/ceramic.ts
+++ b/packages/ceramic-core/src/ceramic.ts
@@ -3,7 +3,7 @@ import Dispatcher from './dispatcher'
 import CeramicUser from './ceramic-user'
 import Document from './document'
 import { AnchorServiceFactory } from "./anchor/anchor-service-factory";
-import ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
+import { getResolver } from '@ceramicnetwork/3id-did-resolver'
 
 import { CeramicApi, DIDProvider, PinApi } from "@ceramicnetwork/ceramic-common"
 import { Doctype, DoctypeHandler, DocOpts } from "@ceramicnetwork/ceramic-common"
@@ -133,7 +133,7 @@ class Ceramic implements CeramicApi {
       await ceramic.setDIDProvider(config.didProvider)
     }
 
-    const threeIdResolver = ThreeIdResolver.getResolver(ceramic)
+    const threeIdResolver = getResolver(ceramic)
     ceramic.context.resolver = new Resolver({
       ...config.didResolver, ...threeIdResolver
     })

--- a/packages/ceramic-doctype-account-link/package.json
+++ b/packages/ceramic-doctype-account-link/package.json
@@ -28,7 +28,7 @@
     "3id-blockchain-utils": "^0.4.0",
     "@ceramicnetwork/ceramic-common": "^0.2.8",
     "@types/lodash.clonedeep": "^4.5.6",
-    "did-resolver": "^2.0.1"
+    "did-resolver": "^2.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/ceramic-doctype-three-id/package.json
+++ b/packages/ceramic-doctype-three-id/package.json
@@ -30,7 +30,7 @@
     "@ceramicnetwork/ceramic-common": "^0.2.8",
     "@types/lodash.clonedeep": "^4.5.6",
     "did-jwt": "^4.0.0",
-    "did-resolver": "^2.0.1"
+    "did-resolver": "^2.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/ceramic-doctype-tile/package.json
+++ b/packages/ceramic-doctype-tile/package.json
@@ -28,7 +28,7 @@
     "3id-blockchain-utils": "^0.4.0",
     "@ceramicnetwork/ceramic-common": "^0.2.8",
     "@types/lodash.clonedeep": "^4.5.6",
-    "did-resolver": "^2.0.1"
+    "did-resolver": "^2.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/ceramic-http-client/package-lock.json
+++ b/packages/ceramic-http-client/package-lock.json
@@ -1164,6 +1164,34 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
+		"@ceramicnetwork/ceramic-common": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-common/-/ceramic-common-0.2.8.tgz",
+			"integrity": "sha512-GAcoxCD0rD9AfkBt5icYhdrrQJKpEptyW6yTubQx/JimDDS3kL+WnrjMiua5pidE7JOszISpLhfUS0sWluJKNA==",
+			"requires": {
+				"@types/json-schema": "^7.0.5",
+				"ajv": "^6.12.3",
+				"did-resolver": "^2.0.1"
+			},
+			"dependencies": {
+				"@types/json-schema": {
+					"version": "7.0.5",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+					"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
+				},
+				"ajv": {
+					"version": "6.12.4",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+					"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				}
+			}
+		},
 		"@cnakazawa/watch": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -1893,16 +1921,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
 			"integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
 			"dev": true
-		},
-		"@types/node-fetch": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-			"integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*",
-				"form-data": "^3.0.0"
-			}
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -2808,6 +2826,14 @@
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
 		},
+		"cross-fetch": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
+			"integrity": "sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==",
+			"requires": {
+				"node-fetch": "2.6.0"
+			}
+		},
 		"cross-spawn": {
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -2969,6 +2995,11 @@
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
+		},
+		"did-resolver": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-2.1.0.tgz",
+			"integrity": "sha512-9skNafNhYB4UHAcQnv5ozCZSITW+m4kNybSuDVNpGeMqppD5DGXrpOrluFjE6TWtinT217wvy/G46IbRDZ1u2A=="
 		},
 		"diff-sequences": {
 			"version": "25.2.6",
@@ -3458,14 +3489,12 @@
 		"fast-deep-equal": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
-			"dev": true
+			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -3546,17 +3575,6 @@
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
 			"dev": true
-		},
-		"form-data": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-			"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			}
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -5591,8 +5609,7 @@
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -6390,8 +6407,7 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"qs": {
 			"version": "6.5.2",
@@ -7712,7 +7728,6 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}


### PR DESCRIPTION
There's a breaking change in `did-resolver` that causes the current issue with building `3id-did-resolver`, these changes should fix it.

It also adds dependencies on `dids` and `rpc-utils` in `ceramic-core` to make the types match with the interfaces expected by `idp2p`.