### PR TITLE
Log file rotation and small improvement

### DIFF
--- a/packages/ceramic-cli/src/__mocks__/fs.ts
+++ b/packages/ceramic-cli/src/__mocks__/fs.ts
@@ -1,0 +1,82 @@
+'use strict'
+const fs = jest.genMockFromModule<any>('fs')
+fs.promises = jest.requireActual('fs').promises
+
+interface MockFile {
+    name: string;
+    birthtime: Date;
+    message: string;
+}
+
+interface MockFs {
+    [filePath: string]: MockFile;
+}
+
+let mockFs: MockFs = {}
+
+class MockStream {
+    filePath: string
+    writeFlag: string
+
+    constructor(filePath: string, writeFlag: string) {
+        this.filePath = filePath
+        this.writeFlag = writeFlag
+    }
+
+    write(message: string): void {
+        const prevFile = mockFs[this.filePath] || {
+            name: this.filePath,
+            birthtime: new Date(),
+            message: ''
+        }
+
+        if (this.writeFlag === 'w') {
+            mockFs[this.filePath] = {
+                ...prevFile,
+                message
+            }
+        } else if (this.writeFlag === 'a') {
+            mockFs[this.filePath] = {
+                ...prevFile,
+                message: prevFile.message.concat(message)
+            }
+        }
+    }
+
+    end(): void {
+        // pass
+    }
+}
+
+function __initMockFs(files: Array<MockFile>): void {
+    mockFs = {}
+    files.forEach((file) => {
+        mockFs[file.name] = file
+    })
+}
+
+function __getMockFs(): MockFs {
+    return mockFs
+}
+
+function createWriteStream(filePath: string, options: { flags: string }): MockStream {
+    return new MockStream(filePath, options.flags)
+}
+
+async function rename(filePath: string, nextFilePath: string): Promise<void> {
+    const file = mockFs[filePath]
+    delete mockFs[filePath]
+    mockFs[nextFilePath] = file
+}
+
+async function stat(filePath: string): Promise<MockFile> {
+    return mockFs[filePath]
+}
+
+fs.__initMockFs = __initMockFs
+fs.__getMockFs = __getMockFs
+fs.createWriteStream = createWriteStream
+fs.promises.rename = rename
+fs.promises.stat = stat
+
+module.exports = fs

--- a/packages/ceramic-cli/src/__tests__/ceramic-logger-plugins.test.ts
+++ b/packages/ceramic-cli/src/__tests__/ceramic-logger-plugins.test.ts
@@ -1,0 +1,115 @@
+import { LogToFiles } from '../ceramic-logger-plugins'
+
+jest.mock('fs')
+import fs from 'fs'
+
+describe('Ceramic Logger Plugins', () => {
+    jest.setTimeout(20000)
+
+    let dateNowSpy: any
+
+    const yesterday = new Date('2020-10-30')
+    const today = new Date('2020-10-31')
+
+    describe('LogToFiles', () => {
+        let mockFiles: Array<any>
+        let mockFs: any
+
+        beforeEach(async () => {
+            mockFiles = [
+                {
+                    name: '/usr/var/log/ceramic/yesterday.log',
+                    message: 'yesterday\n',
+                    birthtime: yesterday
+                },
+                {
+                    name: '/usr/var/log/ceramic/today.log',
+                    message: 'today\n',
+                    birthtime: today
+                }
+            ]
+            fs.__initMockFs(mockFiles)
+            mockFs = fs.__getMockFs()
+        })
+        afterEach(() => {
+            dateNowSpy.mockRestore()
+        })
+
+        describe('_isExpired', () => {
+            it('returns true if amount of time since file was created > expiration time', async () => {
+                dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => today.getTime())
+                const isExpired = await LogToFiles['_isExpired'](mockFiles[0].name)
+                expect(dateNowSpy).toHaveBeenCalled()
+                expect(isExpired).toBe(true)
+            })
+            it('returns false if amount of time since file was created <= expiration time', async () => {
+                dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => today.getTime())
+                const isExpired = await LogToFiles['_isExpired'](mockFiles[1].name)
+                expect(dateNowSpy).toHaveBeenCalled()
+                expect(isExpired).toBe(false)
+            })
+        })
+
+        describe('_writeStream', () => {
+            it('should rotate expired files before overwriting', async () => {
+                dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => today.getTime())
+                const prevFilePath = mockFiles[0].name
+                const prevFileMessage = mockFiles[0].message
+
+                const isExpired = await LogToFiles['_isExpired'](prevFilePath)
+                expect(isExpired).toBe(true)
+
+                const nextFileMessage = 'nextmessage'
+                await LogToFiles['_writeStream'](prevFilePath, nextFileMessage, 'w')
+                const nextFilePath = prevFilePath + '.old'
+
+                expect(mockFs[prevFilePath].message).toBe(nextFileMessage + '\n')
+                expect(mockFs[nextFilePath].message).toBe(prevFileMessage)
+            })
+            it('should rotate expired files before appending', async () => {
+                dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => today.getTime())
+                const prevFilePath = mockFiles[0].name
+                const prevFileMessage = mockFiles[0].message
+
+                const isExpired = await LogToFiles['_isExpired'](prevFilePath)
+                expect(isExpired).toBe(true)
+
+                const nextFileMessage = 'nextmessage'
+                await LogToFiles['_writeStream'](prevFilePath, nextFileMessage, 'a')
+                const nextFilePath = prevFilePath + '.old'
+
+                expect(mockFs[prevFilePath].message).toBe(nextFileMessage + '\n')
+                expect(mockFs[nextFilePath].message).toBe(prevFileMessage)
+            })
+            it('should append the message to an unexpired file without rotating', async () => {
+                dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => today.getTime())
+                const filePath = mockFiles[1].name
+                const prevMessage = mockFiles[1].message
+
+                const isExpired = await LogToFiles['_isExpired'](filePath)
+                expect(isExpired).toBe(false)
+
+                const message = 'message'
+                await LogToFiles['_writeStream'](filePath, message, 'a')
+                const nextFilePath = filePath + '.old'
+
+                expect(mockFs[filePath].message).toBe(prevMessage + message + '\n')
+                expect(mockFs[nextFilePath]).toBeUndefined()
+            })
+            it('should overwrite an unexpired file without rotating', async () => {
+                dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => today.getTime())
+                const filePath = mockFiles[1].name
+
+                const isExpired = await LogToFiles['_isExpired'](filePath)
+                expect(isExpired).toBe(false)
+
+                const message = 'message'
+                await LogToFiles['_writeStream'](filePath, message, 'w')
+                const nextFilePath = filePath + '.old'
+
+                expect(mockFs[filePath].message).toBe(message + '\n')
+                expect(mockFs[nextFilePath]).toBeUndefined()
+            })
+        })
+    })
+})

