### PR TITLE
Specify actually used dependencies in corresponding package.json

### DIFF
--- a/packages/ceramic-cli/package.json
+++ b/packages/ceramic-cli/package.json
@@ -46,7 +46,8 @@
     "express": "^4.17.1",
     "identity-wallet": "2.0.0-alpha.2",
     "ipfs": "^0.50.0",
-    "ipfs-http-client": "^46.1.0"
+    "ipfs-http-client": "^46.1.0",
+    "dag-jose": "^0.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/ceramic-cli/package.json
+++ b/packages/ceramic-cli/package.json
@@ -47,7 +47,8 @@
     "identity-wallet": "2.0.0-alpha.2",
     "ipfs": "^0.50.0",
     "ipfs-http-client": "^46.1.0",
-    "dag-jose": "^0.1.1"
+    "dag-jose": "^0.1.1",
+    "multiformats": "^3.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/ceramic-core/src/store/pin-store.ts
+++ b/packages/ceramic-core/src/store/pin-store.ts
@@ -2,7 +2,6 @@ import {StateStore} from "./state-store";
 import {Pinning} from "../pinning/pinning";
 import {Doctype, DocState} from "@ceramicnetwork/ceramic-common"
 import CID from "cids";
-import _ from "lodash";
 
 export class PinStore {
     constructor(
@@ -32,7 +31,9 @@ export class PinStore {
         const state = await this.stateStore.load(docId)
         if (state) {
             const points = await this.pointsOfInterest(state)
-            Promise.all(points.map(point => this.pinning.unpin(point))).catch(_.noop)
+            Promise.all(points.map(point => this.pinning.unpin(point))).catch(() => {
+                // Do Nothing
+            })
             await this.stateStore.remove(docId)
         }
     }

--- a/packages/ceramic-doctype-three-id/package.json
+++ b/packages/ceramic-doctype-three-id/package.json
@@ -33,7 +33,9 @@
     "cids": "^1.0.0",
     "did-jwt": "^4.0.0",
     "did-resolver": "^2.1.1",
-    "fast-json-patch": "^2.2.1"
+    "fast-json-patch": "^2.2.1",
+    "fast-json-stable-stringify": "^2.1.0",
+    "dids": "^0.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/ceramic-doctype-tile/package.json
+++ b/packages/ceramic-doctype-tile/package.json
@@ -34,7 +34,9 @@
     "cids": "^1.0.0",
     "did-jwt": "^4.0.0",
     "did-resolver": "^2.1.1",
-    "fast-json-patch": "^2.2.1"
+    "fast-json-patch": "^2.2.1",
+    "fast-json-stable-stringify": "^2.1.0",
+    "dids": "^0.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/ceramic-http-client/package.json
+++ b/packages/ceramic-http-client/package.json
@@ -33,7 +33,8 @@
     "@ceramicnetwork/ceramic-doctype-tile": "^0.5.10-alpha.0",
     "cids": "^1.0.0",
     "cross-fetch": "^3.0.5",
-    "lodash.clonedeep": "^4.5.0"
+    "lodash.clonedeep": "^4.5.0",
+    "dids": "^0.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
Somehow, these were missing, yet are required for packages to work.

And by the way remove lodash dependency. It was used just for `_.noop`.