### PR TITLE
Fix/pinning context

### DIFF
--- a/packages/ceramic-core/src/store/pin-store-factory.ts
+++ b/packages/ceramic-core/src/store/pin-store-factory.ts
@@ -13,7 +13,7 @@ export class PinStoreFactory {
 
     constructor(readonly context: Context, stateStorePath: string | undefined, pinnings: string[] | undefined) {
         this.stateStorePath = stateStorePath || path.join(process.cwd(), '.pinning.store')
-        this.pinnings = pinnings && pinnings.length > 0 ? pinnings : ['ipfs://__context']
+        this.pinnings = pinnings && pinnings.length > 0 ? pinnings : ['ipfs+context']
     }
 
     async open(): Promise<PinStore> {

--- a/packages/ceramic-core/src/store/pin-store-factory.ts
+++ b/packages/ceramic-core/src/store/pin-store-factory.ts
@@ -25,7 +25,7 @@ export class PinStoreFactory {
             return blob?.value
         }
         const resolve = async (path: string): Promise<CID> => {
-            return ipfs.dag.resolve(path)
+            return (await ipfs.dag.resolve(path)).cid
         }
         const pinStore = new PinStore(stateStore, pinning, retrieve, resolve)
         await pinStore.open()

--- a/packages/ceramic-core/src/store/pin-store.ts
+++ b/packages/ceramic-core/src/store/pin-store.ts
@@ -5,8 +5,12 @@ import CID from "cids";
 import _ from "lodash";
 
 export class PinStore {
-    constructor(readonly stateStore: StateStore, readonly pinning: Pinning, readonly retrieve: (cid: CID) => Promise<any | null>, readonly resolve: (path: string) => Promise<CID>) {
-    }
+    constructor(
+      readonly stateStore: StateStore,
+      readonly pinning: Pinning,
+      readonly retrieve: (cid: CID) => Promise<any | null>,
+      readonly resolve: (path: string) => Promise<CID>
+    ) {}
 
     async open(): Promise<void> {
         await this.stateStore.open()


### PR DESCRIPTION

Fixes two things:
* use context by default (was missconfigured)
* properly extract the CID when resolving paths of proofs