### PR TITLE
feat: allow any ipfs url to be passed

### DIFF
--- a/Dockerfile.daemon
+++ b/Dockerfile.daemon
@@ -1,7 +1,5 @@
 FROM node:12
 
-ENV IPFS_API_URL=http://host.docker.internal:5001
-
 RUN apt-get update && apt-get install -y netcat
 
 WORKDIR /js-ceramic
@@ -29,4 +27,5 @@ RUN npm run build
 
 EXPOSE 7007
 
-CMD cd packages/ceramic-cli && ./bin/ceramic.js daemon --ipfs-api $IPFS_API_URL
+ENTRYPOINT ["./packages/ceramic-cli/bin/ceramic.js", "daemon"]
+


### PR DESCRIPTION
### Motivation

Currently you will get an error trying to run this if ipfs is not running or running on different host and/or port. Also it is not straightforward to add additional commands like --debug, etc.

### Changes

- Remove env var for ipfs url and use entrypoint instead of cmd