### PR TITLE
feat: 3id resolve v0 and v1 3ids

### DIFF
--- a/packages/3id-did-resolver/package-lock.json
+++ b/packages/3id-did-resolver/package-lock.json
@@ -1727,6 +1727,11 @@
         }
       }
     },
+    "@multiformats/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+    },
     "@sinonjs/commons": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
@@ -1790,12 +1795,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
-    },
-    "@types/eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
     "@types/events": {
@@ -1874,53 +1873,6 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
-    "@typescript-eslint/eslint-plugin": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.31.0.tgz",
-      "integrity": "sha512-iIC0Pb8qDaoit+m80Ln/aaeu9zKQdOLF4SHcGLarSeY1gurW6aU4JsOPMjKQwXlw70MvWKZQc6S2NamA8SJ/gg==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/experimental-utils": "2.31.0",
-        "functional-red-black-tree": "^1.0.1",
-        "regexpp": "^3.0.0",
-        "tsutils": "^3.17.1"
-      },
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "2.31.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.31.0.tgz",
-          "integrity": "sha512-MI6IWkutLYQYTQgZ48IVnRXmLR/0Q6oAyJgiOror74arUMh7EWjJkADfirZhRsUMHeLJ85U2iySDwHTSnNi9vA==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/typescript-estree": "2.31.0",
-            "eslint-scope": "^5.0.0",
-            "eslint-utils": "^2.0.0"
-          }
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "2.31.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.31.0.tgz",
-          "integrity": "sha512-vxW149bXFXXuBrAak0eKHOzbcu9cvi6iNcJDzEtOkRwGHxJG15chiAQAwhLOsk+86p9GTr/TziYvw+H9kMaIgA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "eslint-visitor-keys": "^1.1.0",
-            "glob": "^7.1.6",
-            "is-glob": "^4.0.1",
-            "lodash": "^4.17.15",
-            "semver": "^6.3.0",
-            "tsutils": "^3.17.1"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
     "@typescript-eslint/experimental-utils": {
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.26.0.tgz",
@@ -1931,53 +1883,6 @@
         "@typescript-eslint/typescript-estree": "2.26.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
-      }
-    },
-    "@typescript-eslint/parser": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.33.0.tgz",
-      "integrity": "sha512-AUtmwUUhJoH6yrtxZMHbRUEMsC2G6z5NSxg9KsROOGqNXasM71I8P2NihtumlWTUCRld70vqIZ6Pm4E5PAziEA==",
-      "dev": true,
-      "requires": {
-        "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.33.0",
-        "@typescript-eslint/typescript-estree": "2.33.0",
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "2.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.33.0.tgz",
-          "integrity": "sha512-qzPM2AuxtMrRq78LwyZa8Qn6gcY8obkIrBs1ehqmQADwkYzTE1Pb4y2W+U3rE/iFkSWcWHG2LS6MJfj6SmHApg==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/typescript-estree": "2.33.0",
-            "eslint-scope": "^5.0.0",
-            "eslint-utils": "^2.0.0"
-          }
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "2.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.33.0.tgz",
-          "integrity": "sha512-d8rY6/yUxb0+mEwTShCQF2zYQdLlqihukNfG9IUlLYz5y1CH6G/9XYbrxQLq3Z14RNvkCC6oe+OcFlyUpwUbkg==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "eslint-visitor-keys": "^1.1.0",
-            "glob": "^7.1.6",
-            "is-glob": "^4.0.1",
-            "lodash": "^4.17.15",
-            "semver": "^7.3.2",
-            "tsutils": "^3.17.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
-        }
       }
     },
     "@typescript-eslint/typescript-estree": {
@@ -2380,6 +2285,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
       "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -2445,14 +2351,6 @@
         "electron-to-chromium": "^1.3.390",
         "node-releases": "^1.1.53",
         "pkg-up": "^2.0.0"
-      }
-    },
-    "bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-      "requires": {
-        "base-x": "^3.0.2"
       }
     },
     "bser": {
@@ -2542,6 +2440,23 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "cids": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-1.0.2.tgz",
+      "integrity": "sha512-ohCcYyEHh0Z5Hl+O1IML4kt6Kx5GPho1ybxtqK4zyk6DeV5CvOLoT/mqDh0cgKcAvsls3vcVa9HjZc7RQr3geA==",
+      "requires": {
+        "class-is": "^1.1.0",
+        "multibase": "^3.0.1",
+        "multicodec": "^2.0.1",
+        "multihashes": "^3.0.1",
+        "uint8arrays": "^1.1.0"
+      }
+    },
+    "class-is": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -5732,6 +5647,45 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "multibase": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.0.tgz",
+      "integrity": "sha512-Z+pThrpbS7ckQ2DwW5mPiwCGe1a94f8DWi/OxmbyeRednVOyUKmLSE+60kL/WHFYwWnaD1OakXGk3PYI1NkMFw==",
+      "requires": {
+        "@multiformats/base-x": "^4.0.1",
+        "web-encoding": "^1.0.4"
+      }
+    },
+    "multicodec": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.1.tgz",
+      "integrity": "sha512-YDYeWn9iGa76hOHAyyZa0kbt3tr5FLg1ZXUHrZUJltjnxxdbTIbHnxWLd2zTcMOjdT3QyO+Xs4bQgJUcC2RWUA==",
+      "requires": {
+        "uint8arrays": "1.0.0",
+        "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "uint8arrays": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
+          "integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "web-encoding": "^1.0.2"
+          }
+        }
+      }
+    },
+    "multihashes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
+      "integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
+      "requires": {
+        "multibase": "^3.0.0",
+        "uint8arrays": "^1.0.0",
+        "varint": "^5.0.0"
+      }
+    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -6389,12 +6343,6 @@
         "safe-regex": "^1.1.0"
       }
     },
-    "regexpp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
-      "dev": true
-    },
     "regexpu-core": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
@@ -6616,7 +6564,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -7492,6 +7441,15 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "uint8arrays": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
+      "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
+      "requires": {
+        "multibase": "^3.0.0",
+        "web-encoding": "^1.0.2"
+      }
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -7634,6 +7592,11 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -7673,6 +7636,11 @@
       "requires": {
         "makeerror": "1.0.x"
       }
