### PR TITLE
fix: doctype getters now returns next state

### DIFF
--- a/packages/ceramic-common/src/doctype.ts
+++ b/packages/ceramic-common/src/doctype.ts
@@ -8,7 +8,7 @@ import { DoctypeUtils } from "./utils/doctype-utils"
  * Describes signature status
  */
 export enum SignatureStatus {
-    GENESIS,
+  GENESIS,
     PARTIAL,
     SIGNED
 }
@@ -17,7 +17,7 @@ export enum SignatureStatus {
  * Describes all anchor statuses
  */
 export enum AnchorStatus {
-    NOT_REQUESTED,
+  NOT_REQUESTED,
     PENDING,
     PROCESSING,
     ANCHORED,
@@ -28,142 +28,144 @@ export enum AnchorStatus {
  * Describes anchor record
  */
 export interface AnchorRecord {
-    prev: CID; // should be CID type
-    proof: CID; // should be CID type
-    path: string;
+  prev: CID; // should be CID type
+  proof: CID; // should be CID type
+  path: string;
 }
 
 /**
  * Describes anchor proof
  */
 export interface AnchorProof {
-    chainId: string;
-    blockNumber: number;
-    blockTimestamp: number;
-    txHash: CID;
-    root: CID;
+  chainId: string;
+  blockNumber: number;
+  blockTimestamp: number;
+  txHash: CID;
+  root: CID;
 }
 
 /**
  * Document metadata
  */
 export interface DocMetadata {
-    owners: Array<string>;
-    schema?: string;
-    tags?: Array<string>;
-    isUnique?: boolean;
+  owners: Array<string>;
+  schema?: string;
+  tags?: Array<string>;
+  isUnique?: boolean;
 
-    [index: string]: any; // allow arbitrary properties
+  [index: string]: any; // allow arbitrary properties
 }
 
 /**
  * Document params
  */
 export interface DocParams {
-    metadata?: DocMetadata;
+  metadata?: DocMetadata;
 
-    [index: string]: any; // allow arbitrary properties
+  [index: string]: any; // allow arbitrary properties
 }
 
 /**
  * Document information about the next iteration
  */
 export interface DocNext {
-    content?: any;
-    owners?: Array<string>;
-    metadata?: DocMetadata;
+  content?: any;
+  owners?: Array<string>;
+  metadata?: DocMetadata;
 }
 
 /**
  * Document state
  */
 export interface DocState {
-    doctype: string;
-    content: any;
-    next?: DocNext;
-    metadata: DocMetadata;
-    signature: SignatureStatus;
-    anchorStatus: AnchorStatus;
-    anchorScheduledFor?: number; // only present when anchor status is pending
-    anchorProof?: AnchorProof; // the anchor proof of the latest anchor, only present when anchor status is anchored
-    log: Array<CID>;
+  doctype: string;
+  content: any;
+  next?: DocNext;
+  metadata: DocMetadata;
+  signature: SignatureStatus;
+  anchorStatus: AnchorStatus;
+  anchorScheduledFor?: number; // only present when anchor status is pending
+  anchorProof?: AnchorProof; // the anchor proof of the latest anchor, only present when anchor status is anchored
+  log: Array<CID>;
 }
 
 /**
  * Doctype init options
  */
 export interface DocOpts {
-    applyOnly?: boolean;
-    skipWait?: boolean;
+  applyOnly?: boolean;
+  skipWait?: boolean;
 }
 
 /**
  * Describes common doctype attributes
  */
 export abstract class Doctype extends EventEmitter {
-    constructor(private _state: DocState, private _context: Context) {
-        super()
-    }
+  constructor(private _state: DocState, private _context: Context) {
+    super()
+  }
 
-    get id(): string {
-        return DoctypeUtils.createDocIdFromGenesis(this._state.log[0])
-    }
+  get id(): string {
+    return DoctypeUtils.createDocIdFromGenesis(this._state.log[0])
+  }
 
-    get doctype(): string {
-        return this._state.doctype
-    }
+  get doctype(): string {
+    return this._state.doctype
+  }
 
-    get content(): any {
-        return cloneDeep(this._state.content)
-    }
+  get content(): any {
+    const { next, content } = this._state
+    return cloneDeep(next?.content ?? content)
+  }
 
-    get metadata(): DocMetadata {
-        return cloneDeep(this._state.metadata)
-    }
+  get metadata(): DocMetadata {
+    const { next, metadata } = this._state
+    return cloneDeep(next?.metadata ?? metadata)
+  }
 
-    get owners(): Array<string> {
-        return cloneDeep(this._state.metadata.owners)
-    }
+  get owners(): Array<string> {
+    return this.metadata.owners
+  }
 
-    get head(): CID {
-        return this._state.log[this._state.log.length - 1]
-    }
+  get head(): CID {
+    return this._state.log[this._state.log.length - 1]
+  }
 
-    get state(): DocState {
-        return cloneDeep(this._state)
-    }
+  get state(): DocState {
+    return cloneDeep(this._state)
+  }
 
-    set state(state: DocState) {
-        this._state = state
-    }
+  set state(state: DocState) {
+    this._state = state
+  }
 
-    set context(context: Context) {
-        this._context = context
-    }
+  set context(context: Context) {
+    this._context = context
+  }
 
-    get context(): Context {
-        return this._context
-    }
+  get context(): Context {
+    return this._context
+  }
 
-    /**
-     * Makes a change on an existing document
-     * @param params - Change parameters
-     * @param opts - Initialization options
-     */
-    abstract change(params: DocParams, opts?: DocOpts): Promise<void>
+  /**
+   * Makes a change on an existing document
+   * @param params - Change parameters
+   * @param opts - Initialization options
+   */
+  abstract change(params: DocParams, opts?: DocOpts): Promise<void>
 
     /**
      * Validate Doctype against schema
      */
     async validate(): Promise<void> {
-        const schemaDocId = this.state?.metadata?.schema
-        if (schemaDocId) {
-            const schemaDoc = await this.context.api.loadDocument(schemaDocId)
-            if (!schemaDoc) {
-                throw new Error(`Schema not found for ${schemaDocId}`)
-            }
-            DoctypeUtils.validate(this.content, schemaDoc.content)
+      const schemaDocId = this.state?.metadata?.schema
+      if (schemaDocId) {
+        const schemaDoc = await this.context.api.loadDocument(schemaDocId)
+        if (!schemaDoc) {
+          throw new Error(`Schema not found for ${schemaDocId}`)
         }
+        DoctypeUtils.validate(this.content, schemaDoc.content)
+      }
     }
 
 }
@@ -173,50 +175,50 @@ export abstract class Doctype extends EventEmitter {
  * @constructor
  */
 export function DoctypeStatic<T>() {
-    return <U extends T>(constructor: U): any => { constructor };
+  return <U extends T>(constructor: U): any => { constructor };
 }
 
 /**
  * Doctype static signatures
  */
 export interface DoctypeConstructor<T extends Doctype> {
-    /**
-     * Constructor signature
-     * @param state - Doctype state
-     * @param context - Ceramic context
-     */
-    new (state: DocState, context: Context): T;
+  /**
+   * Constructor signature
+   * @param state - Doctype state
+   * @param context - Ceramic context
+   */
+  new (state: DocState, context: Context): T;
 
-    /**
-     * Makes genesis record
-     * @param params - Create parameters
-     * @param context - Ceramic context
-     * @param opts - Initialization options
-     */
-    makeGenesis(params: DocParams, context?: Context, opts?: DocOpts): Promise<Record<string, any>>;
+  /**
+   * Makes genesis record
+   * @param params - Create parameters
+   * @param context - Ceramic context
+   * @param opts - Initialization options
+   */
+  makeGenesis(params: DocParams, context?: Context, opts?: DocOpts): Promise<Record<string, any>>;
 }
 
 /**
  * Describes document type handler functionality
  */
 export interface DoctypeHandler<T extends Doctype> {
-    /**
-     * The string name of the doctype
-     */
-    name: string;
+  /**
+   * The string name of the doctype
+   */
+  name: string;
 
-    /**
-     * The doctype class
-     */
-    doctype: DoctypeConstructor<T>;
+  /**
+   * The doctype class
+   */
+  doctype: DoctypeConstructor<T>;
 
-    /**
-     * Applies record to the document (genesis|signed|anchored)
-     * @param record - Record instance
-     * @param cid - Record CID
-     * @param context - Ceramic context
-     * @param state - Document state
-     */
-    applyRecord(record: any, cid: CID, context: Context, state?: DocState): Promise<DocState>;
+  /**
+   * Applies record to the document (genesis|signed|anchored)
+   * @param record - Record instance
+   * @param cid - Record CID
+   * @param context - Ceramic context
+   * @param state - Document state
+   */
+  applyRecord(record: any, cid: CID, context: Context, state?: DocState): Promise<DocState>;
 
 }

--- a/packages/ceramic-common/src/doctype.ts
+++ b/packages/ceramic-common/src/doctype.ts
@@ -8,164 +8,158 @@ import { DoctypeUtils } from "./utils/doctype-utils"
  * Describes signature status
  */
 export enum SignatureStatus {
-  GENESIS,
-    PARTIAL,
-    SIGNED
+    GENESIS, PARTIAL, SIGNED
 }
 
 /**
  * Describes all anchor statuses
  */
 export enum AnchorStatus {
-  NOT_REQUESTED,
-    PENDING,
-    PROCESSING,
-    ANCHORED,
-    FAILED
+    NOT_REQUESTED, PENDING, PROCESSING, ANCHORED, FAILED
 }
 
 /**
  * Describes anchor record
  */
 export interface AnchorRecord {
-  prev: CID; // should be CID type
-  proof: CID; // should be CID type
-  path: string;
+    prev: CID; // should be CID type
+    proof: CID; // should be CID type
+    path: string;
 }
 
 /**
  * Describes anchor proof
  */
 export interface AnchorProof {
-  chainId: string;
-  blockNumber: number;
-  blockTimestamp: number;
-  txHash: CID;
-  root: CID;
+    chainId: string;
+    blockNumber: number;
+    blockTimestamp: number;
+    txHash: CID;
+    root: CID;
 }
 
 /**
  * Document metadata
  */
 export interface DocMetadata {
-  owners: Array<string>;
-  schema?: string;
-  tags?: Array<string>;
-  isUnique?: boolean;
+    owners: Array<string>;
+    schema?: string;
+    tags?: Array<string>;
+    isUnique?: boolean;
 
-  [index: string]: any; // allow arbitrary properties
+    [index: string]: any; // allow arbitrary properties
 }
 
 /**
  * Document params
  */
 export interface DocParams {
-  metadata?: DocMetadata;
+    metadata?: DocMetadata;
 
-  [index: string]: any; // allow arbitrary properties
+    [index: string]: any; // allow arbitrary properties
 }
 
 /**
  * Document information about the next iteration
  */
 export interface DocNext {
-  content?: any;
-  owners?: Array<string>;
-  metadata?: DocMetadata;
+    content?: any;
+    owners?: Array<string>;
+    metadata?: DocMetadata;
 }
 
 /**
  * Document state
  */
 export interface DocState {
-  doctype: string;
-  content: any;
-  next?: DocNext;
-  metadata: DocMetadata;
-  signature: SignatureStatus;
-  anchorStatus: AnchorStatus;
-  anchorScheduledFor?: number; // only present when anchor status is pending
-  anchorProof?: AnchorProof; // the anchor proof of the latest anchor, only present when anchor status is anchored
-  log: Array<CID>;
+    doctype: string;
+    content: any;
+    next?: DocNext;
+    metadata: DocMetadata;
+    signature: SignatureStatus;
+    anchorStatus: AnchorStatus;
+    anchorScheduledFor?: number; // only present when anchor status is pending
+    anchorProof?: AnchorProof; // the anchor proof of the latest anchor, only present when anchor status is anchored
+    log: Array<CID>;
 }
 
 /**
  * Doctype init options
  */
 export interface DocOpts {
-  applyOnly?: boolean;
-  skipWait?: boolean;
+    applyOnly?: boolean;
+    skipWait?: boolean;
 }
 
 /**
  * Describes common doctype attributes
  */
 export abstract class Doctype extends EventEmitter {
-  constructor(private _state: DocState, private _context: Context) {
-    super()
-  }
+    constructor(private _state: DocState, private _context: Context) {
+        super()
+    }
 
-  get id(): string {
-    return DoctypeUtils.createDocIdFromGenesis(this._state.log[0])
-  }
+    get id(): string {
+        return DoctypeUtils.createDocIdFromGenesis(this._state.log[0])
+    }
 
-  get doctype(): string {
-    return this._state.doctype
-  }
+    get doctype(): string {
+        return this._state.doctype
+    }
 
-  get content(): any {
-    const { next, content } = this._state
-    return cloneDeep(next?.content ?? content)
-  }
+    get content(): any {
+        const { next, content } = this._state
+        return cloneDeep(next?.content ?? content)
+    }
 
-  get metadata(): DocMetadata {
-    const { next, metadata } = this._state
-    return cloneDeep(next?.metadata ?? metadata)
-  }
+    get metadata(): DocMetadata {
+        const { next, metadata } = this._state
+        return cloneDeep(next?.metadata ?? metadata)
+    }
 
-  get owners(): Array<string> {
-    return this.metadata.owners
-  }
+    get owners(): Array<string> {
+        return this.metadata.owners
+    }
 
-  get head(): CID {
-    return this._state.log[this._state.log.length - 1]
-  }
+    get head(): CID {
+        return this._state.log[this._state.log.length - 1]
+    }
 
-  get state(): DocState {
-    return cloneDeep(this._state)
-  }
+    get state(): DocState {
+        return cloneDeep(this._state)
+    }
 
-  set state(state: DocState) {
-    this._state = state
-  }
+    set state(state: DocState) {
+        this._state = state
+    }
 
-  set context(context: Context) {
-    this._context = context
-  }
+    set context(context: Context) {
+        this._context = context
+    }
 
-  get context(): Context {
-    return this._context
-  }
+    get context(): Context {
+        return this._context
+    }
 
-  /**
-   * Makes a change on an existing document
-   * @param params - Change parameters
-   * @param opts - Initialization options
-   */
-  abstract change(params: DocParams, opts?: DocOpts): Promise<void>
+    /**
+     * Makes a change on an existing document
+     * @param params - Change parameters
+     * @param opts - Initialization options
+     */
+    abstract change(params: DocParams, opts?: DocOpts): Promise<void>
 
     /**
      * Validate Doctype against schema
      */
     async validate(): Promise<void> {
-      const schemaDocId = this.state?.metadata?.schema
-      if (schemaDocId) {
-        const schemaDoc = await this.context.api.loadDocument(schemaDocId)
-        if (!schemaDoc) {
-          throw new Error(`Schema not found for ${schemaDocId}`)
+        const schemaDocId = this.state?.metadata?.schema
+        if (schemaDocId) {
+            const schemaDoc = await this.context.api.loadDocument(schemaDocId)
+            if (!schemaDoc) {
+                throw new Error(`Schema not found for ${schemaDocId}`)
+            }
+            DoctypeUtils.validate(this.content, schemaDoc.content)
         }
-        DoctypeUtils.validate(this.content, schemaDoc.content)
-      }
     }
 
 }
@@ -175,50 +169,50 @@ export abstract class Doctype extends EventEmitter {
  * @constructor
  */
 export function DoctypeStatic<T>() {
-  return <U extends T>(constructor: U): any => { constructor };
+    return <U extends T>(constructor: U): any => { constructor };
 }
 
 /**
  * Doctype static signatures
  */
 export interface DoctypeConstructor<T extends Doctype> {
-  /**
-   * Constructor signature
-   * @param state - Doctype state
-   * @param context - Ceramic context
-   */
-  new (state: DocState, context: Context): T;
+    /**
+     * Constructor signature
+     * @param state - Doctype state
+     * @param context - Ceramic context
+     */
+    new(state: DocState, context: Context): T;
 
-  /**
-   * Makes genesis record
-   * @param params - Create parameters
-   * @param context - Ceramic context
-   * @param opts - Initialization options
-   */
-  makeGenesis(params: DocParams, context?: Context, opts?: DocOpts): Promise<Record<string, any>>;
+    /**
+     * Makes genesis record
+     * @param params - Create parameters
+     * @param context - Ceramic context
+     * @param opts - Initialization options
+     */
+    makeGenesis(params: DocParams, context?: Context, opts?: DocOpts): Promise<Record<string, any>>;
 }
 
 /**
  * Describes document type handler functionality
  */
 export interface DoctypeHandler<T extends Doctype> {
-  /**
-   * The string name of the doctype
-   */
-  name: string;
+    /**
+     * The string name of the doctype
+     */
+    name: string;
 
-  /**
-   * The doctype class
-   */
-  doctype: DoctypeConstructor<T>;
+    /**
+     * The doctype class
+     */
+    doctype: DoctypeConstructor<T>;
 
-  /**
-   * Applies record to the document (genesis|signed|anchored)
-   * @param record - Record instance
-   * @param cid - Record CID
-   * @param context - Ceramic context
-   * @param state - Document state
-   */
-  applyRecord(record: any, cid: CID, context: Context, state?: DocState): Promise<DocState>;
+    /**
+     * Applies record to the document (genesis|signed|anchored)
+     * @param record - Record instance
+     * @param cid - Record CID
+     * @param context - Ceramic context
+     * @param state - Document state
+     */
+    applyRecord(record: any, cid: CID, context: Context, state?: DocState): Promise<DocState>;
 
 }

--- a/packages/ceramic-core/package-lock.json
+++ b/packages/ceramic-core/package-lock.json
@@ -8,6 +8,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/3id-blockchain-utils/-/3id-blockchain-utils-0.4.1.tgz",
 			"integrity": "sha512-z7Qb4CuTVg/ug3i7/Gp+l9ZebNAcz4fPFEjXnS8gwA+mAvRUl4uCF2psvcQJtWtImLvznFwUAtXDG9T0N6ylLA==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
 				"@ethersproject/contracts": "^5.0.1",
@@ -20,6 +21,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.2.tgz",
 					"integrity": "sha512-U1s60+nG02x8FKNMoVNI6MG8SguWCoG9HJtwOqWZ38LBRMsDV4c0w4izKx98kcsN3wXw4U2/YAyJ9LlH7+/hkg==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bignumber": "^5.0.0",
 						"@ethersproject/bytes": "^5.0.0",
@@ -34,6 +36,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.2.tgz",
 					"integrity": "sha512-CzzXbeqKlgayE4YTnvvreGBG3n+HxakGXrxaGM6LjBZnOOIVSYi6HMFG8ZXls7UspRY4hvMrtnKEJKDCOngSBw==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/abstract-provider": "^5.0.0",
 						"@ethersproject/bignumber": "^5.0.0",
@@ -46,6 +49,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.2.tgz",
 					"integrity": "sha512-+rz26RKj7ujGfQynys4V9VJRbR+wpC6eL8F22q3raWMH3152Ha31GwJPWzxE/bEA+43M/zTNVwY0R53gn53L2Q==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bignumber": "^5.0.0",
 						"@ethersproject/bytes": "^5.0.0",
@@ -59,6 +63,7 @@
 					"version": "5.0.5",
 					"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.5.tgz",
 					"integrity": "sha512-24ln7PV0g8ZzjcVZiLW9Wod0i+XCmK6zKkAaxw5enraTIT1p7gVOcSXFSzNQ9WYAwtiFQPvvA+TIO2oEITZNJA==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/logger": "^5.0.0",
@@ -69,6 +74,7 @@
 					"version": "5.0.3",
 					"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.3.tgz",
 					"integrity": "sha512-AyPMAlY+Amaw4Zfp8OAivm1xYPI8mqiUYmEnSUk1CnS2NrQGHEMmFJFiOJdS3gDDpgSOFhWIjZwxKq2VZpqNTA==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/logger": "^5.0.0"
 					}
@@ -77,6 +83,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.2.tgz",
 					"integrity": "sha512-nNoVlNP6bgpog7pQ2EyD1xjlaXcy1Cl4kK5v1KoskHj58EtB6TK8M8AFGi3GgHTdMldfT4eN3OsoQ/CdOTVNFA==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bignumber": "^5.0.0"
 					}
@@ -85,6 +92,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.2.tgz",
 					"integrity": "sha512-Ud3oW8mBNIWE+WHRjvwVEwfvshn7lfYWSSKG0fPSb6baRN9mLOoNguX+VIv3W5Sne9w2utnBmxLF2ESXitw64A==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/abi": "^5.0.0",
 						"@ethersproject/abstract-provider": "^5.0.0",
@@ -101,6 +109,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.2.tgz",
 					"integrity": "sha512-MbroXutc0gPNYIrUjS4Aw0lDuXabdzI7+l7elRWr1G6G+W0v00e/3gbikWkCReGtt2Jnt4lQSgnflhDwQGcIhA==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"js-sha3": "0.5.7"
@@ -109,12 +118,14 @@
 				"@ethersproject/logger": {
 					"version": "5.0.4",
 					"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.4.tgz",
-					"integrity": "sha512-alA2LiAy1LdQ/L1SA9ajUC7MvGAEQLsICEfKK4erX5qhkXE1LwLSPIzobtOWFsMHf2yrXGKBLnnpuVHprI3sAw=="
+					"integrity": "sha512-alA2LiAy1LdQ/L1SA9ajUC7MvGAEQLsICEfKK4erX5qhkXE1LwLSPIzobtOWFsMHf2yrXGKBLnnpuVHprI3sAw==",
+					"dev": true
 				},
 				"@ethersproject/networks": {
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.2.tgz",
 					"integrity": "sha512-T7HVd62D4izNU2tDHf6xUDo7k4JOGX4Lk7vDmVcDKrepSWwL2OmGWrqSlkRe2a1Dnz4+1VPE6fb6+KsmSRe82g==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/logger": "^5.0.0"
 					}
@@ -123,6 +134,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.2.tgz",
 					"integrity": "sha512-FxAisPGAOACQjMJzewl9OJG6lsGCPTm5vpUMtfeoxzAlAb2lv+kHzQPUh9h4jfAILzE8AR1jgXMzRmlhwyra1Q==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/logger": "^5.0.0"
 					}
@@ -131,6 +143,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.2.tgz",
 					"integrity": "sha512-oE0M5jqQ67fi2SuMcrpoewOpEuoXaD8M9JeR9md1bXRMvDYgKXUtDHs22oevpEOdnO2DPIRabp6MVHa4aDuWmw==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/logger": "^5.0.0"
@@ -140,6 +153,7 @@
 					"version": "5.0.3",
 					"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.3.tgz",
 					"integrity": "sha512-5QPZaBRGCLzfVMbFb3LcVjNR0UbTXnwDHASnQYfbzwUOnFYHKxHsrcbl/5ONGoppgi8yXgOocKqlPCFycJJVWQ==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/logger": "^5.0.0",
@@ -151,6 +165,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.2.tgz",
 					"integrity": "sha512-oNa+xvSqsFU96ndzog0IBTtsRFGOqGpzrXJ7shXLBT7juVeSEyZA/sYs0DMZB5mJ9FEjHdZKxR/rTyBY91vuXg==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/constants": "^5.0.0",
@@ -161,6 +176,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.2.tgz",
 					"integrity": "sha512-jZp0ZbbJlq4JLZY6qoMzNtp2HQsX6USQposi3ns0MPUdn3OdZJBDtrcO15r/2VS5t/K1e1GE5MI1HmMKlcTbbQ==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/address": "^5.0.0",
 						"@ethersproject/bignumber": "^5.0.0",
@@ -177,6 +193,7 @@
 					"version": "5.0.3",
 					"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.3.tgz",
 					"integrity": "sha512-9WoIWNxbFOk+8TiWqQMQbYJUIFeC1Z7zNr7oCHpVyhxF0EY54ZVXlP/Y7VJ7KzK++A/iMGOuTIGeL5sMqa2QMg==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/base64": "^5.0.0",
 						"@ethersproject/bytes": "^5.0.0",
@@ -189,6 +206,7 @@
 					"version": "6.5.3",
 					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
 					"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+					"dev": true,
 					"requires": {
 						"bn.js": "^4.4.0",
 						"brorand": "^1.0.1",
@@ -1495,6 +1513,7 @@
 			"version": "7.9.6",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
 			"integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -1541,18 +1560,11 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"@ceramicnetwork/3id-did-resolver": {
-			"version": "0.1.9",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/3id-did-resolver/-/3id-did-resolver-0.1.9.tgz",
-			"integrity": "sha512-0nWx4OMfQBK1+TYuZ4O4UqlnALNpoG2kDz+1MW60opo7Np84PPPSIEaoPLDm1tSSX5s0BTWakqSLj8C5Qd8nvw==",
-			"requires": {
-				"@ceramicnetwork/ceramic-common": "^0.2.8"
-			}
-		},
 		"@ceramicnetwork/ceramic-common": {
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-common/-/ceramic-common-0.2.8.tgz",
 			"integrity": "sha512-GAcoxCD0rD9AfkBt5icYhdrrQJKpEptyW6yTubQx/JimDDS3kL+WnrjMiua5pidE7JOszISpLhfUS0sWluJKNA==",
+			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.5",
 				"ajv": "^6.12.3",
@@ -1562,12 +1574,14 @@
 				"@types/json-schema": {
 					"version": "7.0.5",
 					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-					"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
+					"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+					"dev": true
 				},
 				"ajv": {
 					"version": "6.12.4",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
 					"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"fast-json-stable-stringify": "^2.0.0",
@@ -1575,41 +1589,6 @@
 						"uri-js": "^4.2.2"
 					}
 				}
-			}
-		},
-		"@ceramicnetwork/ceramic-doctype-account-link": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-account-link/-/ceramic-doctype-account-link-0.2.8.tgz",
-			"integrity": "sha512-qXjDE6KfLzFXCXyYYFZfONJNKhuVSciw/Z1BXvxPNqn+iXIAj46hn62GEgnPd+2YW8zTwtozq/exTlPs+i14ng==",
-			"requires": {
-				"3id-blockchain-utils": "^0.4.0",
-				"@ceramicnetwork/ceramic-common": "^0.2.8",
-				"@types/lodash.clonedeep": "^4.5.6",
-				"did-resolver": "^2.0.1"
-			}
-		},
-		"@ceramicnetwork/ceramic-doctype-three-id": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-three-id/-/ceramic-doctype-three-id-0.2.8.tgz",
-			"integrity": "sha512-Uqe1HyXD6tw4heWhx/d0xfCIfRwc0vD4f9N0Or+L3E/zOxr0AgBz/pnarESaH2ewCMucm3BrO0PGlIC8UO8KdA==",
-			"requires": {
-				"3id-blockchain-utils": "^0.4.0",
-				"@ceramicnetwork/3id-did-resolver": "^0.1.9",
-				"@ceramicnetwork/ceramic-common": "^0.2.8",
-				"@types/lodash.clonedeep": "^4.5.6",
-				"did-jwt": "^4.0.0",
-				"did-resolver": "^2.0.1"
-			}
-		},
-		"@ceramicnetwork/ceramic-doctype-tile": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-tile/-/ceramic-doctype-tile-0.2.8.tgz",
-			"integrity": "sha512-FME9KLch6JkY+V4fBzlzwauijND1umzPTaRy7cPiJJpGT7/t3GLXgn3kafv/xm3s/N3MHtklZ15xdvCyoo3Efw==",
-			"requires": {
-				"3id-blockchain-utils": "^0.4.0",
-				"@ceramicnetwork/ceramic-common": "^0.2.8",
-				"@types/lodash.clonedeep": "^4.5.6",
-				"did-resolver": "^2.0.1"
 			}
 		},
 		"@ceramicnetwork/ceramic-http-client": {
@@ -1637,6 +1616,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.1.tgz",
 			"integrity": "sha512-9fqSa3jEYV4nN8tijW+jz4UnT/Ma9/b8y4+nHlsvuWqr32E2kYsT9SCIVpk/51iM6NOud7xsA6UxCox9zBeHKg==",
+			"dev": true,
 			"requires": {
 				"@ethersproject/address": "^5.0.0",
 				"@ethersproject/bignumber": "^5.0.0",
@@ -1653,6 +1633,7 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.1.tgz",
 					"integrity": "sha512-kfQtXpBP2pI2TfoRRAYv8grHGiYw8U0c1KbMsC58/W33TIBy7gFSf/oAzOd94lNzdIUenKU0OuSzrHQfVcDDDA==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bignumber": "^5.0.0",
 						"@ethersproject/bytes": "^5.0.0",
@@ -1666,6 +1647,7 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.1.tgz",
 					"integrity": "sha512-srGDO7ksT0avdDw5pBtj6F81psv5xiJMInwSSatfIKplitubFb6yVwoHGObGRd0Pp3TvrkIDfJkuskoSMj4OHQ==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/logger": "^5.0.0",
@@ -1677,6 +1659,7 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.1.tgz",
 					"integrity": "sha512-Y198536UW9Jb9RBXuqmCsCa9mYJUsxJn+5aGr2XjNMpLBc6vEn/44GHnbQXYgRCzh4rnWtJ9bTgSwDjme9Hgnw==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/logger": "^5.0.0"
 					}
@@ -1685,6 +1668,7 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.1.tgz",
 					"integrity": "sha512-Xec07hFCPN4wfC3WDiRay7KipkApl2msiKTrBHCuAwNMOM8M92+mlQp8tgfEL51DPwCZkmdk1f02kArc6caVSw==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bignumber": "^5.0.0"
 					}
