### PR TITLE
Implement loadDocumentRecords API

### DIFF
--- a/packages/ceramic-cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/ceramic-cli/src/__tests__/ceramic-daemon.test.ts
@@ -130,6 +130,28 @@ describe('Ceramic interop: core <> http-client', () => {
     expect(DoctypeUtils.serializeState(doc3.state)).toEqual(DoctypeUtils.serializeState(doc4.state))
   })
 
+  it('loads document records correctly', async () => {
+    const doc1 = await core.createDocument(DOCTYPE_TILE, { content: { test: 123 } })
+    await anchorUpdate(doc1)
+    const doc2 = await client.loadDocument(doc1.id)
+    expect(doc1.content).toEqual(doc2.content)
+
+    const records1 = await core.loadDocumentRecords(doc1.id)
+    expect(records1).toBeDefined()
+
+    const records2 = await client.loadDocumentRecords(doc2.id)
+    expect(records2).toBeDefined()
+
+    const serializeRecords = (records: any): any => records.map((r: any) => {
+      return {
+        cid: r.cid,
+        value: DoctypeUtils.serializeRecord(r.value)
+      }
+    })
+
+    expect(serializeRecords(records1)).toEqual(serializeRecords(records2))
+  })
+
   it('makes and gets updates correctly', async () => {
     const doc1 = await core.createDocument(DOCTYPE_TILE, { content: { test: 123 } })
     await anchorUpdate(doc1)

--- a/packages/ceramic-common/package.json
+++ b/packages/ceramic-common/package.json
@@ -34,7 +34,8 @@
     "did-resolver": "^2.1.1",
     "lodash.clonedeep": "^4.5.0",
     "loglevel": "^1.7.0",
-    "loglevel-plugin-prefix": "^0.8.4"
+    "loglevel-plugin-prefix": "^0.8.4",
+    "uint8arrays": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/ceramic-common/src/ceramic-api.ts
+++ b/packages/ceramic-common/src/ceramic-api.ts
@@ -71,6 +71,12 @@ export interface CeramicApi {
     loadDocument<T extends Doctype>(docId: string, opts?: DocOpts): Promise<T>;
 
     /**
+     * Load all document records by document ID
+     * @param docId - Document ID
+     */
+    loadDocumentRecords(docId: string): Promise<Array<Record<string, any>>>;
+
+    /**
      * Lists current Doctype versions
      * @param docId - Document ID
      */

--- a/packages/ceramic-common/src/declarations.d.ts
+++ b/packages/ceramic-common/src/declarations.d.ts
@@ -1,0 +1,5 @@
+declare module 'uint8arrays' {
+    export function toString(b: Uint8Array, enc?: string): string
+    export function fromString(s: string, enc?: string): Uint8Array
+    export function concat(bs: Array<Uint8Array>): Uint8Array
+}

--- a/packages/ceramic-common/src/utils/doctype-utils.ts
+++ b/packages/ceramic-common/src/utils/doctype-utils.ts
@@ -3,6 +3,7 @@ import CID from 'cids'
 import cloneDeep from "lodash.clonedeep"
 import * as u8a from 'uint8arrays'
 
+import { Ipfs } from "ipfs"
 import { AnchorStatus, DocState, Doctype } from "../doctype"
 
 /**
@@ -242,6 +243,21 @@ export class DoctypeUtils {
             const errorMessages = this.validator.errorsText()
             throw new Error(`Validation Error: ${errorMessages}`)
         }
+    }
+
+    /**
+     * Converts record to DTO. The only difference is with signed record for now
+     * @param record - Record value
+     * @param ipfs - IPFS instance
+     */
+    static async convertRecordToDTO(record: any, ipfs: Ipfs): Promise<any> {
+        if (DoctypeUtils.isSignedRecord(record)) {
+            const linkedBlock = await ipfs.block.get(record.link)
+            return {
+                jws: record, linkedBlock,
+            }
+        }
+        return record
     }
 
     /**

--- a/packages/ceramic-common/src/utils/doctype-utils.ts
+++ b/packages/ceramic-common/src/utils/doctype-utils.ts
@@ -1,6 +1,7 @@
 import ajv from "ajv"
 import CID from 'cids'
 import cloneDeep from "lodash.clonedeep"
+import * as u8a from 'uint8arrays'
 
 import { AnchorStatus, DocState, Doctype } from "../doctype"
 
@@ -108,8 +109,16 @@ export class DoctypeUtils {
 
         if (DoctypeUtils.isSignedRecordDTO(cloned)) {
             cloned.jws.link = cloned.jws.link.toString()
-            cloned.linkedBlock = Buffer.from(cloned.linkedBlock).toString('base64')
+            cloned.linkedBlock = u8a.toString(cloned.linkedBlock, 'base64')
             return cloned
+        }
+
+        if (DoctypeUtils.isSignedRecord(cloned)) {
+            cloned.link = cloned.link.toString()
+        }
+
+        if (DoctypeUtils.isAnchorRecord(cloned)) {
+            cloned.proof = cloned.proof.toString()
         }
 
         if (cloned.id) {
@@ -131,8 +140,16 @@ export class DoctypeUtils {
 
         if (DoctypeUtils.isSignedRecordDTO(cloned)) {
             cloned.jws.link = new CID(cloned.jws.link)
-            cloned.linkedBlock = Buffer.from(cloned.linkedBlock, 'base64')
+            cloned.linkedBlock = u8a.fromString(cloned.linkedBlock, 'base64')
             return cloned
+        }
+
+        if (DoctypeUtils.isSignedRecord(cloned)) {
+            cloned.link = new CID(cloned.link)
+        }
+
+        if (DoctypeUtils.isAnchorRecord(cloned)) {
+            cloned.proof = new CID(cloned.proof)
         }
 
         if (cloned.id) {
@@ -241,5 +258,13 @@ export class DoctypeUtils {
      */
     static isSignedRecord(record: any): boolean {
         return typeof record === 'object' && 'link' in record && 'payload' in record && 'signatures' in record
+    }
+
+    /**
+     * Checks if record is anchor record
+     * @param record - Record
+     */
+    static isAnchorRecord(record: any): boolean {
+        return typeof record === 'object' && 'proof' in record && 'path' in record
     }
 }

--- a/packages/ceramic-core/src/__tests__/ceramic-api.test.ts
+++ b/packages/ceramic-core/src/__tests__/ceramic-api.test.ts
@@ -332,7 +332,7 @@ describe('Ceramic API', () => {
       const expected = []
       for (const cid of doctype.state.log) {
         expected.push({
-          cid,
+          cid: cid.toString(),
           value: (await ceramic.ipfs.dag.get(cid)).value
         })
       }

--- a/packages/ceramic-core/src/__tests__/ceramic-api.test.ts
+++ b/packages/ceramic-core/src/__tests__/ceramic-api.test.ts
@@ -30,7 +30,7 @@ const createIPFS =(overrideConfig: object = {}): Promise<any> => {
 }
 
 
-describe('Ceramic', () => {
+describe('Ceramic API', () => {
   jest.setTimeout(15000)
   let ipfs: Ipfs;
   let ceramic: Ceramic
@@ -151,10 +151,7 @@ describe('Ceramic', () => {
 
       await ceramic.close()
     })
-  })
 
-
-  describe('API', () => {
     it('cannot create document with invalid schema', async () => {
       ceramic = await createCeramic()
 
@@ -180,9 +177,7 @@ describe('Ceramic', () => {
 
       await ceramic.close()
     })
-  })
 
-  describe('API', () => {
     it('can create document with valid schema', async () => {
       ceramic = await createCeramic()
 
@@ -204,9 +199,7 @@ describe('Ceramic', () => {
       await new Promise(resolve => setTimeout(resolve, 1000)) // wait to propagate
       await ceramic.close()
     })
-  })
 
-  describe('API', () => {
     it('can create document with invalid schema if validation is not set', async () => {
       ceramic = await createCeramic({ validateDocs: false })
 
@@ -228,9 +221,7 @@ describe('Ceramic', () => {
       await new Promise(resolve => setTimeout(resolve, 1000)) // wait to propagate
       await ceramic.close()
     })
-  })
 
-  describe('API', () => {
     it('can update schema if content is valid', async () => {
       ceramic = await createCeramic()
 
@@ -260,9 +251,7 @@ describe('Ceramic', () => {
       await new Promise(resolve => setTimeout(resolve, 1000)) // wait to propagate
       await ceramic.close()
     })
-  })
 
-  describe('API', () => {
     it('cannot update schema if content is not valid', async () => {
       ceramic = await createCeramic()
 
@@ -294,9 +283,7 @@ describe('Ceramic', () => {
 
       await ceramic.close()
     })
-  })
 
-  describe('API', () => {
     it('can update valid content and schema at the same time', async () => {
       ceramic = await createCeramic()
 
@@ -326,5 +313,33 @@ describe('Ceramic', () => {
       await new Promise(resolve => setTimeout(resolve, 1000)) // wait to propagate
       await ceramic.close()
     })
+
+    it('can list log records', async () => {
+      ceramic = await createCeramic()
+
+      const owner = ceramic.context.did.id
+
+      const tileDocParams: TileParams = {
+        metadata: {
+          owners: [owner]
+        }, content: { a: 1 },
+      }
+
+      const doctype = await ceramic.createDocument<TileDoctype>(DOCTYPE_TILE, tileDocParams)
+      const logRecords = await ceramic.loadDocumentRecords(doctype.id)
+      expect(logRecords).toBeDefined()
+
+      const expected = []
+      for (const cid of doctype.state.log) {
+        expected.push({
+          cid,
+          value: (await ceramic.ipfs.dag.get(cid)).value
+        })
+      }
+
+      expect(logRecords).toEqual(expected)
+      await ceramic.close()
+    })
   })
+
 })

--- a/packages/ceramic-core/src/__tests__/ceramic-api.test.ts
+++ b/packages/ceramic-core/src/__tests__/ceramic-api.test.ts
@@ -331,9 +331,10 @@ describe('Ceramic API', () => {
 
       const expected = []
       for (const cid of doctype.state.log) {
+        const record = (await ceramic.ipfs.dag.get(cid)).value
         expected.push({
           cid: cid.toString(),
-          value: (await ceramic.ipfs.dag.get(cid)).value
+          value: await DoctypeUtils.convertRecordToDTO(record, ipfs)
         })
       }
 

--- a/packages/ceramic-core/src/ceramic.ts
+++ b/packages/ceramic-core/src/ceramic.ts
@@ -1,4 +1,3 @@
-import CID from 'cids'
 import Ipfs from 'ipfs'
 import Dispatcher from './dispatcher'
 import Document from './document'

--- a/packages/ceramic-core/src/ceramic.ts
+++ b/packages/ceramic-core/src/ceramic.ts
@@ -211,7 +211,7 @@ class Ceramic implements CeramicApi {
   }
 
   /**
-   * Get document from map by Gensis CID
+   * Get document from map by Genesis CID
    * @param genesisCid
    */
   getDocFromMap(genesisCid: any): Document {
@@ -316,8 +316,10 @@ class Ceramic implements CeramicApi {
     const { state } = doc
 
     return Promise.all(state.log.map(async (cid) => {
+      const record = (await this.ipfs.dag.get(cid)).value
       return {
-        cid: cid.toString(), value: (await this.ipfs.dag.get(cid)).value
+        cid: cid.toString(),
+        value: await DoctypeUtils.convertRecordToDTO(record, this.ipfs)
       }
     }))
   }

--- a/packages/ceramic-core/src/ceramic.ts
+++ b/packages/ceramic-core/src/ceramic.ts
@@ -1,3 +1,4 @@
+import CID from 'cids'
 import Ipfs from 'ipfs'
 import Dispatcher from './dispatcher'
 import Document from './document'
@@ -305,6 +306,21 @@ class Ceramic implements CeramicApi {
 
     const version = DoctypeUtils.getVersionId(normalizedId)
     return (version? await doc.getVersion<T>(version) : doc.doctype) as T
+  }
+
+  /**
+   * Load all document records by document ID
+   * @param docId - Document ID
+   */
+  async loadDocumentRecords(docId: string): Promise<Array<Record<string, any>>> {
+    const doc = await this.loadDocument(docId)
+    const { state } = doc
+
+    return Promise.all(state.log.map(async (cid) => {
+      return {
+        cid: cid.toString(), value: (await this.ipfs.dag.get(cid)).value
+      }
+    }))
   }
 
   /**

--- a/packages/ceramic-core/src/document.ts
+++ b/packages/ceramic-core/src/document.ts
@@ -211,6 +211,10 @@ class Document extends EventEmitter {
     const retrievedRec = await this.dispatcher.retrieveRecord(cid)
     const state = await this._doctypeHandler.applyRecord(retrievedRec, cid, this._context, this.state)
 
+    if (DoctypeUtils.isAnchorRecord(retrievedRec)) {
+      state.anchorStatus = AnchorStatus.ANCHORED
+    }
+
     let payload
     if (retrievedRec.payload && retrievedRec.signatures) {
       payload = (await this._context.ipfs.dag.get(retrievedRec.link)).value

--- a/packages/ceramic-http-client/src/ceramic-http-client.ts
+++ b/packages/ceramic-http-client/src/ceramic-http-client.ts
@@ -96,6 +96,12 @@ class CeramicClient implements CeramicApi {
     return this._docmap[normalizedId] as unknown as T
   }
 
+  async loadDocumentRecords(docId: string): Promise<Array<Record<string, any>>> {
+    const normalizedId = DoctypeUtils.normalizeDocId(docId)
+
+    return Document.loadDocumentRecords(normalizedId, this._apiUrl)
+  }
+
   async applyRecord<T extends Doctype>(docId: string, record: object, opts?: DocOpts): Promise<T> {
     return await Document.applyRecord(this._apiUrl, docId, record, this.context, opts) as unknown as T
   }

--- a/packages/ceramic-http-client/src/document.ts
+++ b/packages/ceramic-http-client/src/document.ts
@@ -1,4 +1,6 @@
-import { Doctype, DocParams, DoctypeUtils, DocState, DocOpts, DoctypeHandler, Context } from "@ceramicnetwork/ceramic-common"
+import {
+  Context, DocOpts, DocParams, DocState, Doctype, DoctypeHandler, DoctypeUtils
+} from "@ceramicnetwork/ceramic-common"
 
 import { fetchJson } from './utils'
 
@@ -64,6 +66,17 @@ class Document extends Doctype {
     const normalizedId = DoctypeUtils.normalizeDocId(id)
     const { versions } = await fetchJson(apiUrl + '/versions' + normalizedId)
     return versions
+  }
+
+  static async loadDocumentRecords (id: string, apiUrl: string): Promise<Array<Record<string, any>>> {
+    const normalizedId = DoctypeUtils.normalizeDocId(id)
+    const { records } = await fetchJson(apiUrl + '/records' + normalizedId)
+
+    return records.map((r: any) => {
+      return {
+        cid: r.cid, value: DoctypeUtils.deserializeRecord(r.value)
+      }
+    })
   }
 
   async change(params: DocParams): Promise<void> {


### PR DESCRIPTION
- implement `loadDocumentRecords` API
- implement full serialize/deserialize record functionality
- use `uint8arrays` instead of `Buffer`
- add and adapt tests