### PR TITLE
Feat/log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 lerna-debug.log
 .idea
 .pinning.store
+.vscode

--- a/packages/ceramic-cli/src/bin/ceramic.ts
+++ b/packages/ceramic-cli/src/bin/ceramic.ts
@@ -13,9 +13,11 @@ program
     .option('--gateway', 'Makes read only endpoints available. It is disabled by default')
     .option('--port <int>', 'Port daemon is availabe. Default is 7007')
     .option('--debug', 'Enable debug logging level. Default is false')
+    .option('--log-to-files', 'If debug is true, write logs to files. Default is false')
+    .option('--log-path <dir>', 'Store logs in this directory. Defaults to "/usr/local/var/log/ceramic"')
     .description('Start the daemon')
-    .action(async ({ ipfsApi, ethereumRpc, anchorServiceApi, validateDocs, pinning, pinningStorePath, gateway, port, debug }) => {
-        await CeramicCliUtils.createDaemon(ipfsApi, ethereumRpc, anchorServiceApi, validateDocs, pinning, pinningStorePath, gateway, port, debug)
+    .action(async ({ ipfsApi, ethereumRpc, anchorServiceApi, validateDocs, pinning, pinningStorePath, gateway, port, debug, logToFiles, logPath }) => {
+        await CeramicCliUtils.createDaemon(ipfsApi, ethereumRpc, anchorServiceApi, validateDocs, pinning, pinningStorePath, gateway, port, debug, logToFiles, logPath)
     })
 
 program

--- a/packages/ceramic-cli/src/ceramic-cli-utils.ts
+++ b/packages/ceramic-cli/src/ceramic-cli-utils.ts
@@ -51,8 +51,10 @@ export class CeramicCliUtils {
      * @param gateway - read only endpoints available. It is disabled by default
      * @param port - port daemon is availabe. Default is 7007
      * @param debug - Enable debug logging level
+     * @param logToFiles - Enable writing logs to files
+     * @param logPath - Store log files in this directory
      */
-    static async createDaemon(ipfsApi: string, ethereumRpc: string, anchorServiceApi: string, validateDocs: boolean, pinning: string[], stateStorePath: string, gateway: boolean, port: number, debug: boolean): Promise<CeramicDaemon> {
+    static async createDaemon(ipfsApi: string, ethereumRpc: string, anchorServiceApi: string, validateDocs: boolean, pinning: string[], stateStorePath: string, gateway: boolean, port: number, debug: boolean, logToFiles: boolean, logPath: string): Promise<CeramicDaemon> {
         if (stateStorePath == null) {
             stateStorePath = DEFAULT_PINNING_STORE_PATH
         }
@@ -65,7 +67,9 @@ export class CeramicCliUtils {
             pinning: pinning,
             gateway,
             port,
-            debug
+            debug,
+            logToFiles,
+            logPath
         }
 
         multiformats.multicodec.add(dagJose)

--- a/packages/ceramic-cli/src/ceramic-daemon.ts
+++ b/packages/ceramic-cli/src/ceramic-daemon.ts
@@ -24,6 +24,8 @@ export interface CreateOpts {
   pinning?: string[];
   gateway?: boolean;
   debug: boolean;
+  logToFiles?: boolean;
+  logPath?: string;
 }
 
 interface HttpLog {
@@ -96,6 +98,8 @@ class CeramicDaemon {
 
     const ceramicConfig: CeramicConfig = {
       logLevel: opts.debug ? 'debug' : 'silent',
+      logToFiles: opts.logToFiles,
+      logPath: opts.logPath,
       gateway: opts.gateway || false
     }
     if (opts.anchorServiceUrl) {

--- a/packages/ceramic-cli/src/ceramic-daemon.ts
+++ b/packages/ceramic-cli/src/ceramic-daemon.ts
@@ -2,7 +2,7 @@ import type Ipfs from 'ipfs'
 import express, { Request, Response, NextFunction } from 'express'
 import Ceramic from '@ceramicnetwork/ceramic-core'
 import type { CeramicConfig } from "@ceramicnetwork/ceramic-core";
-import { DoctypeUtils, RootLogger, Logger } from "@ceramicnetwork/ceramic-common"
+import { DoctypeUtils, RootLogger, Logger, logToFile } from "@ceramicnetwork/ceramic-common"
 // @ts-ignore
 import cors from 'cors'
 
@@ -93,7 +93,9 @@ class CeramicDaemon {
             body,
             errorMessage,
           }
-          this.logger.debug(JSON.stringify(log))
+          const logString = JSON.stringify(log)
+          logToFile(`daemon${opts.gateway && '-gateway' || ''}`, logString)
+          this.logger.debug(logString)
         })
 
         next()

--- a/packages/ceramic-cli/src/ceramic-daemon.ts
+++ b/packages/ceramic-cli/src/ceramic-daemon.ts
@@ -94,7 +94,8 @@ class CeramicDaemon {
             errorMessage,
           }
           const logString = JSON.stringify(log)
-          logToFile(`daemon${opts.gateway && '-gateway' || ''}`, logString)
+          // TODO: Remove logToFile when file plugin works
+          logToFile(`cli${opts.gateway && '-gateway' || ''}`, logString)
           this.logger.debug(logString)
         })
 

--- a/packages/ceramic-cli/src/ceramic-daemon.ts
+++ b/packages/ceramic-cli/src/ceramic-daemon.ts
@@ -2,7 +2,7 @@ import type Ipfs from 'ipfs'
 import express, { Request, Response, NextFunction } from 'express'
 import Ceramic from '@ceramicnetwork/ceramic-core'
 import type { CeramicConfig } from "@ceramicnetwork/ceramic-core";
-import { DoctypeUtils, RootLogger, Logger, logToFile } from "@ceramicnetwork/ceramic-common"
+import { DoctypeUtils, RootLogger, Logger } from "@ceramicnetwork/ceramic-common"
 // @ts-ignore
 import cors from 'cors'
 
@@ -73,8 +73,6 @@ class CeramicDaemon {
         res.on("finish", () => {
           const httpLog = this.buildHttpLog(requestStart, req, res, {requestError, body})
           const logString = JSON.stringify(httpLog)
-          // TODO: Remove logToFile when file plugin works
-          logToFile(`cli${opts.gateway && '-gateway' || ''}`, logString)
           this.logger.debug(logString)
         })
         next()

--- a/packages/ceramic-cli/src/ceramic-daemon.ts
+++ b/packages/ceramic-cli/src/ceramic-daemon.ts
@@ -86,21 +86,12 @@ class CeramicDaemon {
         });
 
         res.on("finish", () => {
-          const { rawHeaders, httpVersion, method, socket, url } = req
-          const { remoteAddress, remoteFamily } = socket
-
           const now = Date.now()
           log.response = {
             timestamp: now,
             processingTime: now - requestStart,
-            rawHeaders,
             body,
             errorMessage,
-            httpVersion,
-            method,
-            remoteAddress,
-            remoteFamily,
-            url
           }
           this.logger.debug(JSON.stringify(log))
         })

--- a/packages/ceramic-cli/src/ceramic-daemon.ts
+++ b/packages/ceramic-cli/src/ceramic-daemon.ts
@@ -154,7 +154,7 @@ class CeramicDaemon {
       }
     }
     const now = Date.now()
-    let logResponse = {
+    httpLog.response = {
       timestamp: now,
       processingTime: now - requestStart,
       body: extra && extra.body || null,
@@ -162,7 +162,6 @@ class CeramicDaemon {
       statusMessage: res.statusMessage,
       requestError: extra && extra.requestError || null
     }
-    httpLog.response = logResponse
     return httpLog
   }
 

--- a/packages/ceramic-cli/src/ceramic-daemon.ts
+++ b/packages/ceramic-cli/src/ceramic-daemon.ts
@@ -38,10 +38,6 @@ class CeramicDaemon {
 
   constructor (public ceramic: Ceramic, opts: CreateOpts) {
     this.debug = opts.debug
-    if (this.debug) {
-      RootLogger.setLevel('debug')
-    }
-
     this.logger = RootLogger.getLogger(CeramicDaemon.name)
 
     const app = express()
@@ -58,7 +54,6 @@ class CeramicDaemon {
         this.logger.error(logString)
         next(err)
       })
-
       app.use((req: Request, res: Response, next: NextFunction): void => {
         const requestStart = Date.now()
 
@@ -82,10 +77,10 @@ class CeramicDaemon {
           logToFile(`cli${opts.gateway && '-gateway' || ''}`, logString)
           this.logger.debug(logString)
         })
-
         next()
       })
     }
+
     app.use((err: Error, req: Request, res: Response, next: NextFunction): void => {
       res.json({ error: err.message })
       next(err)
@@ -102,7 +97,7 @@ class CeramicDaemon {
     const { ipfs } = opts
 
     const ceramicConfig: CeramicConfig = {
-      logLevel: 'silent',
+      logLevel: opts.debug ? 'debug' : 'silent',
       gateway: opts.gateway || false
     }
     if (opts.anchorServiceUrl) {

--- a/packages/ceramic-common/src/logger-provider.ts
+++ b/packages/ceramic-common/src/logger-provider.ts
@@ -283,6 +283,7 @@ class LoggerProvider {
     
 }
 
+// TODO: Remove logToFile in favor of plugin
 /**
  * Appends `msg` to the file `filename`
  * @param filename File name

--- a/packages/ceramic-common/src/logger-provider.ts
+++ b/packages/ceramic-common/src/logger-provider.ts
@@ -279,8 +279,6 @@ class LoggerProvider {
         cache = null
         return retVal
     }
-
-    
 }
 
 // TODO: Remove logToFile in favor of plugin

--- a/packages/ceramic-common/src/logger-provider.ts
+++ b/packages/ceramic-common/src/logger-provider.ts
@@ -1,6 +1,8 @@
 import chalk from 'chalk'
-import log, { Logger, LogLevelDesc, MethodFactory } from 'loglevel'
+import fs from 'fs'
+import log, { Logger, LogLevelDesc, MethodFactory, RootLogger as RLogger } from 'loglevel'
 import prefix from 'loglevel-plugin-prefix'
+import util from 'util'
 
 /**
  * Logger colors
@@ -245,10 +247,23 @@ class LoggerProvider {
         cache = null
         return retVal
     }
+
+function logToFile(namespace: string, msg: string) {
+  const basePath = '/usr/local/var/log/ceramic/'
+  fs.mkdir(basePath, { recursive: true }, (err) => {
+    if (err && (err.code != 'EEXIST')) console.error(err)
+  })
+  const fileLog = fs.createWriteStream(
+    basePath + `${(namespace == '') ? '' : namespace + '-'}common.log`,
+    { flags: 'a' }
+  )
+  fileLog.write(util.format(msg) + '\n')
+  fileLog.end()
 }
 
 export {
-    LoggerProvider,
-    Logger,
-    log as RootLogger,
+  LoggerProvider,
+  Logger,
+  log as RootLogger,
+  logToFile,
 }

--- a/packages/ceramic-core/src/ceramic.ts
+++ b/packages/ceramic-core/src/ceramic.ts
@@ -38,6 +38,8 @@ export interface CeramicConfig {
   pinning?: string[];
 
   logLevel?: string;
+  logToFiles?: boolean;
+  logPath?: string;
   gateway?: boolean;
 
   topic?: string;
@@ -117,7 +119,9 @@ class Ceramic implements CeramicApi {
   static async create(ipfs: Ipfs.Ipfs, config: CeramicConfig = {}): Promise<Ceramic> {
     LoggerProvider.init({
       level: config.logLevel? config.logLevel : 'silent',
-      component: config.gateway? 'GATEWAY' : 'NODE'
+      component: config.gateway? 'GATEWAY' : 'NODE',
+      outputToFiles: config.logToFiles,
+      outputPath: config.logPath
     })
 
     const dispatcher = new Dispatcher(ipfs, config.topic)

--- a/packages/ceramic-core/src/dispatcher.ts
+++ b/packages/ceramic-core/src/dispatcher.ts
@@ -98,11 +98,12 @@ export default class Dispatcher extends EventEmitter {
     }
 
     if (message.from !== this._peerId) {
-      const logMessage = message
-      logMessage.data = JSON.parse(new TextDecoder('utf-8').decode(message.data))
+      const parsedMessageData = JSON.parse(message.data)
+
+      const logMessage = { ...message, data: parsedMessageData }
       this._log({ peer: this._peerId, event: 'received', topic: this.topic, message: logMessage })
 
-      const { typ, id, cid } = message.data
+      const { typ, id, cid } = parsedMessageData
       if (this._documents[id]) {
         switch (typ) {
           case MsgType.UPDATE:

--- a/packages/ceramic-core/src/dispatcher.ts
+++ b/packages/ceramic-core/src/dispatcher.ts
@@ -4,7 +4,7 @@ import CID from 'cids'
 import cloneDeep from 'lodash.clonedeep'
 
 import type Document from "./document"
-import { DoctypeUtils, RootLogger, Logger } from "@ceramicnetwork/ceramic-common"
+import { DoctypeUtils, RootLogger, Logger, logToFile } from "@ceramicnetwork/ceramic-common"
 
 export enum MsgType {
   UPDATE,
@@ -98,9 +98,11 @@ export default class Dispatcher extends EventEmitter {
     }
 
     if (message.from !== this._peerId) {
-      this._log({ peer: this._peerId, event: 'received', topic: this.topic, from: message.from, message: message.data })
+      const logMessage = message
+      logMessage.data = JSON.parse(new TextDecoder('utf-8').decode(message.data))
+      this._log({ peer: this._peerId, event: 'received', topic: this.topic, message: logMessage })
 
-      const { typ, id, cid } = JSON.parse(message.data)
+      const { typ, id, cid } = message.data
       if (this._documents[id]) {
         switch (typ) {
           case MsgType.UPDATE:
@@ -118,7 +120,9 @@ export default class Dispatcher extends EventEmitter {
   }
 
   _log(msg: LogMessage): void {
-    this.logger.debug(JSON.stringify(msg))
+    let msgString = JSON.stringify(msg)
+    logToFile('core', msgString)
+    this.logger.debug(msgString)
   }
 
   async close(): Promise<void> {

--- a/packages/ceramic-core/src/dispatcher.ts
+++ b/packages/ceramic-core/src/dispatcher.ts
@@ -121,6 +121,7 @@ export default class Dispatcher extends EventEmitter {
 
   _log(msg: LogMessage): void {
     let msgString = JSON.stringify(msg)
+    // TODO: Remove logToFile when file plugin works
     logToFile('core', msgString)
     this.logger.debug(msgString)
   }

--- a/packages/ceramic-core/src/dispatcher.ts
+++ b/packages/ceramic-core/src/dispatcher.ts
@@ -132,7 +132,8 @@ export default class Dispatcher extends EventEmitter {
   }
 
   _log(msg: LogMessage): void {
-    this.logger.debug(JSON.stringify(msg))
+    const timestampedMsg = {timestamp: Date.now(), ...msg}
+    this.logger.debug(JSON.stringify(timestampedMsg))
   }
 
   async close(): Promise<void> {

--- a/packages/ceramic-core/src/dispatcher.ts
+++ b/packages/ceramic-core/src/dispatcher.ts
@@ -4,7 +4,7 @@ import CID from 'cids'
 import cloneDeep from 'lodash.clonedeep'
 
 import type Document from "./document"
-import { DoctypeUtils, RootLogger, Logger, logToFile } from "@ceramicnetwork/ceramic-common"
+import { DoctypeUtils, RootLogger, Logger } from "@ceramicnetwork/ceramic-common"
 
 export enum MsgType {
   UPDATE,
@@ -121,8 +121,6 @@ export default class Dispatcher extends EventEmitter {
 
   _log(msg: LogMessage): void {
     let msgString = JSON.stringify(msg)
-    // TODO: Remove logToFile when file plugin works
-    logToFile('core', msgString)
     this.logger.debug(msgString)
   }
 

--- a/packages/ceramic-core/src/dispatcher.ts
+++ b/packages/ceramic-core/src/dispatcher.ts
@@ -120,8 +120,7 @@ export default class Dispatcher extends EventEmitter {
   }
 
   _log(msg: LogMessage): void {
-    let msgString = JSON.stringify(msg)
-    this.logger.debug(msgString)
+    this.logger.debug(JSON.stringify(msg))
   }
 
   async close(): Promise<void> {


### PR DESCRIPTION
Closes #338 #349 

Depends on #351 to properly label gateway logs

### Motivation

- Logging to files, instead of just stdout, allows someone to collect the logs in an aggregation tool and feed them into a monitoring system (for example Promtail/Loki/Grafana)
- Additionally it is valuable to monitor any errors sent from the API and through QA I found the logger used for errors was not structured properly to give error info

### Changes

- Added plugin to the `LoggerProvider` to write logs to files
- Refactored API logging to log errors with req/res metadata
- Removed log level setting in daemon constructor so that plugins do not get overridden. Now the log level is set solely when `CeramicDaemon.create` is called, and this allows plugins to be applied correctly wherever `RootLogger` is used

### Future work
- Updated `handleMessage` in Dispatcher to patch #339 but this needs to be handled better