@@ -1693,6 +1677,7 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.1.tgz",
 					"integrity": "sha512-1ByUXYvkszrSSks07xctBtZfpFnIVmftxWlAAnguxh6Q65vKECd/EPi5uI5xVOvnrYMH9Vb8MK1SofPX/6fArQ==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/keccak256": "^5.0.0",
@@ -1704,6 +1689,7 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.1.tgz",
 					"integrity": "sha512-AtFm/4qHRQUvZcG3WYmaT7zV79dz72+N01w0XphcIBaD/7UZXyW85Uf08sirVlckHmh9fvc4UDWyHiroKsBT6Q==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"js-sha3": "0.5.7"
@@ -1712,12 +1698,14 @@
 				"@ethersproject/logger": {
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.2.tgz",
-					"integrity": "sha512-NQe3O1/Nwkcp6bto6hsTvrcCeR/cOGK+RhOMn0Zi2FND6gdWsf1g+5ie8gQ1REqDX4MTGP/Y131dZas985ls/g=="
+					"integrity": "sha512-NQe3O1/Nwkcp6bto6hsTvrcCeR/cOGK+RhOMn0Zi2FND6gdWsf1g+5ie8gQ1REqDX4MTGP/Y131dZas985ls/g==",
+					"dev": true
 				},
 				"@ethersproject/properties": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.1.tgz",
 					"integrity": "sha512-b3VZ/NpYIf64/hFXeWNxVCbY1xoMPIYM3n6Qnu6Ayr3bLt1olFPQfAaaRB0aOsLz7tMtmkT3DrA1KG/IrOgBRw==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/logger": "^5.0.0"
 					}
