### PR TITLE
fix: add gateway to ceramic config and use pinningStorePath for cli

### DIFF
--- a/packages/ceramic-cli/src/bin/ceramic.ts
+++ b/packages/ceramic-cli/src/bin/ceramic.ts
@@ -14,8 +14,8 @@ program
     .option('--port <int>', 'Port daemon is availabe. Default is 7007')
     .option('--debug', 'Enable debug logging level. Default is false')
     .description('Start the daemon')
-    .action(async ({ ipfsApi, ethereumRpc, anchorServiceApi, validateDocs, pinning, stateStorePath, gateway, port, debug }) => {
-        await CeramicCliUtils.createDaemon(ipfsApi, ethereumRpc, anchorServiceApi, validateDocs, pinning, stateStorePath, gateway, port, debug)
+    .action(async ({ ipfsApi, ethereumRpc, anchorServiceApi, validateDocs, pinning, pinningStorePath, gateway, port, debug }) => {
+        await CeramicCliUtils.createDaemon(ipfsApi, ethereumRpc, anchorServiceApi, validateDocs, pinning, pinningStorePath, gateway, port, debug)
     })
 
 program

--- a/packages/ceramic-cli/src/ceramic-daemon.ts
+++ b/packages/ceramic-cli/src/ceramic-daemon.ts
@@ -124,6 +124,7 @@ class CeramicDaemon {
 
     const ceramicConfig: CeramicConfig = {
       logLevel: 'silent',
+      gateway: opts.gateway || false
     }
     if (opts.anchorServiceUrl) {
       ceramicConfig.ethereumRpcUrl = opts.ethereumRpcUrl


### PR DESCRIPTION
Closes #350 

### Motivation

- Ran into lockfile issue when trying to run two versions of Ceramic bc the pinning store path argument wasn't working
- Logs from the gateway were not being prefixed with "GATEWAY"

### Changes

- Changed the arg `stateStorePath` to `pinningStorePath`
- Added the `gateway` option to `ceramicConfig`