--- a/packages/ceramic-cli/src/ceramic-daemon.ts
+++ b/packages/ceramic-cli/src/ceramic-daemon.ts
@@ -163,12 +163,12 @@ class CeramicDaemon {
   }
 
   _buildHttpLog (requestStart: number, req: Request, res: Response, extra?: any): HttpLog {
-    const { rawHeaders, httpVersion, method, socket, url } = req;
+    const { headers, httpVersion, method, socket, url } = req;
     const { remoteAddress, remoteFamily } = socket;
     const httpLog: HttpLog = {
       request:{
         timestamp: Date.now(),
-        rawHeaders,
+        headers,
         httpVersion,
         method,
         remoteAddress,

--- a/packages/ceramic-cli/src/ceramic-logger-plugins.ts
+++ b/packages/ceramic-cli/src/ceramic-logger-plugins.ts
@@ -13,7 +13,7 @@ import {
  * Plugin for the root logger from the `loglevel` library to write logs to files
  */
 export class LogToFiles {
-    private MINUTES_TO_EXPIRATION = 60
+    private static MINUTES_TO_EXPIRATION: number = 60
 
     /**
      * Modifies `rootLogger` to append log messages to files
@@ -95,8 +95,8 @@ export class LogToFiles {
      */
     private static _isExpired (filePath: string): boolean {
         const { birthtime } = fs.statSync(filePath)
-        const minutesSinceBirth = ((Date.now() - birthtime.getTime()) / (1000 * 60)).toFixed(1)
-        return (minutesSinceBirth >= this.MINUTES_TO_EXPIRATION)
+        const minutesSinceBirth = (Date.now() - birthtime.getTime()) / (1000 * 60)
+        return (minutesSinceBirth >= LogToFiles.MINUTES_TO_EXPIRATION)
     }
 
     /**

--- a/packages/ceramic-cli/src/ceramic-logger-plugins.ts
+++ b/packages/ceramic-cli/src/ceramic-logger-plugins.ts
@@ -13,7 +13,7 @@ import {
  * Plugin for the root logger from the `loglevel` library to write logs to files
  */
 export class LogToFiles {
-    private static MINUTES_TO_EXPIRATION: number = 60
+    private static MINUTES_TO_EXPIRATION = 60
 
     /**
      * Modifies `rootLogger` to append log messages to files


### PR DESCRIPTION
### Motivation

1. We don't want to keep log files to for a long time (they will get large and take up space unnecessarily). We also don't want to implement full rotation because it can be complicated and is not needed atm.

2. With loki 2.0, arrays in json log messages are ignored, so we want to use dictionaries as much as possible.

### Changes

1. "Rotate" logs--so we maintain 2 files per filename, the first `*.log` is being actively written to and the second `*.log.old` contains logs from the previous 60 minutes

2. Use `headers` dictionary instead of `rawHeaders` array