@@ -1726,6 +1714,7 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.1.tgz",
 					"integrity": "sha512-3F8XE1zS4w8w4xiK1hMtFuVs6UnhQlmrEHLT85GanqK8vG5wGi81IQmkukL9tQIu2a5jykoO46ibja+6N1fpFg==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/logger": "^5.0.0"
@@ -1735,6 +1724,7 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.1.tgz",
 					"integrity": "sha512-N8LxdHGBT7GZdogkEOV5xKXYTz5PNHuNzcxLNPYfH3kpvWSyXshZBgAz8YE1a8sMZagGj+Ic6d3mHijdCTSkGA==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/constants": "^5.0.0",
@@ -2243,6 +2233,7 @@
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.2.tgz",
 			"integrity": "sha512-gg86ynLV5k5caNnYpJoYc6WyIUHKMTjOITCk5zXGyVbbkXE07y/fGql4A51W0C6mWkeb5Mzz8AKqzHZECdH30w==",
+			"dev": true,
 			"requires": {
 				"@ethersproject/abstract-provider": "^5.0.0",
 				"@ethersproject/abstract-signer": "^5.0.0",
@@ -2265,6 +2256,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.2.tgz",
 					"integrity": "sha512-U1s60+nG02x8FKNMoVNI6MG8SguWCoG9HJtwOqWZ38LBRMsDV4c0w4izKx98kcsN3wXw4U2/YAyJ9LlH7+/hkg==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bignumber": "^5.0.0",
 						"@ethersproject/bytes": "^5.0.0",
@@ -2279,6 +2271,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.2.tgz",
 					"integrity": "sha512-CzzXbeqKlgayE4YTnvvreGBG3n+HxakGXrxaGM6LjBZnOOIVSYi6HMFG8ZXls7UspRY4hvMrtnKEJKDCOngSBw==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/abstract-provider": "^5.0.0",
 						"@ethersproject/bignumber": "^5.0.0",
@@ -2291,6 +2284,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.2.tgz",
 					"integrity": "sha512-+rz26RKj7ujGfQynys4V9VJRbR+wpC6eL8F22q3raWMH3152Ha31GwJPWzxE/bEA+43M/zTNVwY0R53gn53L2Q==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bignumber": "^5.0.0",
 						"@ethersproject/bytes": "^5.0.0",
@@ -2304,6 +2298,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.2.tgz",
 					"integrity": "sha512-p4m2CeQqI9vma3XipRbP2iDf6zTsbroE0MEXBAYXidsoJQSvePKrC6MVRKfTzfcHej1b9wfmjVBzqhqn3FRhIA==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/properties": "^5.0.0"
@@ -2313,6 +2308,7 @@
 					"version": "5.0.5",
 					"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.5.tgz",
 					"integrity": "sha512-24ln7PV0g8ZzjcVZiLW9Wod0i+XCmK6zKkAaxw5enraTIT1p7gVOcSXFSzNQ9WYAwtiFQPvvA+TIO2oEITZNJA==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/logger": "^5.0.0",
@@ -2323,6 +2319,7 @@
 					"version": "5.0.3",
 					"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.3.tgz",
 					"integrity": "sha512-AyPMAlY+Amaw4Zfp8OAivm1xYPI8mqiUYmEnSUk1CnS2NrQGHEMmFJFiOJdS3gDDpgSOFhWIjZwxKq2VZpqNTA==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/logger": "^5.0.0"
 					}
