### PR TITLE
Feat/log files

### DIFF
--- a/packages/ceramic-cli/src/ceramic-daemon.ts
+++ b/packages/ceramic-cli/src/ceramic-daemon.ts
@@ -3,7 +3,7 @@ import express, { Request, Response, NextFunction } from 'express'
 import Ceramic from '@ceramicnetwork/ceramic-core'
 import type { CeramicConfig } from "@ceramicnetwork/ceramic-core";
 import { DoctypeUtils, RootLogger, Logger } from "@ceramicnetwork/ceramic-common"
-import {loggerProviderPlugins} from "./ceramic-plugins"
+import { LogToFiles } from "./ceramic-logger-plugins"
 // @ts-ignore
 import cors from 'cors'
 
@@ -132,7 +132,7 @@ class CeramicDaemon {
     if (opts.logToFiles) {
         ceramicConfig.logToFiles = opts.logToFiles
         ceramicConfig.logToFilesPlugin = {
-            plugin: loggerProviderPlugins.logToFiles,
+            plugin: LogToFiles.main,
             options: {logPath: opts.logPath}
         }
     }

--- a/packages/ceramic-cli/src/ceramic-daemon.ts
+++ b/packages/ceramic-cli/src/ceramic-daemon.ts
@@ -3,6 +3,7 @@ import express, { Request, Response, NextFunction } from 'express'
 import Ceramic from '@ceramicnetwork/ceramic-core'
 import type { CeramicConfig } from "@ceramicnetwork/ceramic-core";
 import { DoctypeUtils, RootLogger, Logger } from "@ceramicnetwork/ceramic-common"
+import {loggerProviderPlugins} from "./ceramic-plugins"
 // @ts-ignore
 import cors from 'cors'
 
@@ -108,10 +109,9 @@ class CeramicDaemon {
 
     const ceramicConfig: CeramicConfig = {
       logLevel: opts.debug ? 'debug' : 'silent',
-      logToFiles: opts.logToFiles,
-      logPath: opts.logPath,
       gateway: opts.gateway || false
     }
+
     if (opts.anchorServiceUrl) {
       ceramicConfig.ethereumRpcUrl = opts.ethereumRpcUrl
       ceramicConfig.anchorServiceUrl = opts.anchorServiceUrl
@@ -127,6 +127,14 @@ class CeramicDaemon {
       Object.assign(ceramicConfig, {
         pinning: opts.pinning
       })
+    }
+
+    if (opts.logToFiles) {
+        ceramicConfig.logToFiles = opts.logToFiles
+        ceramicConfig.logToFilesPlugin = {
+            plugin: loggerProviderPlugins.logToFiles,
+            options: {logPath: opts.logPath}
+        }
     }
 
     const ceramic = await Ceramic.create(ipfs, ceramicConfig)

--- a/packages/ceramic-cli/src/ceramic-plugins.ts
+++ b/packages/ceramic-cli/src/ceramic-plugins.ts
@@ -1,0 +1,79 @@
+import fs from 'fs'
+import util from 'util'
+
+import {
+    Logger,
+    LoggerMethodFactory,
+    LoggerOptions,
+    LoggerProvider,
+    LoggerPluginOptions
+} from "@ceramicnetwork/ceramic-common"
+
+const loggerProviderPlugins = {
+    /**
+     * Plugin to append log messages to files named after components
+     * @dev Modifies `rootLogger`
+     * @notice If no component name is given 'default' will be included in the file name
+     * @param rootLogger Root logger to use throughout the library
+     * @param loggerOptions Should include `component` name string and `logPath` string
+     * @param pluginOptions Should include `logPath` string to be used a directory to write files to
+     */
+    logToFiles: function (rootLogger: Logger, loggerOptions: LoggerOptions, pluginOptions: LoggerPluginOptions): void {
+        const originalFactory = rootLogger.methodFactory;
+        let basePath = pluginOptions.logPath
+        if ((basePath === undefined) || (basePath === '')) {
+            basePath = '/usr/local/var/log/ceramic/'
+        }
+        if (!basePath.endsWith('/')) {
+            basePath = basePath + '/'
+        }
+
+        rootLogger.methodFactory = (methodName: string, logLevel: any, loggerName: string): LoggerMethodFactory => {
+            const rawMethod = originalFactory(methodName, logLevel, loggerName);
+            return (...args: any[]): any => {
+                const message = LoggerProvider._interpolate(args)
+                const namespace = loggerOptions.component ? loggerOptions.component.toLowerCase() : 'default'
+                fs.mkdir(basePath, { recursive: true }, (err) => {
+                    if (err && (err.code != 'EEXIST')) console.warn('WARNING: Can not write logs to files', err)
+                    else {
+                        const filePrefix = basePath + loggerName.toLowerCase()
+                        const filePath = `${filePrefix}-${namespace}.log`
+
+                        loggerProviderPlugins._writeStream(filePath, message, 'a')
+                        loggerProviderPlugins._writeDocId(filePrefix, message)
+                    }
+                })
+                rawMethod(...args)
+            }
+        };
+        rootLogger.setLevel(rootLogger.getLevel());
+    },
+    _writeStream: function (filePath: string, message: string, writeFlag: string): void {
+        const stream = fs.createWriteStream(
+            filePath,
+            { flags: writeFlag }
+        )
+        stream.write(util.format(message) + '\n')
+        stream.end()
+    },
+    _writeDocId: function (filePrefix: string, message: string): void {
+        const lookup = '/ceramic/'
+        const docIdIndex = message.indexOf(lookup)
+
+        if (docIdIndex > -1) {
+            const docIdSubstring = message.substring(docIdIndex)
+            const match = docIdSubstring.match(/\/ceramic\/\w+/)
+
+            if (match !== null) {
+                const docId = match[0]
+                const filePath = filePrefix + '-docids.log'
+                this._writeStream(filePath, docId, 'w')
+            }
+        }
+    }
+}
+
+
+export {
+    loggerProviderPlugins
+}

--- a/packages/ceramic-common/package.json
+++ b/packages/ceramic-common/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@types/json-schema": "^7.0.5",
     "ajv": "^6.12.3",
-    "chalk": "^4.1.0",
     "cids": "^1.0.0",
     "dag-jose": "^0.3.0",
     "did-resolver": "^2.1.1",

--- a/packages/ceramic-common/src/logger-provider.ts
+++ b/packages/ceramic-common/src/logger-provider.ts
@@ -67,6 +67,7 @@ class LoggerProvider {
      */
     static init(opts = defaultOpts): Options {
         const options = Object.assign(defaultOpts, opts)
+        Object.freeze(options)
 
         if (options.level) {
             log.setLevel(options.level as LogLevelDesc)

--- a/packages/ceramic-common/src/logger-provider.ts
+++ b/packages/ceramic-common/src/logger-provider.ts
@@ -1,23 +1,10 @@
-import chalk from 'chalk'
 import log, { Logger, LogLevelDesc, MethodFactory } from 'loglevel'
 import prefix from 'loglevel-plugin-prefix'
-
-/**
- * Logger colors
- */
-const colors: Record<string, any> = {
-    TRACE: chalk.magenta,
-    DEBUG: chalk.cyan,
-    INFO: chalk.blue,
-    WARN: chalk.yellow,
-    ERROR: chalk.red,
-}
 
 /**
  * Default logger options
  */
 const defaultOpts: Options = {
-    colors: false,
     level: 'info',
     format: 'text',
     stacktrace: {
@@ -32,7 +19,6 @@ const defaultOpts: Options = {
  */
 interface Options {
     level?: string;
-    colors?: boolean;
     format?: string; // [text | json]
     stacktrace?: {
         levels: ['trace', 'warn', 'error'];
@@ -162,10 +148,7 @@ class LoggerProvider {
         if (options.format === 'json') {
             return "" // no prefix
         }
-        if (!options.colors) {
-            return `[${timestamp}] ${level} ${options.component ? options.component : ""} ${name}:`
-        }
-        return `${chalk.gray(`[${timestamp}]`)} ${colors[level.toUpperCase()](level)} ${options.component ? chalk.gray(options.component) : ""} ${chalk.green(`${name}:`)}`
+        return `[${timestamp}] ${level} ${options.component ? options.component : ""} ${name}:`
     }
 
     /**

--- a/packages/ceramic-common/src/logger-provider.ts
+++ b/packages/ceramic-common/src/logger-provider.ts
@@ -3,8 +3,6 @@ import fs from 'fs'
 import log, { Logger, LogLevelDesc, MethodFactory } from 'loglevel'
 import prefix from 'loglevel-plugin-prefix'
 import util from 'util'
-import { DoctypeUtils } from "@ceramicnetwork/ceramic-common"
-import { Doctype } from './doctype'
 
 /**
  * Logger colors
@@ -30,8 +28,7 @@ const defaultOpts: Options = {
         excess: 0,
     },
     outputToFiles: false,
-    outputPath: undefined,
-    getDocument: null
+    outputPath: undefined
 }
 
 /**
@@ -49,7 +46,6 @@ interface Options {
     component?: string;
     outputToFiles?: boolean;
     outputPath?: string;
-    getDocument?: (docId: string) => Promise<Doctype>;
 }
 
 /**

--- a/packages/ceramic-common/src/logger-provider.ts
+++ b/packages/ceramic-common/src/logger-provider.ts
@@ -120,8 +120,7 @@ class LoggerProvider {
                         const filePath = `${filePrefix}-${namespace}.log`
 
                         this._writeStream(filePath, message, 'a')
-                        const docId = this._writeDocId(filePrefix, message)
-                        this._write3id(filePrefix, docId, options.getDocument)
+                        this._writeDocId(filePrefix, message)
                     }
                 })
                 rawMethod(...args)
@@ -130,7 +129,7 @@ class LoggerProvider {
         log.setLevel(log.getLevel());
     }
 
-    static _writeDocId(filePrefix: string, message: string) {
+    static _writeDocId(filePrefix: string, message: string): void {
         const lookup = '/ceramic/'
         const docIdIndex = message.indexOf(lookup)
 
@@ -142,31 +141,11 @@ class LoggerProvider {
                 const docId = match[0]
                 const filePath = filePrefix + '-docids.log'
                 this._writeStream(filePath, docId, 'w')
-                return docId
             }
         }
     }
 
-    static async _write3id(filePrefix: string, docId: string, getDocument: (docId: string) => Promise<Doctype>) {
-        if (!getDocument || !docId) return
-
-        const doc = await getDocument(docId)
-        const docState = DoctypeUtils.serializeState(doc.state)
-
-        let is3id = false
-        try {
-            is3id = docState.metadata.tags.includes('3id')
-        } catch (error) {
-            return
-        }
-
-        if (is3id) {
-            const filePath = filePrefix + '-3ids.log'
-            this._writeStream(filePath, docId, 'w')
-        }
-    }
-    
-    static _writeStream(filePath: string, message: string, writeFlag: string) {
+    static _writeStream(filePath: string, message: string, writeFlag: string): void {
         const stream = fs.createWriteStream(
             filePath,
             { flags: writeFlag }

--- a/packages/ceramic-core/src/ceramic.ts
+++ b/packages/ceramic-core/src/ceramic.ts
@@ -120,6 +120,12 @@ class Ceramic implements CeramicApi {
    * @param config - Ceramic configuration
    */
   static async create(ipfs: Ipfs.Ipfs, config: CeramicConfig = {}): Promise<Ceramic> {
+    LoggerProvider.init({
+      level: config.logLevel? config.logLevel : 'silent',
+      component: config.gateway? 'GATEWAY' : 'NODE',
+      outputToFiles: config.logToFiles,
+      outputPath: config.logPath
+    })
 
     const dispatcher = new Dispatcher(ipfs, config.topic)
     await dispatcher.init()
@@ -144,14 +150,6 @@ class Ceramic implements CeramicApi {
     const threeIdResolver = ThreeIdResolver.getResolver(ceramic)
     ceramic.context.resolver = new Resolver({
       ...config.didResolver, ...threeIdResolver, ...keyDidResolver,
-    })
-
-    LoggerProvider.init({
-      level: config.logLevel? config.logLevel : 'silent',
-      component: config.gateway? 'GATEWAY' : 'NODE',
-      outputToFiles: config.logToFiles,
-      outputPath: config.logPath,
-      getDocument: config.logToFiles? ceramic.loadDocument.bind(ceramic) : null
     })
 
     return ceramic

--- a/packages/ceramic-core/src/ceramic.ts
+++ b/packages/ceramic-core/src/ceramic.ts
@@ -120,12 +120,6 @@ class Ceramic implements CeramicApi {
    * @param config - Ceramic configuration
    */
   static async create(ipfs: Ipfs.Ipfs, config: CeramicConfig = {}): Promise<Ceramic> {
-    LoggerProvider.init({
-      level: config.logLevel? config.logLevel : 'silent',
-      component: config.gateway? 'GATEWAY' : 'NODE',
-      outputToFiles: config.logToFiles,
-      outputPath: config.logPath
-    })
 
     const dispatcher = new Dispatcher(ipfs, config.topic)
     await dispatcher.init()
@@ -151,6 +145,15 @@ class Ceramic implements CeramicApi {
     ceramic.context.resolver = new Resolver({
       ...config.didResolver, ...threeIdResolver, ...keyDidResolver,
     })
+
+    LoggerProvider.init({
+      level: config.logLevel? config.logLevel : 'silent',
+      component: config.gateway? 'GATEWAY' : 'NODE',
+      outputToFiles: config.logToFiles,
+      outputPath: config.logPath,
+      getDocument: config.logToFiles? ceramic.loadDocument.bind(ceramic) : null
+    })
+
     return ceramic
   }
 


### PR DESCRIPTION
Closes #388 

### Motivation

- Move fs library out of ceramic-common (see issue above)

### Changes

- Adds `addPlugin` method to LoggerProvider
- Adds `ceramic-plugins` from which `logToFiles` plugin is passed