### PR TITLE
fix: verify that signatures where made by correct DID

### DIFF
--- a/packages/ceramic-core/src/__tests__/document.test.ts
+++ b/packages/ceramic-core/src/__tests__/document.test.ts
@@ -110,7 +110,7 @@ describe('Document', () => {
   describe('Log logic', () => {
     const initialContent = { abc: 123, def: 456 }
     const newContent = { abc: 321, def: 456, gh: 987 }
-    const owners = ['publickeymock']
+    const owners = ['did:3:bafyasdfasdf']
     let user: DID
     let dispatcher: any;
     let doctypeHandler: ThreeIdDoctypeHandler;
@@ -127,7 +127,7 @@ describe('Document', () => {
         // fake jws
         return 'eyJraWQiOiJkaWQ6MzpiYWZ5YXNkZmFzZGY_dmVyc2lvbj0wI3NpZ25pbmciLCJhbGciOiJFUzI1NksifQ.bbbb.cccc'
       })
-      user._id = 'did:3:bafyuser'
+      user._id = 'did:3:bafyasdfasdf'
       doctypeHandler = new ThreeIdDoctypeHandler()
       doctypeHandler.verifyJWS = async (): Promise<void> => { return }
       findHandler = (): ThreeIdDoctypeHandler => doctypeHandler
@@ -310,7 +310,7 @@ describe('Document', () => {
   describe('Network update logic', () => {
     const initialContent = { abc: 123, def: 456 }
     const newContent = { abc: 321, def: 456, gh: 987 }
-    const owners = ['publickeymock']
+    const owners = ['did:3:bafyasdfasdf']
 
     let dispatcher: any;
     let doctypeHandler: ThreeIdDoctypeHandler;

--- a/packages/ceramic-doctype-three-id/src/__tests__/__snapshots__/three-id-doctype.test.ts.snap
+++ b/packages/ceramic-doctype-three-id/src/__tests__/__snapshots__/three-id-doctype.test.ts.snap
@@ -137,7 +137,7 @@ Object {
   ],
   "metadata": Object {
     "owners": Array [
-      "0x123",
+      "did:3:bafyasdfasdf",
     ],
   },
   "next": Object {},
@@ -198,7 +198,7 @@ Object {
   ],
   "metadata": Object {
     "owners": Array [
-      "0x123",
+      "did:3:bafyasdfasdf",
     ],
   },
   "next": Object {
@@ -302,7 +302,7 @@ Object {
   ],
   "metadata": Object {
     "owners": Array [
-      "0x123",
+      "did:3:bafyasdfasdf",
     ],
   },
   "next": Object {
@@ -312,9 +312,6 @@ Object {
         "test": "0xabc",
       },
     },
-    "owners": Array [
-      "0x123",
-    ],
   },
   "signature": 2,
 }

--- a/packages/ceramic-doctype-three-id/src/three-id-doctype.ts
+++ b/packages/ceramic-doctype-three-id/src/three-id-doctype.ts
@@ -92,7 +92,7 @@ export class ThreeIdDoctype extends Doctype {
         }
 
         const patch = jsonpatch.compare(doctype.state.content, newContent)
-        const header = doctype.metadata
+        const header: Record<string, any> = {}
         if (newOwners) {
             header.owners = newOwners
         }

--- a/packages/ceramic-doctype-tile/src/__tests__/tile-doctype.test.ts
+++ b/packages/ceramic-doctype-tile/src/__tests__/tile-doctype.test.ts
@@ -27,7 +27,7 @@ const RECORDS = {
   genesisGenerated: { doctype: 'tile', header: { owners: [ 'did:3:bafyasdfasdf' ] }, data: { much: 'data' }, signedHeader: 'eyJraWQiOiJkaWQ6MzpiYWZ5YXNkZmFzZGY_dmVyc2lvbj0wI3NpZ25pbmciLCJhbGciOiJFUzI1NksifQ', signature: 'cccc' },
   r1: {
     desiredContent: { much: 'data', very: 'content' },
-    record: { data: [ { op: 'add', path: '/very', value: 'content' } ], header: { owners: ["did:3:bafyasdfasdf"] }, id: FAKE_CID_1, prev: FAKE_CID_1, signedHeader: 'eyJraWQiOiJkaWQ6MzpiYWZ5YXNkZmFzZGY_dmVyc2lvbj0wI3NpZ25pbmciLCJhbGciOiJFUzI1NksifQ', signature: 'cccc' }
+    record: { data: [ { op: 'add', path: '/very', value: 'content' } ], header: {}, id: FAKE_CID_1, prev: FAKE_CID_1, signedHeader: 'eyJraWQiOiJkaWQ6MzpiYWZ5YXNkZmFzZGY_dmVyc2lvbj0wI3NpZ25pbmciLCJhbGciOiJFUzI1NksifQ', signature: 'cccc' }
   },
   r2: { record: { proof: FAKE_CID_4 } },
   proof: {
@@ -163,6 +163,17 @@ describe('TileDoctypeHandler', () => {
     let state = await tileDoctypeHandler.applyRecord(RECORDS.genesisGenerated, FAKE_CID_1, context)
     state = await tileDoctypeHandler.applyRecord(RECORDS.r1.record, FAKE_CID_2, context, state)
     expect(state).toMatchSnapshot()
+  })
+
+  it('throws error if record signed by wrong DID', async () => {
+    const tileDoctypeHandler = new TileDoctypeHandler()
+
+    const genesis = cloneDeep(RECORDS.genesisGenerated)
+    genesis.header.owners = ['did:3:fake']
+    await context.ipfs.dag.put(genesis, FAKE_CID_1)
+    await context.ipfs.dag.put(RECORDS.r1.record, FAKE_CID_2)
+
+    await expect(tileDoctypeHandler.applyRecord(genesis, FAKE_CID_1, context)).rejects.toThrow(/wrong DID/)
   })
 
   it('applies anchor record correctly', async () => {

--- a/packages/ceramic-doctype-tile/src/tile-doctype-handler.ts
+++ b/packages/ceramic-doctype-tile/src/tile-doctype-handler.ts
@@ -71,7 +71,7 @@ export class TileDoctypeHandler implements DoctypeHandler<TileDoctype> {
      * @private
      */
     async _applyGenesis(record: any, cid: CID, context: Context): Promise<DocState> {
-        await this._verifyRecordSignature(record, context)
+        await this._verifyRecordSignature(record, context, record.header.owners[0])
         // TODO - verify genesis record
         return {
             doctype: DOCTYPE,
@@ -98,7 +98,7 @@ export class TileDoctypeHandler implements DoctypeHandler<TileDoctype> {
         if (!record.id.equals(state.log[0])) {
             throw new Error(`Invalid docId ${record.id}, expected ${state.log[0]}`)
         }
-        await this._verifyRecordSignature(record, context)
+        await this._verifyRecordSignature(record, context, state.metadata.owners[0])
         state.log.push(cid)
         return {
             ...state,
@@ -136,7 +136,7 @@ export class TileDoctypeHandler implements DoctypeHandler<TileDoctype> {
      * @param context - Ceramic context
      * @private
      */
-    async _verifyRecordSignature(record: any, context: Context): Promise<void> {
+    async _verifyRecordSignature(record: any, context: Context, did: string): Promise<void> {
         const { signedHeader, signature } = record
         const payload = base64url.encode(stringify({
             doctype: record.doctype,
@@ -150,6 +150,7 @@ export class TileDoctypeHandler implements DoctypeHandler<TileDoctype> {
         const jws = [signedHeader, payload, signature].join('.')
         const decodedHeader = JSON.parse(base64url.decode(signedHeader))
         const { kid } = decodedHeader
+        if (!kid.startsWith(did)) throw new Error(`Signature was made with wrong DID. Expected: ${did}, got: ${kid.split('?')[0]}`)
         const { publicKey } = await context.resolver.resolve(kid)
         try {
             await this.verifyJWS(jws, publicKey)

--- a/packages/ceramic-doctype-tile/src/tile-doctype.ts
+++ b/packages/ceramic-doctype-tile/src/tile-doctype.ts
@@ -94,7 +94,7 @@ export class TileDoctype extends Doctype {
             throw new Error('No DID authenticated')
         }
 
-        const header = doctype.metadata
+        const header: Record<string, any> = {}
         if (schema) {
             header.schema = schema
         }


### PR DESCRIPTION
This PR addresses two issues:
1. Actually verify that the signature was made by the DID that created the document
2. Don't add existing metadata to new records