@@ -2331,6 +2328,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.2.tgz",
 					"integrity": "sha512-nNoVlNP6bgpog7pQ2EyD1xjlaXcy1Cl4kK5v1KoskHj58EtB6TK8M8AFGi3GgHTdMldfT4eN3OsoQ/CdOTVNFA==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bignumber": "^5.0.0"
 					}
@@ -2339,6 +2337,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.2.tgz",
 					"integrity": "sha512-dWGvNwmVRX2bxoQQ3ciMw46Vzl1nqfL+5R8+2ZxsRXD3Cjgw1dL2mdjJF7xMMWPvPdrlhKXWSK0gb8VLwHZ8Cw==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/keccak256": "^5.0.0",
@@ -2350,6 +2349,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.2.tgz",
 					"integrity": "sha512-QAUI5tfseTFqv00Vnbwzofqse81wN9TaL+x5GufTHIHJXgVdguxU+l39E3VYDCmO+eVAA6RCn5dJgeyra+PU2g==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/abstract-signer": "^5.0.0",
 						"@ethersproject/basex": "^5.0.0",
@@ -2369,6 +2369,7 @@
 					"version": "5.0.4",
 					"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.4.tgz",
 					"integrity": "sha512-jqtb+X3rJXWG/w+Qyr7vq1V+fdc5jiLlyc6akwI3SQIHTfcuuyF+eZRd9u2/455urNwV3nuCsnrgxs2NrtHHIw==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/abstract-signer": "^5.0.0",
 						"@ethersproject/address": "^5.0.0",
