### PR TITLE
update npm name

### DIFF
--- a/packages/ceramic-cli/README.md
+++ b/packages/ceramic-cli/README.md
@@ -7,7 +7,7 @@
 ### Installation
 To install the ceramic cli globally you can run:
 ```
-$ npm install -g ceramic-cli
+$ npm install -g @ceramicnetwork/ceramic-cli
 ```
 
 ### Usage


### PR DESCRIPTION
npm install -g ceramic-cli fails with `'ceramic-cli@latest' is not in the npm registry.`

prepended `@ceramicnetwork/`