### PR TITLE
feat: remove log differentiation for gateway

### DIFF
--- a/packages/ceramic-cli/src/ceramic-logger-plugins.ts
+++ b/packages/ceramic-cli/src/ceramic-logger-plugins.ts
@@ -14,10 +14,9 @@ import {
  */
 export class LogToFiles {
     /**
-     * Modifies `rootLogger` to append log messages to files named after components
-     * @notice If no component name is given 'default' will be included in the file name
+     * Modifies `rootLogger` to append log messages to files
      * @param rootLogger Root logger to use throughout the library
-     * @param loggerOptions Should include `component` name string and `logPath` string
+     * @param loggerOptions Not used by this plugin so should be null
      * @param pluginOptions Should include `logPath` string to be used a directory to write files to
      */
     public static main (rootLogger: Logger, loggerOptions: LoggerOptions, pluginOptions: LoggerPluginOptions): void {
@@ -34,12 +33,11 @@ export class LogToFiles {
             const rawMethod = originalFactory(methodName, logLevel, loggerName);
             return (...args: any[]): any => {
                 const message = LoggerProvider._interpolate(args)
-                const namespace = loggerOptions.component ? loggerOptions.component.toLowerCase() : 'default'
                 fs.mkdir(basePath, { recursive: true }, (err) => {
                     if (err && (err.code != 'EEXIST')) console.warn('WARNING: Can not write logs to files', err)
                     else {
                         const filePrefix = basePath + loggerName.toLowerCase()
-                        const filePath = `${filePrefix}-${namespace}.log`
+                        const filePath = `${filePrefix}.log`
 
                         LogToFiles._writeStream(filePath, message, 'a')
                         LogToFiles._writeDocId(filePrefix, message)
@@ -64,7 +62,12 @@ export class LogToFiles {
         stream.write(util.format(message) + '\n')
         stream.end()
     }
-
+    /**
+     * Writes the docId in `message` to `filePath`, if `message` contains a docId.
+     * @notice The write operation overwrites any existing file.
+     * @param filePath Full path of file to write to
+     * @param message Message to write to `filePath`
+     */
     private static _writeDocId (filePrefix: string, message: string): void {
         const lookup = '/ceramic/'
         const docIdIndex = message.indexOf(lookup)

--- a/packages/ceramic-common/src/logger-provider.ts
+++ b/packages/ceramic-common/src/logger-provider.ts
@@ -40,7 +40,7 @@ interface PluginOptions {
  * Function type for plugins
  * @dev Must call `setLevel` on `rootLogger` to be enabled
  */
-type Plugin = (rootLogger: log.RootLogger, loggerOptions: Options, pluginOptions?: PluginOptions) => void;
+type Plugin = (rootLogger: log.RootLogger, loggerOptions?: Options, pluginOptions?: PluginOptions) => void;
 
 /**
  * Global Logger factory
@@ -73,7 +73,7 @@ class LoggerProvider {
      * @param loggerOptions Options returned from LoggerProvider.init
      * @param pluginOptions Options specific to `plugin`
      */
-    static addPlugin(plugin: Plugin, loggerOptions: Options, pluginOptions?: PluginOptions): void {
+    static addPlugin(plugin: Plugin, loggerOptions?: Options, pluginOptions?: PluginOptions): void {
         plugin(log, loggerOptions, pluginOptions)
     }
 

--- a/packages/ceramic-core/src/ceramic.ts
+++ b/packages/ceramic-core/src/ceramic.ts
@@ -135,7 +135,7 @@ class Ceramic implements CeramicApi {
    * @param config - Ceramic configuration
    */
   static async create(ipfs: Ipfs.Ipfs, config: CeramicConfig = {}): Promise<Ceramic> {
-    const loggerOptions = LoggerProvider.init({
+    LoggerProvider.init({
       level: config.logLevel? config.logLevel : 'silent',
       component: config.gateway? 'GATEWAY' : 'NODE',
     })
@@ -143,7 +143,7 @@ class Ceramic implements CeramicApi {
     if (config.logToFiles) {
         LoggerProvider.addPlugin(
             config.logToFilesPlugin.plugin,
-            loggerOptions,
+            null,
             config.logToFilesPlugin.options
         )
     }


### PR DESCRIPTION
### Motivation

Keep log file names consistent across all instances of ceramic. Most people are not running both a node and a gateway so we don't need to add those labels to log file names.

If you do run both you can always set different paths  with the `--log-path` flag or use different filesystems (e.g. running ceramic in containers).

### Changes

- Removed component name from log filename