@@ -2389,6 +2390,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.2.tgz",
 					"integrity": "sha512-MbroXutc0gPNYIrUjS4Aw0lDuXabdzI7+l7elRWr1G6G+W0v00e/3gbikWkCReGtt2Jnt4lQSgnflhDwQGcIhA==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"js-sha3": "0.5.7"
@@ -2397,12 +2399,14 @@
 				"@ethersproject/logger": {
 					"version": "5.0.4",
 					"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.4.tgz",
-					"integrity": "sha512-alA2LiAy1LdQ/L1SA9ajUC7MvGAEQLsICEfKK4erX5qhkXE1LwLSPIzobtOWFsMHf2yrXGKBLnnpuVHprI3sAw=="
+					"integrity": "sha512-alA2LiAy1LdQ/L1SA9ajUC7MvGAEQLsICEfKK4erX5qhkXE1LwLSPIzobtOWFsMHf2yrXGKBLnnpuVHprI3sAw==",
+					"dev": true
 				},
 				"@ethersproject/networks": {
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.2.tgz",
 					"integrity": "sha512-T7HVd62D4izNU2tDHf6xUDo7k4JOGX4Lk7vDmVcDKrepSWwL2OmGWrqSlkRe2a1Dnz4+1VPE6fb6+KsmSRe82g==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/logger": "^5.0.0"
 					}