+    },
+    "web-encoding": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.4.tgz",
+      "integrity": "sha512-DcXs2lbVPzuJmn2kuDEwul2oZg7p4YMa5J2f0YzsOBHaAnBYGPNUB/rJ74DTjTKpw7F0+lSsVM8sFHE2UyBixg=="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/packages/3id-did-resolver/package.json
+++ b/packages/3id-did-resolver/package.json
@@ -27,10 +27,8 @@
     "clean": "rm -rf ./lib"
   },
   "dependencies": {
-    "3id-resolver": "^1.0.1",
     "@ceramicnetwork/common": "^0.12.2",
     "@ceramicnetwork/docid": "^0.2.0",
-    "bs58": "^4.0.1",
     "cross-fetch": "^3.0.6"
   },
   "devDependencies": {

--- a/packages/3id-did-resolver/package.json
+++ b/packages/3id-did-resolver/package.json
@@ -29,7 +29,9 @@
   "dependencies": {
     "@ceramicnetwork/common": "^0.12.2",
     "@ceramicnetwork/docid": "^0.2.0",
-    "cross-fetch": "^3.0.6"
+    "cids": "^1.0.2",
+    "cross-fetch": "^3.0.6",
+    "uint8arrays": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/3id-did-resolver/package.json
+++ b/packages/3id-did-resolver/package.json
@@ -27,8 +27,11 @@
     "clean": "rm -rf ./lib"
   },
   "dependencies": {
+    "3id-resolver": "^1.0.1",
     "@ceramicnetwork/common": "^0.12.2",
-    "bs58": "^4.0.1"
+    "@ceramicnetwork/docid": "^0.2.0",
+    "bs58": "^4.0.1",
+    "cross-fetch": "^3.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
@@ -52,13 +52,13 @@ Object {
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
       "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
-      "publicKeyHex": "03fff18103bdca9458e73cca5f0a0f64964312d686712f2190bf5b4794c6e29924",
+      "publicKeyBase58": "2Bv3fQSJiGJsbUUfUdiPsXXZGG5cXqaSeYnieuJcUFAbm",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
       "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
-      "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug",
+      "publicKeyBase58": "4jQRvHW8RfnRfdTrsxmExsn24z2vCV4xsoGxKB2Pkq2P",
       "type": "Curve25519EncryptionPublicKey",
     },
   ],
@@ -87,13 +87,13 @@ Object {
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
       "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
-      "publicKeyHex": "03fff18103bdca9458e73cca5f0a0f64964312d686712f2190bf5b4794c6e29924",
+      "publicKeyBase58": "2Bv3fQSJiGJsbUUfUdiPsXXZGG5cXqaSeYnieuJcUFAbm",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
       "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
-      "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug",
+      "publicKeyBase58": "4jQRvHW8RfnRfdTrsxmExsn24z2vCV4xsoGxKB2Pkq2P",
       "type": "Curve25519EncryptionPublicKey",
     },
   ],
@@ -157,13 +157,13 @@ Object {
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
       "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
-      "publicKeyHex": "03fff18103bdca9458e73cca5f0a0f64964312d686712f2190bf5b4794c6e29924",
+      "publicKeyBase58": "2Bv3fQSJiGJsbUUfUdiPsXXZGG5cXqaSeYnieuJcUFAbm",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
       "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
-      "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug",
+      "publicKeyBase58": "4jQRvHW8RfnRfdTrsxmExsn24z2vCV4xsoGxKB2Pkq2P",
       "type": "Curve25519EncryptionPublicKey",
     },
   ],

--- a/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
@@ -58,7 +58,7 @@ Object {
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
       "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
-      "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug=",
+      "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug",
       "type": "Curve25519EncryptionPublicKey",
     },
   ],
@@ -93,7 +93,7 @@ Object {
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
       "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
-      "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug=",
+      "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug",
       "type": "Curve25519EncryptionPublicKey",
     },
   ],
@@ -163,7 +163,7 @@ Object {
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
       "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
-      "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug=",
+      "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug",
       "type": "Curve25519EncryptionPublicKey",
     },
   ],

