### PR TITLE
Use forked did-resolver

### DIFF
--- a/packages/3id-did-resolver/package.json
+++ b/packages/3id-did-resolver/package.json
@@ -38,7 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^2.19.0",
     "@typescript-eslint/parser": "^2.19.0",
     "babel-jest": "^25.1.0",
-    "did-resolver": "^2.0.1",
+    "did-resolver": "github:ceramicnetwork/did-resolver",
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.8.2",
     "jest": "^25.1.0",

--- a/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
@@ -13,14 +13,14 @@ Object {
   "keyAgreement": Array [],
   "publicKey": Array [
     Object {
+      "controller": "did:3:bafyiuh3f97hqef97h",
       "id": "did:3:bafyiuh3f97hqef97h#signing",
-      "owner": "did:3:bafyiuh3f97hqef97h",
       "publicKeyHex": "fake signing key",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
+      "controller": "did:3:bafyiuh3f97hqef97h",
       "id": "did:3:bafyiuh3f97hqef97h#encryption",
-      "owner": "did:3:bafyiuh3f97hqef97h",
       "publicKeyBase64": "fake encryption key",
       "type": "Curve25519EncryptionPublicKey",
     },
@@ -48,14 +48,14 @@ Object {
   ],
   "publicKey": Array [
     Object {
+      "controller": "did:3:bafyiuh3f97hqef97h",
       "id": "did:3:bafyiuh3f97hqef97h#signing",
-      "owner": "did:3:bafyiuh3f97hqef97h",
       "publicKeyHex": "03fff18103bdca9458e73cca5f0a0f64964312d686712f2190bf5b4794c6e29924",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
+      "controller": "did:3:bafyiuh3f97hqef97h",
       "id": "did:3:bafyiuh3f97hqef97h#encryption",
-      "owner": "did:3:bafyiuh3f97hqef97h",
       "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug=",
       "type": "Curve25519EncryptionPublicKey",
     },

--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -16,7 +16,7 @@ export function wrapDocument(content: any, did: string): DIDDocument {
     id: did,
     publicKey: [],
     authentication: [],
-    keyAgreement: [] // TODO this should be resolved by the PR in the did-resolver lib
+    keyAgreement: [] // TODO should be resolved by https://github.com/decentralized-identity/did-resolver/pull/56
   }
   return Object.entries(content.publicKeys as string[]).reduce((diddoc, [keyName, keyValue]) => {
     if (keyValue.startsWith('z')) { // we got a multicodec encoded key

--- a/packages/account-template/package.json
+++ b/packages/account-template/package.json
@@ -21,7 +21,7 @@
     "@typescript-eslint/eslint-plugin": "^2.19.0",
     "@typescript-eslint/parser": "^2.19.0",
     "babel-jest": "^25.1.0",
-    "did-resolver": "^2.0.1",
+    "did-resolver": "github:ceramicnetwork/did-resolver",
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.8.2",
     "jest": "^25.1.0",

--- a/packages/ceramic-common/package.json
+++ b/packages/ceramic-common/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@types/json-schema": "^7.0.5",
     "ajv": "^6.12.3",
-    "did-resolver": "^2.0.1"
+    "did-resolver": "github:ceramicnetwork/did-resolver"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/ceramic-core/package.json
+++ b/packages/ceramic-core/package.json
@@ -39,7 +39,7 @@
     "@textile/powergate-client": "^0.2.0",
     "cids": "^0.8.0",
     "cross-fetch": "^3.0.5",
-    "did-resolver": "^2.0.1",
+    "did-resolver": "github:ceramicnetwork/did-resolver",
     "fast-json-patch": "^3.0.0-1",
     "ipfs-http-client": "^45.0.0",
     "level-ts": "^2.0.5",

--- a/packages/ceramic-doctype-account-link/package.json
+++ b/packages/ceramic-doctype-account-link/package.json
@@ -28,7 +28,7 @@
     "3id-blockchain-utils": "^0.4.0",
     "@ceramicnetwork/ceramic-common": "^0.2.8",
     "@types/lodash.clonedeep": "^4.5.6",
-    "did-resolver": "^2.0.1"
+    "did-resolver": "github:ceramicnetwork/did-resolver"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/ceramic-doctype-three-id/package.json
+++ b/packages/ceramic-doctype-three-id/package.json
@@ -30,7 +30,7 @@
     "@ceramicnetwork/ceramic-common": "^0.2.8",
     "@types/lodash.clonedeep": "^4.5.6",
     "did-jwt": "^4.0.0",
-    "did-resolver": "^2.0.1"
+    "did-resolver": "github:ceramicnetwork/did-resolver"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/ceramic-doctype-tile/package.json
+++ b/packages/ceramic-doctype-tile/package.json
@@ -28,7 +28,7 @@
     "3id-blockchain-utils": "^0.4.0",
     "@ceramicnetwork/ceramic-common": "^0.2.8",
     "@types/lodash.clonedeep": "^4.5.6",
-    "did-resolver": "^2.0.1"
+    "did-resolver": "github:ceramicnetwork/did-resolver"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
Use forked `did-resolver` until this [PR](https://github.com/decentralized-identity/did-resolver/pull/56) is not merged.

Note: the PR adds `keyAgreement` property in the `DIDDocument` interface.