### PR TITLE
feat(3id-did-resolver): Support new multicodec key format

### DIFF
--- a/packages/3id-did-resolver/package-lock.json
+++ b/packages/3id-did-resolver/package-lock.json
@@ -1777,6 +1777,14 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-yfAgiWgVLjFCmRv8zAcOIHywYATEwiTVccTLnRp6UxTNavT55M9d/uhK3T03St/+8/z/wW+CRjGKUNmEqoHHCA==",
+      "requires": {
+        "base-x": "^3.0.6"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -2365,6 +2373,14 @@
             "kind-of": "^6.0.2"
           }
         }
+      }
+    },
+    "base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "bcrypt-pbkdf": {
@@ -6591,8 +6607,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",

--- a/packages/3id-did-resolver/package.json
+++ b/packages/3id-did-resolver/package.json
@@ -27,7 +27,8 @@
     "clean": "rm -rf ./lib"
   },
   "dependencies": {
-    "@ceramicnetwork/ceramic-common": "^0.2.8"
+    "@ceramicnetwork/ceramic-common": "^0.2.8",
+    "@types/bs58": "^4.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/3id-did-resolver/package.json
+++ b/packages/3id-did-resolver/package.json
@@ -27,8 +27,7 @@
     "clean": "rm -rf ./lib"
   },
   "dependencies": {
-    "@ceramicnetwork/ceramic-common": "^0.2.8",
-    "@types/bs58": "^4.0.1"
+    "@ceramicnetwork/ceramic-common": "^0.2.8"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",
@@ -43,7 +42,8 @@
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.8.2",
     "jest": "^25.1.0",
-    "tmp-promise": "^2.0.2"
+    "tmp-promise": "^2.0.2",
+    "@types/bs58": "^4.0.1"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1,26 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`3ID DID Resolver resolver works correctly 1`] = `
+exports[`3ID DID Resolver resolver works correctly (old format) 1`] = `
 Object {
   "@context": "https://w3id.org/did/v1",
   "authentication": Array [
     Object {
-      "publicKey": "did:3:bafyiuh3f97hqef97h#signingKey",
+      "publicKey": "did:3:bafyiuh3f97hqef97h#signing",
       "type": "Secp256k1SignatureAuthentication2018",
     },
   ],
   "id": "did:3:bafyiuh3f97hqef97h",
+  "keyAgreement": Array [],
   "publicKey": Array [
     Object {
-      "id": "did:3:bafyiuh3f97hqef97h#signingKey",
+      "id": "did:3:bafyiuh3f97hqef97h#signing",
       "owner": "did:3:bafyiuh3f97hqef97h",
       "publicKeyHex": "fake signing key",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
-      "id": "did:3:bafyiuh3f97hqef97h#encryptionKey",
+      "id": "did:3:bafyiuh3f97hqef97h#encryption",
       "owner": "did:3:bafyiuh3f97hqef97h",
       "publicKeyBase64": "fake encryption key",
+      "type": "Curve25519EncryptionPublicKey",
+    },
+  ],
+}
+`;
+
+exports[`3ID DID Resolver resolves 3id document correctly 1`] = `
+Object {
+  "@context": "https://w3id.org/did/v1",
+  "authentication": Array [
+    Object {
+      "publicKey": "did:3:bafyiuh3f97hqef97h#signing",
+      "type": "Secp256k1SignatureAuthentication2018",
+    },
+  ],
+  "id": "did:3:bafyiuh3f97hqef97h",
+  "keyAgreement": Array [
+    Object {
+      "controller": "did:3:bafyiuh3f97hqef97h",
+      "id": "did:3:bafyiuh3f97hqef97h#encryption",
+      "publicKeyBase58": "4jQRvHW8RfnRfdTrsxmExsn24z2vCV4xsoGxKB2Pkq2P",
+      "type": "X25519KeyAgreementKey2019",
+    },
+  ],
+  "publicKey": Array [
+    Object {
+      "id": "did:3:bafyiuh3f97hqef97h#signing",
+      "owner": "did:3:bafyiuh3f97hqef97h",
+      "publicKeyHex": "03fff18103bdca9458e73cca5f0a0f64964312d686712f2190bf5b4794c6e29924",
+      "type": "Secp256k1VerificationKey2018",
+    },
+    Object {
+      "id": "did:3:bafyiuh3f97hqef97h#encryption",
+      "owner": "did:3:bafyiuh3f97hqef97h",
+      "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug=",
       "type": "Curve25519EncryptionPublicKey",
     },
   ],

--- a/packages/3id-did-resolver/src/__tests__/index.test.ts
+++ b/packages/3id-did-resolver/src/__tests__/index.test.ts
@@ -5,6 +5,17 @@ const ceramicMock = {
   loadDocument: async (): Promise<any> => ({
     content: {
       publicKeys: {
+        signing: 'zQ3shwsCgFanBax6UiaLu1oGvM7vhuqoW88VBUiUTCeHbTeTV',
+        encryption: 'z6LSfQabSbJzX8WAm1qdQcHCHTzVv8a2u6F7kmzdodfvUCo9'
+      }
+    }
+  })
+}
+
+const ceramicMockOld = { // to be removed
+  loadDocument: async (): Promise<any> => ({
+    content: {
+      publicKeys: {
         signing: 'fake signing key',
         encryption: 'fake encryption key'
       }
@@ -19,7 +30,14 @@ describe('3ID DID Resolver', () => {
     expect(Object.keys(threeIdResolver)).toEqual(['3'])
   })
 
-  it('resolver works correctly', async () => {
+  it('resolver works correctly (old format)', async () => {
+    const threeIdResolver = ThreeIdResolver.getResolver(ceramicMockOld)
+    const resolver = new Resolver(threeIdResolver)
+    const fake3ID = 'did:3:bafyiuh3f97hqef97h'
+    expect(await resolver.resolve(fake3ID)).toMatchSnapshot()
+  })
+
+  it('resolves 3id document correctly', async () => {
     const threeIdResolver = ThreeIdResolver.getResolver(ceramicMock)
     const resolver = new Resolver(threeIdResolver)
     const fake3ID = 'did:3:bafyiuh3f97hqef97h'

--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -16,7 +16,7 @@ export function wrapDocument(content: any, did: string): DIDDocument {
     id: did,
     publicKey: [],
     authentication: [],
-    keyAgreement: []
+    keyAgreement: [] // TODO this should be resolved by the PR in the did-resolver lib
   }
   return Object.entries(content.publicKeys as string[]).reduce((diddoc, [keyName, keyValue]) => {
     if (keyValue.startsWith('z')) { // we got a multicodec encoded key

--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -1,3 +1,4 @@
+import bs58 from 'bs58'
 import { Doctype } from "@ceramicnetwork/ceramic-common"
 import type { ParsedDID, DIDResolver, DIDDocument } from 'did-resolver'
 
@@ -9,31 +10,72 @@ interface ResolverRegistry {
   [index: string]: DIDResolver;
 }
 
-export function wrapDocument (content: any, did: string): DIDDocument {
-  // this should be generated in a much more dynamic way based on the content of the doc
-  // keys should be encoded using multicodec, by looking at the codec bits
-  // we can determine the key type.
-  return {
+export function wrapDocument(content: any, did: string): DIDDocument {
+  const startDoc = {
     '@context': 'https://w3id.org/did/v1',
     id: did,
-    publicKey: [{
-      id: `${did}#signingKey`,
-      type: 'Secp256k1VerificationKey2018',
-      owner: did,
-      publicKeyHex: content.publicKeys.signing
-    }, {
-      id: `${did}#encryptionKey`,
-      type: 'Curve25519EncryptionPublicKey',
-      owner: did,
-      publicKeyBase64: content.publicKeys.encryption
-    }],
-    authentication: [{
-      type: 'Secp256k1SignatureAuthentication2018',
-      publicKey: `${did}#signingKey`,
-    }]
+    publicKey: [],
+    authentication: [],
+    keyAgreement: []
   }
+  return Object.entries(content.publicKeys).reduce((diddoc, [keyName, keyValue]) => {
+    if (keyValue.startsWith('z')) { // we got a multicodec encoded key
+      const keyBuf = bs58.decode(keyValue.slice(1))
+      if (keyBuf[0] === 0xe7) { // it's secp256k1
+        diddoc.publicKey.push({
+          id: `${did}#${keyName}`,
+          type: 'Secp256k1VerificationKey2018',
+          owner: did,
+          // remove multicodec varint and encode to hex
+          publicKeyHex: keyBuf.slice(2).toString('hex')
+        })
+        diddoc.authentication.push({
+          type: 'Secp256k1SignatureAuthentication2018',
+          publicKey: `${did}#${keyName}`,
+        })
+      } else if (keyBuf[0] === 0xec) { // it's x25519
+        // old key format, likely not needed in the future
+        diddoc.publicKey.push({
+          id: `${did}#${keyName}`,
+          type: 'Curve25519EncryptionPublicKey',
+          owner: did,
+          publicKeyBase64: keyBuf.slice(2).toString('base64')
+        })
+        // new keyAgreement format for x25519 keys
+        diddoc.keyAgreement.push({
+          id: `${did}#${keyName}`,
+          type: 'X25519KeyAgreementKey2019',
+          controller: did,
+          publicKeyBase58: bs58.encode(keyBuf.slice(2))
+        })
+      }
+    } else { // we need to be backwards compatible (until js-did is used everywhere)
+      if(keyName === 'signing') {
+        diddoc.publicKey.push({
+          id: `${did}#${keyName}`,
+          type: 'Secp256k1VerificationKey2018',
+          owner: did,
+          // remove multicodec varint and encode to hex
+          publicKeyHex: keyValue
+        })
+        diddoc.authentication.push({
+          type: 'Secp256k1SignatureAuthentication2018',
+          publicKey: `${did}#${keyName}`,
+        })
+      } else if (keyName === 'encryption') {
+        diddoc.publicKey.push({
+          id: `${did}#${keyName}`,
+          type: 'Curve25519EncryptionPublicKey',
+          owner: did,
+          publicKeyBase64: keyValue
+        })
+      }
+    }
+    return diddoc
+  }, startDoc)
 }
 
+// TODO - add backwards compatibility for 3IDv0
 export default {
   getResolver: (ceramic: Ceramic): ResolverRegistry => ({
     '3': async (did: string, parsed: ParsedDID): Promise<DIDDocument | null> => {

--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -11,21 +11,21 @@ interface ResolverRegistry {
 }
 
 export function wrapDocument(content: any, did: string): DIDDocument {
-  const startDoc = {
+  const startDoc: DIDDocument = {
     '@context': 'https://w3id.org/did/v1',
     id: did,
     publicKey: [],
     authentication: [],
     keyAgreement: []
   }
-  return Object.entries(content.publicKeys).reduce((diddoc, [keyName, keyValue]) => {
+  return Object.entries(content.publicKeys as string[]).reduce((diddoc, [keyName, keyValue]) => {
     if (keyValue.startsWith('z')) { // we got a multicodec encoded key
       const keyBuf = bs58.decode(keyValue.slice(1))
       if (keyBuf[0] === 0xe7) { // it's secp256k1
         diddoc.publicKey.push({
           id: `${did}#${keyName}`,
           type: 'Secp256k1VerificationKey2018',
-          owner: did,
+          controller: did,
           // remove multicodec varint and encode to hex
           publicKeyHex: keyBuf.slice(2).toString('hex')
         })
@@ -38,7 +38,7 @@ export function wrapDocument(content: any, did: string): DIDDocument {
         diddoc.publicKey.push({
           id: `${did}#${keyName}`,
           type: 'Curve25519EncryptionPublicKey',
-          owner: did,
+          controller: did,
           publicKeyBase64: keyBuf.slice(2).toString('base64')
         })
         // new keyAgreement format for x25519 keys
@@ -54,7 +54,7 @@ export function wrapDocument(content: any, did: string): DIDDocument {
         diddoc.publicKey.push({
           id: `${did}#${keyName}`,
           type: 'Secp256k1VerificationKey2018',
-          owner: did,
+          controller: did,
           // remove multicodec varint and encode to hex
           publicKeyHex: keyValue
         })
@@ -66,7 +66,7 @@ export function wrapDocument(content: any, did: string): DIDDocument {
         diddoc.publicKey.push({
           id: `${did}#${keyName}`,
           type: 'Curve25519EncryptionPublicKey',
-          owner: did,
+          controller: did,
           publicKeyBase64: keyValue
         })
       }


### PR DESCRIPTION
Add support for multcodec encoded keys in the `3id-did-resolver` in a backwards compatible manner. Backwards compatibility can be removed once we use js-did everywhere, as all documents will use the multcodec keys at that point.