@@ -2411,6 +2415,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.2.tgz",
 					"integrity": "sha512-OJFxdX/VtGI5M04lAzXKEOb76XBzjCOzGyko3/bMWat3ePAw7RveBOLyhm79SBs2fh21MSYgdG6JScEMHoSImw==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/sha2": "^5.0.0"
@@ -2420,6 +2425,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.2.tgz",
 					"integrity": "sha512-FxAisPGAOACQjMJzewl9OJG6lsGCPTm5vpUMtfeoxzAlAb2lv+kHzQPUh9h4jfAILzE8AR1jgXMzRmlhwyra1Q==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/logger": "^5.0.0"
 					}
@@ -2428,6 +2434,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.2.tgz",
 					"integrity": "sha512-oE0M5jqQ67fi2SuMcrpoewOpEuoXaD8M9JeR9md1bXRMvDYgKXUtDHs22oevpEOdnO2DPIRabp6MVHa4aDuWmw==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/logger": "^5.0.0"
@@ -2437,6 +2444,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.2.tgz",
 					"integrity": "sha512-VFl4qSStjQZaygpqoAHswaCY59qBm1Sm0rf8iv0tmgVsRf0pBg2nJaNf9NXXvcuJ9AYPyXl57dN8kozdC4z5Cg==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/logger": "^5.0.0",
