### PR TITLE
Ceramic client config

### DIFF
--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -21,6 +21,7 @@ const waitChange = (doc: EventEmitter, count = 1): Promise<void> => {
         doc.on('change', () => {
             if (++c === count) {
                 resolve()
+                doc.removeAllListeners('change')
             }
         })
     })

--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -80,7 +80,7 @@ describe('Ceramic interop: core <> http-client', () => {
         core._doctypeHandlers['tile'] = doctypeHandler
 
         daemon = new CeramicDaemon(core, { port })
-        client = new CeramicClient(apiUrl, { docSyncEnabled: true, docSyncInterval: 2000 })
+        client = new CeramicClient(apiUrl, { docSyncEnabled: true })
 
         const provider = new Ed25519Provider(seed)
         await core.setDIDProvider(provider)

--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -15,7 +15,16 @@ import basicsImport from 'multiformats/cjs/src/basics-import.js'
 import legacy from 'multiformats/cjs/src/legacy.js'
 
 const seed = u8a.fromString('6e34b2e1a9624113d81ece8a8a22e6e97f0e145c25c1d4d2d0e62753b4060c83', 'base16')
-const anchorUpdate = (doc: EventEmitter): Promise<void> => new Promise(resolve => doc.on('change', resolve))
+const waitChange = (doc: EventEmitter, count = 1): Promise<void> => {
+    return new Promise(resolve => {
+        let c = 0
+        doc.on('change', () => {
+            if (++c === count) {
+                resolve()
+            }
+        })
+    })
+}
 const port = 7777
 const apiUrl = 'http://localhost:' + port
 
@@ -71,7 +80,7 @@ describe('Ceramic interop: core <> http-client', () => {
         core._doctypeHandlers['tile'] = doctypeHandler
 
         daemon = new CeramicDaemon(core, { port })
-        client = new CeramicClient(apiUrl, { docSyncEnabled: true })
+        client = new CeramicClient(apiUrl, { docSyncEnabled: true, docSyncInterval: 2000 })
 
         const provider = new Ed25519Provider(seed)
         await core.setDIDProvider(provider)
@@ -109,24 +118,24 @@ describe('Ceramic interop: core <> http-client', () => {
 
     it('gets anchor record updates', async () => {
         const doc1 = await client.createDocument(DOCTYPE_TILE, { content: { test: 123 } })
-        await anchorUpdate(doc1)
+        await waitChange(doc1, 2)
         expect(doc1.state.log.length).toEqual(2)
         expect(doc1.state.anchorStatus).toEqual(AnchorStatus.ANCHORED)
         const doc2 = await client.createDocument(DOCTYPE_TILE, { content: { test: 1234 } })
-        await anchorUpdate(doc2)
+        await waitChange(doc2, 2)
         expect(doc2.state.log.length).toEqual(2)
         expect(doc2.state.anchorStatus).toEqual(AnchorStatus.ANCHORED)
     })
 
     it('loads documents correctly', async () => {
         const doc1 = await core.createDocument(DOCTYPE_TILE, { content: { test: 123 } })
-        await anchorUpdate(doc1)
+        await waitChange(doc1)
         const doc2 = await client.loadDocument(doc1.id)
         expect(doc1.content).toEqual(doc2.content)
         expect(DoctypeUtils.serializeState(doc1.state)).toEqual(DoctypeUtils.serializeState(doc2.state))
 
         const doc3 = await client.createDocument(DOCTYPE_TILE, { content: { test: 456 } })
-        await anchorUpdate(doc3)
+        await waitChange(doc3)
         const doc4 = await core.loadDocument(doc3.id)
         expect(doc3.content).toEqual(doc4.content)
         expect(DoctypeUtils.serializeState(doc3.state)).toEqual(DoctypeUtils.serializeState(doc4.state))
@@ -134,7 +143,7 @@ describe('Ceramic interop: core <> http-client', () => {
 
     it('loads document records correctly', async () => {
         const doc1 = await core.createDocument(DOCTYPE_TILE, { content: { test: 123 } })
-        await anchorUpdate(doc1)
+        await waitChange(doc1)
         const doc2 = await client.loadDocument(doc1.id)
         expect(doc1.content).toEqual(doc2.content)
 
@@ -155,19 +164,19 @@ describe('Ceramic interop: core <> http-client', () => {
 
     it('makes and gets updates correctly', async () => {
         const doc1 = await core.createDocument(DOCTYPE_TILE, { content: { test: 123 } })
-        await anchorUpdate(doc1)
+        await waitChange(doc1)
         const doc2 = await client.loadDocument(doc1.id)
         // change from core viewable in client
         await doc1.change({ content: { test: 123, abc: 987 } })
-        await anchorUpdate(doc1)
-        await anchorUpdate(doc2)
+        await waitChange(doc1)
+        await waitChange(doc2)
         expect(doc1.content).toEqual(doc2.content)
         expect(DoctypeUtils.serializeState(doc1.state)).toEqual(DoctypeUtils.serializeState(doc2.state))
         // change from client viewable in core
 
         await doc2.change({ content: { test: 456, abc: 654 } })
 
-        await anchorUpdate(doc2)
+        await waitChange(doc2)
         expect(doc1.content).toEqual(doc2.content)
         expect(DoctypeUtils.serializeState(doc1.state)).toEqual(DoctypeUtils.serializeState(doc2.state))
     })

--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -71,7 +71,7 @@ describe('Ceramic interop: core <> http-client', () => {
         core._doctypeHandlers['tile'] = doctypeHandler
 
         daemon = new CeramicDaemon(core, { port })
-        client = new CeramicClient(apiUrl)
+        client = new CeramicClient(apiUrl, { docSyncEnabled: true })
 
         const provider = new Ed25519Provider(seed)
         await core.setDIDProvider(provider)

--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -80,7 +80,7 @@ describe('Ceramic interop: core <> http-client', () => {
         core._doctypeHandlers['tile'] = doctypeHandler
 
         daemon = new CeramicDaemon(core, { port })
-        client = new CeramicClient(apiUrl, { docSyncEnabled: true })
+        client = new CeramicClient(apiUrl, { docSyncEnabled: true, docSyncInterval: 1000 })
 
         const provider = new Ed25519Provider(seed)
         await core.setDIDProvider(provider)

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -15,7 +15,7 @@ const CERAMIC_HOST = 'http://localhost:7007'
  */
 export const DEFAULT_CLIENT_CONFIG: CeramicClientConfig = {
   docSyncEnabled: false,
-  docSyncInterval: 1000,
+  docSyncInterval: 5000,
 }
 
 /**

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -37,9 +37,12 @@ export default class CeramicClient implements CeramicApi {
   public readonly pin: PinApi
   public readonly context: Context
 
+  private readonly _config: CeramicClientConfig
   public readonly _doctypeHandlers: Record<string, DoctypeHandler<Doctype>>
 
-  constructor (apiHost: string = CERAMIC_HOST, private _config: CeramicClientConfig = DEFAULT_CLIENT_CONFIG) {
+  constructor (apiHost: string = CERAMIC_HOST, config?: CeramicClientConfig) {
+    this._config = Object.assign(config ? config : {}, DEFAULT_CLIENT_CONFIG)
+
     this._apiUrl = combineURLs(apiHost, API_PATH)
     this._docmap = {}
 

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -22,8 +22,8 @@ export const DEFAULT_CLIENT_CONFIG: CeramicClientConfig = {
  * Ceramic client configuration
  */
 export interface CeramicClientConfig {
-  docSyncEnabled: boolean
-  docSyncInterval: number
+  docSyncEnabled?: boolean
+  docSyncInterval?: number
 }
 
 /**
@@ -96,7 +96,7 @@ export default class CeramicClient implements CeramicApi {
   }
 
   async createDocumentFromGenesis<T extends Doctype>(doctype: string, genesis: any, opts?: DocOpts): Promise<T> {
-    const doc = await Document.createFromGenesis(this._apiUrl, doctype, genesis, this.context, opts)
+    const doc = await Document.createFromGenesis(this._apiUrl, doctype, genesis, this.context, opts, this._config)
     const docIdStr = doc.id.toString()
     if (!this._docmap[docIdStr]) {
       this._docmap[docIdStr] = doc
@@ -109,7 +109,7 @@ export default class CeramicClient implements CeramicApi {
     docId = typeDocID(docId)
     const docIdStr = docId.toString()
     if (!this._docmap[docIdStr]) {
-      this._docmap[docIdStr] = await Document.load(docId, this._apiUrl, this.context)
+      this._docmap[docIdStr] = await Document.load(docId, this._apiUrl, this.context, this._config)
     }
     this._docmap[docIdStr].doctypeHandler = this.findDoctypeHandler(this._docmap[docIdStr].state.doctype)
     return this._docmap[docIdStr] as unknown as T

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -1,4 +1,4 @@
-import { fetchJson, typeDocID } from "./utils"
+import { fetchJson, typeDocID, combineURLs } from "./utils"
 import Document from './document'
 
 import { DID } from 'dids'
@@ -7,10 +7,29 @@ import { TileDoctypeHandler } from "@ceramicnetwork/doctype-tile"
 import { Caip10LinkDoctypeHandler } from "@ceramicnetwork/doctype-caip10-link"
 import DocID from '@ceramicnetwork/docid'
 
-const CERAMIC_HOST = 'http://localhost:7007'
 const API_PATH = '/api/v0'
+const CERAMIC_HOST = 'http://localhost:7007'
 
-class CeramicClient implements CeramicApi {
+/**
+ * Default Ceramic client configuration
+ */
+export const DEFAULT_CLIENT_CONFIG: CeramicClientConfig = {
+  docSyncEnabled: false,
+  docSyncInterval: 1000,
+}
+
+/**
+ * Ceramic client configuration
+ */
+export interface CeramicClientConfig {
+  docSyncEnabled: boolean
+  docSyncInterval: number
+}
+
+/**
+ * Ceramic client implementation
+ */
+export default class CeramicClient implements CeramicApi {
   private readonly _apiUrl: string
   private readonly _docmap: Record<string, Document>
   private _supportedChains: Array<string>
@@ -20,8 +39,8 @@ class CeramicClient implements CeramicApi {
 
   public readonly _doctypeHandlers: Record<string, DoctypeHandler<Doctype>>
 
-  constructor (apiHost: string = CERAMIC_HOST) {
-    this._apiUrl = apiHost + API_PATH
+  constructor (apiHost: string = CERAMIC_HOST, private _config: CeramicClientConfig = DEFAULT_CLIENT_CONFIG) {
+    this._apiUrl = combineURLs(apiHost, API_PATH)
     this._docmap = {}
 
     this.context = { api: this }
@@ -144,5 +163,3 @@ class CeramicClient implements CeramicApi {
     }
   }
 }
-
-export default CeramicClient

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -41,7 +41,7 @@ export default class CeramicClient implements CeramicApi {
   public readonly _doctypeHandlers: Record<string, DoctypeHandler<Doctype>>
 
   constructor (apiHost: string = CERAMIC_HOST, config?: CeramicClientConfig) {
-    this._config = Object.assign(config ? config : {}, DEFAULT_CLIENT_CONFIG)
+    this._config = Object.assign(DEFAULT_CLIENT_CONFIG, config ? config : {})
 
     this._apiUrl = combineURLs(apiHost, API_PATH)
     this._docmap = {}

--- a/packages/http-client/src/document.ts
+++ b/packages/http-client/src/document.ts
@@ -75,7 +75,7 @@ class Document extends Doctype {
         applyOnly: opts.applyOnly,
       }
     })
-    return new Document(DoctypeUtils.deserializeState(state), context, apiUrl)
+    return new Document(DoctypeUtils.deserializeState(state), context, apiUrl, { docSyncEnabled: false })
   }
 
   static async load (docId: DocID | string, apiUrl: string, context: Context, config = DEFAULT_CLIENT_CONFIG): Promise<Document> {

--- a/packages/http-client/src/document.ts
+++ b/packages/http-client/src/document.ts
@@ -5,7 +5,7 @@ import {
 import DocID from '@ceramicnetwork/docid'
 
 import { fetchJson, typeDocID, delay } from './utils'
-import { CeramicClientConfig, DEFAULT_CLIENT_CONFIG } from "./ceramic-http-client"
+import { CeramicClientConfig } from "./ceramic-http-client"
 
 const docIdUrl = (docId: DocID ): string => `/ceramic/${docId.toString()}`
 
@@ -16,7 +16,7 @@ class Document extends Doctype {
 
   public doctypeHandler: DoctypeHandler<Doctype>
 
-  constructor (state: DocState, context: Context, private _apiUrl: string, config: CeramicClientConfig = DEFAULT_CLIENT_CONFIG) {
+  constructor (state: DocState, context: Context, private _apiUrl: string, config: CeramicClientConfig = { docSyncEnabled: false }) {
     super(state, context)
 
     this._syncEnabled = config.docSyncEnabled
@@ -55,7 +55,7 @@ class Document extends Doctype {
     return new DocID(this.state.doctype, this.state.log[0].cid)
   }
 
-  static async createFromGenesis (apiUrl: string, doctype: string, genesis: any, context: Context, opts: DocOpts = {}, config = DEFAULT_CLIENT_CONFIG): Promise<Document> {
+  static async createFromGenesis (apiUrl: string, doctype: string, genesis: any, context: Context, opts: DocOpts = {}, config: CeramicClientConfig): Promise<Document> {
     const { state } = await fetchJson(apiUrl + '/create', {
       doctype,
       genesis: DoctypeUtils.serializeRecord(genesis),
@@ -75,10 +75,10 @@ class Document extends Doctype {
         applyOnly: opts.applyOnly,
       }
     })
-    return new Document(DoctypeUtils.deserializeState(state), context, apiUrl, { docSyncEnabled: false })
+    return new Document(DoctypeUtils.deserializeState(state), context, apiUrl)
   }
 
-  static async load (docId: DocID | string, apiUrl: string, context: Context, config = DEFAULT_CLIENT_CONFIG): Promise<Document> {
+  static async load (docId: DocID | string, apiUrl: string, context: Context, config: CeramicClientConfig): Promise<Document> {
     docId = typeDocID(docId)
     const { state } = await fetchJson(apiUrl + '/state' + docIdUrl(docId))
     return new Document(DoctypeUtils.deserializeState(state), context, apiUrl, config)

--- a/packages/http-client/src/document.ts
+++ b/packages/http-client/src/document.ts
@@ -16,7 +16,7 @@ class Document extends Doctype {
 
   public doctypeHandler: DoctypeHandler<Doctype>
 
-  constructor (state: DocState, context: Context, private _apiUrl: string, config: CeramicClientConfig = { docSyncEnabled: false, docSyncInterval: 1000 }) {
+  constructor (state: DocState, context: Context, private _apiUrl: string, config: CeramicClientConfig = { docSyncEnabled: false }) {
     super(state, context)
 
     this._syncEnabled = config.docSyncEnabled

--- a/packages/http-client/src/document.ts
+++ b/packages/http-client/src/document.ts
@@ -16,7 +16,7 @@ class Document extends Doctype {
 
   public doctypeHandler: DoctypeHandler<Doctype>
 
-  constructor (state: DocState, context: Context, private _apiUrl: string, config: CeramicClientConfig = { docSyncEnabled: false }) {
+  constructor (state: DocState, context: Context, private _apiUrl: string, config: CeramicClientConfig = { docSyncEnabled: false, docSyncInterval: 1000 }) {
     super(state, context)
 
     this._syncEnabled = config.docSyncEnabled

--- a/packages/http-client/src/document.ts
+++ b/packages/http-client/src/document.ts
@@ -2,24 +2,52 @@ import {
   Context, DocOpts, DocParams, DocState, Doctype, DoctypeHandler, DoctypeUtils
 } from "@ceramicnetwork/common"
 
-import { fetchJson, typeDocID } from './utils'
 import DocID from '@ceramicnetwork/docid'
+
+import { fetchJson, typeDocID, delay } from './utils'
+import { CeramicClientConfig, DEFAULT_CLIENT_CONFIG } from "./ceramic-http-client"
 
 const docIdUrl = (docId: DocID ): string => `/ceramic/${docId.toString()}`
 
 class Document extends Doctype {
 
-  private readonly _syncHandle: NodeJS.Timeout
+  private _syncEnabled: boolean
+  private readonly _syncInterval: number
 
   public doctypeHandler: DoctypeHandler<Doctype>
 
-  constructor (state: DocState, context: Context, private _apiUrl: string, syncState = true) {
+  constructor (state: DocState, context: Context, private _apiUrl: string, config: CeramicClientConfig = DEFAULT_CLIENT_CONFIG) {
     super(state, context)
 
-    if (syncState) {
-      this._syncHandle = setInterval(async () => {
-        await this._syncState()
-      }, 1000)
+    this._syncEnabled = config.docSyncEnabled
+    this._syncInterval = config.docSyncInterval
+
+    if (this._syncEnabled) {
+      this._syncPeriodically() // start syncing
+    }
+  }
+
+  /**
+   * Sync document states periodically
+   * @private
+   */
+  async _syncPeriodically() {
+    const _syncState = async () => {
+      let { state } = await fetchJson(this._apiUrl + '/state' + docIdUrl(this.id))
+      state = DoctypeUtils.deserializeState(state)
+      if (JSON.stringify(this.state) !== JSON.stringify(state)) {
+        this.state = state
+        this.emit('change')
+      }
+    }
+
+    while (this._syncEnabled) {
+      try {
+        await _syncState()
+      } catch (e) {
+        console.error(e) // failed to sync state
+      }
+      await delay(this._syncInterval)
     }
   }
 
@@ -27,7 +55,7 @@ class Document extends Doctype {
     return new DocID(this.state.doctype, this.state.log[0].cid)
   }
 
-  static async createFromGenesis (apiUrl: string, doctype: string, genesis: any, context: Context, opts: DocOpts = {}): Promise<Document> {
+  static async createFromGenesis (apiUrl: string, doctype: string, genesis: any, context: Context, opts: DocOpts = {}, config = DEFAULT_CLIENT_CONFIG): Promise<Document> {
     const { state } = await fetchJson(apiUrl + '/create', {
       doctype,
       genesis: DoctypeUtils.serializeRecord(genesis),
@@ -35,7 +63,7 @@ class Document extends Doctype {
         applyOnly: opts.applyOnly,
       }
     })
-    return new Document(DoctypeUtils.deserializeState(state), context, apiUrl)
+    return new Document(DoctypeUtils.deserializeState(state), context, apiUrl, config)
   }
 
   static async applyRecord(apiUrl: string, docId: DocID | string, record: any, context: Context, opts: DocOpts = {}): Promise<Document> {
@@ -47,13 +75,13 @@ class Document extends Doctype {
         applyOnly: opts.applyOnly,
       }
     })
-    return new Document(DoctypeUtils.deserializeState(state), context, apiUrl, false)
+    return new Document(DoctypeUtils.deserializeState(state), context, apiUrl)
   }
 
-  static async load (docId: DocID | string, apiUrl: string, context: Context): Promise<Document> {
+  static async load (docId: DocID | string, apiUrl: string, context: Context, config = DEFAULT_CLIENT_CONFIG): Promise<Document> {
     docId = typeDocID(docId)
     const { state } = await fetchJson(apiUrl + '/state' + docIdUrl(docId))
-    return new Document(DoctypeUtils.deserializeState(state), context, apiUrl)
+    return new Document(DoctypeUtils.deserializeState(state), context, apiUrl, config)
   }
 
   static async loadDocumentRecords (docId: DocID | string, apiUrl: string): Promise<Array<Record<string, any>>> {
@@ -74,17 +102,8 @@ class Document extends Doctype {
     this.state = doctype.state
   }
 
-  async _syncState(): Promise<void> {
-    let { state } = await fetchJson(this._apiUrl + '/state' + docIdUrl(this.id))
-    state = DoctypeUtils.deserializeState(state)
-    if (JSON.stringify(this.state) !== JSON.stringify(state)) {
-      this.state = state
-      this.emit('change')
-    }
-  }
-
   close(): void {
-    clearInterval(this._syncHandle)
+    this._syncEnabled = false
   }
 }
 

--- a/packages/http-client/src/document.ts
+++ b/packages/http-client/src/document.ts
@@ -33,10 +33,10 @@ class Document extends Doctype {
    */
   async _syncPeriodically() {
     const _syncState = async () => {
-      let { state } = await fetchJson(this._apiUrl + '/state' + docIdUrl(this.id))
-      state = DoctypeUtils.deserializeState(state)
-      if (JSON.stringify(this.state) !== JSON.stringify(state)) {
-        this.state = state
+      const { state } = await fetchJson(this._apiUrl + '/state' + docIdUrl(this.id))
+
+      if (JSON.stringify(DoctypeUtils.serializeState(this.state)) !== JSON.stringify(state)) {
+        this.state = DoctypeUtils.deserializeState(state)
         this.emit('change')
       }
     }

--- a/packages/http-client/src/document.ts
+++ b/packages/http-client/src/document.ts
@@ -45,7 +45,7 @@ class Document extends Doctype {
       try {
         await _syncState()
       } catch (e) {
-        console.error(e) // failed to sync state
+        // failed to sync state
       }
       await delay(this._syncInterval)
     }

--- a/packages/http-client/src/utils.ts
+++ b/packages/http-client/src/utils.ts
@@ -18,4 +18,19 @@ export async function fetchJson(url: string, payload?: any): Promise<any> {
 export function typeDocID(docId: DocID | string): DocID  {
     return (typeof docId === 'string') ? DocID.fromString(docId) : docId
 }
-  
+
+export function combineURLs(baseURL, relativeURL) {
+    return relativeURL
+        ? baseURL.replace(/\/+$/, '') + '/' + relativeURL.replace(/^\/+/, '')
+        : baseURL;
+}
+
+export async function delay(mills: number): Promise<void> {
+    await new Promise((resolve => {
+        const h = setTimeout(() => {
+            clearTimeout(h)
+            resolve()
+        }, mills)
+    }))
+}
+

--- a/packages/http-client/src/utils.ts
+++ b/packages/http-client/src/utils.ts
@@ -26,11 +26,6 @@ export function combineURLs(baseURL, relativeURL) {
 }
 
 export async function delay(mills: number): Promise<void> {
-    await new Promise((resolve => {
-        const h = setTimeout(() => {
-            clearTimeout(h)
-            resolve()
-        }, mills)
-    }))
+    await new Promise(resolve => setTimeout(() => resolve(), mills))
 }
 


### PR DESCRIPTION
- add Ceramic client configuration
- replace `setInterval` with `setTimeout`
- disable Ceramic client document polling by default - issue [499](https://github.com/ceramicnetwork/js-ceramic/issues/499)
- fix `applyRecord` functionality - issue [534](https://github.com/ceramicnetwork/js-ceramic/issues/534)