--- a/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
@@ -107,34 +107,6 @@ Object {
 }
 `;
 
-exports[`3ID DID Resolver resolver works correctly (old format) 1`] = `
-Object {
-  "@context": "https://w3id.org/did/v1",
-  "authentication": Array [
-    Object {
-      "publicKey": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
-      "type": "Secp256k1SignatureAuthentication2018",
-    },
-  ],
-  "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
-  "keyAgreement": Array [],
-  "publicKey": Array [
-    Object {
-      "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
-      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
-      "publicKeyHex": "fake signing key",
-      "type": "Secp256k1VerificationKey2018",
-    },
-    Object {
-      "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
-      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
-      "publicKeyBase64": "fake encryption key",
-      "type": "Curve25519EncryptionPublicKey",
-    },
-  ],
-}
-`;
-
 exports[`3ID DID Resolver resolves 3id document correctly 1`] = `
 Object {
   "@context": "https://w3id.org/did/v1",

--- a/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1,40 +1,105 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`3ID DID Resolver adds IDX root as service 1`] = `
+exports[`3ID DID Resolver Legacy (v0) resolves 3id v0 1`] = `
 Object {
   "@context": "https://w3id.org/did/v1",
   "authentication": Array [
     Object {
-      "publicKey": "did:3:bafyiuh3f97hqef97h#signing",
+      "publicKey": "did:3:GENESIS#signingKey",
       "type": "Secp256k1SignatureAuthentication2018",
     },
   ],
-  "id": "did:3:bafyiuh3f97hqef97h",
+  "id": "did:3:GENESIS",
+  "publicKey": Array [
+    Object {
+      "id": "did:3:GENESIS#signingKey",
+      "publicKeyHex": "0452fbcde75f7ddd7cff18767e2b5536211f500ad474c15da8e74577a573e7a346f2192ef49a5aa0552c41f181a7950af3afdb93cafcbff18156943e3ba312e5b2",
+      "type": "Secp256k1VerificationKey2018",
+    },
+    Object {
+      "id": "did:3:GENESIS#encryptionKey",
+      "publicKeyBase64": "DFxR24MNHVxEDAdL2f6pPEwNDJ2p0Ldyjoo7y/ItLDc=",
+      "type": "Curve25519EncryptionPublicKey",
+    },
+    Object {
+      "ethereumAddress": "0x3f0bb6247d647a30f310025662b29e6fa382b61d",
+      "id": "did:3:GENESIS#managementKey",
+      "type": "Secp256k1VerificationKey2018",
+    },
+  ],
+}
+`;
+
+exports[`3ID DID Resolver Legacy (v0) resolves 3id v0 which includs ceramic updates 1`] = `
+Object {
+  "@context": "https://w3id.org/did/v1",
+  "authentication": Array [
+    Object {
+      "publicKey": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
+      "type": "Secp256k1SignatureAuthentication2018",
+    },
+  ],
+  "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
   "keyAgreement": Array [
     Object {
-      "controller": "did:3:bafyiuh3f97hqef97h",
-      "id": "did:3:bafyiuh3f97hqef97h#encryption",
+      "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
       "publicKeyBase58": "4jQRvHW8RfnRfdTrsxmExsn24z2vCV4xsoGxKB2Pkq2P",
       "type": "X25519KeyAgreementKey2019",
     },
   ],
   "publicKey": Array [
     Object {
-      "controller": "did:3:bafyiuh3f97hqef97h",
-      "id": "did:3:bafyiuh3f97hqef97h#signing",
+      "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
       "publicKeyHex": "03fff18103bdca9458e73cca5f0a0f64964312d686712f2190bf5b4794c6e29924",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
-      "controller": "did:3:bafyiuh3f97hqef97h",
-      "id": "did:3:bafyiuh3f97hqef97h#encryption",
+      "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
+      "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug=",
+      "type": "Curve25519EncryptionPublicKey",
+    },
+  ],
+}
+`;
+
+exports[`3ID DID Resolver adds IDX root as service 1`] = `
+Object {
+  "@context": "https://w3id.org/did/v1",
+  "authentication": Array [
+    Object {
+      "publicKey": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
+      "type": "Secp256k1SignatureAuthentication2018",
+    },
+  ],
+  "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
+  "keyAgreement": Array [
+    Object {
+      "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
+      "publicKeyBase58": "4jQRvHW8RfnRfdTrsxmExsn24z2vCV4xsoGxKB2Pkq2P",
+      "type": "X25519KeyAgreementKey2019",
+    },
+  ],
+  "publicKey": Array [
+    Object {
+      "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
+      "publicKeyHex": "03fff18103bdca9458e73cca5f0a0f64964312d686712f2190bf5b4794c6e29924",
+      "type": "Secp256k1VerificationKey2018",
+    },
+    Object {
+      "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
       "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug=",
       "type": "Curve25519EncryptionPublicKey",
     },
   ],
   "service": Array [
     Object {
-      "id": "did:3:bafyiuh3f97hqef97h#idx",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#idx",
       "serviceEndpoint": "ceramic://rootId",
       "type": "IdentityIndexRoot",
     },
@@ -47,22 +112,22 @@ Object {
   "@context": "https://w3id.org/did/v1",
   "authentication": Array [
     Object {
-      "publicKey": "did:3:bafyiuh3f97hqef97h#signing",
+      "publicKey": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
       "type": "Secp256k1SignatureAuthentication2018",
     },
   ],
-  "id": "did:3:bafyiuh3f97hqef97h",
+  "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
   "keyAgreement": Array [],
   "publicKey": Array [
     Object {
-      "controller": "did:3:bafyiuh3f97hqef97h",
-      "id": "did:3:bafyiuh3f97hqef97h#signing",
+      "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
       "publicKeyHex": "fake signing key",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
-      "controller": "did:3:bafyiuh3f97hqef97h",
-      "id": "did:3:bafyiuh3f97hqef97h#encryption",
+      "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
       "publicKeyBase64": "fake encryption key",
       "type": "Curve25519EncryptionPublicKey",
     },
@@ -75,29 +140,29 @@ Object {
   "@context": "https://w3id.org/did/v1",
   "authentication": Array [
     Object {
-      "publicKey": "did:3:bafyiuh3f97hqef97h#signing",
+      "publicKey": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
       "type": "Secp256k1SignatureAuthentication2018",
     },
   ],
-  "id": "did:3:bafyiuh3f97hqef97h",
+  "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
   "keyAgreement": Array [
     Object {
-      "controller": "did:3:bafyiuh3f97hqef97h",
-      "id": "did:3:bafyiuh3f97hqef97h#encryption",
+      "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
       "publicKeyBase58": "4jQRvHW8RfnRfdTrsxmExsn24z2vCV4xsoGxKB2Pkq2P",
       "type": "X25519KeyAgreementKey2019",
     },
   ],
   "publicKey": Array [
     Object {
-      "controller": "did:3:bafyiuh3f97hqef97h",
-      "id": "did:3:bafyiuh3f97hqef97h#signing",
+      "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
       "publicKeyHex": "03fff18103bdca9458e73cca5f0a0f64964312d686712f2190bf5b4794c6e29924",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
-      "controller": "did:3:bafyiuh3f97hqef97h",
-      "id": "did:3:bafyiuh3f97hqef97h#encryption",
+      "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
       "publicKeyBase64": "N2/yXOxq8FCX4zzht8JQA3ftVRl+6C39CeU82eFB4Ug=",
       "type": "Curve25519EncryptionPublicKey",
     },

--- a/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
@@ -5,28 +5,31 @@ Object {
   "@context": "https://w3id.org/did/v1",
   "authentication": Array [
     Object {
-      "publicKey": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#signing",
-      "type": "Secp256k1SignatureAuthentication2018",
-    },
-    Object {
-      "publicKey": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#encryption",
+      "publicKey": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#g75q7J22wuWRyHb",
       "type": "Secp256k1SignatureAuthentication2018",
     },
   ],
   "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi",
-  "keyAgreement": Array [],
+  "keyAgreement": Array [
+    Object {
+      "controller": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi",
+      "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#FRNNWcZDvDZcpVC",
+      "publicKeyBase58": "qFYM1z9dJUC1K7rphEDVCj8U1YTzeFDVXtsjTa2uSiS",
+      "type": "X25519KeyAgreementKey2019",
+    },
+  ],
   "publicKey": Array [
     Object {
       "controller": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi",
-      "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#signing",
+      "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#g75q7J22wuWRyHb",
       "publicKeyBase58": "P8fYfHCRRHYkNwtVjRadhgftUsyEr6FUy65WttgSjqaW2eDXvJeXuCZRTdFM9JXc72eS5EDuu52fsdthsuWN7TS1",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
       "controller": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi",
-      "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#encryption",
+      "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#FRNNWcZDvDZcpVC",
       "publicKeyBase58": "qFYM1z9dJUC1K7rphEDVCj8U1YTzeFDVXtsjTa2uSiS",
-      "type": "Secp256k1VerificationKey2018",
+      "type": "Curve25519EncryptionPublicKey",
     },
   ],
 }
@@ -37,7 +40,7 @@ Object {
   "@context": "https://w3id.org/did/v1",
   "authentication": Array [
     Object {
-      "publicKey": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
+      "publicKey": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#8VBUiUTCeHbTeTV",
       "type": "Secp256k1SignatureAuthentication2018",
     },
   ],
@@ -45,7 +48,7 @@ Object {
   "keyAgreement": Array [
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
-      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#6F7kmzdodfvUCo9",
       "publicKeyBase58": "4jQRvHW8RfnRfdTrsxmExsn24z2vCV4xsoGxKB2Pkq2P",
       "type": "X25519KeyAgreementKey2019",
     },
@@ -53,13 +56,13 @@ Object {
   "publicKey": Array [
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
-      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#8VBUiUTCeHbTeTV",
       "publicKeyBase58": "2Bv3fQSJiGJsbUUfUdiPsXXZGG5cXqaSeYnieuJcUFAbm",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
-      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#6F7kmzdodfvUCo9",
       "publicKeyBase58": "4jQRvHW8RfnRfdTrsxmExsn24z2vCV4xsoGxKB2Pkq2P",
       "type": "Curve25519EncryptionPublicKey",
     },
@@ -72,7 +75,7 @@ Object {
   "@context": "https://w3id.org/did/v1",
   "authentication": Array [
     Object {
-      "publicKey": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
+      "publicKey": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#8VBUiUTCeHbTeTV",
       "type": "Secp256k1SignatureAuthentication2018",
     },
   ],
@@ -80,7 +83,7 @@ Object {
   "keyAgreement": Array [
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
-      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#6F7kmzdodfvUCo9",
       "publicKeyBase58": "4jQRvHW8RfnRfdTrsxmExsn24z2vCV4xsoGxKB2Pkq2P",
       "type": "X25519KeyAgreementKey2019",
     },
@@ -88,13 +91,13 @@ Object {
   "publicKey": Array [
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
-      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#8VBUiUTCeHbTeTV",
       "publicKeyBase58": "2Bv3fQSJiGJsbUUfUdiPsXXZGG5cXqaSeYnieuJcUFAbm",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
-      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#6F7kmzdodfvUCo9",
       "publicKeyBase58": "4jQRvHW8RfnRfdTrsxmExsn24z2vCV4xsoGxKB2Pkq2P",
       "type": "Curve25519EncryptionPublicKey",
     },
@@ -114,7 +117,7 @@ Object {
   "@context": "https://w3id.org/did/v1",
   "authentication": Array [
     Object {
-      "publicKey": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
+      "publicKey": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#8VBUiUTCeHbTeTV",
       "type": "Secp256k1SignatureAuthentication2018",
     },
   ],
@@ -122,7 +125,7 @@ Object {
   "keyAgreement": Array [
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
-      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#6F7kmzdodfvUCo9",
       "publicKeyBase58": "4jQRvHW8RfnRfdTrsxmExsn24z2vCV4xsoGxKB2Pkq2P",
       "type": "X25519KeyAgreementKey2019",
     },
@@ -130,13 +133,13 @@ Object {
   "publicKey": Array [
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
-      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#signing",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#8VBUiUTCeHbTeTV",
       "publicKeyBase58": "2Bv3fQSJiGJsbUUfUdiPsXXZGG5cXqaSeYnieuJcUFAbm",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
       "controller": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
-      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#encryption",
+      "id": "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki#6F7kmzdodfvUCo9",
       "publicKeyBase58": "4jQRvHW8RfnRfdTrsxmExsn24z2vCV4xsoGxKB2Pkq2P",
       "type": "Curve25519EncryptionPublicKey",
     },

--- a/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
@@ -5,25 +5,27 @@ Object {
   "@context": "https://w3id.org/did/v1",
   "authentication": Array [
     Object {
-      "publicKey": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#signingKey",
+      "publicKey": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#signing",
+      "type": "Secp256k1SignatureAuthentication2018",
+    },
+    Object {
+      "publicKey": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#encryption",
       "type": "Secp256k1SignatureAuthentication2018",
     },
   ],
   "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi",
+  "keyAgreement": Array [],
   "publicKey": Array [
     Object {
-      "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#signingKey",
-      "publicKeyHex": "0452fbcde75f7ddd7cff18767e2b5536211f500ad474c15da8e74577a573e7a346f2192ef49a5aa0552c41f181a7950af3afdb93cafcbff18156943e3ba312e5b2",
+      "controller": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi",
+      "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#signing",
+      "publicKeyBase58": "P8fYfHCRRHYkNwtVjRadhgftUsyEr6FUy65WttgSjqaW2eDXvJeXuCZRTdFM9JXc72eS5EDuu52fsdthsuWN7TS1",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
-      "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#encryptionKey",
-      "publicKeyBase64": "DFxR24MNHVxEDAdL2f6pPEwNDJ2p0Ldyjoo7y/ItLDc=",
-      "type": "Curve25519EncryptionPublicKey",
-    },
-    Object {
-      "ethereumAddress": "0x3f0bb6247d647a30f310025662b29e6fa382b61d",
-      "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#managementKey",
+      "controller": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi",
+      "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#encryption",
+      "publicKeyBase58": "qFYM1z9dJUC1K7rphEDVCj8U1YTzeFDVXtsjTa2uSiS",
       "type": "Secp256k1VerificationKey2018",
     },
   ],

--- a/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/3id-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
@@ -5,25 +5,25 @@ Object {
   "@context": "https://w3id.org/did/v1",
   "authentication": Array [
     Object {
-      "publicKey": "did:3:GENESIS#signingKey",
+      "publicKey": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#signingKey",
       "type": "Secp256k1SignatureAuthentication2018",
     },
   ],
-  "id": "did:3:GENESIS",
+  "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi",
   "publicKey": Array [
     Object {
-      "id": "did:3:GENESIS#signingKey",
+      "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#signingKey",
       "publicKeyHex": "0452fbcde75f7ddd7cff18767e2b5536211f500ad474c15da8e74577a573e7a346f2192ef49a5aa0552c41f181a7950af3afdb93cafcbff18156943e3ba312e5b2",
       "type": "Secp256k1VerificationKey2018",
     },
     Object {
-      "id": "did:3:GENESIS#encryptionKey",
+      "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#encryptionKey",
       "publicKeyBase64": "DFxR24MNHVxEDAdL2f6pPEwNDJ2p0Ldyjoo7y/ItLDc=",
       "type": "Curve25519EncryptionPublicKey",
     },
     Object {
       "ethereumAddress": "0x3f0bb6247d647a30f310025662b29e6fa382b61d",
-      "id": "did:3:GENESIS#managementKey",
+      "id": "did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi#managementKey",
       "type": "Secp256k1VerificationKey2018",
     },
   ],

--- a/packages/3id-did-resolver/src/__tests__/index.test.ts
+++ b/packages/3id-did-resolver/src/__tests__/index.test.ts
@@ -10,29 +10,39 @@ import { Resolver } from 'did-resolver'
 import DocID from '@ceramicnetwork/docid'
 
 const ceramicMock = {
-  loadDocument: async (): Promise<any> => ({
-    content: {
-      publicKeys: {
-        signing: 'zQ3shwsCgFanBax6UiaLu1oGvM7vhuqoW88VBUiUTCeHbTeTV',
-        encryption: 'z6LSfQabSbJzX8WAm1qdQcHCHTzVv8a2u6F7kmzdodfvUCo9'
+  loadDocument: async (): Promise<any> => {
+    const signing = 'zQ3shwsCgFanBax6UiaLu1oGvM7vhuqoW88VBUiUTCeHbTeTV'
+    const encryption = 'z6LSfQabSbJzX8WAm1qdQcHCHTzVv8a2u6F7kmzdodfvUCo9'
+    // mimic how IDW sets the 3ID DID document
+    return {
+      content: {
+        publicKeys: {
+          [signing.slice(-15)]: signing,
+          [encryption.slice(-15)]: encryption,
+        },
       }
     }
-  }),
+  },
   createDocument: async (): Promise<any> => ({
     id: DocID.fromString('k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki')
   })
 }
 
 const ceramicMockWithIDX = {
-  loadDocument: async (): Promise<any> => ({
-    content: {
-      publicKeys: {
-        signing: 'zQ3shwsCgFanBax6UiaLu1oGvM7vhuqoW88VBUiUTCeHbTeTV',
-        encryption: 'z6LSfQabSbJzX8WAm1qdQcHCHTzVv8a2u6F7kmzdodfvUCo9'
-      },
-      idx: 'ceramic://rootId'
+  loadDocument: async (): Promise<any> => {
+    const signing = 'zQ3shwsCgFanBax6UiaLu1oGvM7vhuqoW88VBUiUTCeHbTeTV'
+    const encryption = 'z6LSfQabSbJzX8WAm1qdQcHCHTzVv8a2u6F7kmzdodfvUCo9'
+    // mimic how IDW sets the 3ID DID document
+    return {
+      content: {
+        publicKeys: {
+          [signing.slice(-15)]: signing,
+          [encryption.slice(-15)]: encryption,
+        },
+        idx: 'ceramic://rootId'
+      }
     }
-  })
+  }
 }
 
 const ceramicMockNull = { // to be removed

--- a/packages/3id-did-resolver/src/__tests__/index.test.ts
+++ b/packages/3id-did-resolver/src/__tests__/index.test.ts
@@ -23,17 +23,6 @@ const ceramicMock = {
   })
 }
 
-const ceramicMockOld = { // to be removed
-  loadDocument: async (): Promise<any> => ({
-    content: {
-      publicKeys: {
-        signing: 'fake signing key',
-        encryption: 'fake encryption key'
-      }
-    }
-  })
-}
-
 const ceramicMockWithIDX = {
   loadDocument: async (): Promise<any> => ({
     content: {
@@ -59,12 +48,6 @@ describe('3ID DID Resolver', () => {
   it('getResolver works correctly', async () => {
     const threeIdResolver = ThreeIdResolver.getResolver(ceramicMock)
     expect(Object.keys(threeIdResolver)).toEqual(['3'])
-  })
-
-  it('resolver works correctly (old format)', async () => {
-    const threeIdResolver = ThreeIdResolver.getResolver(ceramicMockOld)
-    const resolver = new Resolver(threeIdResolver)
-    expect(await resolver.resolve(fake3ID)).toMatchSnapshot()
   })
 
   it('resolves 3id document correctly', async () => {

--- a/packages/3id-did-resolver/src/__tests__/index.test.ts
+++ b/packages/3id-did-resolver/src/__tests__/index.test.ts
@@ -1,5 +1,8 @@
-jest.mock('./../legacyResolver', () =>  {
- return () => () => JSON.parse('{"id":"did:3:GENESIS","@context":"https://w3id.org/did/v1","publicKey":[{"id":"did:3:GENESIS#signingKey","type":"Secp256k1VerificationKey2018","publicKeyHex":"0452fbcde75f7ddd7cff18767e2b5536211f500ad474c15da8e74577a573e7a346f2192ef49a5aa0552c41f181a7950af3afdb93cafcbff18156943e3ba312e5b2"},{"id":"did:3:GENESIS#encryptionKey","type":"Curve25519EncryptionPublicKey","publicKeyBase64":"DFxR24MNHVxEDAdL2f6pPEwNDJ2p0Ldyjoo7y/ItLDc="},{"id":"did:3:GENESIS#managementKey","type":"Secp256k1VerificationKey2018","ethereumAddress":"0x3f0bb6247d647a30f310025662b29e6fa382b61d"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:3:GENESIS#signingKey"}]}')
+jest.mock('cross-fetch', () =>  {
+  return () => ({
+    ok: true, 
+    json: async () => JSON.parse('{"value":{"id":"did:3:GENESIS","@context":"https://w3id.org/did/v1","publicKey":[{"id":"did:3:GENESIS#signingKey","type":"Secp256k1VerificationKey2018","publicKeyHex":"0452fbcde75f7ddd7cff18767e2b5536211f500ad474c15da8e74577a573e7a346f2192ef49a5aa0552c41f181a7950af3afdb93cafcbff18156943e3ba312e5b2"},{"id":"did:3:GENESIS#encryptionKey","type":"Curve25519EncryptionPublicKey","publicKeyBase64":"DFxR24MNHVxEDAdL2f6pPEwNDJ2p0Ldyjoo7y/ItLDc="},{"id":"did:3:GENESIS#managementKey","type":"Secp256k1VerificationKey2018","ethereumAddress":"0x3f0bb6247d647a30f310025662b29e6fa382b61d"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:3:GENESIS#signingKey"}]}}')
+  })
 })
 
 import ThreeIdResolver from '../index'

--- a/packages/3id-did-resolver/src/__tests__/index.test.ts
+++ b/packages/3id-did-resolver/src/__tests__/index.test.ts
@@ -1,5 +1,10 @@
+jest.mock('./../legacyResolver', () =>  {
+ return () => () => JSON.parse('{"id":"did:3:GENESIS","@context":"https://w3id.org/did/v1","publicKey":[{"id":"did:3:GENESIS#signingKey","type":"Secp256k1VerificationKey2018","publicKeyHex":"0452fbcde75f7ddd7cff18767e2b5536211f500ad474c15da8e74577a573e7a346f2192ef49a5aa0552c41f181a7950af3afdb93cafcbff18156943e3ba312e5b2"},{"id":"did:3:GENESIS#encryptionKey","type":"Curve25519EncryptionPublicKey","publicKeyBase64":"DFxR24MNHVxEDAdL2f6pPEwNDJ2p0Ldyjoo7y/ItLDc="},{"id":"did:3:GENESIS#managementKey","type":"Secp256k1VerificationKey2018","ethereumAddress":"0x3f0bb6247d647a30f310025662b29e6fa382b61d"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:3:GENESIS#signingKey"}]}')
+})
+
 import ThreeIdResolver from '../index'
 import { Resolver } from 'did-resolver'
+import DocID from '@ceramicnetwork/docid'
 
 const ceramicMock = {
   loadDocument: async (): Promise<any> => ({
@@ -9,6 +14,9 @@ const ceramicMock = {
         encryption: 'z6LSfQabSbJzX8WAm1qdQcHCHTzVv8a2u6F7kmzdodfvUCo9'
       }
     }
+  }),
+  createDocument: async (): Promise<any> => ({
+    id: DocID.fromString('k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki')
   })
 }
 
@@ -35,6 +43,14 @@ const ceramicMockWithIDX = {
   })
 }
 
+const ceramicMockNull = { // to be removed
+  loadDocument: async (): Promise<any> => { return { } },
+  createDocument: async (): Promise<any> => ({ id: 'k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki' })
+}
+
+const fake3ID = 'did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki'
+const fakeLegacy3ID = 'did:3:bafyreiffkeeq4wq2htejqla2is5ognligi4lvjhwrpqpl2kazjdoecmugi'
+
 describe('3ID DID Resolver', () => {
 
   it('getResolver works correctly', async () => {
@@ -45,21 +61,32 @@ describe('3ID DID Resolver', () => {
   it('resolver works correctly (old format)', async () => {
     const threeIdResolver = ThreeIdResolver.getResolver(ceramicMockOld)
     const resolver = new Resolver(threeIdResolver)
-    const fake3ID = 'did:3:bafyiuh3f97hqef97h'
     expect(await resolver.resolve(fake3ID)).toMatchSnapshot()
   })
 
   it('resolves 3id document correctly', async () => {
     const threeIdResolver = ThreeIdResolver.getResolver(ceramicMock)
     const resolver = new Resolver(threeIdResolver)
-    const fake3ID = 'did:3:bafyiuh3f97hqef97h'
     expect(await resolver.resolve(fake3ID)).toMatchSnapshot()
   })
 
   it('adds IDX root as service', async () => {
     const threeIdResolver = ThreeIdResolver.getResolver(ceramicMockWithIDX)
     const resolver = new Resolver(threeIdResolver)
-    const fake3ID = 'did:3:bafyiuh3f97hqef97h'
     expect(await resolver.resolve(fake3ID)).toMatchSnapshot()
+  })
+})
+
+describe('3ID DID Resolver Legacy (v0)', () => {
+  it('resolves 3id v0', async () => {
+    const threeIdResolver = ThreeIdResolver.getResolver(ceramicMockNull)
+    const resolver = new Resolver(threeIdResolver)
+    expect(await resolver.resolve(fakeLegacy3ID)).toMatchSnapshot()
+  })
+
+  it('resolves 3id v0 which includs ceramic updates', async () => {
+    const threeIdResolver = ThreeIdResolver.getResolver(ceramicMock)
+    const resolver = new Resolver(threeIdResolver)
+    expect(await resolver.resolve(fakeLegacy3ID)).toMatchSnapshot()
   })
 })

--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -73,7 +73,7 @@ export function wrapDocument(content: any, did: string): DIDDocument {
 
 const isLegacyDid = (didId: string): boolean => {
   try {
-    new CID(didId) 
+    new CID(didId)
     return true
   } catch(e) {
     return false
@@ -84,11 +84,11 @@ const getVersion = (query = ''): string | null => {
   const versionParam = query.split('&').find(e => e.includes('version-id'))
   return versionParam ? versionParam.split('=')[1] : null
 }
- 
+
 const legacyResolve = async (ceramic: Ceramic, didId: string, version?: string): Promise<DIDDocument | null> => {
   const legacyPublicKeys = await LegacyResolver(didId) // can add opt to pass ceramic ipfs to resolve
   if (!legacyPublicKeys) return null
-  
+
   const legacyDoc = wrapDocument(legacyPublicKeys, `did:3:${didId}`)
   if (version === '0') return legacyDoc
 

--- a/packages/3id-did-resolver/src/legacyResolver.ts
+++ b/packages/3id-did-resolver/src/legacyResolver.ts
@@ -1,7 +1,8 @@
-// const get3IdV0Resolver = require('3id-resolver').getResolver
-import { getResolver } from '3id-resolver'
 import fetch from 'cross-fetch'
-import type {  DIDDocument } from 'did-resolver'
+import type { DIDDocument } from 'did-resolver'
+
+const DID_PLACEHOLDER = 'GENESIS'
+const PUBKEY_IDS = ['signingKey', 'managementKey', 'encryptionKey']
 
 interface DAG {
   get(cid: string): any;
@@ -12,7 +13,7 @@ interface IPFS {
 }
 
 interface ProtocolResolver {
-  (did: string): DIDDocument;
+  (didId: string): Promise<DIDDocument>;
 }
 
 interface ErrorStatus extends Error {
@@ -21,20 +22,13 @@ interface ErrorStatus extends Error {
 
 // Legacy 3ids available from 3box, other v1 will always be resolved through ipfs and other services 
 const THREEBOX_API_URL = 'https://ipfs.3box.io'
-
-const HTTPError = (status: number, message: string): ErrorStatus => {
-  const e: ErrorStatus = new Error(message)
-  e.statusCode = status
-  return e
-}
   
 const fetchJson = async (url: string): Promise<any> =>  {
   const r = await fetch(url)
   if (r.ok) {
     return r.json()
   } else {
-    throw HTTPError(r.status, (await r.json()).message)
-  }
+    throw new Error('Not a valid 3ID')  }
 }
 
 const didDocReq = (cid: string): string => `${THREEBOX_API_URL}/did-doc?cid=${encodeURIComponent(cid)}`
@@ -46,6 +40,43 @@ const ipfsMock: IPFS = {
   }
 }
 
-const LegacyResolver = (ipfs?: IPFS): ProtocolResolver => getResolver(ipfs || ipfsMock, { pin: false })['3']
+const  cidToDocument = async (ipfs: IPFS, documentCid:string): Promise<DIDDocument> => {
+  const doc = (await ipfs.dag.get(documentCid)).value
+  // If genesis document replace placeholder identifier with cid
+  if (doc.id.includes(DID_PLACEHOLDER)) {
+    const re = new RegExp(DID_PLACEHOLDER, 'gi')
+    doc.id = doc.id.replace(re, documentCid)
+    if (doc.publicKey) {
+      doc.publicKey = JSON.parse(JSON.stringify(doc.publicKey).replace(re, documentCid))
+    }
+    if (doc.authentication) {
+      doc.authentication = JSON.parse(JSON.stringify(doc.authentication).replace(re, documentCid))
+    }
+    if (doc.service) {
+      doc.service = JSON.parse(JSON.stringify(doc.service).replace(re, documentCid))
+    }
+  }
+  if (doc.previousDocument) {
+    // make CID human readable
+    doc.previousDocument = { '/': doc.previousDocument.toString() }
+  }
+  return doc
+}
+
+const validateDoc = (doc: DIDDocument): void =>  {
+  if (!doc || !doc.publicKey || !doc.authentication) {
+    throw new Error('Not a valid 3ID')
+  }
+  doc.publicKey.map(entry => {
+    const id = entry.id.split('#')[1]
+    if (!PUBKEY_IDS.includes(id)) throw new Error('Not a valid 3ID')
+  })
+}
+
+const LegacyResolver = async (didId: string, ipfs = ipfsMock): Promise<DIDDocument> => {
+  const doc = await cidToDocument(ipfs, didId)
+  validateDoc(doc)
+  return doc 
+}
 
 export default LegacyResolver

--- a/packages/3id-did-resolver/src/legacyResolver.ts
+++ b/packages/3id-did-resolver/src/legacyResolver.ts
@@ -12,14 +12,6 @@ interface IPFS {
   dag: DAG;
 }
 
-interface ProtocolResolver {
-  (didId: string): Promise<DIDDocument>;
-}
-
-interface ErrorStatus extends Error {
-  statusCode?: number;
-}
-
 // Legacy 3ids available from 3box, other v1 will always be resolved through ipfs and other services 
 const THREEBOX_API_URL = 'https://ipfs.3box.io'
   
@@ -52,13 +44,6 @@ const  cidToDocument = async (ipfs: IPFS, documentCid:string): Promise<DIDDocume
     if (doc.authentication) {
       doc.authentication = JSON.parse(JSON.stringify(doc.authentication).replace(re, documentCid))
     }
-    if (doc.service) {
-      doc.service = JSON.parse(JSON.stringify(doc.service).replace(re, documentCid))
-    }
-  }
-  if (doc.previousDocument) {
-    // make CID human readable
-    doc.previousDocument = { '/': doc.previousDocument.toString() }
   }
   return doc
 }

--- a/packages/3id-did-resolver/src/legacyResolver.ts
+++ b/packages/3id-did-resolver/src/legacyResolver.ts
@@ -32,6 +32,7 @@ const ipfsMock: IPFS = {
   }
 }
 
+// just remove keys, return uint8 to consume in wrap doc in resolver
 const  cidToDocument = async (ipfs: IPFS, documentCid:string): Promise<DIDDocument> => {
   const doc = (await ipfs.dag.get(documentCid)).value
   // If genesis document replace placeholder identifier with cid

--- a/packages/3id-did-resolver/src/legacyResolver.ts
+++ b/packages/3id-did-resolver/src/legacyResolver.ts
@@ -1,0 +1,51 @@
+// const get3IdV0Resolver = require('3id-resolver').getResolver
+import { getResolver } from '3id-resolver'
+import fetch from 'cross-fetch'
+import type {  DIDDocument } from 'did-resolver'
+
+interface DAG {
+  get(cid: string): any;
+}
+
+interface IPFS {
+  dag: DAG;
+}
+
+interface ProtocolResolver {
+  (did: string): DIDDocument;
+}
+
+interface ErrorStatus extends Error {
+  statusCode?: number;
+}
+
+// Legacy 3ids available from 3box, other v1 will always be resolved through ipfs and other services 
+const THREEBOX_API_URL = 'https://ipfs.3box.io'
+
+const HTTPError = (status: number, message: string): ErrorStatus => {
+  const e: ErrorStatus = new Error(message)
+  e.statusCode = status
+  return e
+}
+  
+const fetchJson = async (url: string): Promise<any> =>  {
+  const r = await fetch(url)
+  if (r.ok) {
+    return r.json()
+  } else {
+    throw HTTPError(r.status, (await r.json()).message)
+  }
+}
+
+const didDocReq = (cid: string): string => `${THREEBOX_API_URL}/did-doc?cid=${encodeURIComponent(cid)}`
+
+// Mocks ipfs obj for 3id resolve, to resolve through api, until ipfs instance is available
+const ipfsMock: IPFS = {
+  dag: {
+    get: async cid => fetchJson(didDocReq(cid))
+  }
+}
+
+const LegacyResolver = (ipfs?: IPFS): ProtocolResolver => getResolver(ipfs || ipfsMock, { pin: false })['3']
+
+export default LegacyResolver

--- a/packages/core/src/__tests__/document.test.ts
+++ b/packages/core/src/__tests__/document.test.ts
@@ -134,7 +134,7 @@ describe('Document', () => {
   describe('Log logic', () => {
     const initialContent = { abc: 123, def: 456 }
     const newContent = { abc: 321, def: 456, gh: 987 }
-    const controllers = ['did:3:bafyasdfasdf']
+    const controllers = ['did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki']
     let user: DID
     let dispatcher: any;
     let doctypeHandler: TileDoctypeHandler;
@@ -149,9 +149,9 @@ describe('Document', () => {
       user = new DID()
       user.createJWS = jest.fn(async () => {
         // fake jws
-        return 'eyJraWQiOiJkaWQ6MzpiYWZ5YXNkZmFzZGY_dmVyc2lvbj0wI3NpZ25pbmciLCJhbGciOiJFUzI1NksifQ.bbbb.cccc'
+        return 'eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9.bbbb.cccc'
       })
-      user._id = 'did:3:bafyasdfasdf'
+      user._id = 'did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki'
       doctypeHandler = new TileDoctypeHandler()
       doctypeHandler.verifyJWS = async (): Promise<void> => { return }
 
@@ -602,7 +602,7 @@ describe('Document', () => {
   describe('Network update logic', () => {
     const initialContent = { abc: 123, def: 456 }
     const newContent = { abc: 321, def: 456, gh: 987 }
-    const controllers = ['did:3:bafyasdfasdf']
+    const controllers = ['did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki']
 
     let dispatcher: any;
     let doctypeHandler: TileDoctypeHandler;
@@ -620,7 +620,7 @@ describe('Document', () => {
       user = new DID()
       user.createJWS = jest.fn(async () => {
         // fake jws
-        return 'eyJraWQiOiJkaWQ6MzpiYWZ5YXNkZmFzZGY_dmVyc2lvbj0wI3NpZ25pbmciLCJhbGciOiJFUzI1NksifQ.bbbb.cccc'
+        return 'eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9.bbbb.cccc'
       })
       user._id = 'did:3:bafyuser'
       doctypeHandler = new TileDoctypeHandler()

--- a/packages/core/src/store/__tests__/state-store-integration.test.ts
+++ b/packages/core/src/store/__tests__/state-store-integration.test.ts
@@ -139,7 +139,7 @@ const anchorUpdate = (doctype: Doctype): Promise<void> => new Promise(resolve =>
 describe('Level data store', () => {
 
   const initialContent = { abc: 123, def: 456 }
-  const controllers = ['did:3:bafyasdfasdf']
+  const controllers = ['did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki']
 
   let store: PinStore
   let dispatcher: Dispatcher
@@ -164,9 +164,9 @@ describe('Level data store', () => {
     const user: DID = new DID()
     user.createJWS = jest.fn(async () => {
       // fake jws
-      return 'eyJraWQiOiJkaWQ6MzpiYWZ5YXNkZmFzZGY_dmVyc2lvbj0wI3NpZ25pbmciLCJhbGciOiJFUzI1NksifQ.bbbb.cccc'
+      return 'eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9.bbbb.cccc'
     })
-    user._id = 'did:3:bafyasdfasdf'
+    user._id = 'did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki'
 
     const threeIdResolver = ThreeIdResolver.getResolver({
       loadDocument: (): any => {

--- a/packages/doctype-tile/src/__tests__/__snapshots__/tile-doctype.test.ts.snap
+++ b/packages/doctype-tile/src/__tests__/__snapshots__/tile-doctype.test.ts.snap
@@ -146,7 +146,7 @@ Object {
   "metadata": Object {
     "chainId": "fakechain:123",
     "controllers": Array [
-      "did:3:bafyasdfasdf",
+      "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
     ],
   },
   "signature": 2,
@@ -208,7 +208,7 @@ Object {
   "metadata": Object {
     "chainId": "fakechain:123",
     "controllers": Array [
-      "did:3:bafyasdfasdf",
+      "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
     ],
   },
   "signature": 2,
@@ -313,7 +313,7 @@ Object {
   "metadata": Object {
     "chainId": "fakechain:123",
     "controllers": Array [
-      "did:3:bafyasdfasdf",
+      "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
     ],
   },
   "next": Object {
@@ -324,7 +324,7 @@ Object {
     "metadata": Object {
       "chainId": "fakechain:123",
       "controllers": Array [
-        "did:3:bafyasdfasdf",
+        "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki",
       ],
     },
   },

--- a/packages/doctype-tile/src/__tests__/tile-doctype.test.ts
+++ b/packages/doctype-tile/src/__tests__/tile-doctype.test.ts
@@ -25,14 +25,17 @@ const FAKE_CID_2 = new CID('bafybeig6xv5nwphfmvcnektpnojts44jqcuam7bmye2pb54adnr
 const FAKE_CID_3 = new CID('bafybeig6xv5nwphfmvcnektpnojts55jqcuam7bmye2pb54adnrtccjlsu')
 const FAKE_CID_4 = new CID('bafybeig6xv5nwphfmvcnektpnojts66jqcuam7bmye2pb54adnrtccjlsu')
 
+// did:3:bafyasdfasdf
+
 const RECORDS = {
-  genesis: { header: { controllers: [ 'did:3:bafyasdfasdf' ], chainId: 'fakechain:123' }, data: { much: 'data' }, unique: '0' },
+  genesis: { header: { controllers: [ 'did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki' ], chainId: 'fakechain:123' }, data: { much: 'data' }, unique: '0' },
   genesisGenerated: {
     "jws": {
       "payload": "bbbb",
       "signatures": [
         {
-          "protected": "eyJraWQiOiJkaWQ6MzpiYWZ5YXNkZmFzZGY_dmVyc2lvbj0wI3NpZ25pbmciLCJhbGciOiJFUzI1NksifQ",
+          
+          "protected": "eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9",
           "signature": "cccc"
         }
       ],
@@ -44,7 +47,7 @@ const RECORDS = {
       },
       "header": {
         "controllers": [
-          "did:3:bafyasdfasdf"
+          "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki"
         ]
       },
       "unique": "0",
@@ -57,7 +60,7 @@ const RECORDS = {
         "payload": "bbbb",
         "signatures": [
           {
-            "protected": "eyJraWQiOiJkaWQ6MzpiYWZ5YXNkZmFzZGY_dmVyc2lvbj0wI3NpZ25pbmciLCJhbGciOiJFUzI1NksifQ",
+            "protected": "eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9",
             "signature": "cccc"
           }
         ],
@@ -114,9 +117,9 @@ describe('TileDoctypeHandler', () => {
     did = new DID()
     did.createJWS = jest.fn(async () => {
       // fake jws
-      return 'eyJraWQiOiJkaWQ6MzpiYWZ5YXNkZmFzZGY_dmVyc2lvbj0wI3NpZ25pbmciLCJhbGciOiJFUzI1NksifQ.bbbb.cccc'
+      return 'eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9.bbbb.cccc'
     })
-    did._id = 'did:3:bafyasdfasdf'
+    did._id = 'did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki'
 
     const recs: Record<string, any> = {}
     const ipfs = {


### PR DESCRIPTION
Resolves v0 3ids through api, likely in future will want make sure all existing did docs are available in ipfs elsewhere (ie our ceramic ipfs node), and ipfs instance can be passed from ceramic instance already passed to resolver. Likely would not be reliable to resolve through existing 3box ipfs node, as have to directly connect and ipfs ceramic/3box versions diverging. 