@@ -2447,6 +2455,7 @@
 							"version": "1.1.3",
 							"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
 							"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+							"dev": true,
 							"requires": {
 								"inherits": "^2.0.3",
 								"minimalistic-assert": "^1.0.0"
@@ -2458,6 +2467,7 @@
 					"version": "5.0.3",
 					"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.3.tgz",
 					"integrity": "sha512-5QPZaBRGCLzfVMbFb3LcVjNR0UbTXnwDHASnQYfbzwUOnFYHKxHsrcbl/5ONGoppgi8yXgOocKqlPCFycJJVWQ==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/logger": "^5.0.0",
@@ -2469,6 +2479,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.2.tgz",
 					"integrity": "sha512-oNa+xvSqsFU96ndzog0IBTtsRFGOqGpzrXJ7shXLBT7juVeSEyZA/sYs0DMZB5mJ9FEjHdZKxR/rTyBY91vuXg==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/constants": "^5.0.0",
@@ -2479,6 +2490,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.2.tgz",
 					"integrity": "sha512-jZp0ZbbJlq4JLZY6qoMzNtp2HQsX6USQposi3ns0MPUdn3OdZJBDtrcO15r/2VS5t/K1e1GE5MI1HmMKlcTbbQ==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/address": "^5.0.0",
 						"@ethersproject/bignumber": "^5.0.0",
@@ -2495,6 +2507,7 @@
 					"version": "5.0.3",
 					"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.3.tgz",
 					"integrity": "sha512-9WoIWNxbFOk+8TiWqQMQbYJUIFeC1Z7zNr7oCHpVyhxF0EY54ZVXlP/Y7VJ7KzK++A/iMGOuTIGeL5sMqa2QMg==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/base64": "^5.0.0",
 						"@ethersproject/bytes": "^5.0.0",
@@ -2507,6 +2520,7 @@
 					"version": "5.0.2",
 					"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.2.tgz",
 					"integrity": "sha512-6vKDQcjjpnfdSCr0+jNxpFH3ieKxUPkm29tQX2US7a3zT/sJU/BGlKBR7D8oOpwdE0hpkHhJyMlypRBK+A2avA==",
+					"dev": true,
 					"requires": {
 						"@ethersproject/bytes": "^5.0.0",
 						"@ethersproject/hash": "^5.0.0",
@@ -2519,6 +2533,7 @@
 					"version": "6.5.3",
 					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
 					"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+					"dev": true,
 					"requires": {
 						"bn.js": "^4.4.0",
 						"brorand": "^1.0.1",
@@ -2532,7 +2547,8 @@
 				"scrypt-js": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-					"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+					"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+					"dev": true
 				}
 			}
 		},
@@ -3684,11 +3700,6 @@
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
 			"dev": true
 		},
-		"@stablelib/utf8": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-0.10.1.tgz",
-			"integrity": "sha512-+uM1YZ4MhBC82vt99prF7DXNGqhYmJ9cQ3p5qNowMNkkzn9OWEkqBvguBW3ChAt7JvqZ3SD5HJOfc6YgnfMTHw=="
-		},
 		"@szmarczak/http-timer": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -3937,19 +3948,6 @@
 			"integrity": "sha512-SWYkVJylo1dqblkhrr7UtmsQh4wdZA9bV1y3QJSywMPSqGfW0p1w37N1EayZtKbg1dGReIIQEEOtxk4wZvGrWQ==",
 			"dev": true
 		},
-		"@types/lodash": {
-			"version": "4.14.159",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.159.tgz",
-			"integrity": "sha512-gF7A72f7WQN33DpqOWw9geApQPh4M3PxluMtaHxWHXEGSN12/WbcEk/eNSqWNQcQhF66VSZ06vCF94CrHwXJDg=="
-		},
-		"@types/lodash.clonedeep": {
-			"version": "4.5.6",
-			"resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-			"integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-			"requires": {
-				"@types/lodash": "*"
-			}
-		},
 		"@types/long": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
@@ -4153,7 +4151,8 @@
 		"aes-js": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
+			"dev": true
 		},
 		"after": {
 			"version": "0.8.2",
@@ -4667,6 +4666,11 @@
 			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
 			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
 			"dev": true
+		},
+		"base64url": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+			"integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -6052,38 +6056,106 @@
 			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
 			"dev": true
 		},
-		"did-jwt": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-4.3.2.tgz",
-			"integrity": "sha512-emkWdlt24qfhFVkPvAWIS5o5Wdyz3OyN3OQnkgW3iOow4PvtM3uO0rg1L9P9yKwl+pwg005AfM3WInjFbVjZmQ==",
+		"did-resolver": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-2.1.1.tgz",
+			"integrity": "sha512-FYLTkNWofjYNDGV1HTQlyVu1OqZiFxR4I8KM+oxGVOkbXva15NfWzbzciqdXUDqOhe6so5aroAdrVip6gSAYSA=="
+		},
+		"dids": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/dids/-/dids-0.5.0.tgz",
+			"integrity": "sha512-/cf5cQTUH/HNXWqN+R9OMCpIT7qYlHeBgmenmpV64/M248lG6J54Qje3jtvv8BzdvNDbRshL82OvCwM7wY63Mw==",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
-				"@stablelib/utf8": "^0.10.1",
-				"buffer": "^5.2.1",
-				"did-resolver": "^1.0.0",
-				"elliptic": "^6.4.0",
-				"js-sha256": "^0.9.0",
-				"js-sha3": "^0.8.0",
-				"tweetnacl": "^1.0.1",
-				"uport-base64url": "3.0.2-alpha.0"
+				"base64url": "^3.0.1",
+				"cids": "^1.0.0",
+				"did-resolver": "^2.1.1",
+				"ipld-dag-cbor": "^0.17.0",
+				"rpc-utils": "^0.1.3"
 			},
 			"dependencies": {
-				"did-resolver": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-1.1.0.tgz",
-					"integrity": "sha512-Q02Sc5VuQnJzzR8fQ/DzyCHiYb31WpQdocOsxppI66wwT4XalYRDeCr3a48mL6sYPQo76AkBh0mxte9ZBuQzxA=="
+				"cids": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/cids/-/cids-1.0.0.tgz",
+					"integrity": "sha512-HEBCIElSiXlkgZq3dgHJc3eDcnFteFp96N8/1/oqX5lkxBtB66sZ12jqEP3g7Ut++jEk6kIUGifQ1Qrya1jcNQ==",
+					"requires": {
+						"class-is": "^1.1.0",
+						"multibase": "^3.0.0",
+						"multicodec": "^2.0.0",
+						"multihashes": "^3.0.1",
+						"uint8arrays": "^1.0.0"
+					}
+				},
+				"ipld-dag-cbor": {
+					"version": "0.17.0",
+					"resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.17.0.tgz",
+					"integrity": "sha512-YprSTQClJQUyC+RhbWrVXhg7ysII5R/jrmZZ4en4n9Mav+MRbntAW699zd1PHRLB71lNCJbxABE2Uc9QU2Ka7g==",
+					"requires": {
+						"borc": "^2.1.2",
+						"cids": "^1.0.0",
+						"is-circular": "^1.0.2",
+						"multicodec": "^2.0.0",
+						"multihashing-async": "^2.0.0",
+						"uint8arrays": "^1.0.0"
+					}
 				},
 				"js-sha3": {
 					"version": "0.8.0",
 					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
 					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+				},
