### PR TITLE
`pin ls` arguments are optional. No arguments means list all documents.

### DIFF
--- a/packages/ceramic-cli/src/ceramic-cli-utils.ts
+++ b/packages/ceramic-cli/src/ceramic-cli-utils.ts
@@ -243,8 +243,8 @@ export default class CeramicCliUtils {
      * List pinned documents
      * @param docId - optional document ID filter
      */
-    static async pinLs(docId: string): Promise<void> {
-        if (!CeramicCliUtils._validateDocId(docId)) {
+    static async pinLs(docId?: string): Promise<void> {
+        if (docId && !CeramicCliUtils._validateDocId(docId)) {
             console.error(`Invalid docId: ${docId}`)
             return
         }


### PR DESCRIPTION
Without this change `pin ls` command emits an error on invalid docId.