### PR TITLE
fix: properly handle versions and key rotations

### DIFF
--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -91,7 +91,8 @@ export function wrapDocument(content: any, did: string): DIDDocument {
 export default {
   getResolver: (ceramic: Ceramic): ResolverRegistry => ({
     '3': async (did: string, parsed: ParsedDID): Promise<DIDDocument | null> => {
-      const doctype = await ceramic.loadDocument(`/ceramic/${parsed.id}`)
+      const version = (parsed.query || '').replace('version-id', '?version')
+      const doctype = await ceramic.loadDocument(`/ceramic/${parsed.id}${version}`);
       return wrapDocument(doctype.content, did)
     }
   })

--- a/packages/ceramic-common/src/utils/doctype-utils.ts
+++ b/packages/ceramic-common/src/utils/doctype-utils.ts
@@ -77,7 +77,10 @@ export class DoctypeUtils {
         const indexOfVersion = genesis.indexOf('?')
         if (indexOfVersion !== -1) {
             const params = DoctypeUtils._getQueryParam(genesis.substring(indexOfVersion + 1))
-            return params['version']? new CID(params['version']) : null
+            const version = params['version']
+            if (version) {
+                return version === '0' ? new CID(DoctypeUtils.getGenesis(docId)) : new CID(params['version'])
+            }
         }
         return null
     }

--- a/packages/ceramic-doctype-tile/src/tile-doctype.ts
+++ b/packages/ceramic-doctype-tile/src/tile-doctype.ts
@@ -32,7 +32,7 @@ export class TileDoctype extends Doctype {
             throw new Error('No DID authenticated')
         }
 
-        const updateRecord = await TileDoctype._makeRecord(this, this.context.did, params.content, null, params.metadata?.schema)
+        const updateRecord = await TileDoctype._makeRecord(this, this.context.did, params.content, params.metadata?.owners, params.metadata?.schema)
         const updated = await this.context.api.applyRecord(this.id, updateRecord, opts)
         this.state = updated.state
     }


### PR DESCRIPTION
Fixes:
* resolve DIDs correctly in tile handler
* resolve DIDs with `version-id` parameter
* `version = '0'` should refer to the genesis version of a document
* properly rotate keys `owners` in tile doctype