+				"multibase": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
+					"integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
+					"requires": {
+						"base-x": "^3.0.8",
+						"web-encoding": "^1.0.2"
+					}
+				},
+				"multicodec": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.0.tgz",
+					"integrity": "sha512-2SLsdTCXqOpUfoSHkTaVzxnjjl5fsSO283Idb9rAYgKGVu188NFP5KncuZ8Ifg8H2gc5GOi2rkuhLumqv9nweQ==",
+					"requires": {
+						"uint8arrays": "1.0.0",
+						"varint": "^5.0.0"
+					},
+					"dependencies": {
+						"uint8arrays": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
+							"integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
+							"requires": {
+								"multibase": "^3.0.0",
+								"web-encoding": "^1.0.2"
+							}
+						}
+					}
+				},
+				"multihashes": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
+					"integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
+					"requires": {
+						"multibase": "^3.0.0",
+						"uint8arrays": "^1.0.0",
+						"varint": "^5.0.0"
+					}
+				},
+				"multihashing-async": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.0.1.tgz",
+					"integrity": "sha512-LZcH8PqW4iEKymaJ3RpsgpSJhXF29kAvO02ccqbysiXkQhZpVce8rrg+vzRKWO89hhyIBnQHI2e/ZoRVxmiJ2Q==",
+					"requires": {
+						"blakejs": "^1.1.0",
+						"err-code": "^2.0.0",
+						"js-sha3": "^0.8.0",
+						"multihashes": "^3.0.1",
+						"murmurhash3js-revisited": "^3.0.0",
+						"uint8arrays": "^1.0.0"
+					}
 				}
 			}
-		},
-		"did-resolver": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-2.1.1.tgz",
-			"integrity": "sha512-FYLTkNWofjYNDGV1HTQlyVu1OqZiFxR4I8KM+oxGVOkbXva15NfWzbzciqdXUDqOhe6so5aroAdrVip6gSAYSA=="
 		},
 		"diff": {
 			"version": "4.0.2",
@@ -6194,6 +6266,7 @@
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
 			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -6816,7 +6889,8 @@
 		"eventemitter3": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-			"integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+			"integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+			"dev": true
 		},
 		"events": {
 			"version": "3.1.0",
@@ -7058,11 +7132,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.0.0.tgz",
 			"integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
-		},
-		"fast-json-patch": {
-			"version": "3.0.0-1",
-			"resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz",
-			"integrity": "sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw=="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -11596,7 +11665,8 @@
 		"js-sha256": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-			"integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+			"integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+			"dev": true
 		},
 		"js-sha3": {
 			"version": "0.5.7",
@@ -14984,6 +15054,7 @@
 			"version": "6.6.1",
 			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.1.tgz",
 			"integrity": "sha512-miQiSxLYPYBxGkrldecZC18OTLjdUqnlRebGzPRiVxB8mco7usCmm7hFuxiTvp93K18JnLtE4KMMycjAu/cQQg==",
+			"dev": true,
 			"requires": {
 				"eventemitter3": "^4.0.4",
 				"p-timeout": "^3.1.0"
@@ -15041,6 +15112,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
 			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+			"dev": true,
 			"requires": {
 				"p-finally": "^1.0.0"
 			}
@@ -15873,7 +15945,8 @@
 		"regenerator-runtime": {
 			"version": "0.13.5",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.14.4",
@@ -16168,7 +16241,6 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/rpc-utils/-/rpc-utils-0.1.3.tgz",
 			"integrity": "sha512-7KRen4ydhnH5aCduhoCOKXCSjutVVEXTHFi6k/8BMnVOuhLbGa5vHJncfYTRtzQSQT4fUB39lVAs1MppONLLtQ==",
-			"dev": true,
 			"requires": {
 				"nanoid": "^3.1.12"
 			}
@@ -17513,7 +17585,8 @@
 		"tweetnacl": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-			"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+			"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+			"dev": true
 		},
 		"tweetnacl-util": {
 			"version": "0.15.1",
@@ -17573,7 +17646,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
 			"integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
-			"dev": true,
 			"requires": {
 				"multibase": "^3.0.0",
 				"web-encoding": "^1.0.2"
@@ -17583,7 +17655,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
 					"integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
-					"dev": true,
 					"requires": {
 						"base-x": "^3.0.8",
 						"web-encoding": "^1.0.2"
@@ -17763,6 +17834,7 @@
 			"version": "3.0.2-alpha.0",
 			"resolved": "https://registry.npmjs.org/uport-base64url/-/uport-base64url-3.0.2-alpha.0.tgz",
 			"integrity": "sha512-pRu0xm1K39IUzuMQEmFWdqP+H8jOzblwTXf0r9wFBCa6ZLLQsNuDeUwB2Ld+9zlBSvQQv+XEzG7cQukSCueZqw==",
+			"dev": true,
 			"requires": {
 				"buffer": "^5.2.1"
 			}
@@ -17942,8 +18014,7 @@
 		"web-encoding": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.2.tgz",
-			"integrity": "sha512-fe9pqxglgy25Z4Ds+2GwZIrOnLxeozydMj0iV8zx0ZNxE3MPTseF4oXGrrBuH4vSkoDYDXoPRRFY/FEYitEUTA==",
-			"dev": true
+			"integrity": "sha512-fe9pqxglgy25Z4Ds+2GwZIrOnLxeozydMj0iV8zx0ZNxE3MPTseF4oXGrrBuH4vSkoDYDXoPRRFY/FEYitEUTA=="
 		},
 		"webcrypto": {
 			"version": "0.1.1",

--- a/packages/ceramic-core/package.json
+++ b/packages/ceramic-core/package.json
@@ -41,6 +41,7 @@
     "cids": "^0.8.0",
     "cross-fetch": "^3.0.5",
     "did-resolver": "^2.1.1",
+    "dids": "^0.5.0",
     "fast-json-patch": "^2.2.1",
     "ipfs-http-client": "^46.0.0",
     "level-ts": "^2.0.5",


### PR DESCRIPTION
The doctype class getters now return the pending state in `next` if present. Just as already done in the `document` class previously.