### PR TITLE
chore: bump to dids@1.0.0

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1531,32 +1531,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@ceramicnetwork/docid": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ceramicnetwork/docid/-/docid-0.2.0.tgz",
-      "integrity": "sha512-s4YXOFM7CNSYGkfnts9XB6EOmp37uPnc7Q2hF3M5SZDNQhtDzYpuCdY30CFNJ291JOfMlfLQovQv4+k7ytkE6A==",
-      "requires": {
-        "cids": "^1.0.0",
-        "multibase": "^3.0.1",
-        "varint": "^6.0.0"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
-          "integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
-          "requires": {
-            "@multiformats/base-x": "^4.0.1",
-            "web-encoding": "^1.0.2"
-          }
-        },
-        "varint": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-        }
-      }
-    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -2059,11 +2033,6 @@
         }
       }
     },
-    "@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
-    },
     "@sinonjs/commons": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
@@ -2451,7 +2420,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@zondax/filecoin-signing-tools/-/filecoin-signing-tools-0.6.3.tgz",
       "integrity": "sha512-CjqoouTFVDMp6bZSNoyuBaFzf89+sr9uv4evEtLSKXPTpwI03ErnK5lHY3EgkmcKOqEykAudfyyEXsY0ZCPUuA==",
-      "dev": true,
       "requires": {
         "base32-decode": "^1.0.0",
         "base32-encode": "^1.1.1",
@@ -2466,7 +2434,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
           "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-          "dev": true,
           "requires": {
             "bignumber.js": "^9.0.0",
             "buffer": "^5.5.0",
@@ -2481,7 +2448,6 @@
           "version": "5.6.0",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
           "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -2491,7 +2457,6 @@
           "version": "0.8.3",
           "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
           "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
           "requires": {
             "buffer": "^5.6.0",
             "class-is": "^1.1.0",
@@ -2504,7 +2469,6 @@
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
               "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-              "dev": true,
               "requires": {
                 "buffer": "^5.6.0",
                 "varint": "^5.0.0"
@@ -2515,14 +2479,12 @@
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "ipld-dag-cbor": {
           "version": "0.15.3",
           "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.3.tgz",
           "integrity": "sha512-m23nG7ZyoVFnkK55/bLAErc7EfiMgaEQlqHWDTGzPI+O5r6bPfp+qbL5zTVSIT8tpbHmu174dwerVtLoVgeVyA==",
-          "dev": true,
           "requires": {
             "borc": "^2.1.2",
             "buffer": "^5.5.0",
@@ -2535,14 +2497,12 @@
         "iso-url": {
           "version": "0.4.7",
           "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-          "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
-          "dev": true
+          "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
         },
         "multibase": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
           "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
           "requires": {
             "base-x": "^3.0.8",
             "buffer": "^5.5.0"
@@ -2552,7 +2512,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
           "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
           "requires": {
             "buffer": "^5.6.0",
             "multibase": "^1.0.1",
@@ -2951,14 +2910,12 @@
     "base32-decode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base32-decode/-/base32-decode-1.0.0.tgz",
-      "integrity": "sha512-KNWUX/R7wKenwE/G/qFMzGScOgVntOmbE27vvc6GrniDGYb6a5+qWcuoXl8WIOQL7q0TpK7nZDm1Y04Yi3Yn5g==",
-      "dev": true
+      "integrity": "sha512-KNWUX/R7wKenwE/G/qFMzGScOgVntOmbE27vvc6GrniDGYb6a5+qWcuoXl8WIOQL7q0TpK7nZDm1Y04Yi3Yn5g=="
     },
     "base32-encode": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.1.1.tgz",
-      "integrity": "sha512-eqa0BeGghj3guezlasdHJhr3+J5ZbbQvxeprkcDMbRQrjlqOT832IUDT4Al4ofAwekFYMqkkM9KMUHs9Cu0HKA==",
-      "dev": true
+      "integrity": "sha512-eqa0BeGghj3guezlasdHJhr3+J5ZbbQvxeprkcDMbRQrjlqOT832IUDT4Al4ofAwekFYMqkkM9KMUHs9Cu0HKA=="
     },
     "base64-js": {
       "version": "1.3.1",
@@ -2991,7 +2948,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -3000,7 +2956,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.5.tgz",
       "integrity": "sha512-zVY4VvJV+b2fS0/dcap/5XLlpqtgwyN8oRkuGgAS1uLOeEp0Yo6Tw2yUTozTtlrMJO3G8n4g/KX/XGFHW6Pq3g==",
-      "dev": true,
       "requires": {
         "@types/node": "10.12.18",
         "bs58check": "^2.1.1",
@@ -3014,8 +2969,7 @@
         "@types/node": {
           "version": "10.12.18",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-          "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
-          "dev": true
+          "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
         }
       }
     },
@@ -3023,7 +2977,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
       "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
-      "dev": true,
       "requires": {
         "@types/node": "11.11.6",
         "create-hash": "^1.1.0",
@@ -3034,16 +2987,14 @@
         "@types/node": {
           "version": "11.11.6",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==",
-          "dev": true
+          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
         }
       }
     },
     "blakejs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U=",
-      "dev": true
+      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -3188,7 +3139,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
       "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "dev": true,
       "requires": {
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
@@ -3208,7 +3158,6 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
       "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
-      "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -3345,7 +3294,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -3559,7 +3507,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -3572,7 +3519,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -3853,7 +3799,6 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
       "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-      "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -3887,8 +3832,7 @@
     "err-code": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
-      "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw==",
-      "dev": true
+      "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -4417,8 +4361,7 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -4778,7 +4721,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -4788,8 +4730,7 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
@@ -5022,8 +4963,7 @@
     "is-circular": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
-      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA==",
-      "dev": true
+      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -6693,12 +6633,12 @@
       }
     },
     "key-did-provider-ed25519": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/key-did-provider-ed25519/-/key-did-provider-ed25519-0.1.1.tgz",
-      "integrity": "sha512-KtjoTDcX8JaukEu753C9Am8LIqwXb8hvGFmnwUnsvGwau/9L/eRhgXmA7Y9kMEWPzMWJ4qvf852WkSfbqWgjpA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/key-did-provider-ed25519/-/key-did-provider-ed25519-1.0.0.tgz",
+      "integrity": "sha512-EBjhh+Rnyzfpb8GAUgILq8AflDaPmS6eE3vQTtHZgIKJ7wd4p3wSLEZr0QE2AY3h/1KDNbAM3v9IZgZd57urfg==",
       "requires": {
         "@stablelib/ed25519": "^1.0.1",
-        "did-jwt": "^4.6.2",
+        "did-jwt": "^4.6.3",
         "fast-json-stable-stringify": "^2.1.0",
         "rpc-utils": "^0.1.3",
         "uint8arrays": "^1.1.0"
@@ -6830,7 +6770,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -6974,7 +6913,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.0.tgz",
       "integrity": "sha512-CBiLdYcMnVnkN/2kL4AaUH3betYXQGKV5CCmN2CfgHUt5xROtsj91w780ltX6Wy7frgc6en8md3h2UQl6jDXAg==",
-      "dev": true,
       "requires": {
         "varint": "^5.0.0"
       }
@@ -7005,7 +6943,6 @@
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.15.tgz",
       "integrity": "sha512-G/Smj1GWqw1RQP3dRuRRPe3oyLqvPqUaEDIaoi7JF7Loxl4WAWvhJNk84oyDEodSucv0MmSW/ZT0RKUrsIFD3g==",
-      "dev": true,
       "requires": {
         "bs58": "^4.0.1",
         "varint": "^5.0.0"
@@ -7015,7 +6952,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.0.tgz",
       "integrity": "sha512-t0iDSl1kkI65vaKmv9/bBM9/E/ogywB18+A9hI7QzcQjolue1tcaNWKdoFuniF6QQtNOJFplO4nQtLfQeK3lLw==",
-      "dev": true,
       "requires": {
         "blakejs": "^1.1.0",
         "buffer": "^5.4.3",
@@ -7028,8 +6964,7 @@
     "murmurhash3js-revisited": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
-      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==",
-      "dev": true
+      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -7040,13 +6975,12 @@
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "dev": true
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nanoid": {
-      "version": "3.1.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.16.tgz",
-      "integrity": "sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w=="
+      "version": "3.1.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.18.tgz",
+      "integrity": "sha512-rndlDjbbHbcV3xi+R2fpJ+PbGMdfBxz5v1fATIQFq0DP64FsicQdwnKLy47K4kZHdRpmQXtz24eGsxQqamzYTA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -7087,8 +7021,7 @@
     "node-addon-api": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
-      "dev": true
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -7392,7 +7325,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
       "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
-      "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -7610,7 +7542,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -7922,7 +7853,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -8133,7 +8063,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
       "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-      "dev": true,
       "requires": {
         "elliptic": "^6.5.2",
         "node-addon-api": "^2.0.0",
@@ -8143,8 +8072,7 @@
         "node-gyp-build": {
           "version": "4.2.3",
           "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-          "dev": true
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
         }
       }
     },
@@ -8244,7 +8172,6 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -8792,7 +8719,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
       "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
-      "dev": true,
       "requires": {
         "bindings": "^1.3.0",
         "bn.js": "^4.11.8",
@@ -8974,8 +8900,7 @@
     "typeforce": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
-      "dev": true
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "uint8arrays": {
       "version": "1.1.0",
@@ -9260,7 +9185,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
       "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
-      "dev": true,
       "requires": {
         "bs58check": "<3.0.0"
       }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
     "express": "^4.17.1",
     "ipfs": "^0.52.1",
     "ipfs-http-client": "^48.1.1",
-    "key-did-provider-ed25519": "^0.1.1",
+    "key-did-provider-ed25519": "^1.0.0",
     "multiformats": "^3.0.3",
     "uint8arrays": "^1.1.0"
   },

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,25 +1,9 @@
 {
-	"name": "@ceramicnetwork/ceramic-common",
+	"name": "@ceramicnetwork/common",
 	"version": "0.13.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"3id-blockchain-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/3id-blockchain-utils/-/3id-blockchain-utils-1.1.0.tgz",
-			"integrity": "sha512-urCL2tMFaQotcMP6k47nFG+tpUqZt4/0Mo7gnSEDlekurTwkCl2I8xLG+Ay8GWLCD9qU3bwdpKrp2LmFEuNgQQ==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.9.2",
-				"@ethersproject/contracts": "^5.0.1",
-				"@ethersproject/providers": "^5.0.4",
-				"@ethersproject/wallet": "^5.0.1",
-				"@zondax/filecoin-signing-tools": "^0.12.0",
-				"caip": "^0.9.2",
-				"js-sha256": "^0.9.0",
-				"uint8arrays": "^1.1.0"
-			}
-		},
 		"@apidevtools/json-schema-ref-parser": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.5.tgz",
@@ -1102,139 +1086,6 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"@ceramicnetwork/ceramic-common": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-common/-/ceramic-common-0.12.1.tgz",
-			"integrity": "sha512-+jPFAwBy9w95MChZtZHzEGD5uoRkCbDBjPua+UVJRdY8GYqgrRASw169HouvhdNaGEcZoK6TeGfPe0UbMKjwPg==",
-			"dev": true,
-			"requires": {
-				"@ceramicnetwork/docid": "^0.2.0",
-				"cids": "^1.0.0",
-				"dag-jose": "^0.3.0",
-				"did-resolver": "^2.1.1",
-				"lodash.clonedeep": "^4.5.0",
-				"loglevel": "^1.7.0",
-				"loglevel-plugin-prefix": "^0.8.4",
-				"uint8arrays": "^1.1.0"
-			}
-		},
-		"@ceramicnetwork/ceramic-doctype-account-link": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-account-link/-/ceramic-doctype-account-link-0.10.1.tgz",
-			"integrity": "sha512-UZDK28fiui/qTfnLApljNc+KCHZnOK1UVAWHVzxmZH75fpAxNg8rzK3qN0lhluDRyFVN7IgTvvY7GNmJ7XBDhw==",
-			"dev": true,
-			"requires": {
-				"3id-blockchain-utils": "^1.0.0",
-				"@ceramicnetwork/ceramic-common": "^0.12.1",
-				"@types/lodash.clonedeep": "^4.5.6",
-				"cids": "^1.0.0",
-				"did-resolver": "^2.1.1"
-			}
-		},
-		"@ceramicnetwork/ceramic-doctype-tile": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-tile/-/ceramic-doctype-tile-0.10.1.tgz",
-			"integrity": "sha512-eT2L5wFzI3TUyrOmgmSLeY4ew8mhFC+MFHkLL5kV0G6gAPf7bDyhSx6FRhCgtlDNDmP9Ftmjlu+WHRs2Vsfaug==",
-			"dev": true,
-			"requires": {
-				"3id-blockchain-utils": "^1.0.0",
-				"@ceramicnetwork/ceramic-common": "^0.12.1",
-				"@ceramicnetwork/key-did-resolver": "^0.1.2",
-				"@ethersproject/base64": "^5.0.2",
-				"@ethersproject/random": "^5.0.2",
-				"@types/lodash.clonedeep": "^4.5.6",
-				"base64url": "^3.0.1",
-				"cids": "^1.0.0",
-				"did-jwt": "^4.0.0",
-				"did-resolver": "^2.1.1",
-				"dids": "^0.7.0",
-				"fast-json-patch": "^2.2.1",
-				"fast-json-stable-stringify": "^2.1.0"
-			}
-		},
-		"@ceramicnetwork/ceramic-http-client": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-http-client/-/ceramic-http-client-0.7.2.tgz",
-			"integrity": "sha512-OitYQ7dONEV01grIe1tWqV2emWKSnDiIU/KNyT+MYwa1al4taODxw/DXAj5LPI8LIiByah3Cvabe55WZ4yS1+g==",
-			"dev": true,
-			"requires": {
-				"@ceramicnetwork/ceramic-common": "^0.12.1",
-				"@ceramicnetwork/ceramic-doctype-account-link": "^0.10.1",
-				"@ceramicnetwork/ceramic-doctype-tile": "^0.10.1",
-				"@ceramicnetwork/docid": "^0.2.0",
-				"cids": "^1.0.0",
-				"cross-fetch": "^3.0.5",
-				"dids": "^0.7.0",
-				"lodash.clonedeep": "^4.5.0"
-			}
-		},
-		"@ceramicnetwork/docid": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/docid/-/docid-0.2.0.tgz",
-			"integrity": "sha512-s4YXOFM7CNSYGkfnts9XB6EOmp37uPnc7Q2hF3M5SZDNQhtDzYpuCdY30CFNJ291JOfMlfLQovQv4+k7ytkE6A==",
-			"requires": {
-				"cids": "^1.0.0",
-				"multibase": "^3.0.1",
-				"varint": "^6.0.0"
-			},
-			"dependencies": {
-				"multibase": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
-					"integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
-					"requires": {
-						"@multiformats/base-x": "^4.0.1",
-						"web-encoding": "^1.0.2"
-					}
-				},
-				"varint": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-					"integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-				}
-			}
-		},
-		"@ceramicnetwork/key-did-resolver": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/key-did-resolver/-/key-did-resolver-0.1.2.tgz",
-			"integrity": "sha512-FUPiJTQ4mSnieqoafL0Bt0gT+wMBscW198zCAz/AX9UEejgfvfQNdKYEph9vclsJ+obAvwJQfq4aZq40oH/b0w==",
-			"dev": true,
-			"requires": {
-				"multibase": "^3.0.1",
-				"uint8arrays": "^1.1.0",
-				"varint": "^6.0.0"
-			},
-			"dependencies": {
-				"multibase": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.0.tgz",
-					"integrity": "sha512-Z+pThrpbS7ckQ2DwW5mPiwCGe1a94f8DWi/OxmbyeRednVOyUKmLSE+60kL/WHFYwWnaD1OakXGk3PYI1NkMFw==",
-					"dev": true,
-					"requires": {
-						"@multiformats/base-x": "^4.0.1",
-						"web-encoding": "^1.0.4"
-					}
-				},
-				"varint": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-					"integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
-					"dev": true
-				},
-				"web-encoding": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.4.tgz",
-					"integrity": "sha512-DcXs2lbVPzuJmn2kuDEwul2oZg7p4YMa5J2f0YzsOBHaAnBYGPNUB/rJ74DTjTKpw7F0+lSsVM8sFHE2UyBixg==",
-					"dev": true
-				}
-			}
-		},
-		"@ceramicstudio/idx-constants": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@ceramicstudio/idx-constants/-/idx-constants-0.3.0.tgz",
-			"integrity": "sha512-cu/bqvrr0CIzUXWDs7qY1rFWYZWdRDm7/EPMwfWmaa6y9ASdR4/A1OhIptlZ3XKKcE9JZovmMdOegVvbWmj/sw==",
-			"dev": true
-		},
 		"@cnakazawa/watch": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -1243,405 +1094,6 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
-			}
-		},
-		"@ethersproject/abi": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.8.tgz",
-			"integrity": "sha512-QiWzNybzepEmFfwxqEOoUm9i8G5fBuxMiiMcyUwXqywKtktbhNHpUbfOapMkEvPB8VgefzaUf1vHDSqC2Dc8Eg==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/address": "^5.0.4",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.4",
-				"@ethersproject/hash": "^5.0.4",
-				"@ethersproject/keccak256": "^5.0.3",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/strings": "^5.0.4"
-			}
-		},
-		"@ethersproject/abstract-provider": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.6.tgz",
-			"integrity": "sha512-3GJjD+wM8J160XFiTMkDu1UFV9uA1OdbMUI0aYy1CFepxYGSh9vY12bsbiYiTJLXQ86usvSBK6OA9U7IqmKZVw==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/networks": "^5.0.3",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/transactions": "^5.0.5",
-				"@ethersproject/web": "^5.0.6"
-			}
-		},
-		"@ethersproject/abstract-signer": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.8.tgz",
-			"integrity": "sha512-Q5ZJtxs5txKBfTbdXRI4n6Nn4EJlKg3zA22S4Eg+P3hIZ+cXoLoK9CnA1GeKMRHJiDBqECnWqeQl+yyGR7D+jg==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.4",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3"
-			}
-		},
-		"@ethersproject/address": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.7.tgz",
-			"integrity": "sha512-+63DiYG+2og6rFNvQmLlLw8i5LtyT65n+jtHd06Ic81rLHc+JUKRpeZFhBa+gqh9f+P8V0xtKR5NI/EHXOfgSw==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bignumber": "^5.0.10",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/keccak256": "^5.0.3",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/rlp": "^5.0.3"
-			}
-		},
-		"@ethersproject/base64": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.5.tgz",
-			"integrity": "sha512-4GJ9InM+zDDiiejPG/TrNGXVgD8D4BClEfJ3w45+ufyFA7QDT3gkAy+SdmmQCGAEBB+79MmXMLFq7TNtDM2DaA==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4"
-			}
-		},
-		"@ethersproject/basex": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.5.tgz",
-			"integrity": "sha512-Echs7nWq1K/HqDaxnT0nJ2Qe5uXH5v/L6AdKVlH+FQ0FrRAMl0XgWoWECsYo9lt16/Pk4wiMksLvVEW8djluEg==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/properties": "^5.0.3"
-			}
-		},
-		"@ethersproject/bignumber": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.10.tgz",
-			"integrity": "sha512-1b3bMe+PCjx6xI5IINzaWtNZEKtwq2guVrhuwRqQmHEsAgKDK+UMckXYsu0CwMwRsQoeq+sNuCWd64pCxkBqMw==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"bn.js": "^4.4.0"
-			}
-		},
-		"@ethersproject/bytes": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.6.tgz",
-			"integrity": "sha512-axEmVeVy5IS0Sg46fNk4mygMm96uGd/15b6zmMu53w0NpHmOC/GYfpqMBHYxavjFYN+LUL7vVwgpbIFYGO2QHA==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/logger": "^5.0.5"
-			}
-		},
-		"@ethersproject/constants": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.6.tgz",
-			"integrity": "sha512-ioBMaUsVb2+C8UVAHUpfrrkNtFEcAYNaZSf79Lw7VhjFRY5f1ImWGqSZhJb4/wKxaw0RIYLW7ZriDgcx2YMwWA==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bignumber": "^5.0.7"
-			}
-		},
-		"@ethersproject/contracts": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.7.tgz",
-			"integrity": "sha512-JFk+2yckhQQg6poCS2FQHtUnPpwE+U3MuoMV6pAyYXLidrQ7h2OU4nqJ/evO0Lo42oUtVc4vWn+1Nv5dDF8kKg==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/abi": "^5.0.5",
-				"@ethersproject/abstract-provider": "^5.0.4",
-				"@ethersproject/abstract-signer": "^5.0.4",
-				"@ethersproject/address": "^5.0.4",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3"
-			}
-		},
-		"@ethersproject/hash": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.7.tgz",
-			"integrity": "sha512-vYuRJRTAGHcYqQFAxxCgDpJtJv4aGC5TQm5NDZat/55BeLGLmH90ftJG1ldv7MhzGRxBPJtpqSHzJDizB6VKoA==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.6",
-				"@ethersproject/address": "^5.0.5",
-				"@ethersproject/bignumber": "^5.0.8",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/keccak256": "^5.0.3",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.4",
-				"@ethersproject/strings": "^5.0.4"
-			}
-		},
-		"@ethersproject/hdnode": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.6.tgz",
-			"integrity": "sha512-cS2xZJZP7Tsaz695U0G3gdTYZatmSjHWY/VQGVc/E1DnLSBz0ZfQaikhU5uzDNLYaOfcEKd7helezrsfU2xguw==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.4",
-				"@ethersproject/basex": "^5.0.3",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/pbkdf2": "^5.0.3",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/sha2": "^5.0.3",
-				"@ethersproject/signing-key": "^5.0.4",
-				"@ethersproject/strings": "^5.0.4",
-				"@ethersproject/transactions": "^5.0.5",
-				"@ethersproject/wordlists": "^5.0.4"
-			}
-		},
-		"@ethersproject/json-wallets": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.8.tgz",
-			"integrity": "sha512-henOyQpUTfjI7JLCnEgMR+FYrj2VcGgLNjDSUmhOlGWagrvB9LPH/7MJaXr+GxBuPIRe8pkrD0hjIDD+PMMAZA==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.4",
-				"@ethersproject/address": "^5.0.4",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/hdnode": "^5.0.4",
-				"@ethersproject/keccak256": "^5.0.3",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/pbkdf2": "^5.0.3",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/random": "^5.0.3",
-				"@ethersproject/strings": "^5.0.4",
-				"@ethersproject/transactions": "^5.0.5",
-				"aes-js": "3.0.0",
-				"scrypt-js": "3.0.1"
-			}
-		},
-		"@ethersproject/keccak256": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.5.tgz",
-			"integrity": "sha512-9hXXp113jW5yPf27krofmnZ26u5SXsmuvrMTUuXyVdIDIJDLGorVyB2bBiWwENVok92E4WDnfAZHG+A+E6TCMQ==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"js-sha3": "0.5.7"
-			},
-			"dependencies": {
-				"js-sha3": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-					"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-					"dev": true
-				}
-			}
-		},
-		"@ethersproject/logger": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.7.tgz",
-			"integrity": "sha512-1wl+kDTPdDptpQdrkTmImubygUf0mVeo0I/p8d21qdzT16h/GnoJWt7q6Kt0xvTfcI7Jv4kryskxI2xV++w5Hg==",
-			"dev": true
-		},
-		"@ethersproject/networks": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.5.tgz",
-			"integrity": "sha512-DEcGEoRPtpbM+no9JmpwdCVVQELqYhP42BKArLsqps6nIEqOInWnjfpXfEss+nTrBp3zDrL4KNfOe7mS96C/mQ==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/logger": "^5.0.5"
-			}
-		},
-		"@ethersproject/pbkdf2": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.5.tgz",
-			"integrity": "sha512-cIi1idxnAE0mN0BqVAZ3/QDfAtl6fY2uvHgzjKmUwKt0+DR5Vsmo9vomSXxMm3zcoh4MyaPSc5XvU5GkPpOXKg==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/sha2": "^5.0.3"
-			}
-		},
-		"@ethersproject/properties": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.5.tgz",
-			"integrity": "sha512-2HwajwTUwlrOsiLVyyxiS4oP0a4xBNi1i90/kDJESmtlDmf2DkrY6qjBssa9YnWoEH34N/ZpLFVndimIrlo8kg==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/logger": "^5.0.5"
-			}
-		},
-		"@ethersproject/providers": {
-			"version": "5.0.15",
-			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.15.tgz",
-			"integrity": "sha512-9SrJkIQiqq9tDHQhUG6rKG0YApra0ByVINSJq8A33JvBhYlyYsFXofdy8S2FzzZRXwNAo90f44q+Pfi9stiB6A==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.4",
-				"@ethersproject/abstract-signer": "^5.0.4",
-				"@ethersproject/address": "^5.0.4",
-				"@ethersproject/basex": "^5.0.3",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.4",
-				"@ethersproject/hash": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/networks": "^5.0.3",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/random": "^5.0.3",
-				"@ethersproject/rlp": "^5.0.3",
-				"@ethersproject/sha2": "^5.0.3",
-				"@ethersproject/strings": "^5.0.4",
-				"@ethersproject/transactions": "^5.0.5",
-				"@ethersproject/web": "^5.0.6",
-				"bech32": "1.1.4",
-				"ws": "7.2.3"
-			},
-			"dependencies": {
-				"ws": {
-					"version": "7.2.3",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-					"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
-					"dev": true
-				}
-			}
-		},
-		"@ethersproject/random": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.5.tgz",
-			"integrity": "sha512-MZU+W03FVEKeiKb9w/guTMiBa17Wub6mTNeVLQk8Nte/7onXt8iRgdPGoXquXhyM6lqL8PsxeunFYYa6azr0rA==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5"
-			}
-		},
-		"@ethersproject/rlp": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.5.tgz",
-			"integrity": "sha512-RAUhk5+VH2UquTawgf7eK1i4Qbbzt0Ky6M27Q9JniRx0SBqmTkbKx/iXRZN/0x9vqQJhT596Z3vVevhqSa+GPQ==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5"
-			}
-		},
-		"@ethersproject/sha2": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.5.tgz",
-			"integrity": "sha512-DbBlEtWc6ssQbbN61Jc5XOYcXPkkPr3lPAj+v4kqZ5MIJN2mHk8B9+oCoArp/uDqFXuJlpSze19p/kdSDOljKQ==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"hash.js": "1.1.3"
-			},
-			"dependencies": {
-				"hash.js": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-					"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"minimalistic-assert": "^1.0.0"
-					}
-				}
-			}
-		},
-		"@ethersproject/signing-key": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.6.tgz",
-			"integrity": "sha512-KjyePQsh+L6BwmPWD5JoXCrRGjNfYSD5YeXQhy6YWQeMAfG0+WMG7U2SKzl+DWM+8/Ymat3s6o3U2GLXhGrcMg==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3",
-				"elliptic": "6.5.3"
-			}
-		},
-		"@ethersproject/strings": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.6.tgz",
-			"integrity": "sha512-eJf0TKk/X2MvR3OSaOsS4XhKkWTi4p7YrZp2P1DaiTP+xsxizMYI1Ds5VUB4DH4RIseUe4Sbf6eN2dfG+fhW2w==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5"
-			}
-		},
-		"@ethersproject/transactions": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.7.tgz",
-			"integrity": "sha512-U7dyBMQ73lHUoAnp3fdcfhgvJwcow88b0/q7Fl6Id21/Ll7Dxe7qrWjR6pH6XTKV+h2a74o/pJS7CxNiwahaHw==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/address": "^5.0.4",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.4",
-				"@ethersproject/keccak256": "^5.0.3",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/rlp": "^5.0.3",
-				"@ethersproject/signing-key": "^5.0.4"
-			}
-		},
-		"@ethersproject/wallet": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.8.tgz",
-			"integrity": "sha512-sraAhJPuuvcfqh/Af1nkQzyozUb9yyQGtNEwcDgU4bzIoltnFpr3CzPoXN6QIxh/bKCYq2LG5++Jui2hjIIPuw==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.4",
-				"@ethersproject/abstract-signer": "^5.0.4",
-				"@ethersproject/address": "^5.0.4",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/hash": "^5.0.4",
-				"@ethersproject/hdnode": "^5.0.4",
-				"@ethersproject/json-wallets": "^5.0.6",
-				"@ethersproject/keccak256": "^5.0.3",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/random": "^5.0.3",
-				"@ethersproject/signing-key": "^5.0.4",
-				"@ethersproject/transactions": "^5.0.5",
-				"@ethersproject/wordlists": "^5.0.4"
-			}
-		},
-		"@ethersproject/web": {
-			"version": "5.0.10",
-			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.10.tgz",
-			"integrity": "sha512-j49TbzUJBggILUuZahNXG59ugktjfCJyJfNhmC068DwIG0k+ygYK2BV1CWP3uuh7H2DHZ6LMLC+IsWWKb8MDlA==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/base64": "^5.0.3",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/strings": "^5.0.4"
-			}
-		},
-		"@ethersproject/wordlists": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.6.tgz",
-			"integrity": "sha512-dEs2DW+YcX/2y5zpAf9KF72zOtzlPbjG80LQlwX/YXoFH8eJpvaQyXJUHceeJhJBw8B6bgF6Ps9jW7VuGPrf6Q==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/hash": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@istanbuljs/load-nyc-config": {
@@ -2372,12 +1824,6 @@
 				"@stablelib/wipe": "^1.0.0"
 			}
 		},
-		"@stablelib/utf8": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.0.tgz",
-			"integrity": "sha512-Y8QWrK4T0yW0HMFfSI3ZaMHKV37q27hX5ilsmKV358x01mzYfj5fwIf2LjzTlF+UIemHEXSlSN9XJnv1ML4znQ==",
-			"dev": true
-		},
 		"@stablelib/wipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
@@ -2746,103 +2192,6 @@
 				}
 			}
 		},
-		"@zondax/filecoin-signing-tools": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@zondax/filecoin-signing-tools/-/filecoin-signing-tools-0.12.0.tgz",
-			"integrity": "sha512-f/HTnXBRNiUQgpfYwMncMqh0+pcAr9jeOKgMcbxyFAv5MBdE6UkRjFNaMkmosmh7JZcDET/dfVTN/RovvFy9aA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"base32-decode": "^1.0.0",
-				"base32-encode": "^1.1.1",
-				"bip32": "^2.0.5",
-				"bip39": "^3.0.2",
-				"blakejs": "^1.1.0",
-				"ipld-dag-cbor": "^0.15.3",
-				"leb128": "0.0.5",
-				"secp256k1": "^4.0.1"
-			},
-			"dependencies": {
-				"cids": {
-					"version": "0.8.3",
-					"resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-					"integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"buffer": "^5.6.0",
-						"class-is": "^1.1.0",
-						"multibase": "^1.0.0",
-						"multicodec": "^1.0.1",
-						"multihashes": "^1.0.1"
-					}
-				},
-				"ipld-dag-cbor": {
-					"version": "0.15.3",
-					"resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.3.tgz",
-					"integrity": "sha512-m23nG7ZyoVFnkK55/bLAErc7EfiMgaEQlqHWDTGzPI+O5r6bPfp+qbL5zTVSIT8tpbHmu174dwerVtLoVgeVyA==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"borc": "^2.1.2",
-						"buffer": "^5.5.0",
-						"cids": "~0.8.0",
-						"is-circular": "^1.0.2",
-						"multicodec": "^1.0.0",
-						"multihashing-async": "~0.8.0"
-					}
-				},
-				"multibase": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-					"integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"base-x": "^3.0.8",
-						"buffer": "^5.5.0"
-					}
-				},
-				"multicodec": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-					"integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"buffer": "^5.6.0",
-						"varint": "^5.0.0"
-					}
-				},
-				"multihashes": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-					"integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"buffer": "^5.6.0",
-						"multibase": "^1.0.1",
-						"varint": "^5.0.0"
-					}
-				},
-				"multihashing-async": {
-					"version": "0.8.2",
-					"resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
-					"integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"blakejs": "^1.1.0",
-						"buffer": "^5.4.3",
-						"err-code": "^2.0.0",
-						"js-sha3": "^0.8.0",
-						"multihashes": "^1.0.1",
-						"murmurhash3js-revisited": "^3.0.0"
-					}
-				}
-			}
-		},
 		"abab": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
@@ -2883,12 +2232,6 @@
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
 			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
-			"dev": true
-		},
-		"aes-js": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
 			"dev": true
 		},
 		"ajv": {
@@ -3252,30 +2595,10 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"base32-decode": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/base32-decode/-/base32-decode-1.0.0.tgz",
-			"integrity": "sha512-KNWUX/R7wKenwE/G/qFMzGScOgVntOmbE27vvc6GrniDGYb6a5+qWcuoXl8WIOQL7q0TpK7nZDm1Y04Yi3Yn5g==",
-			"dev": true,
-			"optional": true
-		},
-		"base32-encode": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.1.1.tgz",
-			"integrity": "sha512-eqa0BeGghj3guezlasdHJhr3+J5ZbbQvxeprkcDMbRQrjlqOT832IUDT4Al4ofAwekFYMqkkM9KMUHs9Cu0HKA==",
-			"dev": true,
-			"optional": true
-		},
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-		},
-		"base64url": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-			"integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
-			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -3294,73 +2617,10 @@
 				}
 			}
 		},
-		"bech32": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-			"dev": true
-		},
 		"bignumber.js": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
 			"integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
-		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bip32": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.6.tgz",
-			"integrity": "sha512-HpV5OMLLGTjSVblmrtYRfFFKuQB+GArM0+XP8HGWfJ5vxYBqo+DesvJwOdC2WJ3bCkZShGf0QIfoIpeomVzVdA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"@types/node": "10.12.18",
-				"bs58check": "^2.1.1",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"tiny-secp256k1": "^1.1.3",
-				"typeforce": "^1.11.5",
-				"wif": "^2.0.6"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "10.12.18",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-					"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
-		"bip39": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.3.tgz",
-			"integrity": "sha512-P0dKrz4g0V0BjXfx7d9QNkJ/Txcz/k+hM9TnjqjUaXtuOfAvxXSw2rJw8DX0e3ZPwnK/IgDxoRqf0bvoVCqbMg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"@types/node": "11.11.6",
-				"create-hash": "^1.1.0",
-				"pbkdf2": "^3.0.9",
-				"randombytes": "^2.0.1"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "11.11.6",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-					"integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==",
-					"dev": true,
-					"optional": true
-				}
-			}
 		},
 		"blakejs": {
 			"version": "1.1.0",
@@ -3448,28 +2708,6 @@
 				"pkg-up": "^2.0.0"
 			}
 		},
-		"bs58": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"base-x": "^3.0.2"
-			}
-		},
-		"bs58check": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"bs58": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"safe-buffer": "^5.1.2"
-			}
-		},
 		"bser": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -3494,16 +2732,6 @@
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
 		},
-		"buffer-pipe": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.3.tgz",
-			"integrity": "sha512-GlxfuD/NrKvCNs0Ut+7b1IHjylfdegMBxQIlZHj7bObKVQBxB5S84gtm2yu1mQ8/sSggceWBDPY0cPXgvX2MuA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"safe-buffer": "^5.1.2"
-			}
-		},
 		"cache-base": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -3520,12 +2748,6 @@
 				"union-value": "^1.0.0",
 				"unset-value": "^1.0.0"
 			}
-		},
-		"caip": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/caip/-/caip-0.9.2.tgz",
-			"integrity": "sha512-o4aIUSR9lkn7B9lIw8Xgkj+hDh+S1PtsBphoSqP2Dt95gRWPniaqEpnPwiUEhaPQr84JzWIEm4Cck3lMZtIkTA==",
-			"dev": true
 		},
 		"call-me-maybe": {
 			"version": "1.0.1",
@@ -3599,17 +2821,6 @@
 						"web-encoding": "^1.0.2"
 					}
 				}
-			}
-		},
-		"cipher-base": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"class-is": {
@@ -3800,44 +3011,6 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
-		},
-		"create-hash": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"md5.js": "^1.3.4",
-				"ripemd160": "^2.0.1",
-				"sha.js": "^2.4.0"
-			}
-		},
-		"create-hmac": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"cipher-base": "^1.0.3",
-				"create-hash": "^1.1.0",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
-		},
-		"cross-fetch": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-			"integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
-			"dev": true,
-			"requires": {
-				"node-fetch": "2.6.1"
-			}
 		},
 		"cross-spawn": {
 			"version": "6.0.5",
@@ -4048,16 +3221,15 @@
 			"dev": true
 		},
 		"did-jwt": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-4.6.2.tgz",
-			"integrity": "sha512-T77RnUjhhEvwusQ8gxaMqGekyYjpgaZoq6HM3zEkVH7LA5otasqa5XZpbsxeaGgyT7e9sXeofNNzBWvSZM3G2g==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-4.7.0.tgz",
+			"integrity": "sha512-tkiZk4gukBAtnhqooBSBW0XYrjXIxEhk/bIHvr6VIwilFL9gQrceJOuJqZuE8s5/UbiUClINv6nOJ+DGPio0DQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.11.2",
 				"@stablelib/ed25519": "^1.0.1",
 				"@stablelib/random": "^1.0.0",
 				"@stablelib/sha256": "^1.0.0",
-				"@stablelib/utf8": "^1.0.0",
 				"@stablelib/x25519": "^1.0.0",
 				"@stablelib/xchacha20poly1305": "^1.0.0",
 				"did-resolver": "^2.1.1",
@@ -4067,9 +3239,9 @@
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
-					"integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
+					"version": "7.12.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+					"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
 					"dev": true,
 					"requires": {
 						"regenerator-runtime": "^0.13.4"
@@ -4083,14 +3255,15 @@
 			"integrity": "sha512-FYLTkNWofjYNDGV1HTQlyVu1OqZiFxR4I8KM+oxGVOkbXva15NfWzbzciqdXUDqOhe6so5aroAdrVip6gSAYSA=="
 		},
 		"dids": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/dids/-/dids-0.7.0.tgz",
-			"integrity": "sha512-v0KQBE0UoB15n8cDZ5uxdTpadm3LnICP7RkpHIZ79zoDfB8/yPneeu7Xnvzd3PSfkHRnoOWkuJtQ8IoVC37OMA==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dids/-/dids-1.0.0.tgz",
+			"integrity": "sha512-z9bjdMmf3xzDymRQJvX8L1RYIKiz+NRSoewu3EXM9aZ/fNncUBEyYnZnJN6NSpN0SbLSElgiPjxVucAGskRIcQ==",
 			"dev": true,
 			"requires": {
+				"@stablelib/random": "^1.0.0",
 				"cids": "^1.0.0",
 				"dag-jose-utils": "^0.1.0",
-				"did-jwt": "^4.6.2",
+				"did-jwt": "^4.6.3",
 				"did-resolver": "^2.1.1",
 				"rpc-utils": "^0.1.3",
 				"uint8arrays": "^1.1.0"
@@ -4763,23 +3936,6 @@
 				"picomatch": "^2.2.1"
 			}
 		},
-		"fast-json-patch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-			"integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
-			"dev": true,
-			"requires": {
-				"fast-deep-equal": "^2.0.1"
-			},
-			"dependencies": {
-				"fast-deep-equal": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-					"dev": true
-				}
-			}
-		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4827,13 +3983,6 @@
 			"requires": {
 				"flat-cache": "^2.0.1"
 			}
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true,
-			"optional": true
 		},
 		"fill-range": {
 			"version": "7.0.1",
@@ -5102,27 +4251,6 @@
 				}
 			}
 		},
-		"hash-base": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.6.0",
-				"safe-buffer": "^5.2.0"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
 		"hash.js": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
@@ -5189,40 +4317,6 @@
 			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
-			}
-		},
-		"identity-wallet": {
-			"version": "2.0.0-alpha.20",
-			"resolved": "https://registry.npmjs.org/identity-wallet/-/identity-wallet-2.0.0-alpha.20.tgz",
-			"integrity": "sha512-JLOYY6GJMHIozC86aypYCBpKJ4QMhEPvyEtEFnuHRZvpLHS9LxsTVwF4D5OACPfbYGo+X9NiIUpTWqBZ60jaHQ==",
-			"dev": true,
-			"requires": {
-				"3id-blockchain-utils": "^1.0.0",
-				"@babel/runtime": "^7.12.1",
-				"@ceramicnetwork/ceramic-http-client": "^0.7.1",
-				"@ceramicstudio/idx-constants": "^0.3.0",
-				"@ethersproject/hdnode": "^5.0.5",
-				"@ethersproject/wallet": "^5.0.7",
-				"@stablelib/random": "^1.0.0",
-				"@stablelib/x25519": "^1.0.0",
-				"caip": "^0.9.2",
-				"dag-jose-utils": "^0.1.0",
-				"did-jwt": "^4.6.2",
-				"fast-json-stable-stringify": "^2.1.0",
-				"rpc-utils": "^0.1.2",
-				"store": "^2.0.12",
-				"uint8arrays": "^1.1.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-					"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"ieee754": {
@@ -7154,26 +6248,6 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
-		"leb128": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/leb128/-/leb128-0.0.5.tgz",
-			"integrity": "sha512-elbNtfmu3GndZbesVF6+iQAfVjOXW9bM/aax9WwMlABZW+oK9sbAZEXoewaPHmL34sxa8kVwWsru8cNE/yn2gg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"bn.js": "^5.0.0",
-				"buffer-pipe": "0.0.3"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "5.1.3",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-					"integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7320,18 +6394,6 @@
 			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
-			}
-		},
-		"md5.js": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
 			}
 		},
 		"memoizee": {
@@ -7532,17 +6594,10 @@
 				"thenify-all": "^1.0.0"
 			}
 		},
-		"nan": {
-			"version": "2.14.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-			"dev": true,
-			"optional": true
-		},
 		"nanoid": {
-			"version": "3.1.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.16.tgz",
-			"integrity": "sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==",
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.18.tgz",
+			"integrity": "sha512-rndlDjbbHbcV3xi+R2fpJ+PbGMdfBxz5v1fATIQFq0DP64FsicQdwnKLy47K4kZHdRpmQXtz24eGsxQqamzYTA==",
 			"dev": true
 		},
 		"nanomatch": {
@@ -7582,31 +6637,11 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
-		"node-addon-api": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
-			"dev": true,
-			"optional": true
-		},
 		"node-cleanup": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
 			"integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
 			"dev": true
-		},
-		"node-fetch": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-			"dev": true
-		},
-		"node-gyp-build": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-			"dev": true,
-			"optional": true
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -7917,20 +6952,6 @@
 				"through": "~2.3"
 			}
 		},
-		"pbkdf2": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
-			"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4",
-				"ripemd160": "^2.0.1",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
-		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -8142,16 +7163,6 @@
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
-		},
-		"randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"safe-buffer": "^5.1.0"
-			}
 		},
 		"react-is": {
 			"version": "16.13.1",
@@ -8521,17 +7532,6 @@
 				"glob": "^7.1.3"
 			}
 		},
-		"ripemd160": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
-			}
-		},
 		"rpc-utils": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/rpc-utils/-/rpc-utils-0.1.3.tgz",
@@ -8738,24 +7738,6 @@
 				"xmlchars": "^2.1.1"
 			}
 		},
-		"scrypt-js": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-			"dev": true
-		},
-		"secp256k1": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"elliptic": "^6.5.2",
-				"node-addon-api": "^2.0.0",
-				"node-gyp-build": "^4.2.0"
-			}
-		},
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -8789,17 +7771,6 @@
 						"is-extendable": "^0.1.0"
 					}
 				}
-			}
-		},
-		"sha.js": {
-			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
 			}
 		},
 		"shebang-command": {
@@ -9152,12 +8123,6 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
-		"store": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/store/-/store-2.0.12.tgz",
-			"integrity": "sha1-jFNOKguDH3K3X8XxEZhXxE711ZM=",
-			"dev": true
-		},
 		"stream-combiner": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
@@ -9398,20 +8363,6 @@
 				"next-tick": "1"
 			}
 		},
-		"tiny-secp256k1": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
-			"integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"bindings": "^1.3.0",
-				"bn.js": "^4.11.8",
-				"create-hmac": "^1.1.7",
-				"elliptic": "^6.4.0",
-				"nan": "^2.13.2"
-			}
-		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -9650,13 +8601,6 @@
 			"requires": {
 				"is-typedarray": "^1.0.0"
 			}
-		},
-		"typeforce": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-			"integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
-			"dev": true,
-			"optional": true
 		},
 		"typescript": {
 			"version": "3.9.7",
@@ -10053,16 +8997,6 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
-		},
-		"wif": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-			"integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"bs58check": "<3.0.0"
-			}
 		},
 		"word-wrap": {
 			"version": "1.2.3",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -50,7 +50,7 @@
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",
     "babel-jest": "^25.1.0",
-    "dids": "^0.8.0",
+    "dids": "^1.0.0",
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.8.2",
     "jest": "^25.1.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1339,58 +1339,6 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"@ceramicnetwork/docid": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/docid/-/docid-0.2.0.tgz",
-			"integrity": "sha512-s4YXOFM7CNSYGkfnts9XB6EOmp37uPnc7Q2hF3M5SZDNQhtDzYpuCdY30CFNJ291JOfMlfLQovQv4+k7ytkE6A==",
-			"requires": {
-				"cids": "^1.0.0",
-				"multibase": "^3.0.1",
-				"varint": "^6.0.0"
-			},
-			"dependencies": {
-				"multibase": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
-					"integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
-					"requires": {
-						"@multiformats/base-x": "^4.0.1",
-						"web-encoding": "^1.0.2"
-					}
-				},
-				"varint": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-					"integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-				}
-			}
-		},
-		"@ceramicnetwork/key-did-resolver": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/key-did-resolver/-/key-did-resolver-0.1.2.tgz",
-			"integrity": "sha512-FUPiJTQ4mSnieqoafL0Bt0gT+wMBscW198zCAz/AX9UEejgfvfQNdKYEph9vclsJ+obAvwJQfq4aZq40oH/b0w==",
-			"requires": {
-				"multibase": "^3.0.1",
-				"uint8arrays": "^1.1.0",
-				"varint": "^6.0.0"
-			},
-			"dependencies": {
-				"multibase": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
-					"integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
-					"requires": {
-						"@multiformats/base-x": "^4.0.1",
-						"web-encoding": "^1.0.2"
-					}
-				},
-				"varint": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-					"integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-				}
-			}
-		},
 		"@cnakazawa/watch": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -3518,35 +3466,33 @@
 			},
 			"dependencies": {
 				"multibase": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
-					"integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.0.tgz",
+					"integrity": "sha512-Z+pThrpbS7ckQ2DwW5mPiwCGe1a94f8DWi/OxmbyeRednVOyUKmLSE+60kL/WHFYwWnaD1OakXGk3PYI1NkMFw==",
 					"requires": {
 						"@multiformats/base-x": "^4.0.1",
-						"web-encoding": "^1.0.2"
+						"web-encoding": "^1.0.4"
 					}
 				},
 				"multihashes": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
-					"integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.1.0.tgz",
+					"integrity": "sha512-snU+w6aZy5bTrrqIHW3wkT0MfHmxcpOsaVNJt0NzUnseksbjFDVUZjSmhDMAVOVnIdLMS7xHjo55pKlBIGmC3g==",
 					"requires": {
-						"multibase": "^3.0.0",
+						"multibase": "^3.1.0",
 						"uint8arrays": "^1.0.0",
-						"varint": "^5.0.0"
-					},
-					"dependencies": {
-						"varint": {
-							"version": "5.0.2",
-							"resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-							"integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-						}
+						"varint": "^6.0.0"
 					}
 				},
 				"varint": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
 					"integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+				},
+				"web-encoding": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.4.tgz",
+					"integrity": "sha512-DcXs2lbVPzuJmn2kuDEwul2oZg7p4YMa5J2f0YzsOBHaAnBYGPNUB/rJ74DTjTKpw7F0+lSsVM8sFHE2UyBixg=="
 				}
 			}
 		},
@@ -3719,13 +3665,14 @@
 			"integrity": "sha512-FYLTkNWofjYNDGV1HTQlyVu1OqZiFxR4I8KM+oxGVOkbXva15NfWzbzciqdXUDqOhe6so5aroAdrVip6gSAYSA=="
 		},
 		"dids": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/dids/-/dids-0.7.0.tgz",
-			"integrity": "sha512-v0KQBE0UoB15n8cDZ5uxdTpadm3LnICP7RkpHIZ79zoDfB8/yPneeu7Xnvzd3PSfkHRnoOWkuJtQ8IoVC37OMA==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dids/-/dids-1.0.0.tgz",
+			"integrity": "sha512-z9bjdMmf3xzDymRQJvX8L1RYIKiz+NRSoewu3EXM9aZ/fNncUBEyYnZnJN6NSpN0SbLSElgiPjxVucAGskRIcQ==",
 			"requires": {
+				"@stablelib/random": "^1.0.0",
 				"cids": "^1.0.0",
 				"dag-jose-utils": "^0.1.0",
-				"did-jwt": "^4.6.2",
+				"did-jwt": "^4.6.3",
 				"did-resolver": "^2.1.1",
 				"rpc-utils": "^0.1.3",
 				"uint8arrays": "^1.1.0"
@@ -6503,12 +6450,13 @@
 			}
 		},
 		"key-did-provider-ed25519": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/key-did-provider-ed25519/-/key-did-provider-ed25519-0.1.1.tgz",
-			"integrity": "sha512-KtjoTDcX8JaukEu753C9Am8LIqwXb8hvGFmnwUnsvGwau/9L/eRhgXmA7Y9kMEWPzMWJ4qvf852WkSfbqWgjpA==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/key-did-provider-ed25519/-/key-did-provider-ed25519-1.0.0.tgz",
+			"integrity": "sha512-EBjhh+Rnyzfpb8GAUgILq8AflDaPmS6eE3vQTtHZgIKJ7wd4p3wSLEZr0QE2AY3h/1KDNbAM3v9IZgZd57urfg==",
+			"dev": true,
 			"requires": {
 				"@stablelib/ed25519": "^1.0.1",
-				"did-jwt": "^4.6.2",
+				"did-jwt": "^4.6.3",
 				"fast-json-stable-stringify": "^2.1.0",
 				"rpc-utils": "^0.1.3",
 				"uint8arrays": "^1.1.0"
@@ -8153,12 +8101,19 @@
 			},
 			"dependencies": {
 				"multibase": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
-					"integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.0.tgz",
+					"integrity": "sha512-Z+pThrpbS7ckQ2DwW5mPiwCGe1a94f8DWi/OxmbyeRednVOyUKmLSE+60kL/WHFYwWnaD1OakXGk3PYI1NkMFw==",
 					"requires": {
 						"@multiformats/base-x": "^4.0.1",
-						"web-encoding": "^1.0.2"
+						"web-encoding": "^1.0.4"
+					},
+					"dependencies": {
+						"web-encoding": {
+							"version": "1.0.4",
+							"resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.4.tgz",
+							"integrity": "sha512-DcXs2lbVPzuJmn2kuDEwul2oZg7p4YMa5J2f0YzsOBHaAnBYGPNUB/rJ74DTjTKpw7F0+lSsVM8sFHE2UyBixg=="
+						}
 					}
 				},
 				"uint8arrays": {
@@ -8212,23 +8167,33 @@
 					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
 				},
 				"multibase": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
-					"integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.0.tgz",
+					"integrity": "sha512-Z+pThrpbS7ckQ2DwW5mPiwCGe1a94f8DWi/OxmbyeRednVOyUKmLSE+60kL/WHFYwWnaD1OakXGk3PYI1NkMFw==",
 					"requires": {
 						"@multiformats/base-x": "^4.0.1",
-						"web-encoding": "^1.0.2"
+						"web-encoding": "^1.0.4"
 					}
 				},
 				"multihashes": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
-					"integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.1.0.tgz",
+					"integrity": "sha512-snU+w6aZy5bTrrqIHW3wkT0MfHmxcpOsaVNJt0NzUnseksbjFDVUZjSmhDMAVOVnIdLMS7xHjo55pKlBIGmC3g==",
 					"requires": {
-						"multibase": "^3.0.0",
+						"multibase": "^3.1.0",
 						"uint8arrays": "^1.0.0",
-						"varint": "^5.0.0"
+						"varint": "^6.0.0"
 					}
+				},
+				"varint": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+					"integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+				},
+				"web-encoding": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.4.tgz",
+					"integrity": "sha512-DcXs2lbVPzuJmn2kuDEwul2oZg7p4YMa5J2f0YzsOBHaAnBYGPNUB/rJ74DTjTKpw7F0+lSsVM8sFHE2UyBixg=="
 				}
 			}
 		},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,10 +45,9 @@
     "cross-fetch": "^3.0.6",
     "did-jwt": "^4.6.3",
     "did-resolver": "^2.1.1",
-    "dids": "^0.8.0",
+    "dids": "^1.0.0",
     "fast-json-patch": "^2.2.1",
     "ipfs-http-client": "^48.1.1",
-    "key-did-provider-ed25519": "^0.1.1",
     "level-ts": "^2.0.5",
     "lodash.clonedeep": "^4.5.0",
     "multiformats": "^3.0.3",
@@ -74,6 +73,7 @@
     "jest": "^25.1.0",
     "jest-mock-extended": "^1.0.9",
     "js-sha256": "^0.9.0",
+    "key-did-provider-ed25519": "^1.0.0",
     "tmp-promise": "^2.0.2"
   },
   "jest": {

--- a/packages/core/src/__tests__/document.test.ts
+++ b/packages/core/src/__tests__/document.test.ts
@@ -153,7 +153,7 @@ describe('Document', () => {
       user = new DID()
       user.createJWS = jest.fn(async () => {
         // fake jws
-        return 'eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9.bbbb.cccc'
+        return { payload: 'bbbb', signatures: [{ protected: 'eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9', signature: 'cccc'}]}
       })
       user._id = 'did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki'
       doctypeHandler = new TileDoctypeHandler()
@@ -624,7 +624,7 @@ describe('Document', () => {
       user = new DID()
       user.createJWS = jest.fn(async () => {
         // fake jws
-        return 'eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9.bbbb.cccc'
+        return { payload: 'bbbb', signatures: [{ protected: 'eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9', signature: 'cccc'}]}
       })
       user._id = 'did:3:bafyuser'
       doctypeHandler = new TileDoctypeHandler()

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -166,15 +166,15 @@ class Ceramic implements CeramicApi {
     const ceramic = new Ceramic(dispatcher, pinStore, context, config.validateDocs)
     anchorService.ceramic = ceramic
 
-    if (config.didProvider) {
-      await ceramic.setDIDProvider(config.didProvider)
-    }
-
     const keyDidResolver = KeyDidResolver.getResolver()
     const threeIdResolver = ThreeIdResolver.getResolver(ceramic)
     ceramic.context.resolver = new Resolver({
       ...config.didResolver, ...threeIdResolver, ...keyDidResolver,
     })
+
+    if (config.didProvider) {
+      await ceramic.setDIDProvider(config.didProvider)
+    }
 
     return ceramic
   }
@@ -185,7 +185,7 @@ class Ceramic implements CeramicApi {
    */
   async setDIDProvider (provider: DIDProvider): Promise<void> {
     this.context.provider = provider;
-    this.context.did = new DID( { provider })
+    this.context.did = new DID( { provider, resolver: this.context.resolver })
 
     if (!this.context.did.authenticated) {
       await this.context.did.authenticate()

--- a/packages/core/src/store/__tests__/state-store-integration.test.ts
+++ b/packages/core/src/store/__tests__/state-store-integration.test.ts
@@ -168,7 +168,7 @@ describe('Level data store', () => {
     const user: DID = new DID()
     user.createJWS = jest.fn(async () => {
       // fake jws
-      return 'eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9.bbbb.cccc'
+      return { payload: 'bbbb', signatures: [{ protected: 'eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9', signature: 'cccc'}]}
     })
     user._id = 'did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki'
 

--- a/packages/doctype-tile/package-lock.json
+++ b/packages/doctype-tile/package-lock.json
@@ -1,96 +1,9 @@
 {
-	"name": "@ceramicnetwork/ceramic-doctype-tile",
+	"name": "@ceramicnetwork/doctype-tile",
 	"version": "0.11.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"3id-blockchain-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/3id-blockchain-utils/-/3id-blockchain-utils-1.0.0.tgz",
-			"integrity": "sha512-+6128bRssiaPGY08cxdQpYdKacB82X2S5ydTm06qiV+ERWH4ywrmNXypc2/U6+EyBd9HM4Qf/Z5E95I01CGSHA==",
-			"requires": {
-				"@babel/runtime": "^7.9.2",
-				"@ethersproject/contracts": "^5.0.1",
-				"@ethersproject/providers": "^5.0.4",
-				"@ethersproject/wallet": "^5.0.1",
-				"caip": "^0.9.2",
-				"js-sha256": "^0.9.0"
-			},
-			"dependencies": {
-				"@ethersproject/contracts": {
-					"version": "5.0.2",
-					"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.2.tgz",
-					"integrity": "sha512-Ud3oW8mBNIWE+WHRjvwVEwfvshn7lfYWSSKG0fPSb6baRN9mLOoNguX+VIv3W5Sne9w2utnBmxLF2ESXitw64A==",
-					"requires": {
-						"@ethersproject/abi": "^5.0.0",
-						"@ethersproject/abstract-provider": "^5.0.0",
-						"@ethersproject/abstract-signer": "^5.0.0",
-						"@ethersproject/address": "^5.0.0",
-						"@ethersproject/bignumber": "^5.0.0",
-						"@ethersproject/bytes": "^5.0.0",
-						"@ethersproject/constants": "^5.0.0",
-						"@ethersproject/logger": "^5.0.0",
-						"@ethersproject/properties": "^5.0.0"
-					}
-				},
-				"@ethersproject/providers": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.5.tgz",
-					"integrity": "sha512-ZR3yFg/m8qDl7317yXOHE7tKeGfoyZIZ/imhVC4JqAH+SX1rb6bdZcSjhJfet7rLmnJSsnYLTgIiVIT85aVLgg==",
-					"requires": {
-						"@ethersproject/abstract-provider": "^5.0.0",
-						"@ethersproject/abstract-signer": "^5.0.0",
-						"@ethersproject/address": "^5.0.0",
-						"@ethersproject/bignumber": "^5.0.0",
-						"@ethersproject/bytes": "^5.0.0",
-						"@ethersproject/constants": "^5.0.0",
-						"@ethersproject/hash": "^5.0.0",
-						"@ethersproject/logger": "^5.0.0",
-						"@ethersproject/networks": "^5.0.0",
-						"@ethersproject/properties": "^5.0.0",
-						"@ethersproject/random": "^5.0.0",
-						"@ethersproject/rlp": "^5.0.0",
-						"@ethersproject/strings": "^5.0.0",
-						"@ethersproject/transactions": "^5.0.0",
-						"@ethersproject/web": "^5.0.0",
-						"ws": "7.2.3"
-					}
-				},
-				"@ethersproject/wallet": {
-					"version": "5.0.2",
-					"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.2.tgz",
-					"integrity": "sha512-gg86ynLV5k5caNnYpJoYc6WyIUHKMTjOITCk5zXGyVbbkXE07y/fGql4A51W0C6mWkeb5Mzz8AKqzHZECdH30w==",
-					"requires": {
-						"@ethersproject/abstract-provider": "^5.0.0",
-						"@ethersproject/abstract-signer": "^5.0.0",
-						"@ethersproject/address": "^5.0.0",
-						"@ethersproject/bignumber": "^5.0.0",
-						"@ethersproject/bytes": "^5.0.0",
-						"@ethersproject/hash": "^5.0.0",
-						"@ethersproject/hdnode": "^5.0.0",
-						"@ethersproject/json-wallets": "^5.0.0",
-						"@ethersproject/keccak256": "^5.0.0",
-						"@ethersproject/logger": "^5.0.0",
-						"@ethersproject/properties": "^5.0.0",
-						"@ethersproject/random": "^5.0.0",
-						"@ethersproject/signing-key": "^5.0.0",
-						"@ethersproject/transactions": "^5.0.0",
-						"@ethersproject/wordlists": "^5.0.0"
-					}
-				},
-				"ws": {
-					"version": "7.2.3",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-					"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
-				}
-			}
-		},
-		"@assemblyscript/loader": {
-			"version": "0.9.4",
-			"resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.9.4.tgz",
-			"integrity": "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA==",
-			"dev": true
-		},
 		"@babel/code-frame": {
 			"version": "7.10.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
@@ -1084,6 +997,7 @@
 			"version": "7.10.3",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
 			"integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -1133,139 +1047,6 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"@ceramicnetwork/3id-did-resolver": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/3id-did-resolver/-/3id-did-resolver-0.4.7.tgz",
-			"integrity": "sha512-QRS8r9qPAXPxvw265iKQcLDjngsvVBdBnhzH8tbqk5eleqzNKs3wXgyXe1ul6hzjburhHGWgnfI+NqLFzvXmBQ==",
-			"dev": true,
-			"requires": {
-				"@ceramicnetwork/ceramic-common": "^0.12.0",
-				"bs58": "^4.0.1"
-			}
-		},
-		"@ceramicnetwork/ceramic-common": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-common/-/ceramic-common-0.12.0.tgz",
-			"integrity": "sha512-C43IMV2N4J3LOyF9Tvu3xI2oEFv8Fv7o5tca7bEklay8wUo4oeA47j7JBD7rO9bzbx3vQbH7FEk4NsQHVUAryQ==",
-			"requires": {
-				"@ceramicnetwork/docid": "^0.2.0",
-				"cids": "^1.0.0",
-				"dag-jose": "^0.3.0",
-				"did-resolver": "^2.1.1",
-				"lodash.clonedeep": "^4.5.0",
-				"loglevel": "^1.7.0",
-				"loglevel-plugin-prefix": "^0.8.4",
-				"uint8arrays": "^1.1.0"
-			}
-		},
-		"@ceramicnetwork/ceramic-doctype-account-link": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-account-link/-/ceramic-doctype-account-link-0.10.0.tgz",
-			"integrity": "sha512-pud0g5pJL3zQ4FMYPo9RxMQAJ1DqBqEKYI9QVA8XnIv9n3XDem7T+67JZt9qOGxu4juP3z/Se6OOplVzpJTc0Q==",
-			"dev": true,
-			"requires": {
-				"3id-blockchain-utils": "^1.0.0",
-				"@ceramicnetwork/ceramic-common": "^0.12.0",
-				"@types/lodash.clonedeep": "^4.5.6",
-				"cids": "^1.0.0",
-				"did-resolver": "^2.1.1"
-			}
-		},
-		"@ceramicnetwork/ceramic-doctype-tile": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-tile/-/ceramic-doctype-tile-0.10.0.tgz",
-			"integrity": "sha512-IvKpRYCN0Q20PIub2r2ZjFlwy6sQgKGC7VBVj1HEQEttd+VxyapioHzwMEBzSmosiW/7k6SgBsB7XlKU2TdEAA==",
-			"dev": true,
-			"requires": {
-				"3id-blockchain-utils": "^1.0.0",
-				"@ceramicnetwork/ceramic-common": "^0.12.0",
-				"@ceramicnetwork/key-did-resolver": "^0.1.2",
-				"@ethersproject/base64": "^5.0.2",
-				"@ethersproject/random": "^5.0.2",
-				"@types/lodash.clonedeep": "^4.5.6",
-				"base64url": "^3.0.1",
-				"cids": "^1.0.0",
-				"did-jwt": "^4.0.0",
-				"did-resolver": "^2.1.1",
-				"dids": "^0.7.0",
-				"fast-json-patch": "^2.2.1",
-				"fast-json-stable-stringify": "^2.1.0"
-			}
-		},
-		"@ceramicnetwork/ceramic-http-client": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-http-client/-/ceramic-http-client-0.7.1.tgz",
-			"integrity": "sha512-Ef8bxHxJiZZJ87PPH2mRIGjkxhNczALX98pUq3qzKEuaPBEWyM1f5a6hkRu1cJFi954oky3VCkBi6+weh6u1Iw==",
-			"dev": true,
-			"requires": {
-				"@ceramicnetwork/ceramic-common": "^0.12.0",
-				"@ceramicnetwork/ceramic-doctype-account-link": "^0.10.0",
-				"@ceramicnetwork/ceramic-doctype-tile": "^0.10.0",
-				"@ceramicnetwork/docid": "^0.2.0",
-				"cids": "^1.0.0",
-				"cross-fetch": "^3.0.5",
-				"dids": "^0.7.0",
-				"lodash.clonedeep": "^4.5.0"
-			}
-		},
-		"@ceramicnetwork/docid": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/docid/-/docid-0.2.0.tgz",
-			"integrity": "sha512-s4YXOFM7CNSYGkfnts9XB6EOmp37uPnc7Q2hF3M5SZDNQhtDzYpuCdY30CFNJ291JOfMlfLQovQv4+k7ytkE6A==",
-			"requires": {
-				"cids": "^1.0.0",
-				"multibase": "^3.0.1",
-				"varint": "^6.0.0"
-			},
-			"dependencies": {
-				"multibase": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
-					"integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
-					"requires": {
-						"@multiformats/base-x": "^4.0.1",
-						"web-encoding": "^1.0.2"
-					}
-				},
-				"varint": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-					"integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-				}
-			}
-		},
-		"@ceramicnetwork/key-did-resolver": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/key-did-resolver/-/key-did-resolver-0.1.2.tgz",
-			"integrity": "sha512-FUPiJTQ4mSnieqoafL0Bt0gT+wMBscW198zCAz/AX9UEejgfvfQNdKYEph9vclsJ+obAvwJQfq4aZq40oH/b0w==",
-			"requires": {
-				"multibase": "^3.0.1",
-				"uint8arrays": "^1.1.0",
-				"varint": "^6.0.0"
-			},
-			"dependencies": {
-				"multibase": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
-					"integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
-					"requires": {
-						"@multiformats/base-x": "^4.0.1",
-						"web-encoding": "^1.0.2"
-					}
-				},
-				"varint": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-					"integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-				}
-			}
-		},
-		"@ceramicstudio/idx-constants": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@ceramicstudio/idx-constants/-/idx-constants-0.3.0.tgz",
-			"integrity": "sha512-cu/bqvrr0CIzUXWDs7qY1rFWYZWdRDm7/EPMwfWmaa6y9ASdR4/A1OhIptlZ3XKKcE9JZovmMdOegVvbWmj/sw==",
-			"dev": true
-		},
 		"@cnakazawa/watch": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -1274,61 +1055,6 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
-			}
-		},
-		"@ethersproject/abi": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.1.tgz",
-			"integrity": "sha512-9fqSa3jEYV4nN8tijW+jz4UnT/Ma9/b8y4+nHlsvuWqr32E2kYsT9SCIVpk/51iM6NOud7xsA6UxCox9zBeHKg==",
-			"requires": {
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
-			}
-		},
-		"@ethersproject/abstract-provider": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.1.tgz",
-			"integrity": "sha512-/KOw65ayviYPtKLqFE1qozeIJJlfI1wE/tNA+iKUPUai6bU6vg2tbfLFGarRTCQe3HoWV1t7xSsD/z9T9xg74g==",
-			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/networks": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/web": "^5.0.0"
-			}
-		},
-		"@ethersproject/abstract-signer": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.1.tgz",
-			"integrity": "sha512-Rp8DP+cLcSNFkd1YhwPSBcgEWLRipNakitwIwHngAmhbo4zdiWgALD/OLqdQ7SKF75CufF1W4BCuXcQgiWaRow==",
-			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0"
-			}
-		},
-		"@ethersproject/address": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.1.tgz",
-			"integrity": "sha512-kfQtXpBP2pI2TfoRRAYv8grHGiYw8U0c1KbMsC58/W33TIBy7gFSf/oAzOd94lNzdIUenKU0OuSzrHQfVcDDDA==",
-			"requires": {
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
-				"bn.js": "^4.4.0"
 			}
 		},
 		"@ethersproject/base64": {
@@ -1354,132 +1080,6 @@
 				}
 			}
 		},
-		"@ethersproject/basex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.1.tgz",
-			"integrity": "sha512-ssL2+p/A5bZgkZkiWy0iQDVz2mVJxZfzpf7dpw8t0sKF9VpoM3ZiMthRapH/QBhd4Rr6TNbr619pFLAGmMi9Ug==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0"
-			}
-		},
-		"@ethersproject/bignumber": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.1.tgz",
-			"integrity": "sha512-srGDO7ksT0avdDw5pBtj6F81psv5xiJMInwSSatfIKplitubFb6yVwoHGObGRd0Pp3TvrkIDfJkuskoSMj4OHQ==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"bn.js": "^4.4.0"
-			}
-		},
-		"@ethersproject/bytes": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.1.tgz",
-			"integrity": "sha512-Y198536UW9Jb9RBXuqmCsCa9mYJUsxJn+5aGr2XjNMpLBc6vEn/44GHnbQXYgRCzh4rnWtJ9bTgSwDjme9Hgnw==",
-			"requires": {
-				"@ethersproject/logger": "^5.0.0"
-			}
-		},
-		"@ethersproject/constants": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.1.tgz",
-			"integrity": "sha512-Xec07hFCPN4wfC3WDiRay7KipkApl2msiKTrBHCuAwNMOM8M92+mlQp8tgfEL51DPwCZkmdk1f02kArc6caVSw==",
-			"requires": {
-				"@ethersproject/bignumber": "^5.0.0"
-			}
-		},
-		"@ethersproject/hash": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.1.tgz",
-			"integrity": "sha512-1ByUXYvkszrSSks07xctBtZfpFnIVmftxWlAAnguxh6Q65vKECd/EPi5uI5xVOvnrYMH9Vb8MK1SofPX/6fArQ==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
-			}
-		},
-		"@ethersproject/hdnode": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.1.tgz",
-			"integrity": "sha512-L2OZP4SKKxNtHUdwfK8cND09kHRH62ncxXW33WAJU9shKo8Sbz31HVqSdov84bMAGm8QfEKZbfbAJV/7DM6DjQ==",
-			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/basex": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/pbkdf2": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"@ethersproject/wordlists": "^5.0.0"
-			}
-		},
-		"@ethersproject/json-wallets": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.1.tgz",
-			"integrity": "sha512-QjqQCh1a0a6wRVHdnqVccCLWX0vAgxnvGZeGqpOk2NbyNE8HTzV7GpOE+4LU+iCc8oonfy1gYd4hpsf+iEUWGg==",
-			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.0",
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/hdnode": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/pbkdf2": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/random": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0",
-				"@ethersproject/transactions": "^5.0.0",
-				"aes-js": "3.0.0",
-				"scrypt-js": "3.0.1",
-				"uuid": "2.0.1"
-			}
-		},
-		"@ethersproject/keccak256": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.1.tgz",
-			"integrity": "sha512-AtFm/4qHRQUvZcG3WYmaT7zV79dz72+N01w0XphcIBaD/7UZXyW85Uf08sirVlckHmh9fvc4UDWyHiroKsBT6Q==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"js-sha3": "0.5.7"
-			}
-		},
-		"@ethersproject/logger": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.2.tgz",
-			"integrity": "sha512-NQe3O1/Nwkcp6bto6hsTvrcCeR/cOGK+RhOMn0Zi2FND6gdWsf1g+5ie8gQ1REqDX4MTGP/Y131dZas985ls/g=="
-		},
-		"@ethersproject/networks": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.1.tgz",
-			"integrity": "sha512-Pe34JCTC6Apm/DkK3z97xotvEyu9YHKIFlDIu5hGV6yFDb4/sUfY2SHKYSGdUrV0418ZZVrwYDveJtBFMmYu2Q==",
-			"requires": {
-				"@ethersproject/logger": "^5.0.0"
-			}
-		},
-		"@ethersproject/pbkdf2": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.1.tgz",
-			"integrity": "sha512-4wc8Aov0iJmiomu6Dv1JNGOlhm3L7omITjLmChz/vgeDnW4Unv4J/nGybCeWKgY4hnjyQMVXkdkQ15BCRbkaYg==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/sha2": "^5.0.0"
-			}
-		},
-		"@ethersproject/properties": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.1.tgz",
-			"integrity": "sha512-b3VZ/NpYIf64/hFXeWNxVCbY1xoMPIYM3n6Qnu6Ayr3bLt1olFPQfAaaRB0aOsLz7tMtmkT3DrA1KG/IrOgBRw==",
-			"requires": {
-				"@ethersproject/logger": "^5.0.0"
-			}
-		},
 		"@ethersproject/random": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.4.tgz",
@@ -1502,735 +1102,6 @@
 					"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.6.tgz",
 					"integrity": "sha512-FrX0Vnb3JZ1md/7GIZfmJ06XOAA8r3q9Uqt9O5orr4ZiksnbpXKlyDzQtlZ5Yv18RS8CAUbiKH9vwidJg1BPmQ=="
 				}
-			}
-		},
-		"@ethersproject/rlp": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.1.tgz",
-			"integrity": "sha512-3F8XE1zS4w8w4xiK1hMtFuVs6UnhQlmrEHLT85GanqK8vG5wGi81IQmkukL9tQIu2a5jykoO46ibja+6N1fpFg==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
-			}
-		},
-		"@ethersproject/sha2": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.1.tgz",
-			"integrity": "sha512-5wNdULNDMJKwyzqrTH66e2TZPZTSqqluS7RNtuuuQSTP+yIALoID7ewLjDoj31g4kZyq/pqQbackKJLOXejTKw==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"hash.js": "1.1.3"
-			},
-			"dependencies": {
-				"hash.js": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-					"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"minimalistic-assert": "^1.0.0"
-					}
-				}
-			}
-		},
-		"@ethersproject/signing-key": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.1.tgz",
-			"integrity": "sha512-Z3yMPFFf4KkWltndDNi/tpese7qZh6ZWKbGu3DHd8xOX0PJqbScdAs6gCfFeMatO06qyX307Y52soc/Ayf8ZSg==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"elliptic": "6.5.2"
-			}
-		},
-		"@ethersproject/strings": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.1.tgz",
-			"integrity": "sha512-N8LxdHGBT7GZdogkEOV5xKXYTz5PNHuNzcxLNPYfH3kpvWSyXshZBgAz8YE1a8sMZagGj+Ic6d3mHijdCTSkGA==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0"
-			}
-		},
-		"@ethersproject/transactions": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.1.tgz",
-			"integrity": "sha512-IGc6/5hri3PrqR/ZCj89osDiq3Lt0CSrycn6vlRl8SjpBKYDdcT+Ru5xkeC7YcsnqcdBmTL+jyR3SLudU+x2Kw==",
-			"requires": {
-				"@ethersproject/address": "^5.0.0",
-				"@ethersproject/bignumber": "^5.0.0",
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/constants": "^5.0.0",
-				"@ethersproject/keccak256": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/rlp": "^5.0.0",
-				"@ethersproject/signing-key": "^5.0.0"
-			}
-		},
-		"@ethersproject/wallet": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.7.tgz",
-			"integrity": "sha512-n2GX1+2Tc0qV8dguUcLkjNugINKvZY7u/5fEsn0skW9rz5+jHTR5IKMV6jSfXA+WjQT8UCNMvkI3CNcdhaPbTQ==",
-			"dev": true,
-			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.4",
-				"@ethersproject/abstract-signer": "^5.0.4",
-				"@ethersproject/address": "^5.0.4",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/hash": "^5.0.4",
-				"@ethersproject/hdnode": "^5.0.4",
-				"@ethersproject/json-wallets": "^5.0.6",
-				"@ethersproject/keccak256": "^5.0.3",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/random": "^5.0.3",
-				"@ethersproject/signing-key": "^5.0.4",
-				"@ethersproject/transactions": "^5.0.5",
-				"@ethersproject/wordlists": "^5.0.4"
-			},
-			"dependencies": {
-				"@ethersproject/abstract-provider": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.5.tgz",
-					"integrity": "sha512-i/CjElAkzV7vQBAeoz+IpjGfcFYEP9eD7j3fzZ0fzTq03DO7PPnR+xkEZ1IoDXGwDS+55aLM1xvLDwB/Lx6IOQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bignumber": "^5.0.7",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/networks": "^5.0.3",
-						"@ethersproject/properties": "^5.0.3",
-						"@ethersproject/transactions": "^5.0.5",
-						"@ethersproject/web": "^5.0.6"
-					}
-				},
-				"@ethersproject/abstract-signer": {
-					"version": "5.0.7",
-					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.7.tgz",
-					"integrity": "sha512-8W8gy/QutEL60EoMEpvxZ8MFAEWs/JvH5nmZ6xeLXoZvmBCasGmxqHdYjo2cxg0nevkPkq9SeenSsBBZSCx+SQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/abstract-provider": "^5.0.4",
-						"@ethersproject/bignumber": "^5.0.7",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/properties": "^5.0.3"
-					}
-				},
-				"@ethersproject/address": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
-					"integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bignumber": "^5.0.7",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/keccak256": "^5.0.3",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/rlp": "^5.0.3",
-						"bn.js": "^4.4.0"
-					}
-				},
-				"@ethersproject/basex": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.4.tgz",
-					"integrity": "sha512-ixIr/kKiAoSzOnSc777AGIOAhKai5Ivqr4HO/Gz+YG+xkfv6kqD6AW4ga9vM20Wwb0QBhh3LoRWTu4V1K+x9Ew==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/properties": "^5.0.3"
-					}
-				},
-				"@ethersproject/bignumber": {
-					"version": "5.0.8",
-					"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-					"integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"bn.js": "^4.4.0"
-					}
-				},
-				"@ethersproject/bytes": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-					"integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/logger": "^5.0.5"
-					}
-				},
-				"@ethersproject/constants": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
-					"integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bignumber": "^5.0.7"
-					}
-				},
-				"@ethersproject/hash": {
-					"version": "5.0.6",
-					"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.6.tgz",
-					"integrity": "sha512-Gvh57v6BWhwnud6l7tMfQm32PRQ2DYx2WaAAQmAxAfYvmzUkpQCBstnGeNMXIL8/2wdkvcB2u+WZRWaZtsFuUQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/abstract-signer": "^5.0.6",
-						"@ethersproject/address": "^5.0.5",
-						"@ethersproject/bignumber": "^5.0.8",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/keccak256": "^5.0.3",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/properties": "^5.0.4",
-						"@ethersproject/strings": "^5.0.4"
-					}
-				},
-				"@ethersproject/hdnode": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.5.tgz",
-					"integrity": "sha512-Ho4HZaK+KijE5adayvjAGusWMnT0mgwGa5hGMBofBOgX9nqiKf6Wxx68SXBGI1/L3rmKo6mlAjxUd8gefs0teQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/abstract-signer": "^5.0.4",
-						"@ethersproject/basex": "^5.0.3",
-						"@ethersproject/bignumber": "^5.0.7",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/pbkdf2": "^5.0.3",
-						"@ethersproject/properties": "^5.0.3",
-						"@ethersproject/sha2": "^5.0.3",
-						"@ethersproject/signing-key": "^5.0.4",
-						"@ethersproject/strings": "^5.0.4",
-						"@ethersproject/transactions": "^5.0.5",
-						"@ethersproject/wordlists": "^5.0.4"
-					}
-				},
-				"@ethersproject/json-wallets": {
-					"version": "5.0.7",
-					"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.7.tgz",
-					"integrity": "sha512-dgOn9JtGgjT28mDXs4LYY2rT4CzS6bG/rxoYuPq3TLHIf6nmvBcr33Fee6RrM/y8UAx4gyIkf6wb2cXsOctvQQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/abstract-signer": "^5.0.4",
-						"@ethersproject/address": "^5.0.4",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/hdnode": "^5.0.4",
-						"@ethersproject/keccak256": "^5.0.3",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/pbkdf2": "^5.0.3",
-						"@ethersproject/properties": "^5.0.3",
-						"@ethersproject/random": "^5.0.3",
-						"@ethersproject/strings": "^5.0.4",
-						"@ethersproject/transactions": "^5.0.5",
-						"aes-js": "3.0.0",
-						"scrypt-js": "3.0.1"
-					}
-				},
-				"@ethersproject/keccak256": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.4.tgz",
-					"integrity": "sha512-GNpiOUm9PGUxFNqOxYKDQBM0u68bG9XC9iOulEQ8I0tOx/4qUpgVzvgXL6ugxr0RY554Gz/NQsVqknqPzUcxpQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"js-sha3": "0.5.7"
-					}
-				},
-				"@ethersproject/logger": {
-					"version": "5.0.6",
-					"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.6.tgz",
-					"integrity": "sha512-FrX0Vnb3JZ1md/7GIZfmJ06XOAA8r3q9Uqt9O5orr4ZiksnbpXKlyDzQtlZ5Yv18RS8CAUbiKH9vwidJg1BPmQ==",
-					"dev": true
-				},
-				"@ethersproject/networks": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.4.tgz",
-					"integrity": "sha512-/wHDTRms5mpJ09BoDrbNdFWINzONe05wZRgohCXvEv39rrH/Gd/yAnct8wC0RsW3tmFOgjgQxuBvypIxuUynTw==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/logger": "^5.0.5"
-					}
-				},
-				"@ethersproject/pbkdf2": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.4.tgz",
-					"integrity": "sha512-9jVBjHXQKfr9+3bkCg01a8Cd1H9e+7Kw3ZMIvAxD0lZtuzrXsJxm1hVwY9KA+PRUvgS/9tTP4viXQYwLAax7zg==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/sha2": "^5.0.3"
-					}
-				},
-				"@ethersproject/properties": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.4.tgz",
-					"integrity": "sha512-UdyX3GqBxFt15B0uSESdDNmhvEbK3ACdDXl2soshoPcneXuTswHDeA0LoPlnaZzhbgk4p6jqb4GMms5C26Qu6A==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/logger": "^5.0.5"
-					}
-				},
-				"@ethersproject/rlp": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.4.tgz",
-					"integrity": "sha512-5qrrZad7VTjofxSsm7Zg/7Dr4ZOln4S2CqiDdOuTv6MBKnXj0CiBojXyuDy52M8O3wxH0CyE924hXWTDV1PQWQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5"
-					}
-				},
-				"@ethersproject/sha2": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.4.tgz",
-					"integrity": "sha512-0yFhf1mspxAfWdXXoPtK94adUeu1R7/FzAa+DfEiZTc76sz/vHXf0LSIazoR3znYKFny6haBxME+usbvvEcF3A==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"hash.js": "1.1.3"
-					},
-					"dependencies": {
-						"hash.js": {
-							"version": "1.1.3",
-							"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-							"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.3",
-								"minimalistic-assert": "^1.0.0"
-							}
-						}
-					}
-				},
-				"@ethersproject/signing-key": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.5.tgz",
-					"integrity": "sha512-Z1wY7JC1HVO4CvQWY2TyTTuAr8xK3bJijZw1a9G92JEmKdv1j255R/0YLBBcFTl2J65LUjtXynNJ2GbArPGi5g==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/properties": "^5.0.3",
-						"elliptic": "6.5.3"
-					}
-				},
-				"@ethersproject/strings": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
-					"integrity": "sha512-JED6WaIV00xM/gvj8vSnd+0VWtDYdidTmavFRCTQakqfz+4tDo6Jz5LHgG+dd45h7ah7ykCHW0C7ZXWEDROCXQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/constants": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5"
-					}
-				},
-				"@ethersproject/transactions": {
-					"version": "5.0.6",
-					"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
-					"integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/address": "^5.0.4",
-						"@ethersproject/bignumber": "^5.0.7",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/constants": "^5.0.4",
-						"@ethersproject/keccak256": "^5.0.3",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/properties": "^5.0.3",
-						"@ethersproject/rlp": "^5.0.3",
-						"@ethersproject/signing-key": "^5.0.4"
-					}
-				},
-				"@ethersproject/web": {
-					"version": "5.0.9",
-					"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.9.tgz",
-					"integrity": "sha512-//QNlv1MSkOII1hv3+HQwWoiVFS+BMVGI0KYeUww4cyrEktnx1QIez5bTSab9s9fWTFaWKNmQNBwMbxAqPuYDw==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/base64": "^5.0.3",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/properties": "^5.0.3",
-						"@ethersproject/strings": "^5.0.4"
-					}
-				},
-				"@ethersproject/wordlists": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.5.tgz",
-					"integrity": "sha512-XA3ycFltVrCTQt04w5nHu3Xq5Z6HjqWsXaAYQHFdqtugyUsIumaO9S5MOwFFuUYTNkZUoT3jCRa/OBS+K4tLfA==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/hash": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/properties": "^5.0.3",
-						"@ethersproject/strings": "^5.0.4"
-					}
-				},
-				"elliptic": {
-					"version": "6.5.3",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-					"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.4.0",
-						"brorand": "^1.0.1",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.0",
-						"inherits": "^2.0.1",
-						"minimalistic-assert": "^1.0.0",
-						"minimalistic-crypto-utils": "^1.0.0"
-					}
-				}
-			}
-		},
-		"@ethersproject/web": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.1.tgz",
-			"integrity": "sha512-lWPg8BR6KoyiIKYRIM6j+XO9bT9vGM1JnxFj2HmhIvOrOjba7ZRd8ANBOsDVGfw5igLUdfqAUOf9WpSsH//TzA==",
-			"requires": {
-				"@ethersproject/base64": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
-			}
-		},
-		"@ethersproject/wordlists": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.1.tgz",
-			"integrity": "sha512-R7boLmpewucz5v4jD7cWwI0BGHR/DstiZtjdhUOft6XdMqM1OGb1UTL0GBQeS4vDXzCLuJEHddjJ69beGVN/4Q==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.0",
-				"@ethersproject/hash": "^5.0.0",
-				"@ethersproject/logger": "^5.0.0",
-				"@ethersproject/properties": "^5.0.0",
-				"@ethersproject/strings": "^5.0.0"
-			}
-		},
-		"@hapi/accept": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
-			"integrity": "sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==",
-			"dev": true,
-			"requires": {
-				"@hapi/boom": "9.x.x",
-				"@hapi/hoek": "9.x.x"
-			}
-		},
-		"@hapi/ammo": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
-			"integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "9.x.x"
-			}
-		},
-		"@hapi/b64": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
-			"integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "9.x.x"
-			}
-		},
-		"@hapi/boom": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
-			"integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "9.x.x"
-			}
-		},
-		"@hapi/bounce": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
-			"integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
-			"dev": true,
-			"requires": {
-				"@hapi/boom": "9.x.x",
-				"@hapi/hoek": "9.x.x"
-			}
-		},
-		"@hapi/bourne": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
-			"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
-			"dev": true
-		},
-		"@hapi/call": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
-			"integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
-			"dev": true,
-			"requires": {
-				"@hapi/boom": "9.x.x",
-				"@hapi/hoek": "9.x.x"
-			}
-		},
-		"@hapi/catbox": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
-			"integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
-			"dev": true,
-			"requires": {
-				"@hapi/boom": "9.x.x",
-				"@hapi/hoek": "9.x.x",
-				"@hapi/podium": "4.x.x",
-				"@hapi/validate": "1.x.x"
-			}
-		},
-		"@hapi/catbox-memory": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.0.tgz",
-			"integrity": "sha512-ByuxVJPHNaXwLzbBv4GdTr6ccpe1nG+AfYt+8ftDWEJY7EWBWzD+Klhy5oPTDGzU26pNUh1e7fcYI1ILZRxAXQ==",
-			"dev": true,
-			"requires": {
-				"@hapi/boom": "9.x.x",
-				"@hapi/hoek": "9.x.x"
-			}
-		},
-		"@hapi/content": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
-			"integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
-			"dev": true,
-			"requires": {
-				"@hapi/boom": "9.x.x"
-			}
-		},
-		"@hapi/cryptiles": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
-			"integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
-			"dev": true,
-			"requires": {
-				"@hapi/boom": "9.x.x"
-			}
-		},
-		"@hapi/file": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
-			"integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
-			"dev": true
-		},
-		"@hapi/hapi": {
-			"version": "20.0.1",
-			"resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.0.1.tgz",
-			"integrity": "sha512-v8NapLf5vkKWIJoBCUBIOk6ZdH9vrxZco4GZbjdM3ROQBDl4eXwW3pySTBL7xWANYp3Nzdn+fiFWjDwdgsSoQg==",
-			"dev": true,
-			"requires": {
-				"@hapi/accept": "^5.0.1",
-				"@hapi/ammo": "^5.0.1",
-				"@hapi/boom": "9.x.x",
-				"@hapi/bounce": "2.x.x",
-				"@hapi/call": "8.x.x",
-				"@hapi/catbox": "^11.1.1",
-				"@hapi/catbox-memory": "5.x.x",
-				"@hapi/heavy": "^7.0.1",
-				"@hapi/hoek": "9.x.x",
-				"@hapi/mimos": "5.x.x",
-				"@hapi/podium": "^4.1.1",
-				"@hapi/shot": "^5.0.1",
-				"@hapi/somever": "3.x.x",
-				"@hapi/statehood": "^7.0.3",
-				"@hapi/subtext": "^7.0.3",
-				"@hapi/teamwork": "5.x.x",
-				"@hapi/topo": "5.x.x",
-				"@hapi/validate": "^1.1.0"
-			}
-		},
-		"@hapi/heavy": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
-			"integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
-			"dev": true,
-			"requires": {
-				"@hapi/boom": "9.x.x",
-				"@hapi/hoek": "9.x.x",
-				"@hapi/validate": "1.x.x"
-			}
-		},
-		"@hapi/hoek": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-			"integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
-			"dev": true
-		},
-		"@hapi/inert": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-6.0.3.tgz",
-			"integrity": "sha512-Z6Pi0Wsn2pJex5CmBaq+Dky9q40LGzXLUIUFrYpDtReuMkmfy9UuUeYc4064jQ1Xe9uuw7kbwE6Fq6rqKAdjAg==",
-			"dev": true,
-			"requires": {
-				"@hapi/ammo": "5.x.x",
-				"@hapi/boom": "9.x.x",
-				"@hapi/bounce": "2.x.x",
-				"@hapi/hoek": "9.x.x",
-				"@hapi/validate": "1.x.x",
-				"lru-cache": "^6.0.0"
-			}
-		},
-		"@hapi/iron": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
-			"integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
-			"dev": true,
-			"requires": {
-				"@hapi/b64": "5.x.x",
-				"@hapi/boom": "9.x.x",
-				"@hapi/bourne": "2.x.x",
-				"@hapi/cryptiles": "5.x.x",
-				"@hapi/hoek": "9.x.x"
-			}
-		},
-		"@hapi/mimos": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
-			"integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "9.x.x",
-				"mime-db": "1.x.x"
-			}
-		},
-		"@hapi/nigel": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
-			"integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "^9.0.4",
-				"@hapi/vise": "^4.0.0"
-			}
-		},
-		"@hapi/pez": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
-			"integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
-			"dev": true,
-			"requires": {
-				"@hapi/b64": "5.x.x",
-				"@hapi/boom": "9.x.x",
-				"@hapi/content": "^5.0.2",
-				"@hapi/hoek": "9.x.x",
-				"@hapi/nigel": "4.x.x"
-			}
-		},
-		"@hapi/podium": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.1.tgz",
-			"integrity": "sha512-jh7a6+5Z4FUWzx8fgmxjaAa1DTBu+Qfg+NbVdo0f++rE5DgsVidUYrLDp3db65+QjDLleA2MfKQXkpT8ylBDXA==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "9.x.x",
-				"@hapi/teamwork": "5.x.x",
-				"@hapi/validate": "1.x.x"
-			}
-		},
-		"@hapi/shot": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.4.tgz",
-			"integrity": "sha512-PcEz0WJgFDA3xNSMeONgQmothFr7jhbbRRSAKaDh7chN7zOXBlhl13bvKZW6CMb2xVfJUmt34CW3e/oExMgBhQ==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "9.x.x",
-				"@hapi/validate": "1.x.x"
-			}
-		},
-		"@hapi/somever": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
-			"integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
-			"dev": true,
-			"requires": {
-				"@hapi/bounce": "2.x.x",
-				"@hapi/hoek": "9.x.x"
-			}
-		},
-		"@hapi/statehood": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
-			"integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
-			"dev": true,
-			"requires": {
-				"@hapi/boom": "9.x.x",
-				"@hapi/bounce": "2.x.x",
-				"@hapi/bourne": "2.x.x",
-				"@hapi/cryptiles": "5.x.x",
-				"@hapi/hoek": "9.x.x",
-				"@hapi/iron": "6.x.x",
-				"@hapi/validate": "1.x.x"
-			}
-		},
-		"@hapi/subtext": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
-			"integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
-			"dev": true,
-			"requires": {
-				"@hapi/boom": "9.x.x",
-				"@hapi/bourne": "2.x.x",
-				"@hapi/content": "^5.0.2",
-				"@hapi/file": "2.x.x",
-				"@hapi/hoek": "9.x.x",
-				"@hapi/pez": "^5.0.1",
-				"@hapi/wreck": "17.x.x"
-			}
-		},
-		"@hapi/teamwork": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
-			"integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
-			"dev": true
-		},
-		"@hapi/topo": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
-			"integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "^9.0.0"
-			}
-		},
-		"@hapi/validate": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
-			"integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "^9.0.0",
-				"@hapi/topo": "^5.0.0"
-			}
-		},
-		"@hapi/vise": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
-			"integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "9.x.x"
-			}
-		},
-		"@hapi/wreck": {
-			"version": "17.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.0.0.tgz",
-			"integrity": "sha512-d8lqCinbKyDByn7GzJDRDbitddhIEydNm44UcAMejfhEH3o4IYvKYq6K8cAqXbilXPuvZc0ErlUOg9SDdgRtMw==",
-			"dev": true,
-			"requires": {
-				"@hapi/boom": "9.x.x",
-				"@hapi/bourne": "2.x.x",
-				"@hapi/hoek": "9.x.x"
 			}
 		},
 		"@istanbuljs/load-nyc-config": {
@@ -2795,97 +1666,6 @@
 			"resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
 			"integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
 		},
-		"@protobufjs/aspromise": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
-			"dev": true
-		},
-		"@protobufjs/base64": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-			"dev": true
-		},
-		"@protobufjs/codegen": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-			"dev": true
-		},
-		"@protobufjs/eventemitter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
-			"dev": true
-		},
-		"@protobufjs/fetch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-			"integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
-			"dev": true,
-			"requires": {
-				"@protobufjs/aspromise": "^1.1.1",
-				"@protobufjs/inquire": "^1.1.0"
-			}
-		},
-		"@protobufjs/float": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-			"integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
-			"dev": true
-		},
-		"@protobufjs/inquire": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
-			"dev": true
-		},
-		"@protobufjs/path": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
-			"dev": true
-		},
-		"@protobufjs/pool": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
-			"dev": true
-		},
-		"@protobufjs/utf8": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
-			"dev": true
-		},
-		"@sideway/address": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
-			"integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "^9.0.0"
-			}
-		},
-		"@sideway/formula": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-			"integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
-			"dev": true
-		},
-		"@sideway/pinpoint": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-			"integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-			"dev": true
-		},
-		"@sindresorhus/is": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
-			"dev": true
-		},
 		"@sinonjs/commons": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
@@ -2894,42 +1674,6 @@
 			"requires": {
 				"type-detect": "4.0.8"
 			}
-		},
-		"@sinonjs/fake-timers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
-			"integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
-			"dev": true,
-			"requires": {
-				"@sinonjs/commons": "^1.7.0"
-			}
-		},
-		"@sinonjs/formatio": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
-			"integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
-			"dev": true,
-			"requires": {
-				"@sinonjs/commons": "^1",
-				"@sinonjs/samsam": "^5.0.2"
-			}
-		},
-		"@sinonjs/samsam": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.2.0.tgz",
-			"integrity": "sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==",
-			"dev": true,
-			"requires": {
-				"@sinonjs/commons": "^1.6.0",
-				"lodash.get": "^4.4.2",
-				"type-detect": "^4.0.8"
-			}
-		},
-		"@sinonjs/text-encoding": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
-			"dev": true
 		},
 		"@stablelib/aead": {
 			"version": "1.0.0",
@@ -3042,11 +1786,6 @@
 				"@stablelib/wipe": "^1.0.0"
 			}
 		},
-		"@stablelib/utf8": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.0.tgz",
-			"integrity": "sha512-Y8QWrK4T0yW0HMFfSI3ZaMHKV37q27hX5ilsmKV358x01mzYfj5fwIf2LjzTlF+UIemHEXSlSN9XJnv1ML4znQ=="
-		},
 		"@stablelib/wipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
@@ -3083,21 +1822,6 @@
 				"@stablelib/wipe": "^1.0.0",
 				"@stablelib/xchacha20": "^1.0.0"
 			}
-		},
-		"@szmarczak/http-timer": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-			"dev": true,
-			"requires": {
-				"defer-to-connect": "^1.0.1"
-			}
-		},
-		"@tokenizer/token": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-			"integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w==",
-			"dev": true
 		},
 		"@types/abstract-leveldown": {
 			"version": "5.0.1",
@@ -3146,34 +1870,10 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
-		"@types/bl": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@types/bl/-/bl-2.1.0.tgz",
-			"integrity": "sha512-1TdA9IXOy4sdqn8vgieQ6GZAiHiPNrOiO1s2GJjuYPw4QVY7gYoVjkW049avj33Ez7IcIvu43hQsMsoUFbCn2g==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
-		"@types/bn.js": {
-			"version": "4.11.6",
-			"resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-			"integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-			"dev": true
-		},
-		"@types/debug": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
 			"dev": true
 		},
 		"@types/encoding-down": {
@@ -3185,12 +1885,6 @@
 				"@types/abstract-leveldown": "*",
 				"@types/level-codec": "*"
 			}
-		},
-		"@types/eslint-visitor-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
-			"dev": true
 		},
 		"@types/events": {
 			"version": "3.0.0",
@@ -3257,12 +1951,6 @@
 				"@types/lodash": "*"
 			}
 		},
-		"@types/long": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
-			"dev": true
-		},
 		"@types/node": {
 			"version": "13.13.15",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
@@ -3275,29 +1963,11 @@
 			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
 			"dev": true
 		},
-		"@types/pbkdf2": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
-			"integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/prettier": {
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
 			"integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
 			"dev": true
-		},
-		"@types/secp256k1": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
-			"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
 		},
 		"@types/stack-utils": {
 			"version": "1.0.1",
@@ -3320,18 +1990,6 @@
 			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
 			"dev": true
 		},
-		"@typescript-eslint/eslint-plugin": {
-			"version": "2.34.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz",
-			"integrity": "sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/experimental-utils": "2.34.0",
-				"functional-red-black-tree": "^1.0.1",
-				"regexpp": "^3.0.0",
-				"tsutils": "^3.17.1"
-			}
-		},
 		"@typescript-eslint/experimental-utils": {
 			"version": "2.34.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
@@ -3342,18 +2000,6 @@
 				"@typescript-eslint/typescript-estree": "2.34.0",
 				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^2.0.0"
-			}
-		},
-		"@typescript-eslint/parser": {
-			"version": "2.34.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.34.0.tgz",
-			"integrity": "sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==",
-			"dev": true,
-			"requires": {
-				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "2.34.0",
-				"@typescript-eslint/typescript-estree": "2.34.0",
-				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
@@ -3384,50 +2030,6 @@
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
 			"integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
 			"dev": true
-		},
-		"abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"dev": true,
-			"requires": {
-				"event-target-shim": "^5.0.0"
-			}
-		},
-		"abortable-iterator": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-3.0.0.tgz",
-			"integrity": "sha512-7KqcPPnMhfot4GrEjK51zesS4Ye/lUCHBgYt3oRxIlU24HO3mVxBwEo9niNyfHqoWKqWLuZTc3zErNomdHA+ag==",
-			"dev": true,
-			"requires": {
-				"get-iterator": "^1.0.2"
-			}
-		},
-		"abstract-leveldown": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.3.tgz",
-			"integrity": "sha512-jzewKKpZbaYUa6HTThnrl+GrJhzjEAeuc7hTVpZdzg7kupXZFoqQDFwyOwLNbmJKJlmzw8yiipMPkDiuKkT06Q==",
-			"dev": true,
-			"requires": {
-				"level-concat-iterator": "~2.0.0",
-				"xtend": "~4.0.0"
-			}
-		},
-		"abstract-logging": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
-			"integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
-			"dev": true
-		},
-		"accepts": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-			"dev": true,
-			"requires": {
-				"mime-types": "~2.1.24",
-				"negotiator": "0.6.2"
-			}
 		},
 		"acorn": {
 			"version": "7.3.1",
@@ -3465,27 +2067,6 @@
 			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
 			"dev": true
 		},
-		"aes-js": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
-		},
-		"after": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-			"integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
-			"dev": true
-		},
-		"aggregate-error": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-			"dev": true,
-			"requires": {
-				"clean-stack": "^2.0.0",
-				"indent-string": "^4.0.0"
-			}
-		},
 		"ajv": {
 			"version": "6.12.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
@@ -3496,40 +2077,6 @@
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
-			}
-		},
-		"ansi-align": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-			"integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
-			"dev": true,
-			"requires": {
-				"string-width": "^3.0.0"
-			},
-			"dependencies": {
-				"emoji-regex": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				}
 			}
 		},
 		"ansi-escapes": {
@@ -3564,15 +2111,6 @@
 				"color-convert": "^1.9.0"
 			}
 		},
-		"any-signal": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/any-signal/-/any-signal-1.2.0.tgz",
-			"integrity": "sha512-Cl08k4xItix3jvu4cxO/dt2rQ6iUAjO66pTyRMub+WL1VXeAyZydCpD8GqWTPKfdL28U0R0UucmQVsUsBnvCmQ==",
-			"dev": true,
-			"requires": {
-				"abort-controller": "^3.0.0"
-			}
-		},
 		"anymatch": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
@@ -3590,32 +2128,6 @@
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
-			}
-		},
-		"args": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
-			"integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
-			"dev": true,
-			"requires": {
-				"camelcase": "5.0.0",
-				"chalk": "2.4.2",
-				"leven": "2.1.0",
-				"mri": "1.1.4"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
-					"dev": true
-				},
-				"leven": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-					"dev": true
-				}
 			}
 		},
 		"arr-diff": {
@@ -3642,22 +2154,10 @@
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
 			"dev": true
 		},
-		"array-shuffle": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/array-shuffle/-/array-shuffle-1.0.1.tgz",
-			"integrity": "sha1-fqSIKjVrS8pfVF4LblLq9tlxVXo=",
-			"dev": true
-		},
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-			"dev": true
-		},
-		"arraybuffer.slice": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-			"integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
 			"dev": true
 		},
 		"asn1": {
@@ -3669,28 +2169,10 @@
 				"safer-buffer": "~2.1.0"
 			}
 		},
-		"asn1.js": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"safer-buffer": "^2.1.0"
-			}
-		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
-		},
-		"assertion-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
 			"dev": true
 		},
 		"assign-symbols": {
@@ -3705,43 +2187,16 @@
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
 		},
-		"async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.14"
-			}
-		},
-		"async-limiter": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-			"dev": true
-		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
 		},
-		"at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"dev": true
-		},
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-			"dev": true
-		},
-		"atomic-sleep": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
 			"dev": true
 		},
 		"aws-sign2": {
@@ -3886,12 +2341,6 @@
 				"babel-preset-current-node-syntax": "^0.1.2"
 			}
 		},
-		"backo2": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-			"dev": true
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -3961,28 +2410,10 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"base32.js": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
-			"integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI=",
-			"dev": true
-		},
-		"base64-arraybuffer": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
-			"integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
-			"dev": true
-		},
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-		},
-		"base64id": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-			"integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-			"dev": true
 		},
 		"base64url": {
 			"version": "3.0.1",
@@ -4006,148 +2437,15 @@
 				}
 			}
 		},
-		"bcrypto": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.3.0.tgz",
-			"integrity": "sha512-SP48cpoc4BkEPNOErdsZ1VjbtdXY/C0f5wAywWniLne/Fd/5oOBqLbC6ZavngLvk4oik76g4I7PO5KduJoqECQ==",
-			"dev": true,
-			"requires": {
-				"bufio": "~1.0.7",
-				"loady": "~0.0.5"
-			}
-		},
-		"bech32": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-			"dev": true
-		},
-		"better-assert": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-			"integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-			"dev": true,
-			"requires": {
-				"callsite": "1.0.0"
-			}
-		},
 		"bignumber.js": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
 			"integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
 		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bintrees": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-			"integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=",
-			"dev": true
-		},
-		"bip174": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/bip174/-/bip174-2.0.1.tgz",
-			"integrity": "sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ==",
-			"dev": true
-		},
-		"bip32": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.6.tgz",
-			"integrity": "sha512-HpV5OMLLGTjSVblmrtYRfFFKuQB+GArM0+XP8HGWfJ5vxYBqo+DesvJwOdC2WJ3bCkZShGf0QIfoIpeomVzVdA==",
-			"dev": true,
-			"requires": {
-				"@types/node": "10.12.18",
-				"bs58check": "^2.1.1",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"tiny-secp256k1": "^1.1.3",
-				"typeforce": "^1.11.5",
-				"wif": "^2.0.6"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "10.12.18",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-					"integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
-					"dev": true
-				}
-			}
-		},
-		"bip66": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"bitcoin-ops": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
-			"integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==",
-			"dev": true
-		},
-		"bitcoinjs-lib": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.2.0.tgz",
-			"integrity": "sha512-5DcLxGUDejgNBYcieMIUfjORtUeNWl828VWLHJGVKZCb4zIS1oOySTUr0LGmcqJBQgTBz3bGbRQla4FgrdQEIQ==",
-			"dev": true,
-			"requires": {
-				"bech32": "^1.1.2",
-				"bip174": "^2.0.1",
-				"bip32": "^2.0.4",
-				"bip66": "^1.1.0",
-				"bitcoin-ops": "^1.4.0",
-				"bs58check": "^2.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.3",
-				"merkle-lib": "^2.0.10",
-				"pushdata-bitcoin": "^1.0.1",
-				"randombytes": "^2.0.1",
-				"tiny-secp256k1": "^1.1.1",
-				"typeforce": "^1.11.3",
-				"varuint-bitcoin": "^1.0.4",
-				"wif": "^2.0.1"
-			}
-		},
-		"bl": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-			"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.5.0",
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.4.0"
-			}
-		},
 		"blakejs": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
 			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
-		},
-		"blob": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
-			"integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
-			"dev": true
-		},
-		"blob-to-it": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-0.0.2.tgz",
-			"integrity": "sha512-3/NRr0mUWQTkS71MYEC1teLbT5BTs7RZ6VMPXDV6qApjw3B4TAZspQuvDkYfHuD/XzL5p/RO91x5XRPeJvcCqg==",
-			"dev": true,
-			"requires": {
-				"browser-readablestream-to-it": "^0.0.2"
-			}
 		},
 		"bn.js": {
 			"version": "4.11.9",
@@ -4166,73 +2464,6 @@
 				"iso-url": "~0.4.7",
 				"json-text-sequence": "~0.1.0",
 				"readable-stream": "^3.6.0"
-			}
-		},
-		"boxen": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
-			"integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
-			"dev": true,
-			"requires": {
-				"ansi-align": "^3.0.0",
-				"camelcase": "^5.3.1",
-				"chalk": "^3.0.0",
-				"cli-boxes": "^2.2.0",
-				"string-width": "^4.1.0",
-				"term-size": "^2.1.0",
-				"type-fest": "^0.8.1",
-				"widest-line": "^3.1.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"brace-expansion": {
@@ -4265,12 +2496,6 @@
 			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
 			"dev": true
 		},
-		"browser-readablestream-to-it": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-0.0.2.tgz",
-			"integrity": "sha512-bbiTccngeAbPmpTUJcUyr6JhivADKV9xkNJVLdA91vjdzXyFBZ6fgrzElQsV3k1UNGQACRTl3p4y+cEGG9U48A==",
-			"dev": true
-		},
 		"browser-resolve": {
 			"version": "1.11.3",
 			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
@@ -4288,107 +2513,6 @@
 				}
 			}
 		},
-		"browserify-aes": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-			"dev": true,
-			"requires": {
-				"buffer-xor": "^1.0.3",
-				"cipher-base": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.3",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"browserify-cipher": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-			"dev": true,
-			"requires": {
-				"browserify-aes": "^1.0.4",
-				"browserify-des": "^1.0.0",
-				"evp_bytestokey": "^1.0.0"
-			}
-		},
-		"browserify-des": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-			"dev": true,
-			"requires": {
-				"cipher-base": "^1.0.1",
-				"des.js": "^1.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"browserify-rsa": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.1.0",
-				"randombytes": "^2.0.1"
-			}
-		},
-		"browserify-sign": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
-			"integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^5.1.1",
-				"browserify-rsa": "^4.0.1",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"elliptic": "^6.5.3",
-				"inherits": "^2.0.4",
-				"parse-asn1": "^5.1.5",
-				"readable-stream": "^3.6.0",
-				"safe-buffer": "^5.2.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "5.1.3",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
-					"integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
-					"dev": true
-				},
-				"elliptic": {
-					"version": "6.5.3",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-					"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.4.0",
-						"brorand": "^1.0.1",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.0",
-						"inherits": "^2.0.1",
-						"minimalistic-assert": "^1.0.0",
-						"minimalistic-crypto-utils": "^1.0.0"
-					},
-					"dependencies": {
-						"bn.js": {
-							"version": "4.11.9",
-							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-							"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-							"dev": true
-						}
-					}
-				},
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-					"dev": true
-				}
-			}
-		},
 		"browserslist": {
 			"version": "4.12.0",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
@@ -4399,26 +2523,6 @@
 				"electron-to-chromium": "^1.3.413",
 				"node-releases": "^1.1.53",
 				"pkg-up": "^2.0.0"
-			}
-		},
-		"bs58": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-			"dev": true,
-			"requires": {
-				"base-x": "^3.0.2"
-			}
-		},
-		"bs58check": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-			"dev": true,
-			"requires": {
-				"bs58": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"safe-buffer": "^5.1.2"
 			}
 		},
 		"bser": {
@@ -4445,36 +2549,6 @@
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
 		},
-		"buffer-indexof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-			"integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
-			"dev": true
-		},
-		"buffer-xor": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-			"dev": true
-		},
-		"bufio": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
-			"integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A==",
-			"dev": true
-		},
-		"byteman": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/byteman/-/byteman-1.3.5.tgz",
-			"integrity": "sha512-FzWDstifFRxtHX234b93AGa1b77dA6NUFpEXe+AoG1NydGN//XDZLMXxRNUoMf7SYYhVxfpwUEUgQOziearJvA==",
-			"dev": true
-		},
-		"bytes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-			"dev": true
-		},
 		"cache-base": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -4491,49 +2565,6 @@
 				"union-value": "^1.0.0",
 				"unset-value": "^1.0.0"
 			}
-		},
-		"cacheable-request": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-			"dev": true,
-			"requires": {
-				"clone-response": "^1.0.2",
-				"get-stream": "^5.1.0",
-				"http-cache-semantics": "^4.0.0",
-				"keyv": "^3.0.0",
-				"lowercase-keys": "^2.0.0",
-				"normalize-url": "^4.1.0",
-				"responselike": "^1.0.2"
-			},
-			"dependencies": {
-				"get-stream": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"lowercase-keys": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-					"dev": true
-				}
-			}
-		},
-		"caip": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/caip/-/caip-0.9.2.tgz",
-			"integrity": "sha512-o4aIUSR9lkn7B9lIw8Xgkj+hDh+S1PtsBphoSqP2Dt95gRWPniaqEpnPwiUEhaPQr84JzWIEm4Cck3lMZtIkTA=="
-		},
-		"callsite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
-			"dev": true
 		},
 		"callsites": {
 			"version": "3.1.0",
@@ -4568,36 +2599,6 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
 		},
-		"cbor": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cbor/-/cbor-5.1.0.tgz",
-			"integrity": "sha512-qzEc7kUShdMbWTaUH7X+aHW8owvBU3FS0dfYR1lGYpoZr0mGJhhojLlZJH653x/DfeMZ56h315FRNBUIG1R7qg==",
-			"dev": true,
-			"requires": {
-				"bignumber.js": "^9.0.0",
-				"nofilter": "^1.0.4"
-			}
-		},
-		"chai": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-			"dev": true,
-			"requires": {
-				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
-				"get-func-name": "^2.0.0",
-				"pathval": "^1.1.0",
-				"type-detect": "^4.0.5"
-			}
-		},
-		"chai-checkmark": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/chai-checkmark/-/chai-checkmark-1.0.1.tgz",
-			"integrity": "sha1-n7s8mtkQHwl+8ogyjTD0In10//s=",
-			"dev": true
-		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -4615,32 +2616,11 @@
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
 		},
-		"check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-			"dev": true
-		},
 		"ci-info": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
 			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
 			"dev": true
-		},
-		"cid-tool": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-1.0.0.tgz",
-			"integrity": "sha512-K7NGZBo1P6N2ogUmBtJWwMNfqXxU3ROiCHs+YKDDwBecsZ46J+9vJ6pOEJzds1JzqRnYRxxZBPfgBEYQebMXJg==",
-			"dev": true,
-			"requires": {
-				"cids": "^1.0.0",
-				"explain-error": "^1.0.4",
-				"multibase": "^3.0.0",
-				"multihashes": "^3.0.1",
-				"split2": "^3.1.1",
-				"uint8arrays": "^1.1.0",
-				"yargs": "^15.0.2"
-			}
 		},
 		"cids": {
 			"version": "1.0.2",
@@ -4685,16 +2665,6 @@
 				}
 			}
 		},
-		"cipher-base": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"class-is": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
@@ -4722,18 +2692,6 @@
 					}
 				}
 			}
-		},
-		"clean-stack": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-			"dev": true
-		},
-		"cli-boxes": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-			"integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
-			"dev": true
 		},
 		"cli-cursor": {
 			"version": "3.1.0",
@@ -4770,15 +2728,6 @@
 						"ansi-regex": "^5.0.0"
 					}
 				}
-			}
-		},
-		"clone-response": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-			"dev": true,
-			"requires": {
-				"mimic-response": "^1.0.0"
 			}
 		},
 		"co": {
@@ -4832,22 +2781,10 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 		},
-		"component-bind": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-			"integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
-			"dev": true
-		},
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
 			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-			"dev": true
-		},
-		"component-inherit": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
 			"dev": true
 		},
 		"concat-map": {
@@ -4855,20 +2792,6 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
-		},
-		"configstore": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-			"integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-			"dev": true,
-			"requires": {
-				"dot-prop": "^5.2.0",
-				"graceful-fs": "^4.1.2",
-				"make-dir": "^3.0.0",
-				"unique-string": "^2.0.0",
-				"write-file-atomic": "^3.0.0",
-				"xdg-basedir": "^4.0.0"
-			}
 		},
 		"convert-source-map": {
 			"version": "1.7.0",
@@ -4878,12 +2801,6 @@
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
-		},
-		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-			"dev": true
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
@@ -4915,69 +2832,6 @@
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
 		},
-		"create-ecdh": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
-			"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.1.0",
-				"elliptic": "^6.5.3"
-			},
-			"dependencies": {
-				"elliptic": {
-					"version": "6.5.3",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-					"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.4.0",
-						"brorand": "^1.0.1",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.0",
-						"inherits": "^2.0.1",
-						"minimalistic-assert": "^1.0.0",
-						"minimalistic-crypto-utils": "^1.0.0"
-					}
-				}
-			}
-		},
-		"create-hash": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"dev": true,
-			"requires": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"md5.js": "^1.3.4",
-				"ripemd160": "^2.0.1",
-				"sha.js": "^2.4.0"
-			}
-		},
-		"create-hmac": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"dev": true,
-			"requires": {
-				"cipher-base": "^1.0.3",
-				"create-hash": "^1.1.0",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
-		},
-		"cross-fetch": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-			"integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
-			"dev": true,
-			"requires": {
-				"node-fetch": "2.6.1"
-			}
-		},
 		"cross-spawn": {
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -5002,31 +2856,6 @@
 				}
 			}
 		},
-		"crypto-browserify": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-			"dev": true,
-			"requires": {
-				"browserify-cipher": "^1.0.0",
-				"browserify-sign": "^4.0.0",
-				"create-ecdh": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.0",
-				"diffie-hellman": "^5.0.0",
-				"inherits": "^2.0.1",
-				"pbkdf2": "^3.0.3",
-				"public-encrypt": "^4.0.0",
-				"randombytes": "^2.0.0",
-				"randomfill": "^1.0.3"
-			}
-		},
-		"crypto-random-string": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-			"dev": true
-		},
 		"cssom": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -5048,26 +2877,6 @@
 					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
 					"dev": true
 				}
-			}
-		},
-		"dag-cbor-links": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-2.0.2.tgz",
-			"integrity": "sha512-PS5skw2eGKVZ1VVu9wquoIoefgMvKhl9/OItzf+7UMot0Nnd3oe/Ai5AP48GvEkAi6GkmglhWwuoKF23hTHJqQ==",
-			"dev": true,
-			"requires": {
-				"cids": "^1.0.0",
-				"ipld-dag-cbor": "^0.17.0"
-			}
-		},
-		"dag-jose": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/dag-jose/-/dag-jose-0.3.0.tgz",
-			"integrity": "sha512-2utzhBhsrMf7nnpqnT2MVm/2aLhwGSbbSpIDvHN6czvTk1mqrxg6L/VR7QdF2qLOeW90A5ZQ4OpN672TZ6LM5Q==",
-			"requires": {
-				"borc": "^2.1.2",
-				"cids": "^1.0.0",
-				"uint8arrays": "^1.1.0"
 			}
 		},
 		"dag-jose-utils": {
@@ -5109,90 +2918,6 @@
 				"whatwg-url": "^7.0.0"
 			}
 		},
-		"datastore-core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-2.0.0.tgz",
-			"integrity": "sha512-E6SS3GEZNMCRZScWO98qQ14MIb7+3MLsJtcgla/ULCjfnhThsUE21HN+wT0+QLoYrKR54puWy/3XKp5N+5+zyA==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.1",
-				"interface-datastore": "^2.0.0",
-				"ipfs-utils": "^2.3.1"
-			},
-			"dependencies": {
-				"ipfs-utils": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
-					"integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
-					"dev": true,
-					"requires": {
-						"abort-controller": "^3.0.0",
-						"any-signal": "^1.1.0",
-						"buffer": "^5.6.0",
-						"err-code": "^2.0.0",
-						"fs-extra": "^9.0.1",
-						"is-electron": "^2.2.0",
-						"iso-url": "^0.4.7",
-						"it-glob": "0.0.8",
-						"it-to-stream": "^0.1.2",
-						"merge-options": "^2.0.0",
-						"nanoid": "^3.1.3",
-						"node-fetch": "^2.6.0",
-						"stream-to-it": "^0.2.0"
-					}
-				}
-			}
-		},
-		"datastore-fs": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-2.0.1.tgz",
-			"integrity": "sha512-W0qOEJDHVmzSfCXMBcgnHI7n0SROQ7vpD24v9AicVWE/DPju4CUWl/1NHSQO3RR3ooaFdG31c1J2OjDKJO6+Fg==",
-			"dev": true,
-			"requires": {
-				"datastore-core": "^2.0.0",
-				"fast-write-atomic": "^0.2.0",
-				"interface-datastore": "^2.0.0",
-				"it-glob": "0.0.8",
-				"mkdirp": "^1.0.4"
-			},
-			"dependencies": {
-				"mkdirp": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-					"dev": true
-				}
-			}
-		},
-		"datastore-level": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-2.0.0.tgz",
-			"integrity": "sha512-52qSxZG75QRqO502cSvnYnXj/5sO29Dvtd9uuiRLSzUaSPher8pS0hl5xzlx7zglpzAjQpjaq9oy2UFO6vMn6g==",
-			"dev": true,
-			"requires": {
-				"datastore-core": "^2.0.0",
-				"interface-datastore": "^2.0.0",
-				"level": "^5.0.1"
-			}
-		},
-		"datastore-pubsub": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.4.1.tgz",
-			"integrity": "sha512-OVKIlSqILBSFApJ5FPmiWaSA71l53sX52sV0JgyGBaghzqbFTTB1HQikB8npSyGMEJfmpCVhKue9rkTHF+WoXg==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.1",
-				"err-code": "^2.0.3",
-				"interface-datastore": "^2.0.0",
-				"uint8arrays": "^1.1.0"
-			}
-		},
-		"dateformat": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-			"dev": true
-		},
 		"debug": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -5214,30 +2939,6 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
-		"decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-			"dev": true,
-			"requires": {
-				"mimic-response": "^1.0.0"
-			}
-		},
-		"deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-			"dev": true,
-			"requires": {
-				"type-detect": "^4.0.0"
-			}
-		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"dev": true
-		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -5249,37 +2950,6 @@
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
 			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 			"dev": true
-		},
-		"defer-to-connect": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
-			"dev": true
-		},
-		"deferred-leveldown": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
-			"integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
-			"dev": true,
-			"requires": {
-				"abstract-leveldown": "~6.2.1",
-				"inherits": "^2.0.3"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "6.2.3",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-					"integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-					"dev": true,
-					"requires": {
-						"buffer": "^5.5.0",
-						"immediate": "^3.2.3",
-						"level-concat-iterator": "~2.0.0",
-						"level-supports": "~1.0.0",
-						"xtend": "~4.0.0"
-					}
-				}
-			}
 		},
 		"define-properties": {
 			"version": "1.1.3",
@@ -5331,12 +3001,6 @@
 				}
 			}
 		},
-		"delay": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/delay/-/delay-4.4.0.tgz",
-			"integrity": "sha512-txgOrJu3OdtOfTiEOT2e76dJVfG/1dz2NZ4F0Pyt4UGZJryssMRp5vdM5wQoLwSOBNdrJv3F9PAhp/heqd7vrA==",
-			"dev": true
-		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -5348,79 +3012,11 @@
 			"resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
 			"integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
 		},
-		"denque": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
-			"dev": true
-		},
-		"des.js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-			"integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
-			}
-		},
 		"detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
-		},
-		"detect-node": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
-			"dev": true
-		},
-		"did-jwt": {
-			"version": "4.5.1",
-			"resolved": "git+https://github.com/oed/did-jwt.git#efbce0057dccc30b63823e12b806db547356f174",
-			"requires": {
-				"@babel/runtime": "^7.11.2",
-				"@stablelib/ed25519": "^1.0.1",
-				"@stablelib/random": "^1.0.0",
-				"@stablelib/sha256": "^1.0.0",
-				"@stablelib/utf8": "^1.0.0",
-				"@stablelib/x25519": "^1.0.0",
-				"@stablelib/xchacha20poly1305": "^1.0.0",
-				"did-resolver": "^2.1.1",
-				"elliptic": "^6.5.3",
-				"js-sha3": "^0.8.0",
-				"uint8arrays": "^1.1.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
-					"integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"elliptic": {
-					"version": "6.5.3",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-					"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-					"requires": {
-						"bn.js": "^4.4.0",
-						"brorand": "^1.0.1",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.0",
-						"inherits": "^2.0.1",
-						"minimalistic-assert": "^1.0.0",
-						"minimalistic-crypto-utils": "^1.0.0"
-					}
-				},
-				"js-sha3": {
-					"version": "0.8.0",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-				}
-			}
 		},
 		"did-resolver": {
 			"version": "2.1.1",
@@ -5428,36 +3024,36 @@
 			"integrity": "sha512-FYLTkNWofjYNDGV1HTQlyVu1OqZiFxR4I8KM+oxGVOkbXva15NfWzbzciqdXUDqOhe6so5aroAdrVip6gSAYSA=="
 		},
 		"dids": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/dids/-/dids-0.7.0.tgz",
-			"integrity": "sha512-v0KQBE0UoB15n8cDZ5uxdTpadm3LnICP7RkpHIZ79zoDfB8/yPneeu7Xnvzd3PSfkHRnoOWkuJtQ8IoVC37OMA==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dids/-/dids-1.0.0.tgz",
+			"integrity": "sha512-z9bjdMmf3xzDymRQJvX8L1RYIKiz+NRSoewu3EXM9aZ/fNncUBEyYnZnJN6NSpN0SbLSElgiPjxVucAGskRIcQ==",
 			"requires": {
+				"@stablelib/random": "^1.0.0",
 				"cids": "^1.0.0",
 				"dag-jose-utils": "^0.1.0",
-				"did-jwt": "^4.6.2",
+				"did-jwt": "^4.6.3",
 				"did-resolver": "^2.1.1",
 				"rpc-utils": "^0.1.3",
 				"uint8arrays": "^1.1.0"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
-					"integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
+					"version": "7.12.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+					"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
 					"requires": {
 						"regenerator-runtime": "^0.13.4"
 					}
 				},
 				"did-jwt": {
-					"version": "4.6.2",
-					"resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-4.6.2.tgz",
-					"integrity": "sha512-T77RnUjhhEvwusQ8gxaMqGekyYjpgaZoq6HM3zEkVH7LA5otasqa5XZpbsxeaGgyT7e9sXeofNNzBWvSZM3G2g==",
+					"version": "4.7.0",
+					"resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-4.7.0.tgz",
+					"integrity": "sha512-tkiZk4gukBAtnhqooBSBW0XYrjXIxEhk/bIHvr6VIwilFL9gQrceJOuJqZuE8s5/UbiUClINv6nOJ+DGPio0DQ==",
 					"requires": {
 						"@babel/runtime": "^7.11.2",
 						"@stablelib/ed25519": "^1.0.1",
 						"@stablelib/random": "^1.0.0",
 						"@stablelib/sha256": "^1.0.0",
-						"@stablelib/utf8": "^1.0.0",
 						"@stablelib/x25519": "^1.0.0",
 						"@stablelib/xchacha20poly1305": "^1.0.0",
 						"did-resolver": "^2.1.1",
@@ -5487,56 +3083,11 @@
 				}
 			}
 		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true
-		},
-		"diff-match-patch": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-			"integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
-			"dev": true
-		},
 		"diff-sequences": {
 			"version": "25.2.6",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
 			"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
 			"dev": true
-		},
-		"diffie-hellman": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.1.0",
-				"miller-rabin": "^4.0.0",
-				"randombytes": "^2.0.0"
-			}
-		},
-		"dirty-chai": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz",
-			"integrity": "sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==",
-			"dev": true
-		},
-		"dlv": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-			"dev": true
-		},
-		"dns-packet": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz",
-			"integrity": "sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==",
-			"dev": true,
-			"requires": {
-				"ip": "^1.1.5",
-				"safe-buffer": "^5.1.1"
-			}
 		},
 		"doctrine": {
 			"version": "3.0.0",
@@ -5555,21 +3106,6 @@
 			"requires": {
 				"webidl-conversions": "^4.0.2"
 			}
-		},
-		"dot-prop": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-			"dev": true,
-			"requires": {
-				"is-obj": "^2.0.0"
-			}
-		},
-		"duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"dev": true
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
@@ -5595,52 +3131,11 @@
 			"integrity": "sha512-q2PeCP2PQXSYadDo9uNY+uHXjdB9PcsUpCVoGlY8TZOPHGlXdevlqW9PkKeqCxn2QBkGB8b6AcMO++gh8X82bA==",
 			"dev": true
 		},
-		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
-			}
-		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
-		},
-		"encoding-down": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
-			"integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
-			"dev": true,
-			"requires": {
-				"abstract-leveldown": "^6.2.1",
-				"inherits": "^2.0.3",
-				"level-codec": "^9.0.0",
-				"level-errors": "^2.0.0"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
-					"integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
-					"dev": true,
-					"requires": {
-						"buffer": "^5.5.0",
-						"immediate": "^3.2.3",
-						"level-concat-iterator": "~2.0.0",
-						"level-supports": "~1.0.0",
-						"xtend": "~4.0.0"
-					}
-				}
-			}
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -5651,103 +3146,10 @@
 				"once": "^1.4.0"
 			}
 		},
-		"engine.io": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.2.tgz",
-			"integrity": "sha512-b4Q85dFkGw+TqgytGPrGgACRUhsdKc9S9ErRAXpPGy/CXKs4tYoHDkvIRdsseAF7NjfVwjRFIn6KTnbw7LwJZg==",
-			"dev": true,
-			"requires": {
-				"accepts": "~1.3.4",
-				"base64id": "2.0.0",
-				"cookie": "0.3.1",
-				"debug": "~4.1.0",
-				"engine.io-parser": "~2.2.0",
-				"ws": "^7.1.2"
-			}
-		},
-		"engine.io-client": {
-			"version": "3.4.4",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.4.tgz",
-			"integrity": "sha512-iU4CRr38Fecj8HoZEnFtm2EiKGbYZcPn3cHxqNGl/tmdWRf60KhK+9vE0JeSjgnlS/0oynEfLgKbT9ALpim0sQ==",
-			"dev": true,
-			"requires": {
-				"component-emitter": "~1.3.0",
-				"component-inherit": "0.0.3",
-				"debug": "~3.1.0",
-				"engine.io-parser": "~2.2.0",
-				"has-cors": "1.1.0",
-				"indexof": "0.0.1",
-				"parseqs": "0.0.6",
-				"parseuri": "0.0.6",
-				"ws": "~6.1.0",
-				"xmlhttprequest-ssl": "~1.5.4",
-				"yeast": "0.1.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"parseqs": {
-					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-					"integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
-					"dev": true
-				},
-				"parseuri": {
-					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-					"integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
-					"dev": true
-				},
-				"ws": {
-					"version": "6.1.4",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-					"integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
-					"dev": true,
-					"requires": {
-						"async-limiter": "~1.0.0"
-					}
-				}
-			}
-		},
-		"engine.io-parser": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
-			"integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
-			"dev": true,
-			"requires": {
-				"after": "0.8.2",
-				"arraybuffer.slice": "~0.0.7",
-				"base64-arraybuffer": "0.1.4",
-				"blob": "0.0.5",
-				"has-binary2": "~1.0.2"
-			}
-		},
 		"err-code": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
 			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
-		},
-		"errno": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-			"dev": true,
-			"requires": {
-				"prr": "~1.0.1"
-			}
 		},
 		"error-ex": {
 			"version": "1.3.2",
@@ -5757,12 +3159,6 @@
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
-		},
-		"escape-goat": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
-			"integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
-			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -5958,293 +3354,6 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
-		"ethereum-cryptography": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-			"integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-			"dev": true,
-			"requires": {
-				"@types/pbkdf2": "^3.0.0",
-				"@types/secp256k1": "^4.0.1",
-				"blakejs": "^1.1.0",
-				"browserify-aes": "^1.2.0",
-				"bs58check": "^2.1.2",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"hash.js": "^1.1.7",
-				"keccak": "^3.0.0",
-				"pbkdf2": "^3.0.17",
-				"randombytes": "^2.1.0",
-				"safe-buffer": "^5.1.2",
-				"scrypt-js": "^3.0.0",
-				"secp256k1": "^4.0.1",
-				"setimmediate": "^1.0.5"
-			}
-		},
-		"ethereumjs-account": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-3.0.0.tgz",
-			"integrity": "sha512-WP6BdscjiiPkQfF9PVfMcwx/rDvfZTjFKY0Uwc09zSQr9JfIVH87dYIJu0gNhBhpmovV4yq295fdllS925fnBA==",
-			"dev": true,
-			"requires": {
-				"ethereumjs-util": "^6.0.0",
-				"rlp": "^2.2.1",
-				"safe-buffer": "^5.1.1"
-			}
-		},
-		"ethereumjs-block": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
-			"integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
-			"dev": true,
-			"requires": {
-				"async": "^2.0.1",
-				"ethereumjs-common": "^1.5.0",
-				"ethereumjs-tx": "^2.1.1",
-				"ethereumjs-util": "^5.0.0",
-				"merkle-patricia-tree": "^2.1.2"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-					"integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-					"dev": true,
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				},
-				"deferred-leveldown": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-					"integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-					"dev": true,
-					"requires": {
-						"abstract-leveldown": "~2.6.0"
-					}
-				},
-				"ethereumjs-util": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-					"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"elliptic": "^6.5.2",
-						"ethereum-cryptography": "^0.1.3",
-						"ethjs-util": "^0.1.3",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"level-codec": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-					"integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
-					"dev": true
-				},
-				"level-errors": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-					"integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-					"dev": true,
-					"requires": {
-						"errno": "~0.1.1"
-					}
-				},
-				"level-iterator-stream": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-					"integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.1",
-						"level-errors": "^1.0.3",
-						"readable-stream": "^1.0.33",
-						"xtend": "^4.0.0"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "1.1.14",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-							"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-							"dev": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.1",
-								"isarray": "0.0.1",
-								"string_decoder": "~0.10.x"
-							}
-						}
-					}
-				},
-				"levelup": {
-					"version": "1.3.9",
-					"resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-					"integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-					"dev": true,
-					"requires": {
-						"deferred-leveldown": "~1.2.1",
-						"level-codec": "~7.0.0",
-						"level-errors": "~1.0.3",
-						"level-iterator-stream": "~1.3.0",
-						"prr": "~1.0.1",
-						"semver": "~5.4.1",
-						"xtend": "~4.0.0"
-					}
-				},
-				"merkle-patricia-tree": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-					"integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
-					"dev": true,
-					"requires": {
-						"async": "^1.4.2",
-						"ethereumjs-util": "^5.0.0",
-						"level-ws": "0.0.0",
-						"levelup": "^1.2.1",
-						"memdown": "^1.0.0",
-						"readable-stream": "^2.0.0",
-						"rlp": "^2.0.0",
-						"semaphore": ">=1.0.1"
-					},
-					"dependencies": {
-						"async": {
-							"version": "1.5.2",
-							"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-							"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-							"dev": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					},
-					"dependencies": {
-						"isarray": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-							"dev": true
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-							"dev": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
-				"semver": {
-					"version": "5.4.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-					"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-					"dev": true
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
-		"ethereumjs-common": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
-			"integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA==",
-			"dev": true
-		},
-		"ethereumjs-tx": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-			"integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-			"dev": true,
-			"requires": {
-				"ethereumjs-common": "^1.5.0",
-				"ethereumjs-util": "^6.0.0"
-			}
-		},
-		"ethereumjs-util": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-			"integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-			"dev": true,
-			"requires": {
-				"@types/bn.js": "^4.11.3",
-				"bn.js": "^4.11.0",
-				"create-hash": "^1.1.2",
-				"elliptic": "^6.5.2",
-				"ethereum-cryptography": "^0.1.3",
-				"ethjs-util": "0.1.6",
-				"rlp": "^2.2.3"
-			}
-		},
-		"ethjs-util": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-			"integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-			"dev": true,
-			"requires": {
-				"is-hex-prefixed": "1.0.0",
-				"strip-hex-prefix": "1.0.0"
-			}
-		},
-		"event-iterator": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
-			"integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ==",
-			"dev": true
-		},
-		"event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"dev": true
-		},
-		"eventemitter3": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-			"dev": true
-		},
-		"events": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
-			"integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
-			"dev": true
-		},
-		"evp_bytestokey": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-			"dev": true,
-			"requires": {
-				"md5.js": "^1.3.4",
-				"safe-buffer": "^5.1.1"
-			}
-		},
 		"exec-sh": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
@@ -6363,12 +3472,6 @@
 				}
 			}
 		},
-		"explain-error": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
-			"integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk=",
-			"dev": true
-		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -6484,12 +3587,6 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
-		"fast-fifo": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.0.0.tgz",
-			"integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ==",
-			"dev": true
-		},
 		"fast-json-patch": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
@@ -6514,24 +3611,6 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-			"dev": true
-		},
-		"fast-redact": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
-			"integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w==",
-			"dev": true
-		},
-		"fast-safe-stringify": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-			"dev": true
-		},
-		"fast-write-atomic": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/fast-write-atomic/-/fast-write-atomic-0.2.1.tgz",
-			"integrity": "sha512-WvJe06IfNYlr+6cO3uQkdKdy3Cb1LlCJSF8zRs2eT8yuhdbSlR9nIt+TgQ92RUxiRrQm+/S7RARnMfCs5iuAjw==",
 			"dev": true
 		},
 		"fb-watchman": {
@@ -6560,30 +3639,6 @@
 			"requires": {
 				"flat-cache": "^2.0.1"
 			}
-		},
-		"file-type": {
-			"version": "14.7.1",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-14.7.1.tgz",
-			"integrity": "sha512-sXAMgFk67fQLcetXustxfKX+PZgHIUFn96Xld9uH8aXPdX3xOp0/jg9OdouVTvQrf7mrn+wAa4jN/y9fUOOiRA==",
-			"dev": true,
-			"requires": {
-				"readable-web-to-node-stream": "^2.0.0",
-				"strtok3": "^6.0.3",
-				"token-types": "^2.0.0",
-				"typedarray-to-buffer": "^3.1.5"
-			}
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true
-		},
-		"filesize": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
-			"integrity": "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==",
-			"dev": true
 		},
 		"fill-range": {
 			"version": "7.0.1",
@@ -6614,22 +3669,10 @@
 				"write": "1.0.3"
 			}
 		},
-		"flatstr": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-			"integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
-			"dev": true
-		},
 		"flatted": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
 			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
-			"dev": true
-		},
-		"fnv1a": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.0.1.tgz",
-			"integrity": "sha1-kV4tbQI8Q9UiStn20qPEFW9XEvU=",
 			"dev": true
 		},
 		"for-in": {
@@ -6644,17 +3687,6 @@
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
 			"dev": true
 		},
-		"form-data": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-			"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			}
-		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -6662,18 +3694,6 @@
 			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
-			}
-		},
-		"fs-extra": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-			"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-			"dev": true,
-			"requires": {
-				"at-least-node": "^1.0.0",
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^1.0.0"
 			}
 		},
 		"fs.realpath": {
@@ -6701,598 +3721,16 @@
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
-		"gar": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
-			"integrity": "sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w==",
-			"dev": true
-		},
-		"gc-stats": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/gc-stats/-/gc-stats-1.4.0.tgz",
-			"integrity": "sha512-4FcCj9e8j8rCjvLkqRpGZBLgTC/xr9XEf5By3x77cDucWWB3pJK6FEwXZCTCbb4z8xdaOoi4owBNrvn3ciDdxA==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"nan": "^2.13.2",
-				"node-pre-gyp": "^0.13.0"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"debug": {
-					"version": "4.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"deep-extend": {
-					"version": "0.6.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"fs-minipass": {
-					"version": "1.2.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minipass": "^2.2.1"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minimatch": "^3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"minipass": {
-					"version": "2.3.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "1.2.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minipass": "^2.2.1"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"needle": {
-					"version": "2.3.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"debug": "^4.1.0",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.13.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.1",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.2.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.0.6",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"npm-packlist": {
-					"version": "1.4.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.8",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"deep-extend": "^0.6.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"semver": {
-					"version": "5.7.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"tar": {
-					"version": "4.4.8",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.3.4",
-						"minizlib": "^1.1.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.2"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"wide-align": {
-					"version": "1.1.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"string-width": "^1.0.2 || 2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"yallist": {
-					"version": "3.0.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
 		"gensync": {
 			"version": "1.0.0-beta.1",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
 			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
 			"dev": true
 		},
-		"get-browser-rtc": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.0.2.tgz",
-			"integrity": "sha1-u81AyEUaftTvXDc7gWmkCd0dEdk=",
-			"dev": true
-		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true
-		},
-		"get-folder-size": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-2.0.1.tgz",
-			"integrity": "sha512-+CEb+GDCM7tkOS2wdMKTn9vU7DgnKUTuDlehkNJKNSovdCOVxs14OfKCk4cvSaR3za4gj+OBdl9opPN9xrJ0zA==",
-			"dev": true,
-			"requires": {
-				"gar": "^1.0.4",
-				"tiny-each-async": "2.0.3"
-			}
-		},
-		"get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-			"dev": true
-		},
-		"get-iterator": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
-			"integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==",
 			"dev": true
 		},
 		"get-package-type": {
@@ -7348,56 +3786,11 @@
 				"is-glob": "^4.0.1"
 			}
 		},
-		"global-dirs": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-			"integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
-			"dev": true,
-			"requires": {
-				"ini": "^1.3.5"
-			}
-		},
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true
-		},
-		"globalthis": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.1.tgz",
-			"integrity": "sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3"
-			}
-		},
-		"got": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-			"dev": true,
-			"requires": {
-				"@sindresorhus/is": "^0.14.0",
-				"@szmarczak/http-timer": "^1.1.2",
-				"cacheable-request": "^6.0.0",
-				"decompress-response": "^3.3.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^4.1.0",
-				"lowercase-keys": "^1.0.1",
-				"mimic-response": "^1.0.1",
-				"p-cancelable": "^1.0.0",
-				"to-readable-stream": "^1.0.0",
-				"url-parse-lax": "^3.0.0"
-			},
-			"dependencies": {
-				"p-cancelable": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-					"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-					"dev": true
-				}
-			}
 		},
 		"graceful-fs": {
 			"version": "4.2.4",
@@ -7411,27 +3804,6 @@
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
 			"dev": true,
 			"optional": true
-		},
-		"hamt-sharding": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-1.0.0.tgz",
-			"integrity": "sha512-jDk8N1U8qprvSt3KopOrrP46zUogxeZY+znDHP196MLBQKldld0TQFTneT1bxOFDw8vttbAQy1bG7L3/pzYorg==",
-			"dev": true,
-			"requires": {
-				"sparse-array": "^1.3.1"
-			}
-		},
-		"hapi-pino": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-8.3.0.tgz",
-			"integrity": "sha512-8Cm1WIs6jp8B9ZzYqPFbCWNKt6F6jNCfLmCIHmPsm35sTOvT/r5+d9KpYR2vigWQRLS23VBXzOqUVESpP7r+jA==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "^9.0.0",
-				"abstract-logging": "^2.0.0",
-				"pino": "^6.0.0",
-				"pino-pretty": "^4.0.0"
-			}
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -7448,29 +3820,6 @@
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
 			}
-		},
-		"has-binary2": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-			"integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
-			"dev": true,
-			"requires": {
-				"isarray": "2.0.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-					"dev": true
-				}
-			}
-		},
-		"has-cors": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-			"integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
-			"dev": true
 		},
 		"has-flag": {
 			"version": "3.0.0",
@@ -7536,31 +3885,6 @@
 				}
 			}
 		},
-		"has-yarn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
-			"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
-			"dev": true
-		},
-		"hash-base": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.6.0",
-				"safe-buffer": "^5.2.0"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-					"dev": true
-				}
-			}
-		},
 		"hash.js": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
@@ -7569,18 +3893,6 @@
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
 			}
-		},
-		"hashlru": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
-			"integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
-			"dev": true
-		},
-		"heap": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
-			"integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=",
-			"dev": true
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -7613,12 +3925,6 @@
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
 		},
-		"http-cache-semantics": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-			"dev": true
-		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -7645,342 +3951,6 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
-		"identity-wallet": {
-			"version": "2.0.0-alpha.18",
-			"resolved": "https://registry.npmjs.org/identity-wallet/-/identity-wallet-2.0.0-alpha.18.tgz",
-			"integrity": "sha512-Iro78pz3cS2zy9B+hz8VjNgLNB7byoJtORJLeJ3ij0PG8n+wRyXpy/776012vRqxzFr9lZZrEP2+PMydg0rJqg==",
-			"dev": true,
-			"requires": {
-				"3id-blockchain-utils": "^1.0.0",
-				"@babel/runtime": "^7.12.1",
-				"@ceramicnetwork/ceramic-http-client": "^0.7.1",
-				"@ceramicstudio/idx-constants": "^0.3.0",
-				"@ethersproject/hdnode": "^5.0.5",
-				"@ethersproject/wallet": "^5.0.7",
-				"@stablelib/random": "^1.0.0",
-				"@stablelib/x25519": "^1.0.0",
-				"caip": "^0.9.2",
-				"dag-jose-utils": "^0.1.0",
-				"did-jwt": "^4.6.2",
-				"fast-json-stable-stringify": "^2.1.0",
-				"rpc-utils": "^0.1.2",
-				"store": "^2.0.12",
-				"uint8arrays": "^1.1.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-					"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				},
-				"@ethersproject/abstract-provider": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.5.tgz",
-					"integrity": "sha512-i/CjElAkzV7vQBAeoz+IpjGfcFYEP9eD7j3fzZ0fzTq03DO7PPnR+xkEZ1IoDXGwDS+55aLM1xvLDwB/Lx6IOQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bignumber": "^5.0.7",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/networks": "^5.0.3",
-						"@ethersproject/properties": "^5.0.3",
-						"@ethersproject/transactions": "^5.0.5",
-						"@ethersproject/web": "^5.0.6"
-					}
-				},
-				"@ethersproject/abstract-signer": {
-					"version": "5.0.7",
-					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.7.tgz",
-					"integrity": "sha512-8W8gy/QutEL60EoMEpvxZ8MFAEWs/JvH5nmZ6xeLXoZvmBCasGmxqHdYjo2cxg0nevkPkq9SeenSsBBZSCx+SQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/abstract-provider": "^5.0.4",
-						"@ethersproject/bignumber": "^5.0.7",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/properties": "^5.0.3"
-					}
-				},
-				"@ethersproject/address": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
-					"integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bignumber": "^5.0.7",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/keccak256": "^5.0.3",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/rlp": "^5.0.3",
-						"bn.js": "^4.4.0"
-					}
-				},
-				"@ethersproject/basex": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.4.tgz",
-					"integrity": "sha512-ixIr/kKiAoSzOnSc777AGIOAhKai5Ivqr4HO/Gz+YG+xkfv6kqD6AW4ga9vM20Wwb0QBhh3LoRWTu4V1K+x9Ew==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/properties": "^5.0.3"
-					}
-				},
-				"@ethersproject/bignumber": {
-					"version": "5.0.8",
-					"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-					"integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"bn.js": "^4.4.0"
-					}
-				},
-				"@ethersproject/bytes": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-					"integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/logger": "^5.0.5"
-					}
-				},
-				"@ethersproject/constants": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
-					"integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bignumber": "^5.0.7"
-					}
-				},
-				"@ethersproject/hash": {
-					"version": "5.0.6",
-					"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.6.tgz",
-					"integrity": "sha512-Gvh57v6BWhwnud6l7tMfQm32PRQ2DYx2WaAAQmAxAfYvmzUkpQCBstnGeNMXIL8/2wdkvcB2u+WZRWaZtsFuUQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/abstract-signer": "^5.0.6",
-						"@ethersproject/address": "^5.0.5",
-						"@ethersproject/bignumber": "^5.0.8",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/keccak256": "^5.0.3",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/properties": "^5.0.4",
-						"@ethersproject/strings": "^5.0.4"
-					}
-				},
-				"@ethersproject/hdnode": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.5.tgz",
-					"integrity": "sha512-Ho4HZaK+KijE5adayvjAGusWMnT0mgwGa5hGMBofBOgX9nqiKf6Wxx68SXBGI1/L3rmKo6mlAjxUd8gefs0teQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/abstract-signer": "^5.0.4",
-						"@ethersproject/basex": "^5.0.3",
-						"@ethersproject/bignumber": "^5.0.7",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/pbkdf2": "^5.0.3",
-						"@ethersproject/properties": "^5.0.3",
-						"@ethersproject/sha2": "^5.0.3",
-						"@ethersproject/signing-key": "^5.0.4",
-						"@ethersproject/strings": "^5.0.4",
-						"@ethersproject/transactions": "^5.0.5",
-						"@ethersproject/wordlists": "^5.0.4"
-					}
-				},
-				"@ethersproject/keccak256": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.4.tgz",
-					"integrity": "sha512-GNpiOUm9PGUxFNqOxYKDQBM0u68bG9XC9iOulEQ8I0tOx/4qUpgVzvgXL6ugxr0RY554Gz/NQsVqknqPzUcxpQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"js-sha3": "0.5.7"
-					}
-				},
-				"@ethersproject/logger": {
-					"version": "5.0.6",
-					"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.6.tgz",
-					"integrity": "sha512-FrX0Vnb3JZ1md/7GIZfmJ06XOAA8r3q9Uqt9O5orr4ZiksnbpXKlyDzQtlZ5Yv18RS8CAUbiKH9vwidJg1BPmQ==",
-					"dev": true
-				},
-				"@ethersproject/networks": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.4.tgz",
-					"integrity": "sha512-/wHDTRms5mpJ09BoDrbNdFWINzONe05wZRgohCXvEv39rrH/Gd/yAnct8wC0RsW3tmFOgjgQxuBvypIxuUynTw==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/logger": "^5.0.5"
-					}
-				},
-				"@ethersproject/pbkdf2": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.4.tgz",
-					"integrity": "sha512-9jVBjHXQKfr9+3bkCg01a8Cd1H9e+7Kw3ZMIvAxD0lZtuzrXsJxm1hVwY9KA+PRUvgS/9tTP4viXQYwLAax7zg==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/sha2": "^5.0.3"
-					}
-				},
-				"@ethersproject/properties": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.4.tgz",
-					"integrity": "sha512-UdyX3GqBxFt15B0uSESdDNmhvEbK3ACdDXl2soshoPcneXuTswHDeA0LoPlnaZzhbgk4p6jqb4GMms5C26Qu6A==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/logger": "^5.0.5"
-					}
-				},
-				"@ethersproject/rlp": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.4.tgz",
-					"integrity": "sha512-5qrrZad7VTjofxSsm7Zg/7Dr4ZOln4S2CqiDdOuTv6MBKnXj0CiBojXyuDy52M8O3wxH0CyE924hXWTDV1PQWQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5"
-					}
-				},
-				"@ethersproject/sha2": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.4.tgz",
-					"integrity": "sha512-0yFhf1mspxAfWdXXoPtK94adUeu1R7/FzAa+DfEiZTc76sz/vHXf0LSIazoR3znYKFny6haBxME+usbvvEcF3A==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"hash.js": "1.1.3"
-					},
-					"dependencies": {
-						"hash.js": {
-							"version": "1.1.3",
-							"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-							"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-							"dev": true,
-							"requires": {
-								"inherits": "^2.0.3",
-								"minimalistic-assert": "^1.0.0"
-							}
-						}
-					}
-				},
-				"@ethersproject/signing-key": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.5.tgz",
-					"integrity": "sha512-Z1wY7JC1HVO4CvQWY2TyTTuAr8xK3bJijZw1a9G92JEmKdv1j255R/0YLBBcFTl2J65LUjtXynNJ2GbArPGi5g==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/properties": "^5.0.3",
-						"elliptic": "6.5.3"
-					}
-				},
-				"@ethersproject/strings": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
-					"integrity": "sha512-JED6WaIV00xM/gvj8vSnd+0VWtDYdidTmavFRCTQakqfz+4tDo6Jz5LHgG+dd45h7ah7ykCHW0C7ZXWEDROCXQ==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/constants": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5"
-					}
-				},
-				"@ethersproject/transactions": {
-					"version": "5.0.6",
-					"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
-					"integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/address": "^5.0.4",
-						"@ethersproject/bignumber": "^5.0.7",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/constants": "^5.0.4",
-						"@ethersproject/keccak256": "^5.0.3",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/properties": "^5.0.3",
-						"@ethersproject/rlp": "^5.0.3",
-						"@ethersproject/signing-key": "^5.0.4"
-					}
-				},
-				"@ethersproject/web": {
-					"version": "5.0.9",
-					"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.9.tgz",
-					"integrity": "sha512-//QNlv1MSkOII1hv3+HQwWoiVFS+BMVGI0KYeUww4cyrEktnx1QIez5bTSab9s9fWTFaWKNmQNBwMbxAqPuYDw==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/base64": "^5.0.3",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/properties": "^5.0.3",
-						"@ethersproject/strings": "^5.0.4"
-					}
-				},
-				"@ethersproject/wordlists": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.5.tgz",
-					"integrity": "sha512-XA3ycFltVrCTQt04w5nHu3Xq5Z6HjqWsXaAYQHFdqtugyUsIumaO9S5MOwFFuUYTNkZUoT3jCRa/OBS+K4tLfA==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/hash": "^5.0.4",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/properties": "^5.0.3",
-						"@ethersproject/strings": "^5.0.4"
-					}
-				},
-				"did-jwt": {
-					"version": "4.6.2",
-					"resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-4.6.2.tgz",
-					"integrity": "sha512-T77RnUjhhEvwusQ8gxaMqGekyYjpgaZoq6HM3zEkVH7LA5otasqa5XZpbsxeaGgyT7e9sXeofNNzBWvSZM3G2g==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.11.2",
-						"@stablelib/ed25519": "^1.0.1",
-						"@stablelib/random": "^1.0.0",
-						"@stablelib/sha256": "^1.0.0",
-						"@stablelib/utf8": "^1.0.0",
-						"@stablelib/x25519": "^1.0.0",
-						"@stablelib/xchacha20poly1305": "^1.0.0",
-						"did-resolver": "^2.1.1",
-						"elliptic": "^6.5.3",
-						"js-sha3": "^0.8.0",
-						"uint8arrays": "^1.1.0"
-					},
-					"dependencies": {
-						"js-sha3": {
-							"version": "0.8.0",
-							"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-							"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-							"dev": true
-						}
-					}
-				},
-				"elliptic": {
-					"version": "6.5.3",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-					"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.4.0",
-						"brorand": "^1.0.1",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.0",
-						"inherits": "^2.0.1",
-						"minimalistic-assert": "^1.0.0",
-						"minimalistic-crypto-utils": "^1.0.0"
-					}
-				}
-			}
-		},
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -7990,12 +3960,6 @@
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
 			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-			"dev": true
-		},
-		"immediate": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-			"integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
 			"dev": true
 		},
 		"import-fresh": {
@@ -8016,12 +3980,6 @@
 				}
 			}
 		},
-		"import-lazy": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-			"dev": true
-		},
 		"import-local": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
@@ -8038,18 +3996,6 @@
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
 			"dev": true
 		},
-		"indent-string": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-			"dev": true
-		},
-		"indexof": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-			"dev": true
-		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -8064,12 +4010,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
 		},
 		"inquirer": {
 			"version": "7.2.0",
@@ -8153,44 +4093,6 @@
 				}
 			}
 		},
-		"interface-datastore": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-2.0.0.tgz",
-			"integrity": "sha512-wOImix5uVEZWo+8zPSRMJ9nHbszZi3PhZ14KHLN7oRQjaYQtjtOpYj6n5EXTjDAfIQI8KN9vntHXxyAw1lcRIA==",
-			"dev": true,
-			"requires": {
-				"class-is": "^1.1.0",
-				"err-code": "^2.0.1",
-				"ipfs-utils": "^2.3.1",
-				"iso-random-stream": "^1.1.1",
-				"it-all": "^1.0.2",
-				"it-drain": "^1.0.1",
-				"nanoid": "^3.0.2"
-			},
-			"dependencies": {
-				"ipfs-utils": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
-					"integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
-					"dev": true,
-					"requires": {
-						"abort-controller": "^3.0.0",
-						"any-signal": "^1.1.0",
-						"buffer": "^5.6.0",
-						"err-code": "^2.0.0",
-						"fs-extra": "^9.0.1",
-						"is-electron": "^2.2.0",
-						"iso-url": "^0.4.7",
-						"it-glob": "0.0.8",
-						"it-to-stream": "^0.1.2",
-						"merge-options": "^2.0.0",
-						"nanoid": "^3.1.3",
-						"node-fetch": "^2.6.0",
-						"stream-to-it": "^0.2.0"
-					}
-				}
-			}
-		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -8198,529 +4100,6 @@
 			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
-			}
-		},
-		"ip": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-			"dev": true
-		},
-		"ip-address": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-6.4.0.tgz",
-			"integrity": "sha512-c5uxc2WUTuRBVHT/6r4m7HIr/DfV0bF6DvLH3iZGSK8wp8iMwwZSgIq2do0asFf8q9ECug0SE+6+1ACMe4sorA==",
-			"dev": true,
-			"requires": {
-				"jsbn": "1.1.0",
-				"lodash.find": "4.6.0",
-				"lodash.max": "4.0.1",
-				"lodash.merge": "4.6.2",
-				"lodash.padstart": "4.6.1",
-				"lodash.repeat": "4.1.0",
-				"sprintf-js": "1.1.2"
-			},
-			"dependencies": {
-				"sprintf-js": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-					"dev": true
-				}
-			}
-		},
-		"ip-regex": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.2.0.tgz",
-			"integrity": "sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A==",
-			"dev": true
-		},
-		"ipfs": {
-			"version": "github:simonovic86/ipfs#d8214b84af790634d0eede0459acea57c83f62d0",
-			"from": "github:simonovic86/ipfs",
-			"dev": true,
-			"requires": {
-				"@hapi/ammo": "^5.0.1",
-				"@hapi/boom": "^9.1.0",
-				"@hapi/content": "^5.0.2",
-				"@hapi/hapi": "^20.0.0",
-				"abort-controller": "^3.0.0",
-				"any-signal": "^1.1.0",
-				"array-shuffle": "^1.0.1",
-				"bignumber.js": "^9.0.0",
-				"bl": "^4.0.2",
-				"byteman": "^1.3.5",
-				"cbor": "^5.0.1",
-				"cid-tool": "^1.0.0",
-				"cids": "^1.0.0",
-				"class-is": "^1.1.0",
-				"dag-cbor-links": "^2.0.0",
-				"datastore-core": "^2.0.0",
-				"datastore-pubsub": "^0.4.0",
-				"debug": "^4.1.0",
-				"dlv": "^1.1.3",
-				"err-code": "^2.0.0",
-				"execa": "^4.0.0",
-				"file-type": "^14.1.4",
-				"fnv1a": "^1.0.1",
-				"get-folder-size": "^2.0.0",
-				"hamt-sharding": "^1.0.0",
-				"hapi-pino": "^8.2.0",
-				"hashlru": "^2.3.0",
-				"interface-datastore": "^2.0.0",
-				"ipfs-bitswap": "^3.0.0",
-				"ipfs-block-service": "^0.18.0",
-				"ipfs-core-utils": "^0.4.0",
-				"ipfs-http-client": "^47.0.1",
-				"ipfs-http-response": "^0.6.0",
-				"ipfs-repo": "^6.0.3",
-				"ipfs-unixfs": "^2.0.2",
-				"ipfs-unixfs-exporter": "^3.0.2",
-				"ipfs-unixfs-importer": "^3.0.2",
-				"ipfs-utils": "^3.0.0",
-				"ipld": "^0.27.1",
-				"ipld-bitcoin": "^0.4.0",
-				"ipld-block": "^0.10.0",
-				"ipld-dag-cbor": "^0.17.0",
-				"ipld-dag-pb": "^0.20.0",
-				"ipld-ethereum": "^5.0.1",
-				"ipld-git": "^0.6.1",
-				"ipld-raw": "^6.0.0",
-				"ipld-zcash": "^0.5.0",
-				"ipns": "^0.8.0",
-				"is-domain-name": "^1.0.1",
-				"is-ipfs": "^2.0.0",
-				"iso-url": "^0.4.7",
-				"it-all": "^1.0.1",
-				"it-concat": "^1.0.0",
-				"it-drain": "^1.0.1",
-				"it-first": "^1.0.1",
-				"it-glob": "0.0.8",
-				"it-last": "^1.0.2",
-				"it-map": "^1.0.2",
-				"it-multipart": "^1.0.1",
-				"it-pipe": "^1.1.0",
-				"it-tar": "^1.2.2",
-				"it-to-stream": "^0.1.1",
-				"iterable-ndjson": "^1.1.0",
-				"joi": "^17.2.1",
-				"jsondiffpatch": "^0.4.1",
-				"just-safe-set": "^2.1.0",
-				"libp2p": "^0.29.0",
-				"libp2p-bootstrap": "^0.12.0",
-				"libp2p-crypto": "^0.18.0",
-				"libp2p-delegated-content-routing": "^0.7.0",
-				"libp2p-delegated-peer-routing": "^0.7.0",
-				"libp2p-floodsub": "^0.23.0",
-				"libp2p-gossipsub": "^0.6.0",
-				"libp2p-kad-dht": "^0.20.0",
-				"libp2p-mdns": "^0.15.0",
-				"libp2p-mplex": "^0.10.0",
-				"libp2p-noise": "^2.0.0",
-				"libp2p-record": "^0.9.0",
-				"libp2p-secio": "^0.13.0",
-				"libp2p-tcp": "^0.15.0",
-				"libp2p-webrtc-star": "^0.20.0",
-				"libp2p-websockets": "^0.14.0",
-				"mafmt": "^8.0.0",
-				"merge-options": "^2.0.0",
-				"mortice": "^2.0.0",
-				"multiaddr": "^8.0.0",
-				"multiaddr-to-uri": "^6.0.0",
-				"multibase": "^3.0.0",
-				"multicodec": "^2.0.0",
-				"multihashing-async": "^2.0.1",
-				"p-defer": "^3.0.0",
-				"p-queue": "^6.1.0",
-				"parse-duration": "^0.4.4",
-				"peer-id": "^0.14.0",
-				"pretty-bytes": "^5.3.0",
-				"progress": "^2.0.1",
-				"prom-client": "^12.0.0",
-				"prometheus-gc-stats": "^0.6.0",
-				"protons": "^2.0.0",
-				"semver": "^7.3.2",
-				"stream-to-it": "^0.2.1",
-				"streaming-iterables": "^5.0.0",
-				"temp": "^0.9.0",
-				"timeout-abort-controller": "^1.1.0",
-				"uint8arrays": "^1.1.0",
-				"update-notifier": "^4.0.0",
-				"uri-to-multiaddr": "^4.0.0",
-				"varint": "^5.0.0",
-				"yargs": "^15.1.0",
-				"yargs-promise": "^1.1.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.1.0",
-						"shebang-command": "^2.0.0",
-						"which": "^2.0.1"
-					}
-				},
-				"execa": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-					"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^7.0.0",
-						"get-stream": "^5.0.0",
-						"human-signals": "^1.1.1",
-						"is-stream": "^2.0.0",
-						"merge-stream": "^2.0.0",
-						"npm-run-path": "^4.0.0",
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2",
-						"strip-final-newline": "^2.0.0"
-					}
-				},
-				"get-stream": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"is-stream": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-					"dev": true
-				},
-				"npm-run-path": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-					"dev": true,
-					"requires": {
-						"path-key": "^3.0.0"
-					}
-				},
-				"path-key": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-					"dev": true
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-					"dev": true
-				},
-				"shebang-command": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^3.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-					"dev": true
-				}
-			}
-		},
-		"ipfs-bitswap": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-3.0.0.tgz",
-			"integrity": "sha512-9rX9vMUEegk61O4OoUWBUcU/WLLwALhyzHQdJzqW1DCn+nNnZVbRrzIWY1v5PnlywMtcUvd/ennpegVKCPuiUA==",
-			"dev": true,
-			"requires": {
-				"abort-controller": "^3.0.0",
-				"any-signal": "^1.1.0",
-				"bignumber.js": "^9.0.0",
-				"cids": "^1.0.0",
-				"debug": "^4.1.0",
-				"ipld-block": "^0.10.0",
-				"it-length-prefixed": "^3.0.0",
-				"it-pipe": "^1.1.0",
-				"just-debounce-it": "^1.1.0",
-				"libp2p-interfaces": "^0.4.1",
-				"moving-average": "^1.0.0",
-				"multicodec": "^2.0.0",
-				"multihashing-async": "^2.0.1",
-				"protons": "^2.0.0",
-				"streaming-iterables": "^5.0.2",
-				"uint8arrays": "^1.1.0",
-				"varint-decoder": "^1.0.0"
-			}
-		},
-		"ipfs-block-service": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.18.0.tgz",
-			"integrity": "sha512-tye5Uxbf3bYlfcGkV3CspP2JNcM2Ggm/5Kxph0jGKtAZtgfFxUq3NeSmvS6nGtZZBaFP4nwRF2yq7dQMALWzVg==",
-			"dev": true,
-			"requires": {
-				"err-code": "^2.0.0",
-				"streaming-iterables": "^5.0.2"
-			}
-		},
-		"ipfs-core-utils": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.4.0.tgz",
-			"integrity": "sha512-IBPFvYjWPfVFpCeYUL/0gCUOabdBhh7aO5i4tU//UlF2gVCXPH4PRYlbBH9WM83zE2+o4vDi+dBXsdAI6nLPAg==",
-			"dev": true,
-			"requires": {
-				"blob-to-it": "0.0.2",
-				"browser-readablestream-to-it": "0.0.2",
-				"cids": "^1.0.0",
-				"err-code": "^2.0.0",
-				"ipfs-utils": "^3.0.0",
-				"it-all": "^1.0.1",
-				"it-map": "^1.0.2",
-				"it-peekable": "0.0.1",
-				"uint8arrays": "^1.1.0"
-			}
-		},
-		"ipfs-http-client": {
-			"version": "47.0.1",
-			"resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-47.0.1.tgz",
-			"integrity": "sha512-IAQf+uTLvXw5QFOzbyhu/5lH3rn7jEwwwdCGaNKVhoPI7yfyOV0wRse3hVWejjP1Id0P9mKuMKG8rhcY7pVAdQ==",
-			"dev": true,
-			"requires": {
-				"abort-controller": "^3.0.0",
-				"any-signal": "^1.1.0",
-				"bignumber.js": "^9.0.0",
-				"cids": "^1.0.0",
-				"debug": "^4.1.0",
-				"form-data": "^3.0.0",
-				"ipfs-core-utils": "^0.4.0",
-				"ipfs-utils": "^3.0.0",
-				"ipld-block": "^0.10.0",
-				"ipld-dag-cbor": "^0.17.0",
-				"ipld-dag-pb": "^0.20.0",
-				"ipld-raw": "^6.0.0",
-				"iso-url": "^0.4.7",
-				"it-last": "^1.0.2",
-				"it-map": "^1.0.2",
-				"it-tar": "^1.2.2",
-				"it-to-buffer": "^1.0.0",
-				"it-to-stream": "^0.1.1",
-				"merge-options": "^2.0.0",
-				"multiaddr": "^8.0.0",
-				"multiaddr-to-uri": "^6.0.0",
-				"multibase": "^3.0.0",
-				"multicodec": "^2.0.0",
-				"multihashes": "^3.0.1",
-				"nanoid": "^3.0.2",
-				"node-fetch": "^2.6.0",
-				"parse-duration": "^0.4.4",
-				"stream-to-it": "^0.2.1",
-				"uint8arrays": "^1.1.0"
-			}
-		},
-		"ipfs-http-response": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.6.0.tgz",
-			"integrity": "sha512-x1x4ZGvR0azgasT2ql6qKjiH+aPVjra9rJbNq89KzQVxrQLf9zlEHfLzfL7p8m0iYY4MiD+fW+QZF8xA18Xh2g==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.1",
-				"file-type": "^14.7.1",
-				"filesize": "^6.1.0",
-				"it-buffer": "^0.1.1",
-				"it-concat": "^1.0.0",
-				"it-reader": "^2.1.0",
-				"it-to-stream": "^0.1.1",
-				"mime-types": "^2.1.27",
-				"multihashes": "^3.0.1",
-				"p-try-each": "^1.0.1"
-			}
-		},
-		"ipfs-repo": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-6.0.3.tgz",
-			"integrity": "sha512-98dAkXAbX0JDGg2ML+h3usEZbQzghF/sCfAM/1Knh/VLdC7xcy34MqZQl+LyRTQEz872iUgk/TqqjkX2Sr2j2A==",
-			"dev": true,
-			"requires": {
-				"bignumber.js": "^9.0.0",
-				"bytes": "^3.1.0",
-				"cids": "^1.0.0",
-				"datastore-core": "^2.0.0",
-				"datastore-fs": "^2.0.0",
-				"datastore-level": "^2.0.0",
-				"debug": "^4.1.0",
-				"err-code": "^2.0.0",
-				"interface-datastore": "^2.0.0",
-				"ipfs-repo-migrations": "^5.0.3",
-				"ipfs-utils": "^2.3.1",
-				"ipld-block": "^0.10.0",
-				"it-map": "^1.0.2",
-				"it-pushable": "^1.4.0",
-				"just-safe-get": "^2.0.0",
-				"just-safe-set": "^2.1.0",
-				"multibase": "^3.0.0",
-				"p-queue": "^6.0.0",
-				"proper-lockfile": "^4.0.0",
-				"sort-keys": "^4.0.0",
-				"uint8arrays": "^1.0.0"
-			},
-			"dependencies": {
-				"ipfs-utils": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
-					"integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
-					"dev": true,
-					"requires": {
-						"abort-controller": "^3.0.0",
-						"any-signal": "^1.1.0",
-						"buffer": "^5.6.0",
-						"err-code": "^2.0.0",
-						"fs-extra": "^9.0.1",
-						"is-electron": "^2.2.0",
-						"iso-url": "^0.4.7",
-						"it-glob": "0.0.8",
-						"it-to-stream": "^0.1.2",
-						"merge-options": "^2.0.0",
-						"nanoid": "^3.1.3",
-						"node-fetch": "^2.6.0",
-						"stream-to-it": "^0.2.0"
-					}
-				}
-			}
-		},
-		"ipfs-repo-migrations": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-5.0.5.tgz",
-			"integrity": "sha512-dbg9LY+f1MhKLCUTQ28z+TmS7+fC6dgZPJhsWpNXSSwicEgMjUssGMoaft9AjoOuOTISeF3WWVVKRqFpOvCxQg==",
-			"dev": true,
-			"requires": {
-				"cbor": "^5.0.2",
-				"cids": "^1.0.0",
-				"datastore-core": "^2.0.0",
-				"debug": "^4.1.0",
-				"fnv1a": "^1.0.1",
-				"interface-datastore": "^2.0.0",
-				"ipld-dag-pb": "^0.20.0",
-				"it-length": "0.0.2",
-				"multibase": "^3.0.0",
-				"multicodec": "^2.0.0",
-				"multihashing-async": "^2.0.0",
-				"proper-lockfile": "^4.1.1",
-				"protons": "^2.0.0",
-				"uint8arrays": "^1.0.0",
-				"varint": "^5.0.0"
-			}
-		},
-		"ipfs-unixfs": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-2.0.3.tgz",
-			"integrity": "sha512-WpzG/VTqWBPh1cYW3CXk2naElYO3xU0rJnL3SBHbviZ6ZeHRadxR5k0v3/yxPuygs2AwBhaLqBNlV6uB6OCiQw==",
-			"dev": true,
-			"requires": {
-				"err-code": "^2.0.0",
-				"protons": "^2.0.0"
-			}
-		},
-		"ipfs-unixfs-exporter": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-3.0.4.tgz",
-			"integrity": "sha512-e5rA97JeLaaCBOsuG62MJ2UJZQ3xgd8MoJpNotO37VDXRuE/X0/ny6N8AIxikZ8kHkNmCbclW+B5yQHcmqtRvA==",
-			"dev": true,
-			"requires": {
-				"cids": "^1.0.0",
-				"err-code": "^2.0.0",
-				"hamt-sharding": "^1.0.0",
-				"ipfs-unixfs": "^2.0.3",
-				"ipfs-utils": "^3.0.0",
-				"it-last": "^1.0.1",
-				"multihashing-async": "^2.0.0"
-			}
-		},
-		"ipfs-unixfs-importer": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-3.0.4.tgz",
-			"integrity": "sha512-2Lz1WSrmmMxBZzk99Uh1o76OZMWzkzgvSpcZcG8AdzpBDdjtsGWWED9FBuU31INT2dZk9Yszm8qxX3a8iYcXJg==",
-			"dev": true,
-			"requires": {
-				"bl": "^4.0.0",
-				"err-code": "^2.0.0",
-				"hamt-sharding": "^1.0.0",
-				"ipfs-unixfs": "^2.0.3",
-				"ipfs-utils": "^3.0.0",
-				"ipld-dag-pb": "^0.20.0",
-				"it-all": "^1.0.1",
-				"it-batch": "^1.0.3",
-				"it-first": "^1.0.1",
-				"it-parallel-batch": "^1.0.3",
-				"merge-options": "^2.0.0",
-				"multihashing-async": "^2.0.0",
-				"rabin-wasm": "^0.1.1",
-				"uint8arrays": "^1.1.0"
-			}
-		},
-		"ipfs-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-3.0.0.tgz",
-			"integrity": "sha512-qahDc+fghrM57sbySr2TeWjaVR/RH/YEB/hvdAjiTbjESeD87qZawrXwj+19Q2LtGmFGusKNLo5wExeuI5ZfDQ==",
-			"dev": true,
-			"requires": {
-				"abort-controller": "^3.0.0",
-				"any-signal": "^1.1.0",
-				"buffer": "^5.6.0",
-				"err-code": "^2.0.0",
-				"fs-extra": "^9.0.1",
-				"is-electron": "^2.2.0",
-				"iso-url": "^0.4.7",
-				"it-glob": "0.0.8",
-				"merge-options": "^2.0.0",
-				"nanoid": "^3.1.3",
-				"node-fetch": "^2.6.0",
-				"stream-to-it": "^0.2.0"
-			}
-		},
-		"ipld": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/ipld/-/ipld-0.27.1.tgz",
-			"integrity": "sha512-rX9TVFk9ZpMtjVdi74yaOgBcGRcz8NhGQHS4t/A4v/4UKp+nBWzDSMSAHpKXM1PGXYdlzYyIsfQMMoimQXVTxw==",
-			"dev": true,
-			"requires": {
-				"cids": "^1.0.0",
-				"ipld-block": "^0.10.0",
-				"ipld-dag-cbor": "^0.17.0",
-				"ipld-dag-pb": "^0.20.0",
-				"ipld-raw": "^6.0.0",
-				"merge-options": "^2.0.0",
-				"multicodec": "^2.0.0",
-				"typical": "^6.0.0"
-			}
-		},
-		"ipld-bitcoin": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.4.0.tgz",
-			"integrity": "sha512-SRcNRMvdeIKlCCMymqas5ZX9tVjAZ/cid2LPd0vWrLtwc1r4liWvHAxbaU/fJa8Xo6neYWuS/XIqaE/yzMAhRw==",
-			"dev": true,
-			"requires": {
-				"bitcoinjs-lib": "^5.0.0",
-				"buffer": "^5.6.0",
-				"cids": "^1.0.0",
-				"multicodec": "^2.0.0",
-				"multihashes": "^3.0.0",
-				"multihashing-async": "^2.0.0",
-				"uint8arrays": "^1.0.0"
-			}
-		},
-		"ipld-block": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.10.1.tgz",
-			"integrity": "sha512-lPMfW9tA2hVZw9hdO/YSppTxFmA0+5zxcefBOlCTOn+12RLyy+pdepKMbQw8u0KESFu3pYVmabNRWuFGcgHLLw==",
-			"dev": true,
-			"requires": {
-				"cids": "^1.0.0",
-				"class-is": "^1.1.0"
 			}
 		},
 		"ipld-dag-cbor": {
@@ -8734,99 +4113,6 @@
 				"multicodec": "^2.0.0",
 				"multihashing-async": "^2.0.0",
 				"uint8arrays": "^1.0.0"
-			}
-		},
-		"ipld-dag-pb": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.20.0.tgz",
-			"integrity": "sha512-zfM0EdaolqNjAxIrtpuGKvXxWk5YtH9jKinBuQGTcngOsWFQhyybGCTJHGNGGtRjHNJi2hz5Udy/8pzv4kcKyg==",
-			"dev": true,
-			"requires": {
-				"cids": "^1.0.0",
-				"class-is": "^1.1.0",
-				"multicodec": "^2.0.0",
-				"multihashing-async": "^2.0.0",
-				"protons": "^2.0.0",
-				"reset": "^0.1.0",
-				"run": "^1.4.0",
-				"stable": "^0.1.8",
-				"uint8arrays": "^1.0.0"
-			}
-		},
-		"ipld-ethereum": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-5.0.1.tgz",
-			"integrity": "sha512-M0n4z4y0LwsBKIvQev8xHOfxwjwR+jl6ot8z2ujScE6MX+inhojw2/vjvoWIk4N7oleNf3sg4ZxBzdttulvPTA==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.6.0",
-				"cids": "^1.0.0",
-				"ethereumjs-account": "^3.0.0",
-				"ethereumjs-block": "^2.2.1",
-				"ethereumjs-tx": "^2.1.1",
-				"merkle-patricia-tree": "^3.0.0",
-				"multicodec": "^2.0.0",
-				"multihashes": "^3.0.1",
-				"multihashing-async": "^2.0.0",
-				"rlp": "^2.2.4"
-			}
-		},
-		"ipld-git": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.6.1.tgz",
-			"integrity": "sha512-HjKjmMX8vIEMk+isMBaU0/g+xi6LZOQHQ7oFaQ15wUUYLWe5rwkpdr8/3GqHEt3hKdEeWDCX2FqrmQsT9lrQFA==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.6.0",
-				"cids": "^1.0.0",
-				"multicodec": "^2.0.0",
-				"multihashing-async": "^2.0.1",
-				"smart-buffer": "^4.1.0",
-				"strftime": "^0.10.0",
-				"uint8arrays": "^1.0.0"
-			}
-		},
-		"ipld-raw": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-6.0.0.tgz",
-			"integrity": "sha512-UK7fjncAzs59iu/o2kwYtb8jgTtW6B+cNWIiNpAJkfRwqoMk1xD/6i25ktzwe4qO8gQgoR9RxA5ibC23nq8BLg==",
-			"dev": true,
-			"requires": {
-				"cids": "^1.0.0",
-				"multicodec": "^2.0.0",
-				"multihashing-async": "^2.0.0"
-			}
-		},
-		"ipld-zcash": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.5.0.tgz",
-			"integrity": "sha512-nBeyZ/g/hvP3FQl9IODe6mW+UoO10hQMb3k9elcAuwfromljE/rozoDMiMYagZAm03dkSHsk/YSeEWdWqRKaPQ==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.6.0",
-				"cids": "^1.0.0",
-				"multicodec": "^2.0.0",
-				"multihashes": "^3.0.1",
-				"multihashing-async": "^2.0.0",
-				"zcash-block": "^2.0.0"
-			}
-		},
-		"ipns": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/ipns/-/ipns-0.8.0.tgz",
-			"integrity": "sha512-DbveKyLuiO6GgZ4lILxQ3h+27dV/5MPriDTDny3/WHEaCOYH8Gs64CRP5MBQPQcsnZ2Tg+YkjnUAKX/pWAwNhA==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.1",
-				"err-code": "^2.0.0",
-				"interface-datastore": "^2.0.0",
-				"libp2p-crypto": "^0.18.0",
-				"multibase": "^3.0.0",
-				"multihashes": "^3.0.1",
-				"peer-id": "^0.14.0",
-				"protons": "^2.0.0",
-				"timestamp-nano": "^1.0.0",
-				"uint8arrays": "^1.1.0"
 			}
 		},
 		"is-accessor-descriptor": {
@@ -8921,18 +4207,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"is-domain-name": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-domain-name/-/is-domain-name-1.0.1.tgz",
-			"integrity": "sha1-9uszsUpJdUHcpYM1E31EZuDCDaE=",
-			"dev": true
-		},
-		"is-electron": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
-			"integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==",
-			"dev": true
-		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -8943,12 +4217,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
-		},
-		"is-fn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
-			"integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw=",
 			"dev": true
 		},
 		"is-fullwidth-code-point": {
@@ -8972,80 +4240,10 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
-		"is-hex-prefixed": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-			"integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
-			"dev": true
-		},
-		"is-installed-globally": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
-			"integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
-			"dev": true,
-			"requires": {
-				"global-dirs": "^2.0.1",
-				"is-path-inside": "^3.0.1"
-			}
-		},
-		"is-ip": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-			"integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-			"dev": true,
-			"requires": {
-				"ip-regex": "^4.0.0"
-			}
-		},
-		"is-ipfs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-2.0.0.tgz",
-			"integrity": "sha512-X4Cg/JO+h/ygBCrIQSMgicHRLo5QpB+i5tHLhFgGBksKi3zvX6ByFCshDxNBvcq4NFxF3coI2AaLqwzugNzKcw==",
-			"dev": true,
-			"requires": {
-				"cids": "^1.0.0",
-				"iso-url": "~0.4.7",
-				"mafmt": "^8.0.0",
-				"multiaddr": "^8.0.0",
-				"multibase": "^3.0.0",
-				"multihashes": "^3.0.1",
-				"uint8arrays": "^1.1.0"
-			}
-		},
-		"is-loopback-addr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-loopback-addr/-/is-loopback-addr-1.0.1.tgz",
-			"integrity": "sha512-DhWU/kqY7X2F6KrrVTu7mHlbd2Pbo4D1YkAzasBMjQs6lJAoefxaA6m6CpSX0K6pjt9D0b9PNFI5zduy/vzOYw==",
-			"dev": true
-		},
-		"is-npm": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
-			"integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
-			"dev": true
-		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true
-		},
-		"is-obj": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-			"dev": true
-		},
-		"is-path-inside": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-			"integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
-			"dev": true
-		},
-		"is-plain-obj": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
 			"dev": true
 		},
 		"is-plain-object": {
@@ -9085,12 +4283,6 @@
 				"is-docker": "^2.0.0"
 			}
 		},
-		"is-yarn-global": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
-			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
-			"dev": true
-		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -9102,22 +4294,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
-		},
-		"iso-constants": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/iso-constants/-/iso-constants-0.1.2.tgz",
-			"integrity": "sha512-OTCM5ZCQsHBCI4Wdu4tSxvDIkmDHd5EwJDps5mKqnQnWJSKlnwMs3EDZ4n3Fh1tmkWkDlyd2vCDbEYuPbyrUNQ==",
-			"dev": true
-		},
-		"iso-random-stream": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.1.tgz",
-			"integrity": "sha512-YEt/7xOwTdu4KXIgtdgGFkiLUsBaddbnkmHyaFdjJYIcD7V4gpQHPvYC5tyh3kA0PQ01y9lWm1ruVdf8Mqzovg==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.4.3",
-				"readable-stream": "^3.4.0"
-			}
 		},
 		"iso-url": {
 			"version": "0.4.7",
@@ -9217,291 +4393,6 @@
 			"requires": {
 				"html-escaper": "^2.0.0",
 				"istanbul-lib-report": "^3.0.0"
-			}
-		},
-		"it-all": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.4.tgz",
-			"integrity": "sha512-7K+gjHHzZ7t+bCkrtulYiow35k3UgqH7miC+iUa9RGiyDRXJ6hVDeFsDrnWrlscjrkLFOJRKHxNOke4FNoQnhw==",
-			"dev": true
-		},
-		"it-batch": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.6.tgz",
-			"integrity": "sha512-W17vOT8tZTaPMw2NcXItBIAglBz3JxNdXE0+zgqPGMk6zrEb5YF+sAn+PuNed7R6Fsnp8IKDr1sa76GL8Cp52g==",
-			"dev": true
-		},
-		"it-buffer": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/it-buffer/-/it-buffer-0.1.2.tgz",
-			"integrity": "sha512-NOJ3ogSNq3Y2c75ZDcPs9qlgitWyCkUQdmgqqMw+/LMmHZqwWQw7OBDodonz250nJ4EEBXkRQ+pIwz1sL9Zuyg==",
-			"dev": true,
-			"requires": {
-				"bl": "^4.0.2",
-				"buffer": "^5.5.0"
-			}
-		},
-		"it-concat": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/it-concat/-/it-concat-1.0.2.tgz",
-			"integrity": "sha512-YZtXOe10qBcTDOsz59AscfmsKRoVPYX5AFxCans2L/QL20Jah1H1/+wzWDaJj8zu0KiA9gys3vBoZIZwhsUeeg==",
-			"dev": true,
-			"requires": {
-				"bl": "^4.0.0"
-			}
-		},
-		"it-drain": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.3.tgz",
-			"integrity": "sha512-KxwHBEpWW+0/EkGCOPR2MaHanvBW2A76tOC5CiitoJGLd8J56FxM6jJX3uow20v5qMidX5lnKgwH5oCIyYDszQ==",
-			"dev": true
-		},
-		"it-first": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.4.tgz",
-			"integrity": "sha512-L5ZB5k3Ol5ouAzLHo6fOCtByOy2lNjteNJpZLkE+VgmRt0MbC1ibmBW1AbOt6WzDx/QXFG5C8EEvY2nTXHg+Hw==",
-			"dev": true
-		},
-		"it-glob": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.8.tgz",
-			"integrity": "sha512-PmIAgb64aJPM6wwT1UTlNDAJnNgdGrvr0vRr3AYCngcUuq1KaAovuz0dQAmUkaXudDG3EQzc7OttuLW9DaL3YQ==",
-			"dev": true,
-			"requires": {
-				"fs-extra": "^8.1.0",
-				"minimatch": "^3.0.4"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-					"dev": true
-				}
-			}
-		},
-		"it-goodbye": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/it-goodbye/-/it-goodbye-2.0.2.tgz",
-			"integrity": "sha512-k56lqArpxkIU0yyhnPhvnyOBpzRQn+4VEyd+dUBWhN5kvCgPBeC0XMuHiA71iU98sDpCrJrT/X+81ajT0AOQtQ==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.6.0"
-			}
-		},
-		"it-handshake": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-1.0.2.tgz",
-			"integrity": "sha512-uutOim5xF1eyDQD3u8qd3TxbWKwxqGMlbvacZsRsPdjO1BD9lnPTVci0jSMGsvMOu+5Y3W/QQ4hPQb87qPmPVQ==",
-			"dev": true,
-			"requires": {
-				"it-pushable": "^1.4.0",
-				"it-reader": "^2.0.0",
-				"p-defer": "^3.0.0"
-			}
-		},
-		"it-last": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.4.tgz",
-			"integrity": "sha512-h0aV43BaD+1nubAKwStWcda6vlbejPSTQKfOrQvyNrrceluWfoq8DrBXnL0PSz6RkyHSiVSHtAEaqUijYMPo8Q==",
-			"dev": true
-		},
-		"it-length": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/it-length/-/it-length-0.0.2.tgz",
-			"integrity": "sha512-4HJKhSx/hWg54DLzDSe4HYtjMqDVj2ZR8WBTjJuGqRTH342x2vt6h9KeycUgzNNfygSLJvGzFYtZ7Gw1Kez9Qg==",
-			"dev": true
-		},
-		"it-length-prefixed": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-3.1.0.tgz",
-			"integrity": "sha512-E5GwT6qfZEwh3/XThyYwgjKJ4/hxvTC9kdbj3gxXDeUDKtC7+K2T647sPeX7xDEWqunsnoQyvOrjoHPegaT3uw==",
-			"dev": true,
-			"requires": {
-				"@types/bl": "^2.1.0",
-				"bl": "^4.0.2",
-				"buffer": "^5.5.0",
-				"varint": "^5.0.0"
-			}
-		},
-		"it-map": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.4.tgz",
-			"integrity": "sha512-LZgYdb89XMo8cFUp6jF0cn5j3gF7wcZnKRVFS3qHHn0bPB2rpToh2vIkTBKduZLZxRRjWx1VW/udd98x+j2ulg==",
-			"dev": true
-		},
-		"it-multipart": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/it-multipart/-/it-multipart-1.0.5.tgz",
-			"integrity": "sha512-HW0/ycdwqM1Xz1cwkBUwmU2HTxrJrUdVZBIgX5/fNzEjIgbnL3oZUysG2NeKNbIA0vt4wnqLK6fAps/nvQ0AbA==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.5.0",
-				"buffer-indexof": "^1.1.1",
-				"parse-headers": "^2.0.2"
-			}
-		},
-		"it-pair": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/it-pair/-/it-pair-1.0.0.tgz",
-			"integrity": "sha512-9raOiDu5OAuDOahtMtapKQDrQTxBfzlzrNcB6o7JARHkt+7Bb1dMkW/TpYdAjBJE77KH3e2zGzwpGUP9tXbLww==",
-			"dev": true,
-			"requires": {
-				"get-iterator": "^1.0.2"
-			}
-		},
-		"it-parallel-batch": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.6.tgz",
-			"integrity": "sha512-ym2o1bZHZAl2euR79ojKsvVJt77DGQrmSTgDf+g3ERF/Agp2+VI9VM3ikQ9T1BBdgbSIylPeatNGMIyZgz7J7g==",
-			"dev": true,
-			"requires": {
-				"it-batch": "^1.0.6"
-			}
-		},
-		"it-pb-rpc": {
-			"version": "0.1.9",
-			"resolved": "https://registry.npmjs.org/it-pb-rpc/-/it-pb-rpc-0.1.9.tgz",
-			"integrity": "sha512-IMPXz+a+lUEclV5qIlT/1WAjCMIZyqQtMRaKaL8cwgvH2P5LtMJlrbNZr3b4VEONK1H6mqAV1upfMTSSBSrOqA==",
-			"dev": true,
-			"requires": {
-				"is-buffer": "^2.0.4",
-				"it-handshake": "^1.0.2",
-				"it-length-prefixed": "^3.1.0"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-					"dev": true
-				}
-			}
-		},
-		"it-peekable": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-0.0.1.tgz",
-			"integrity": "sha512-fd0JzbNldseeq+FFWthbqYB991UpKNyjPG6LqFhIOmJviCxSompMyoopKIXvLPLY+fBhhv2CT5PT31O/lEnTHw==",
-			"dev": true
-		},
-		"it-pipe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
-			"integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg==",
-			"dev": true
-		},
-		"it-protocol-buffers": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/it-protocol-buffers/-/it-protocol-buffers-0.2.1.tgz",
-			"integrity": "sha512-UbezSc9BZTw0DU7mFS6iG9PXeycJfTDJlFAlniI3x1CRrKeDP+IW6ERPAFskHI3O+wij18Mk7eHgDtFz4Zk65A==",
-			"dev": true,
-			"requires": {
-				"it-buffer": "^0.1.1",
-				"it-length-prefixed": "^3.0.0"
-			}
-		},
-		"it-pushable": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-1.4.0.tgz",
-			"integrity": "sha512-W7251Tj88YBqUIEDWCwd3F8JettSbze+bBp5B3ASzz5tYWaLUI1VDNGbjllH1T6RJ71a5jUSTSt5vHjvuzwoFw==",
-			"dev": true,
-			"requires": {
-				"fast-fifo": "^1.0.0"
-			}
-		},
-		"it-reader": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/it-reader/-/it-reader-2.1.0.tgz",
-			"integrity": "sha512-hSysqWTO9Tlwc5EGjVf8JYZzw0D2FsxD/g+eNNWrez9zODxWt6QlN6JAMmycK72Mv4jHEKEXoyzUN4FYGmJaZw==",
-			"dev": true,
-			"requires": {
-				"bl": "^4.0.0"
-			}
-		},
-		"it-tar": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/it-tar/-/it-tar-1.2.2.tgz",
-			"integrity": "sha512-M8V4a9I+x/vwXTjqvixcEZbQZHjwDIb8iUQ+D4M2QbhAdNs3WKVSl+45u5/F2XFx6jYMFOGzMVlKNK/uONgNIA==",
-			"dev": true,
-			"requires": {
-				"bl": "^4.0.0",
-				"buffer": "^5.4.3",
-				"iso-constants": "^0.1.2",
-				"it-concat": "^1.0.0",
-				"it-reader": "^2.0.0",
-				"p-defer": "^3.0.0"
-			}
-		},
-		"it-to-buffer": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/it-to-buffer/-/it-to-buffer-1.0.4.tgz",
-			"integrity": "sha512-wycpGeAdQ8WH8eSBkMHN/HMNiQ0Y88XEXo6s6LGJbQZjf9K7ppVzUfCXn7OnxFfUPN0HTWZr+uhthwtrwMTTfw==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.5.0"
-			}
-		},
-		"it-to-stream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-0.1.2.tgz",
-			"integrity": "sha512-DTB5TJRZG3untmZehcaFN0kGWl2bNv7tnJRgQHAO9QEt8jfvVRrebZtnD5NZd4SCj4WVPjl0LSrugNWE/UaZRQ==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.6.0",
-				"fast-fifo": "^1.0.0",
-				"get-iterator": "^1.0.2",
-				"p-defer": "^3.0.0",
-				"p-fifo": "^1.0.0",
-				"readable-stream": "^3.6.0"
-			}
-		},
-		"it-ws": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/it-ws/-/it-ws-3.0.2.tgz",
-			"integrity": "sha512-INZhCXNjd5Xr7mYWtNZQb9y5i6XIsf4CKD4XUXeCD3tbaoIya1bPVtJNP1lN5UVGo6Ql9rAn3WVre/8IKtKShw==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.6.0",
-				"event-iterator": "^2.0.0",
-				"relative-url": "^1.0.2",
-				"ws": "^7.3.1"
-			},
-			"dependencies": {
-				"ws": {
-					"version": "7.3.1",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-					"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
-					"dev": true
-				}
-			}
-		},
-		"iterable-ndjson": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
-			"integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
-			"dev": true,
-			"requires": {
-				"string_decoder": "^1.2.0"
 			}
 		},
 		"jest": {
@@ -10761,40 +5652,11 @@
 				}
 			}
 		},
-		"jmespath": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
-			"dev": true
-		},
-		"joi": {
-			"version": "17.3.0",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
-			"integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
-			"dev": true,
-			"requires": {
-				"@hapi/hoek": "^9.0.0",
-				"@hapi/topo": "^5.0.0",
-				"@sideway/address": "^4.1.0",
-				"@sideway/formula": "^3.0.0",
-				"@sideway/pinpoint": "^2.0.0"
-			}
-		},
-		"joycon": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
-			"integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ==",
-			"dev": true
-		},
 		"js-sha256": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-			"integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-		},
-		"js-sha3": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-			"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+			"integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+			"dev": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -10811,12 +5673,6 @@
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
 			}
-		},
-		"jsbn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-			"integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA=",
-			"dev": true
 		},
 		"jsdom": {
 			"version": "15.2.1",
@@ -10856,12 +5712,6 @@
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true
-		},
-		"json-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
 			"dev": true
 		},
 		"json-parse-better-errors": {
@@ -10911,26 +5761,6 @@
 				"minimist": "^1.2.5"
 			}
 		},
-		"jsondiffpatch": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.4.1.tgz",
-			"integrity": "sha512-t0etAxTUk1w5MYdNOkZBZ8rvYYN5iL+2dHCCx/DpkFm/bW28M6y5nUS83D4XdZiHy35Fpaw6LBb+F88fHZnVCw==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.3.0",
-				"diff-match-patch": "^1.0.0"
-			}
-		},
-		"jsonfile": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-			"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.6",
-				"universalify": "^1.0.0"
-			}
-		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -10941,64 +5771,6 @@
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
-			}
-		},
-		"just-debounce-it": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/just-debounce-it/-/just-debounce-it-1.1.0.tgz",
-			"integrity": "sha512-87Nnc0qZKgBZuhFZjYVjSraic0x7zwjhaTMrCKlj0QYKH6lh0KbFzVnfu6LHan03NO7J8ygjeBeD0epejn5Zcg==",
-			"dev": true
-		},
-		"just-extend": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
-			"integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
-			"dev": true
-		},
-		"just-safe-get": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/just-safe-get/-/just-safe-get-2.0.0.tgz",
-			"integrity": "sha512-OBUeNXA7efFIGh0hSLW4nxrOtFWfmjoc3T8B5oixm3b+D7SZN10VKwORUEk4oDeBaR/sqkDMxXb0gE0DRYreEA==",
-			"dev": true
-		},
-		"just-safe-set": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/just-safe-set/-/just-safe-set-2.1.0.tgz",
-			"integrity": "sha512-wSTg/2bQpzyivBYbWPqQgafdfxW0tr3hX9qYGDRS2ws+AXwc7tvn8ABqkp8iPQHChjj4F5JvL3t0FQLbcNuKig==",
-			"dev": true
-		},
-		"k-bucket": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.0.0.tgz",
-			"integrity": "sha512-r/q+wV/Kde62/tk+rqyttEJn6h0jR7x+incdMVSYTqK73zVxVrzJa70kJL49cIKen8XjIgUZKSvk8ktnrQbK4w==",
-			"dev": true,
-			"requires": {
-				"randombytes": "^2.0.3"
-			}
-		},
-		"keccak": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-			"integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-			"dev": true,
-			"requires": {
-				"node-addon-api": "^2.0.0",
-				"node-gyp-build": "^4.2.0"
-			}
-		},
-		"keypair": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz",
-			"integrity": "sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs=",
-			"dev": true
-		},
-		"keyv": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-			"dev": true,
-			"requires": {
-				"json-buffer": "3.0.0"
 			}
 		},
 		"kind-of": {
@@ -11012,305 +5784,6 @@
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
-		},
-		"latest-version": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
-			"integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
-			"dev": true,
-			"requires": {
-				"package-json": "^6.3.0"
-			}
-		},
-		"level": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/level/-/level-5.0.1.tgz",
-			"integrity": "sha512-wcak5OQeA4rURGacqS62R/xNHjCYnJSQDBOlm4KNUGJVE9bWv2B04TclqReYejN+oD65PzD4FsqeWoI5wNC5Lg==",
-			"dev": true,
-			"requires": {
-				"level-js": "^4.0.0",
-				"level-packager": "^5.0.0",
-				"leveldown": "^5.0.0",
-				"opencollective-postinstall": "^2.0.0"
-			}
-		},
-		"level-codec": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
-			"integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
-			"dev": true,
-			"requires": {
-				"buffer": "^5.6.0"
-			}
-		},
-		"level-concat-iterator": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
-			"integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
-			"dev": true
-		},
-		"level-errors": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-			"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-			"dev": true,
-			"requires": {
-				"errno": "~0.1.1"
-			}
-		},
-		"level-iterator-stream": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
-			"integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.4.0",
-				"xtend": "^4.0.2"
-			}
-		},
-		"level-js": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/level-js/-/level-js-4.0.2.tgz",
-			"integrity": "sha512-PeGjZsyMG4O89KHiez1zoMJxStnkM+oBIqgACjoo5PJqFiSUUm3GNod/KcbqN5ktyZa8jkG7I1T0P2u6HN9lIg==",
-			"dev": true,
-			"requires": {
-				"abstract-leveldown": "~6.0.1",
-				"immediate": "~3.2.3",
-				"inherits": "^2.0.3",
-				"ltgt": "^2.1.2",
-				"typedarray-to-buffer": "~3.1.5"
-			}
-		},
-		"level-mem": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/level-mem/-/level-mem-3.0.1.tgz",
-			"integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
-			"dev": true,
-			"requires": {
-				"level-packager": "~4.0.0",
-				"memdown": "~3.0.0"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-					"integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-					"dev": true,
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				},
-				"deferred-leveldown": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
-					"integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
-					"dev": true,
-					"requires": {
-						"abstract-leveldown": "~5.0.0",
-						"inherits": "^2.0.3"
-					}
-				},
-				"encoding-down": {
-					"version": "5.0.4",
-					"resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
-					"integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
-					"dev": true,
-					"requires": {
-						"abstract-leveldown": "^5.0.0",
-						"inherits": "^2.0.3",
-						"level-codec": "^9.0.0",
-						"level-errors": "^2.0.0",
-						"xtend": "^4.0.1"
-					}
-				},
-				"level-iterator-stream": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
-					"integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.3.6",
-						"xtend": "^4.0.0"
-					}
-				},
-				"level-packager": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
-					"integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
-					"dev": true,
-					"requires": {
-						"encoding-down": "~5.0.0",
-						"levelup": "^3.0.0"
-					}
-				},
-				"levelup": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
-					"integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
-					"dev": true,
-					"requires": {
-						"deferred-leveldown": "~4.0.0",
-						"level-errors": "~2.0.0",
-						"level-iterator-stream": "~3.0.0",
-						"xtend": "~4.0.0"
-					}
-				},
-				"memdown": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
-					"integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
-					"dev": true,
-					"requires": {
-						"abstract-leveldown": "~5.0.0",
-						"functional-red-black-tree": "~1.0.1",
-						"immediate": "~3.2.3",
-						"inherits": "~2.0.1",
-						"ltgt": "~2.2.0",
-						"safe-buffer": "~5.1.1"
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
-		},
-		"level-packager": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
-			"integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
-			"dev": true,
-			"requires": {
-				"encoding-down": "^6.3.0",
-				"levelup": "^4.3.2"
-			}
-		},
-		"level-supports": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
-			"integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
-			"dev": true,
-			"requires": {
-				"xtend": "^4.0.2"
-			}
-		},
-		"level-ws": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
-			"integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "~1.0.15",
-				"xtend": "~2.1.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"object-keys": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-					"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				},
-				"xtend": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-					"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-					"dev": true,
-					"requires": {
-						"object-keys": "~0.4.0"
-					}
-				}
-			}
-		},
-		"leveldown": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.6.0.tgz",
-			"integrity": "sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==",
-			"dev": true,
-			"requires": {
-				"abstract-leveldown": "~6.2.1",
-				"napi-macros": "~2.0.0",
-				"node-gyp-build": "~4.1.0"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "6.2.3",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-					"integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-					"dev": true,
-					"requires": {
-						"buffer": "^5.5.0",
-						"immediate": "^3.2.3",
-						"level-concat-iterator": "~2.0.0",
-						"level-supports": "~1.0.0",
-						"xtend": "~4.0.0"
-					}
-				},
-				"node-gyp-build": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
-					"integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==",
-					"dev": true
-				}
-			}
-		},
-		"levelup": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
-			"integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
-			"dev": true,
-			"requires": {
-				"deferred-leveldown": "~5.3.0",
-				"level-errors": "~2.0.0",
-				"level-iterator-stream": "~4.0.0",
-				"level-supports": "~1.0.0",
-				"xtend": "~4.0.0"
-			}
 		},
 		"leven": {
 			"version": "3.1.0",
@@ -11337,597 +5810,10 @@
 				"type-check": "~0.3.2"
 			}
 		},
-		"libp2p": {
-			"version": "0.29.2",
-			"resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.29.2.tgz",
-			"integrity": "sha512-figd1NEBHNMpRCztxH4ZJl4flu+lMiFPMbNTkkoDES6FSZ0+wI7C72z579jh63eN124rsxpFRZaPYmpbKXi9CQ==",
-			"dev": true,
-			"requires": {
-				"abort-controller": "^3.0.0",
-				"aggregate-error": "^3.0.1",
-				"any-signal": "^1.1.0",
-				"bignumber.js": "^9.0.0",
-				"class-is": "^1.1.0",
-				"debug": "^4.1.1",
-				"err-code": "^2.0.0",
-				"events": "^3.1.0",
-				"hashlru": "^2.3.0",
-				"interface-datastore": "^2.0.0",
-				"ipfs-utils": "^2.2.0",
-				"it-all": "^1.0.1",
-				"it-buffer": "^0.1.2",
-				"it-handshake": "^1.0.1",
-				"it-length-prefixed": "^3.0.1",
-				"it-pipe": "^1.1.0",
-				"it-protocol-buffers": "^0.2.0",
-				"libp2p-crypto": "^0.18.0",
-				"libp2p-interfaces": "^0.5.1",
-				"libp2p-utils": "^0.2.0",
-				"mafmt": "^8.0.0",
-				"merge-options": "^2.0.0",
-				"moving-average": "^1.0.0",
-				"multiaddr": "^8.0.0",
-				"multicodec": "^2.0.0",
-				"multistream-select": "^1.0.0",
-				"mutable-proxy": "^1.0.0",
-				"node-forge": "^0.9.1",
-				"p-any": "^3.0.0",
-				"p-fifo": "^1.0.0",
-				"p-settle": "^4.0.1",
-				"peer-id": "^0.14.2",
-				"protons": "^2.0.0",
-				"retimer": "^2.0.0",
-				"sanitize-filename": "^1.6.3",
-				"streaming-iterables": "^5.0.2",
-				"timeout-abort-controller": "^1.1.1",
-				"varint": "^5.0.0",
-				"xsalsa20": "^1.0.2"
-			},
-			"dependencies": {
-				"ipfs-utils": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
-					"integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
-					"dev": true,
-					"requires": {
-						"abort-controller": "^3.0.0",
-						"any-signal": "^1.1.0",
-						"buffer": "^5.6.0",
-						"err-code": "^2.0.0",
-						"fs-extra": "^9.0.1",
-						"is-electron": "^2.2.0",
-						"iso-url": "^0.4.7",
-						"it-glob": "0.0.8",
-						"it-to-stream": "^0.1.2",
-						"merge-options": "^2.0.0",
-						"nanoid": "^3.1.3",
-						"node-fetch": "^2.6.0",
-						"stream-to-it": "^0.2.0"
-					}
-				},
-				"libp2p-interfaces": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.2.tgz",
-					"integrity": "sha512-jnf7D2tJ0eemfQp0j+u4s9fRlILduqXuanCpXt0QSxwqj8LVXUvglQddqoHjH6LGzxBvWXdOAk/ZXEUCcH4ZTw==",
-					"dev": true,
-					"requires": {
-						"abort-controller": "^3.0.0",
-						"abortable-iterator": "^3.0.0",
-						"chai": "^4.2.0",
-						"chai-checkmark": "^1.0.1",
-						"class-is": "^1.1.0",
-						"debug": "^4.1.1",
-						"delay": "^4.3.0",
-						"detect-node": "^2.0.4",
-						"dirty-chai": "^2.0.1",
-						"err-code": "^2.0.0",
-						"it-goodbye": "^2.0.1",
-						"it-length-prefixed": "^3.1.0",
-						"it-pair": "^1.0.0",
-						"it-pipe": "^1.1.0",
-						"it-pushable": "^1.4.0",
-						"libp2p-crypto": "^0.18.0",
-						"libp2p-tcp": "^0.15.0",
-						"multiaddr": "^8.0.0",
-						"multibase": "^3.0.0",
-						"p-defer": "^3.0.0",
-						"p-limit": "^2.3.0",
-						"p-wait-for": "^3.1.0",
-						"peer-id": "^0.14.0",
-						"protons": "^2.0.0",
-						"sinon": "^9.0.2",
-						"streaming-iterables": "^5.0.2",
-						"uint8arrays": "^1.1.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				}
-			}
-		},
-		"libp2p-bootstrap": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.12.1.tgz",
-			"integrity": "sha512-atHXxfxE8isHb+XKHsJ5UgFMteqfi0Xal94h+2EAJmobXcIq1mBMUeIgmkHMsaZZNwJwQxq6MKFthJngWJ8vEw==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.1",
-				"mafmt": "^8.0.0",
-				"multiaddr": "^8.0.0",
-				"peer-id": "^0.14.0"
-			}
-		},
-		"libp2p-crypto": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
-			"integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
-			"dev": true,
-			"requires": {
-				"err-code": "^2.0.0",
-				"is-typedarray": "^1.0.0",
-				"iso-random-stream": "^1.1.0",
-				"keypair": "^1.0.1",
-				"multibase": "^3.0.0",
-				"multicodec": "^2.0.0",
-				"multihashing-async": "^2.0.1",
-				"node-forge": "^0.9.1",
-				"pem-jwk": "^2.0.0",
-				"protons": "^2.0.0",
-				"secp256k1": "^4.0.0",
-				"uint8arrays": "^1.1.0",
-				"ursa-optional": "^0.10.1"
-			}
-		},
-		"libp2p-delegated-content-routing": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/libp2p-delegated-content-routing/-/libp2p-delegated-content-routing-0.7.0.tgz",
-			"integrity": "sha512-eyh6ckCJvAuH+dSI6lKrZ6JLdxazpPUpd2NbRcgmgb6sfpTyFaxhqMa5FHz304mX2FsvE3pX91pTShcL9Aitjg==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.1",
-				"it-all": "^1.0.0",
-				"multiaddr": "^8.0.0",
-				"p-defer": "^3.0.0",
-				"p-queue": "^6.2.1"
-			}
-		},
-		"libp2p-delegated-peer-routing": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/libp2p-delegated-peer-routing/-/libp2p-delegated-peer-routing-0.7.0.tgz",
-			"integrity": "sha512-bdSnCRts+AMlUv592ZITot+vels1UYQc4WMg8/y+gur1ifEE6GeGWnxneJyCuuzrrjmo2Svr4yY72kuMev+wVQ==",
-			"dev": true,
-			"requires": {
-				"cids": "^1.0.0",
-				"debug": "^4.1.1",
-				"p-defer": "^3.0.0",
-				"p-queue": "^6.3.0",
-				"peer-id": "^0.14.0"
-			}
-		},
-		"libp2p-floodsub": {
-			"version": "0.23.1",
-			"resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.23.1.tgz",
-			"integrity": "sha512-d5Hl055SV3bkJ2u+bsRp+iWBsg1rVq2CehW2TYq4zoIp/bCGQyY/oQF6NzqnysKloElgRACfWOa/oQBRaSZFng==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.1",
-				"libp2p-interfaces": "^0.5.1",
-				"time-cache": "^0.3.0",
-				"uint8arrays": "^1.1.0"
-			},
-			"dependencies": {
-				"libp2p-interfaces": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.2.tgz",
-					"integrity": "sha512-jnf7D2tJ0eemfQp0j+u4s9fRlILduqXuanCpXt0QSxwqj8LVXUvglQddqoHjH6LGzxBvWXdOAk/ZXEUCcH4ZTw==",
-					"dev": true,
-					"requires": {
-						"abort-controller": "^3.0.0",
-						"abortable-iterator": "^3.0.0",
-						"chai": "^4.2.0",
-						"chai-checkmark": "^1.0.1",
-						"class-is": "^1.1.0",
-						"debug": "^4.1.1",
-						"delay": "^4.3.0",
-						"detect-node": "^2.0.4",
-						"dirty-chai": "^2.0.1",
-						"err-code": "^2.0.0",
-						"it-goodbye": "^2.0.1",
-						"it-length-prefixed": "^3.1.0",
-						"it-pair": "^1.0.0",
-						"it-pipe": "^1.1.0",
-						"it-pushable": "^1.4.0",
-						"libp2p-crypto": "^0.18.0",
-						"libp2p-tcp": "^0.15.0",
-						"multiaddr": "^8.0.0",
-						"multibase": "^3.0.0",
-						"p-defer": "^3.0.0",
-						"p-limit": "^2.3.0",
-						"p-wait-for": "^3.1.0",
-						"peer-id": "^0.14.0",
-						"protons": "^2.0.0",
-						"sinon": "^9.0.2",
-						"streaming-iterables": "^5.0.2",
-						"uint8arrays": "^1.1.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				}
-			}
-		},
-		"libp2p-gossipsub": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.6.4.tgz",
-			"integrity": "sha512-zCS2Ze0ZgxcpL0jkkfV6SJM8sV3SfeOjfMH02G7OrVQYksFKXH//F3ZbksWjUeoAggdpP9+a66IWPBkj16CfCA==",
-			"dev": true,
-			"requires": {
-				"@types/debug": "^4.1.5",
-				"debug": "^4.1.1",
-				"denque": "^1.4.1",
-				"err-code": "^2.0.0",
-				"it-pipe": "^1.0.1",
-				"libp2p-interfaces": "^0.6.0",
-				"peer-id": "^0.14.0",
-				"protons": "^2.0.0",
-				"time-cache": "^0.3.0",
-				"uint8arrays": "^1.1.0"
-			},
-			"dependencies": {
-				"libp2p-interfaces": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.6.0.tgz",
-					"integrity": "sha512-KJV+eaExDviPKGRY/UWFSQ186As0VUWy0+MjmbGOA9yGzze8lcZ+4iuR5EM7RMd+ZfuZOX63Nkt0v8BIxBhq+Q==",
-					"dev": true,
-					"requires": {
-						"abort-controller": "^3.0.0",
-						"abortable-iterator": "^3.0.0",
-						"chai": "^4.2.0",
-						"chai-checkmark": "^1.0.1",
-						"class-is": "^1.1.0",
-						"debug": "^4.1.1",
-						"delay": "^4.3.0",
-						"detect-node": "^2.0.4",
-						"dirty-chai": "^2.0.1",
-						"err-code": "^2.0.0",
-						"it-goodbye": "^2.0.1",
-						"it-length-prefixed": "^3.1.0",
-						"it-pair": "^1.0.0",
-						"it-pipe": "^1.1.0",
-						"it-pushable": "^1.4.0",
-						"libp2p-crypto": "^0.18.0",
-						"libp2p-tcp": "^0.15.0",
-						"multiaddr": "^8.0.0",
-						"multibase": "^3.0.0",
-						"p-defer": "^3.0.0",
-						"p-limit": "^2.3.0",
-						"p-wait-for": "^3.1.0",
-						"peer-id": "^0.14.0",
-						"protons": "^2.0.0",
-						"sinon": "^9.0.2",
-						"streaming-iterables": "^5.0.2",
-						"uint8arrays": "^1.1.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				}
-			}
-		},
-		"libp2p-interfaces": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.4.1.tgz",
-			"integrity": "sha512-LvoK21WtoRxmdLFWGGKMomK4SLXSqcyntoCQ254IOao/EOjis0Za09THENjK+pL1Lk84D1tXLwwK+8pT19EWDw==",
-			"dev": true,
-			"requires": {
-				"abort-controller": "^3.0.0",
-				"abortable-iterator": "^3.0.0",
-				"buffer": "^5.6.0",
-				"chai": "^4.2.0",
-				"chai-checkmark": "^1.0.1",
-				"class-is": "^1.1.0",
-				"delay": "^4.3.0",
-				"detect-node": "^2.0.4",
-				"dirty-chai": "^2.0.1",
-				"err-code": "^2.0.0",
-				"it-goodbye": "^2.0.1",
-				"it-pair": "^1.0.0",
-				"it-pipe": "^1.1.0",
-				"libp2p-tcp": "^0.15.0",
-				"multiaddr": "^8.0.0",
-				"p-defer": "^3.0.0",
-				"p-limit": "^2.3.0",
-				"p-wait-for": "^3.1.0",
-				"peer-id": "^0.14.0",
-				"sinon": "^9.0.2",
-				"streaming-iterables": "^5.0.2"
-			},
-			"dependencies": {
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				}
-			}
-		},
-		"libp2p-kad-dht": {
-			"version": "0.20.1",
-			"resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.20.1.tgz",
-			"integrity": "sha512-khffe6L6O6oU53LO8BrI3bULH4i6FLibvFEyV+7FAPXnFYhTKHa9TsIifkL/MEAfLI0hI9QN4NwMf0DpOLMvDA==",
-			"dev": true,
-			"requires": {
-				"abort-controller": "^3.0.0",
-				"async": "^2.6.2",
-				"base32.js": "~0.1.0",
-				"cids": "^1.0.0",
-				"debug": "^4.1.1",
-				"err-code": "^2.0.0",
-				"hashlru": "^2.3.0",
-				"heap": "~0.2.6",
-				"interface-datastore": "^2.0.0",
-				"it-length-prefixed": "^3.0.0",
-				"it-pipe": "^1.1.0",
-				"k-bucket": "^5.0.0",
-				"libp2p-crypto": "^0.18.0",
-				"libp2p-interfaces": "^0.4.0",
-				"libp2p-record": "^0.9.0",
-				"multiaddr": "^8.0.0",
-				"multihashing-async": "^2.0.1",
-				"p-filter": "^2.1.0",
-				"p-map": "^4.0.0",
-				"p-queue": "^6.2.1",
-				"p-timeout": "^3.2.0",
-				"p-times": "^3.0.0",
-				"peer-id": "^0.14.0",
-				"promise-to-callback": "^1.0.0",
-				"protons": "^2.0.0",
-				"streaming-iterables": "^5.0.2",
-				"uint8arrays": "^1.1.0",
-				"varint": "^5.0.0",
-				"xor-distance": "^2.0.0"
-			}
-		},
-		"libp2p-mdns": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.15.0.tgz",
-			"integrity": "sha512-wuILE+mwC6ww/0TMkR3k2h53D5Ma9TXpz0siacbsACcGukkS+mIpsvruaf9U1Uxe0F1aC8+Y+Vi5lP8C3YR9Lg==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.1",
-				"multiaddr": "^8.0.0",
-				"multicast-dns": "^7.2.0",
-				"peer-id": "^0.14.0"
-			}
-		},
-		"libp2p-mplex": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.10.1.tgz",
-			"integrity": "sha512-D7XslSL2MpoQdWFW9m62fZb6U1iq5x18WDIJmBIxM4PKBbhNVsicMAfRGvm/ZntLmxkl2KO8utIcVjYBFg9tsQ==",
-			"dev": true,
-			"requires": {
-				"abort-controller": "^3.0.0",
-				"abortable-iterator": "^3.0.0",
-				"bl": "^4.0.0",
-				"debug": "^4.1.1",
-				"err-code": "^2.0.3",
-				"it-pipe": "^1.0.1",
-				"it-pushable": "^1.3.1",
-				"varint": "^5.0.0"
-			}
-		},
-		"libp2p-noise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/libp2p-noise/-/libp2p-noise-2.0.1.tgz",
-			"integrity": "sha512-Jhd/jirWL3qkqGqIC1P4SH+OYlmKFll6UjFVYdw7otBKnbmdBUTW2Lg75/L1+7dYKwitHKu5EWlAd3zPU36gfg==",
-			"dev": true,
-			"requires": {
-				"bcrypto": "^5.2.0",
-				"buffer": "^5.4.3",
-				"debug": "^4.1.1",
-				"it-buffer": "^0.1.1",
-				"it-length-prefixed": "^3.0.0",
-				"it-pair": "^1.0.0",
-				"it-pb-rpc": "^0.1.8",
-				"it-pipe": "^1.1.0",
-				"libp2p-crypto": "^0.18.0",
-				"peer-id": "^0.14.0",
-				"protobufjs": "^6.10.1",
-				"uint8arrays": "^1.1.0"
-			}
-		},
-		"libp2p-record": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.9.0.tgz",
-			"integrity": "sha512-8FlhzP+UlXTYOR+9D8nYoGOIJ6S8XogKD625bqzHJbXJQyJNCNaW3tZPHqrQrvUW7o6GsAeyQAfCp5WLEH0FZg==",
-			"dev": true,
-			"requires": {
-				"err-code": "^2.0.0",
-				"multihashes": "^3.0.1",
-				"multihashing-async": "^2.0.1",
-				"protons": "^2.0.0",
-				"uint8arrays": "^1.1.0"
-			}
-		},
-		"libp2p-secio": {
-			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.13.1.tgz",
-			"integrity": "sha512-1rJBqaCTeKAyA1BedfGCjG8SKB+fOqWXPJLklkaRBcdwmtoNdvCLuLt5So81Z/5sqrbETM1vAQRVdMpyTfPrKw==",
-			"dev": true,
-			"requires": {
-				"bl": "^4.0.0",
-				"debug": "^4.1.1",
-				"it-length-prefixed": "^3.0.1",
-				"it-pair": "^1.0.0",
-				"it-pb-rpc": "^0.1.4",
-				"it-pipe": "^1.1.0",
-				"libp2p-crypto": "^0.18.0",
-				"libp2p-interfaces": "^0.4.0",
-				"multiaddr": "^8.0.0",
-				"multihashing-async": "^2.0.1",
-				"peer-id": "^0.14.0",
-				"protons": "^2.0.0",
-				"uint8arrays": "^1.1.0"
-			}
-		},
-		"libp2p-tcp": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.15.1.tgz",
-			"integrity": "sha512-alvgZ3lSNUyiz4vJOqvm6RpMQN9d17gSJa+VT+2pYLGf82o8pX3QvyhltMkBG7u9I+qZAkD6L27s8o0h38dpOg==",
-			"dev": true,
-			"requires": {
-				"abortable-iterator": "^3.0.0",
-				"class-is": "^1.1.0",
-				"debug": "^4.1.1",
-				"err-code": "^2.0.0",
-				"libp2p-utils": "^0.2.0",
-				"mafmt": "^8.0.0",
-				"multiaddr": "^8.0.0",
-				"stream-to-it": "^0.2.2"
-			}
-		},
-		"libp2p-utils": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.2.1.tgz",
-			"integrity": "sha512-oaPUhYZrg3iW8+V7/PJsMHbLsFiOaNKM+D3WzNkne8mP7CCM4+0B4TIid5nEvrUT8Z432Nb64nFaqie/Wif5GA==",
-			"dev": true,
-			"requires": {
-				"abortable-iterator": "^3.0.0",
-				"debug": "^4.2.0",
-				"err-code": "^2.0.3",
-				"ip-address": "^6.1.0",
-				"is-loopback-addr": "^1.0.0",
-				"multiaddr": "^8.0.0",
-				"private-ip": "^1.0.5"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				}
-			}
-		},
-		"libp2p-webrtc-peer": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/libp2p-webrtc-peer/-/libp2p-webrtc-peer-10.0.1.tgz",
-			"integrity": "sha512-Qi/YVrSI5sjU+iBvr1iAjGrakIEvzCS8S76v4q43jjlDb6Wj+S4OnFLH/uRlt7eLXcx4vlaI6huMzYrUAoopMg==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.0.1",
-				"err-code": "^2.0.3",
-				"get-browser-rtc": "^1.0.0",
-				"queue-microtask": "^1.1.0",
-				"randombytes": "^2.0.3",
-				"readable-stream": "^3.4.0"
-			}
-		},
-		"libp2p-webrtc-star": {
-			"version": "0.20.1",
-			"resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.20.1.tgz",
-			"integrity": "sha512-VQNL24A3rN1/9U0fTO8MqUx3+6d99iz/HvPI3p+IzHb6MgBe7er+rgbvRep7uheZ2894IxiJI848Vs0ZNypn2w==",
-			"dev": true,
-			"requires": {
-				"@hapi/hapi": "^20.0.0",
-				"@hapi/inert": "^6.0.2",
-				"abortable-iterator": "^3.0.0",
-				"class-is": "^1.1.0",
-				"debug": "^4.1.1",
-				"err-code": "^2.0.0",
-				"ipfs-utils": "^3.0.0",
-				"it-pipe": "^1.0.1",
-				"libp2p-utils": "^0.2.0",
-				"libp2p-webrtc-peer": "^10.0.1",
-				"mafmt": "^8.0.0",
-				"menoetius": "0.0.2",
-				"minimist": "^1.2.0",
-				"multiaddr": "^8.0.0",
-				"p-defer": "^3.0.0",
-				"peer-id": "^0.14.0",
-				"prom-client": "^12.0.0",
-				"socket.io": "^2.3.0",
-				"socket.io-client": "^2.3.0",
-				"stream-to-it": "^0.2.2",
-				"streaming-iterables": "^5.0.2"
-			}
-		},
-		"libp2p-websockets": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.14.0.tgz",
-			"integrity": "sha512-UeI0uqw2xYXFhImJucewG7fuL6hOR2tnSwlSAAxilyK0Z3Yya+GeVkqy7Vufj9ax3EWFx6lPO8mC3uBl30TkpA==",
-			"dev": true,
-			"requires": {
-				"abortable-iterator": "^3.0.0",
-				"class-is": "^1.1.0",
-				"debug": "^4.1.1",
-				"err-code": "^2.0.0",
-				"it-ws": "^3.0.0",
-				"libp2p-utils": "^0.2.0",
-				"mafmt": "^8.0.0",
-				"multiaddr": "^8.0.0",
-				"multiaddr-to-uri": "^6.0.0",
-				"p-timeout": "^3.2.0"
-			}
-		},
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
 			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-			"dev": true
-		},
-		"loady": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
-			"integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ==",
 			"dev": true
 		},
 		"locate-path": {
@@ -11946,68 +5832,11 @@
 			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
 			"dev": true
 		},
-		"lodash.clonedeep": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-		},
-		"lodash.find": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
-			"dev": true
-		},
-		"lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-			"dev": true
-		},
-		"lodash.max": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
-			"integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o=",
-			"dev": true
-		},
-		"lodash.merge": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
-		},
-		"lodash.padstart": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-			"integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
-			"dev": true
-		},
-		"lodash.repeat": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
-			"integrity": "sha1-/H3oEx2MisB+S0n3T/6CnR8r7EQ=",
-			"dev": true
-		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
-		},
-		"lodash.throttle": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
-			"dev": true
-		},
-		"loglevel": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
-			"integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ=="
-		},
-		"loglevel-plugin-prefix": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
-			"integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g=="
 		},
 		"lolex": {
 			"version": "5.1.2",
@@ -12018,12 +5847,6 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
-		"long": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-			"dev": true
-		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -12031,36 +5854,6 @@
 			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
-		},
-		"lowercase-keys": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-			"dev": true
-		},
-		"lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"requires": {
-				"yallist": "^4.0.0"
-			}
-		},
-		"ltgt": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-			"integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
-			"dev": true
-		},
-		"mafmt": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/mafmt/-/mafmt-8.0.0.tgz",
-			"integrity": "sha512-MdaeaqZxjoYYWvlhr1GQ7sbsR3+L3s8QL0VtCuja+Iax3EhqAEgluSWPJezSDLyns7Ds4DGRyoq5+eIU7UDang==",
-			"dev": true,
-			"requires": {
-				"multiaddr": "^8.0.0"
 			}
 		},
 		"make-dir": {
@@ -12104,151 +5897,11 @@
 				"object-visit": "^1.0.0"
 			}
 		},
-		"md5.js": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-			"dev": true,
-			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"memdown": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-			"integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
-			"dev": true,
-			"requires": {
-				"abstract-leveldown": "~2.7.1",
-				"functional-red-black-tree": "^1.0.1",
-				"immediate": "^3.2.3",
-				"inherits": "~2.0.1",
-				"ltgt": "~2.2.0",
-				"safe-buffer": "~5.1.1"
-			},
-			"dependencies": {
-				"abstract-leveldown": {
-					"version": "2.7.2",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-					"integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-					"dev": true,
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				}
-			}
-		},
-		"menoetius": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/menoetius/-/menoetius-0.0.2.tgz",
-			"integrity": "sha512-7W0ayHMNgvEdFh+m3m29KA87nvT0JIGCXeSZa26fiSof+bwpg+olEjD8AAvtxZ3uhTcp2d+5r1dcV/KhR8PBVQ==",
-			"dev": true,
-			"requires": {
-				"prom-client": "^11.5.3"
-			},
-			"dependencies": {
-				"prom-client": {
-					"version": "11.5.3",
-					"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
-					"integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
-					"dev": true,
-					"requires": {
-						"tdigest": "^0.1.1"
-					}
-				}
-			}
-		},
-		"merge-options": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-options/-/merge-options-2.0.0.tgz",
-			"integrity": "sha512-S7xYIeWHl2ZUKF7SDeBhGg6rfv5bKxVBdk95s/I7wVF8d+hjLSztJ/B271cnUiF6CAFduEQ5Zn3HYwAjT16DlQ==",
-			"dev": true,
-			"requires": {
-				"is-plain-obj": "^2.0.0"
-			}
-		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
-		},
-		"merkle-lib": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
-			"integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY=",
-			"dev": true
-		},
-		"merkle-patricia-tree": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-3.0.0.tgz",
-			"integrity": "sha512-soRaMuNf/ILmw3KWbybaCjhx86EYeBbD8ph0edQCTed0JN/rxDt1EBN52Ajre3VyGo+91f8+/rfPIRQnnGMqmQ==",
-			"dev": true,
-			"requires": {
-				"async": "^2.6.1",
-				"ethereumjs-util": "^5.2.0",
-				"level-mem": "^3.0.1",
-				"level-ws": "^1.0.0",
-				"readable-stream": "^3.0.6",
-				"rlp": "^2.0.0",
-				"semaphore": ">=1.0.1"
-			},
-			"dependencies": {
-				"ethereumjs-util": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-					"integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"elliptic": "^6.5.2",
-						"ethereum-cryptography": "^0.1.3",
-						"ethjs-util": "^0.1.3",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"level-ws": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/level-ws/-/level-ws-1.0.0.tgz",
-					"integrity": "sha512-RXEfCmkd6WWFlArh3X8ONvQPm8jNpfA0s/36M4QzLqrLEIt1iJE9WBHLZ5vZJK6haMjJPJGJCQWfjMNnRcq/9Q==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.2.8",
-						"xtend": "^4.0.1"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.7",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-							"dev": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						}
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
 		},
 		"micromatch": {
 			"version": "4.0.2",
@@ -12258,16 +5911,6 @@
 			"requires": {
 				"braces": "^3.0.1",
 				"picomatch": "^2.0.5"
-			}
-		},
-		"miller-rabin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.0.0",
-				"brorand": "^1.0.1"
 			}
 		},
 		"mime-db": {
@@ -12289,12 +5932,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true
-		},
-		"mimic-response": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
 			"dev": true
 		},
 		"minimalistic-assert": {
@@ -12352,59 +5989,11 @@
 				"minimist": "^1.2.5"
 			}
 		},
-		"mortice": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mortice/-/mortice-2.0.0.tgz",
-			"integrity": "sha512-rXcjRgv2MRhpwGHErxKcDcp5IoA9CPvPFLXmmseQYIuQ2fSVu8tsMKi/eYUXzp/HH1s6y3IID/GwRqlSglDdRA==",
-			"dev": true,
-			"requires": {
-				"globalthis": "^1.0.0",
-				"observable-webworkers": "^1.0.0",
-				"p-queue": "^6.0.0",
-				"promise-timeout": "^1.3.0",
-				"shortid": "^2.2.8"
-			}
-		},
-		"moving-average": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/moving-average/-/moving-average-1.0.0.tgz",
-			"integrity": "sha512-97cgMz0U2zciiDp4xRl/n+MYgrm9l7UiYbtsBLPr0rhw6KH3m4LyK2w4d96V6+UwKo+ph7KtQSoL2qgnqZVgvA==",
-			"dev": true
-		},
-		"mri": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
-			"integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
-			"dev": true
-		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
-		},
-		"multiaddr": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-8.0.0.tgz",
-			"integrity": "sha512-4OOyr0u0i4lvh9MY/mvuCNmH5eqoTamcnGeXz6umFGc0eaVQUGPDQNbp52YfFY92NlZ76pO6h4K2HkXsT5X43w==",
-			"dev": true,
-			"requires": {
-				"cids": "^1.0.0",
-				"class-is": "^1.1.0",
-				"is-ip": "^3.1.0",
-				"multibase": "^3.0.0",
-				"uint8arrays": "^1.1.0",
-				"varint": "^5.0.0"
-			}
-		},
-		"multiaddr-to-uri": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-6.0.0.tgz",
-			"integrity": "sha512-OjpkVHOXEmIKMO8WChzzQ7aZQcSQX8squxmvtDbRpy7/QNmJ3Z7jv6qyD74C28QtaeNie8O8ngW2AkeiMmKP7A==",
-			"dev": true,
-			"requires": {
-				"multiaddr": "^8.0.0"
-			}
 		},
 		"multibase": {
 			"version": "3.0.0",
@@ -12413,16 +6002,6 @@
 			"requires": {
 				"base-x": "^3.0.8",
 				"web-encoding": "^1.0.2"
-			}
-		},
-		"multicast-dns": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.2.tgz",
-			"integrity": "sha512-XqSMeO8EWV/nOXOpPV8ztIpNweVfE1dSpz6SQvDPp71HD74lMXjt4m/mWB1YBMG0kHtOodxRWc5WOb/UNN1A5g==",
-			"dev": true,
-			"requires": {
-				"dns-packet": "^4.0.0",
-				"thunky": "^1.0.2"
 			}
 		},
 		"multicodec": {
@@ -12455,47 +6034,6 @@
 				"varint": "^5.0.0"
 			}
 		},
-		"multihashing": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/multihashing/-/multihashing-0.3.3.tgz",
-			"integrity": "sha512-jXVWf5uqnZUhc1mLFPWOssuOpkj/A/vVLKrtEscD1PzSLobXYocBy9Gqa/Aw4229/heGnl0RBHU3cD53MbHUig==",
-			"dev": true,
-			"requires": {
-				"blakejs": "^1.1.0",
-				"js-sha3": "~0.8.0",
-				"multihashes": "~0.4.14",
-				"webcrypto": "~0.1.1"
-			},
-			"dependencies": {
-				"js-sha3": {
-					"version": "0.8.0",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-					"dev": true
-				},
-				"multibase": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-					"integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-					"dev": true,
-					"requires": {
-						"base-x": "^3.0.8",
-						"buffer": "^5.5.0"
-					}
-				},
-				"multihashes": {
-					"version": "0.4.21",
-					"resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-					"integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-					"dev": true,
-					"requires": {
-						"buffer": "^5.5.0",
-						"multibase": "^0.7.0",
-						"varint": "^5.0.0"
-					}
-				}
-			}
-		},
 		"multihashing-async": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.0.1.tgz",
@@ -12516,33 +6054,10 @@
 				}
 			}
 		},
-		"multistream-select": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-1.0.0.tgz",
-			"integrity": "sha512-82riQ+qZ0RPY+KbRdeeKKQnFSBCVpUbZ15EniGU2nfwM8NdrpPIeUYXFw4a/pyprcNeRfMgLlG9aCh874p8nJg==",
-			"dev": true,
-			"requires": {
-				"bl": "^4.0.0",
-				"debug": "^4.1.1",
-				"err-code": "^2.0.0",
-				"it-handshake": "^1.0.2",
-				"it-length-prefixed": "^3.0.0",
-				"it-pipe": "^1.0.1",
-				"it-reader": "^2.0.0",
-				"p-defer": "^3.0.0",
-				"uint8arrays": "^1.1.0"
-			}
-		},
 		"murmurhash3js-revisited": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
 			"integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
-		},
-		"mutable-proxy": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/mutable-proxy/-/mutable-proxy-1.0.0.tgz",
-			"integrity": "sha512-4OvNRr1DJpy2QuDUV74m+BWZ//n4gG4bmd21MzDSPqHEidIDWqwyOjcadU1LBMO3vXYGurVKjfBrxrSQIHFu9A==",
-			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.8",
@@ -12550,16 +6065,10 @@
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
 		},
-		"nan": {
-			"version": "2.14.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-			"dev": true
-		},
 		"nanoid": {
-			"version": "3.1.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.16.tgz",
-			"integrity": "sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w=="
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.18.tgz",
+			"integrity": "sha512-rndlDjbbHbcV3xi+R2fpJ+PbGMdfBxz5v1fATIQFq0DP64FsicQdwnKLy47K4kZHdRpmQXtz24eGsxQqamzYTA=="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -12580,65 +6089,16 @@
 				"to-regex": "^3.0.1"
 			}
 		},
-		"napi-macros": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-			"integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
-			"dev": true
-		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
-		"negotiator": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-			"dev": true
-		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-			"dev": true
-		},
-		"nise": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
-			"integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
-			"dev": true,
-			"requires": {
-				"@sinonjs/commons": "^1.7.0",
-				"@sinonjs/fake-timers": "^6.0.0",
-				"@sinonjs/text-encoding": "^0.7.1",
-				"just-extend": "^4.0.2",
-				"path-to-regexp": "^1.7.0"
-			}
-		},
-		"node-addon-api": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-			"integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
-			"dev": true
-		},
-		"node-fetch": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-			"dev": true
-		},
-		"node-forge": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.2.tgz",
-			"integrity": "sha512-naKSScof4Wn+aoHU6HBsifh92Zeicm1GDQKd1vp3Y/kOi8ub0DozCa9KpvYNCXslFHYRmLNiqRopGdTGwNLpNw==",
-			"dev": true
-		},
-		"node-gyp-build": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-			"integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
 			"dev": true
 		},
 		"node-int64": {
@@ -12692,12 +6152,6 @@
 			"integrity": "sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg==",
 			"dev": true
 		},
-		"nofilter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
-			"integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
-			"dev": true
-		},
 		"normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -12714,12 +6168,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true
-		},
-		"normalize-url": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
 			"dev": true
 		},
 		"npm-run-path": {
@@ -12741,12 +6189,6 @@
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-			"dev": true
-		},
-		"object-component": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-			"integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
 			"dev": true
 		},
 		"object-copy": {
@@ -12816,12 +6258,6 @@
 				"isobject": "^3.0.1"
 			}
 		},
-		"observable-webworkers": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-1.0.0.tgz",
-			"integrity": "sha512-+cECwCR8IEh8UY5nefQVLO9Cydqpk1izO+o7BABmKjXfJZyEOzBWY3ss5jbOPM6KmEa9aQExvAtTW6tVTOsNAQ==",
-			"dev": true
-		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -12839,19 +6275,6 @@
 			"requires": {
 				"mimic-fn": "^2.1.0"
 			}
-		},
-		"opencollective-postinstall": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
-			"integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
-			"dev": true
-		},
-		"optional": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
-			"integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==",
-			"dev": true,
-			"optional": true
 		},
 		"optionator": {
 			"version": "0.8.3",
@@ -12873,60 +6296,11 @@
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
 		},
-		"p-any": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-any/-/p-any-3.0.0.tgz",
-			"integrity": "sha512-5rqbqfsRWNb0sukt0awwgJMlaep+8jV45S15SKKB34z4UuzjcofIfnriCBhWjZP2jbVtjt9yRl7buB6RlKsu9w==",
-			"dev": true,
-			"requires": {
-				"p-cancelable": "^2.0.0",
-				"p-some": "^5.0.0"
-			}
-		},
-		"p-cancelable": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-			"integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
-			"dev": true
-		},
-		"p-defer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-			"integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
-			"dev": true
-		},
 		"p-each-series": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
 			"integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
 			"dev": true
-		},
-		"p-fifo": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
-			"integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
-			"dev": true,
-			"requires": {
-				"fast-fifo": "^1.0.0",
-				"p-defer": "^3.0.0"
-			}
-		},
-		"p-filter": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
-			"integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
-			"dev": true,
-			"requires": {
-				"p-map": "^2.0.0"
-			},
-			"dependencies": {
-				"p-map": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-					"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-					"dev": true
-				}
-			}
 		},
 		"p-finally": {
 			"version": "1.0.0",
@@ -12952,126 +6326,11 @@
 				"p-limit": "^1.1.0"
 			}
 		},
-		"p-map": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-			"dev": true,
-			"requires": {
-				"aggregate-error": "^3.0.0"
-			}
-		},
-		"p-queue": {
-			"version": "6.6.2",
-			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
-			"integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
-			"dev": true,
-			"requires": {
-				"eventemitter3": "^4.0.4",
-				"p-timeout": "^3.2.0"
-			}
-		},
-		"p-reflect": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-reflect/-/p-reflect-2.1.0.tgz",
-			"integrity": "sha512-paHV8NUz8zDHu5lhr/ngGWQiW067DK/+IbJ+RfZ4k+s8y4EKyYCz8pGYWjxCg35eHztpJAt+NUgvN4L+GCbPlg==",
-			"dev": true
-		},
-		"p-settle": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/p-settle/-/p-settle-4.1.1.tgz",
-			"integrity": "sha512-6THGh13mt3gypcNMm0ADqVNCcYa3BK6DWsuJWFCuEKP1rpY+OKGp7gaZwVmLspmic01+fsg/fN57MfvDzZ/PuQ==",
-			"dev": true,
-			"requires": {
-				"p-limit": "^2.2.2",
-				"p-reflect": "^2.1.0"
-			},
-			"dependencies": {
-				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				}
-			}
-		},
-		"p-some": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/p-some/-/p-some-5.0.0.tgz",
-			"integrity": "sha512-Js5XZxo6vHjB9NOYAzWDYAIyyiPvva0DWESAIWIK7uhSpGsyg5FwUPxipU/SOQx5x9EqhOh545d1jo6cVkitig==",
-			"dev": true,
-			"requires": {
-				"aggregate-error": "^3.0.0",
-				"p-cancelable": "^2.0.0"
-			}
-		},
-		"p-timeout": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-			"dev": true,
-			"requires": {
-				"p-finally": "^1.0.0"
-			}
-		},
-		"p-times": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-times/-/p-times-3.0.0.tgz",
-			"integrity": "sha512-/Z7mcs8Liie8E7IHI9SBtmkHVW/GjLroQ94ALoAMIG20mqFMuh56/3WYhtOTqX9ccRSOxgaCkFC94Bat1Ofskg==",
-			"dev": true,
-			"requires": {
-				"p-map": "^4.0.0"
-			}
-		},
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
 			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 			"dev": true
-		},
-		"p-try-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/p-try-each/-/p-try-each-1.0.1.tgz",
-			"integrity": "sha512-WyUjRAvK4CG9DUW21ZsNYcBj6guN7pgZAOFR8mUtyNXyPC5WUo3L48nxI5TsGEZ+VJhZXzyeH/Sxi2lxYcPp3A==",
-			"dev": true
-		},
-		"p-wait-for": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.1.0.tgz",
-			"integrity": "sha512-0Uy19uhxbssHelu9ynDMcON6BmMk6pH8551CvxROhiz3Vx+yC4RqxjyIDk2V4ll0g9177RKT++PK4zcV58uJ7A==",
-			"dev": true,
-			"requires": {
-				"p-timeout": "^3.0.0"
-			}
-		},
-		"package-json": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
-			"integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
-			"dev": true,
-			"requires": {
-				"got": "^9.6.0",
-				"registry-auth-token": "^4.0.0",
-				"registry-url": "^5.0.0",
-				"semver": "^6.2.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
-			}
 		},
 		"parent-module": {
 			"version": "1.0.1",
@@ -13081,31 +6340,6 @@
 			"requires": {
 				"callsites": "^3.0.0"
 			}
-		},
-		"parse-asn1": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
-			"integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
-			"dev": true,
-			"requires": {
-				"asn1.js": "^5.2.0",
-				"browserify-aes": "^1.0.0",
-				"evp_bytestokey": "^1.0.0",
-				"pbkdf2": "^3.0.3",
-				"safe-buffer": "^5.1.1"
-			}
-		},
-		"parse-duration": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.4.4.tgz",
-			"integrity": "sha512-KbAJuYGUhZkB9gotDiKLnZ7Z3VTacK3fgwmDdB6ZVDtJbMBT6MfLga0WJaYpPDu0mzqT0NgHtHDt5PY4l0nidg==",
-			"dev": true
-		},
-		"parse-headers": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-			"integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA==",
-			"dev": true
 		},
 		"parse-json": {
 			"version": "5.0.0",
@@ -13124,24 +6358,6 @@
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
 			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
 			"dev": true
-		},
-		"parseqs": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-			"integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-			"dev": true,
-			"requires": {
-				"better-assert": "~1.0.0"
-			}
-		},
-		"parseuri": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-			"integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-			"dev": true,
-			"requires": {
-				"better-assert": "~1.0.0"
-			}
 		},
 		"pascalcase": {
 			"version": "0.1.1",
@@ -13173,72 +6389,6 @@
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
-		"path-to-regexp": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-			"integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-			"dev": true,
-			"requires": {
-				"isarray": "0.0.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				}
-			}
-		},
-		"pathval": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-			"dev": true
-		},
-		"pbkdf2": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
-			"integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
-			"dev": true,
-			"requires": {
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4",
-				"ripemd160": "^2.0.1",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
-		},
-		"peek-readable": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.0.tgz",
-			"integrity": "sha512-KGuODSTV6hcgdZvDrIDBUkN0utcAVj1LL7FfGbM0viKTtCHmtZcuEJ+lGqsp0fTFkGqesdtemV2yUSMeyy3ddA==",
-			"dev": true
-		},
-		"peer-id": {
-			"version": "0.14.2",
-			"resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.14.2.tgz",
-			"integrity": "sha512-8iZWaUT7jq8rVyyFZUHYUwFCvhoI5B1Q2MAJjUF9MTf4TsNRQPnod4Mycf2jrK/uXFBN5/9K1NhPoieFyz/PRw==",
-			"dev": true,
-			"requires": {
-				"cids": "^1.0.0",
-				"class-is": "^1.1.0",
-				"libp2p-crypto": "^0.18.0",
-				"minimist": "^1.2.5",
-				"multihashes": "^3.0.1",
-				"protons": "^2.0.0",
-				"uint8arrays": "^1.1.0"
-			}
-		},
-		"pem-jwk": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-2.0.0.tgz",
-			"integrity": "sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==",
-			"dev": true,
-			"requires": {
-				"asn1.js": "^5.0.1"
-			}
-		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -13249,102 +6399,6 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-			"dev": true
-		},
-		"pino": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-6.7.0.tgz",
-			"integrity": "sha512-vPXJ4P9rWCwzlTJt+f0Ni4THc3DWyt8iDDCO4edQ8narTu6hnpzdXu8FqeSJCGndl1W6lfbYQUQihUO54y66Lw==",
-			"dev": true,
-			"requires": {
-				"fast-redact": "^3.0.0",
-				"fast-safe-stringify": "^2.0.7",
-				"flatstr": "^1.0.12",
-				"pino-std-serializers": "^2.4.2",
-				"quick-format-unescaped": "^4.0.1",
-				"sonic-boom": "^1.0.2"
-			}
-		},
-		"pino-pretty": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.3.0.tgz",
-			"integrity": "sha512-uEc9SUCCGVEs0goZvyznKXBHtI1PNjGgqHviJHxOCEFEWZN6Z/IQKv5pO9gSdm/b+WfX+/dfheWhtZUyScqjlQ==",
-			"dev": true,
-			"requires": {
-				"@hapi/bourne": "^2.0.0",
-				"args": "^5.0.1",
-				"chalk": "^4.0.0",
-				"dateformat": "^3.0.3",
-				"fast-safe-stringify": "^2.0.7",
-				"jmespath": "^0.15.0",
-				"joycon": "^2.2.5",
-				"pump": "^3.0.0",
-				"readable-stream": "^3.6.0",
-				"split2": "^3.1.1",
-				"strip-json-comments": "^3.1.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"strip-json-comments": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"pino-std-serializers": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz",
-			"integrity": "sha512-wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg==",
 			"dev": true
 		},
 		"pirates": {
@@ -13443,18 +6497,6 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
 		},
-		"prepend-http": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-			"dev": true
-		},
-		"pretty-bytes": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
-			"integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==",
-			"dev": true
-		},
 		"pretty-format": {
 			"version": "25.5.0",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
@@ -13500,59 +6542,11 @@
 			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
 			"dev": true
 		},
-		"private-ip": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/private-ip/-/private-ip-1.0.5.tgz",
-			"integrity": "sha1-ItAYP7oJ0OwaKk4PRv63cVY9FEk=",
-			"dev": true
-		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
-		},
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
-		},
-		"prom-client": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
-			"integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
-			"dev": true,
-			"requires": {
-				"tdigest": "^0.1.1"
-			}
-		},
-		"prometheus-gc-stats": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.3.tgz",
-			"integrity": "sha512-vCX+HZ1jZHkha25r5dAcRSNjue+K3Hn0B33EcZl7y3hgp3o1YsQ4Y3x7oJWKvDdbelFIL0McsXGmRg3zBrmq+g==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"gc-stats": "^1.4.0",
-				"optional": "^0.1.3"
-			}
-		},
-		"promise-timeout": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/promise-timeout/-/promise-timeout-1.3.0.tgz",
-			"integrity": "sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg==",
-			"dev": true
-		},
-		"promise-to-callback": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
-			"integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
-			"dev": true,
-			"requires": {
-				"is-fn": "^1.0.0",
-				"set-immediate-shim": "^1.0.1"
-			}
 		},
 		"prompts": {
 			"version": "2.3.2",
@@ -13564,81 +6558,11 @@
 				"sisteransi": "^1.0.4"
 			}
 		},
-		"proper-lockfile": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.1.tgz",
-			"integrity": "sha512-1w6rxXodisVpn7QYvLk706mzprPTAPCYAqxMvctmPN3ekuRk/kuGkGc82pangZiAt4R3lwSuUzheTTn0/Yb7Zg==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.11",
-				"retry": "^0.12.0",
-				"signal-exit": "^3.0.2"
-			}
-		},
-		"protobufjs": {
-			"version": "6.10.1",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
-			"integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
-			"dev": true,
-			"requires": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
-				"@types/long": "^4.0.1",
-				"@types/node": "^13.7.0",
-				"long": "^4.0.0"
-			}
-		},
-		"protocol-buffers-schema": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
-			"integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA==",
-			"dev": true
-		},
-		"protons": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-			"integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
-			"dev": true,
-			"requires": {
-				"protocol-buffers-schema": "^3.3.1",
-				"signed-varint": "^2.0.1",
-				"uint8arrays": "^1.0.0",
-				"varint": "^5.0.0"
-			}
-		},
-		"prr": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-			"dev": true
-		},
 		"psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
 			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
-		},
-		"public-encrypt": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.1.0",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"parse-asn1": "^5.0.0",
-				"randombytes": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
 		},
 		"pump": {
 			"version": "3.0.0",
@@ -13656,94 +6580,11 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"pupa": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
-			"integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
-			"dev": true,
-			"requires": {
-				"escape-goat": "^2.0.0"
-			}
-		},
-		"pushdata-bitcoin": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
-			"integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
-			"dev": true,
-			"requires": {
-				"bitcoin-ops": "^1.3.0"
-			}
-		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
-		},
-		"queue-microtask": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.0.tgz",
-			"integrity": "sha512-J95OVUiS4b8qqmpqhCodN8yPpHG2mpZUPQ8tDGyIY0VhM+kBHszOuvsMJVGNQ1OH2BnTFbqz45i+2jGpDw9H0w==",
-			"dev": true
-		},
-		"quick-format-unescaped": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
-			"integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==",
-			"dev": true
-		},
-		"rabin-wasm": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/rabin-wasm/-/rabin-wasm-0.1.4.tgz",
-			"integrity": "sha512-y8Rq8lGwUGeAaiQV//3hlyzQHLxg2HTEgZmZ8Mqef5LCH4SOpuUZqHqniCFz60FvF2IWp9mtEz9MRc3RewrJcA==",
-			"dev": true,
-			"requires": {
-				"@assemblyscript/loader": "^0.9.2",
-				"bl": "^4.0.1",
-				"debug": "^4.1.1",
-				"minimist": "^1.2.0",
-				"node-fetch": "^2.6.0",
-				"readable-stream": "^3.6.0"
-			}
-		},
-		"randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
-		"randomfill": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-			"dev": true,
-			"requires": {
-				"randombytes": "^2.0.5",
-				"safe-buffer": "^5.1.0"
-			}
-		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"dev": true,
-			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"dependencies": {
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"dev": true
-				}
-			}
 		},
 		"react-is": {
 			"version": "16.13.1",
@@ -13843,12 +6684,6 @@
 				"util-deprecate": "^1.0.1"
 			}
 		},
-		"readable-web-to-node-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz",
-			"integrity": "sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA==",
-			"dev": true
-		},
 		"realpath-native": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
@@ -13895,12 +6730,6 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
-			"dev": true
-		},
 		"regexpu-core": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
@@ -13913,24 +6742,6 @@
 				"regjsparser": "^0.6.4",
 				"unicode-match-property-ecmascript": "^1.0.4",
 				"unicode-match-property-value-ecmascript": "^1.2.0"
-			}
-		},
-		"registry-auth-token": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
-			"integrity": "sha512-P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==",
-			"dev": true,
-			"requires": {
-				"rc": "^1.2.8"
-			}
-		},
-		"registry-url": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
-			"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
-			"dev": true,
-			"requires": {
-				"rc": "^1.2.8"
 			}
 		},
 		"regjsgen": {
@@ -13955,12 +6766,6 @@
 					"dev": true
 				}
 			}
-		},
-		"relative-url": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
-			"integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc=",
-			"dev": true
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -14081,12 +6886,6 @@
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
 		},
-		"reset": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/reset/-/reset-0.1.0.tgz",
-			"integrity": "sha1-n8cxQXGZWubLC35YsGznUir0uvs=",
-			"dev": true
-		},
 		"resolve": {
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -14117,15 +6916,6 @@
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
 		},
-		"responselike": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-			"dev": true,
-			"requires": {
-				"lowercase-keys": "^1.0.0"
-			}
-		},
 		"restore-cursor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -14142,18 +6932,6 @@
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
 			"dev": true
 		},
-		"retimer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/retimer/-/retimer-2.0.0.tgz",
-			"integrity": "sha512-KLXY85WkEq2V2bKex/LOO1ViXVn2KGYe4PYysAdYdjmraYIUsVkXu8O4am+8+5UbaaGl1qho4aqAAPHNQ4GSbg==",
-			"dev": true
-		},
-		"retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-			"dev": true
-		},
 		"rimraf": {
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -14161,25 +6939,6 @@
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
-			}
-		},
-		"ripemd160": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-			"dev": true,
-			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
-			}
-		},
-		"rlp": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
-			"integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
-			"dev": true,
-			"requires": {
-				"bn.js": "^4.11.1"
 			}
 		},
 		"rpc-utils": {
@@ -14195,15 +6954,6 @@
 			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
 			"integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
 			"dev": true
-		},
-		"run": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/run/-/run-1.4.0.tgz",
-			"integrity": "sha1-4X2ekEOrL+F3dsspnhI3848LT/o=",
-			"dev": true,
-			"requires": {
-				"minimatch": "*"
-			}
 		},
 		"run-async": {
 			"version": "2.4.1",
@@ -14381,15 +7131,6 @@
 				}
 			}
 		},
-		"sanitize-filename": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-			"integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
-			"dev": true,
-			"requires": {
-				"truncate-utf8-bytes": "^1.0.0"
-			}
-		},
 		"saxes": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
@@ -14399,61 +7140,16 @@
 				"xmlchars": "^2.1.1"
 			}
 		},
-		"scrypt-js": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
-		},
-		"secp256k1": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-			"integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-			"dev": true,
-			"requires": {
-				"elliptic": "^6.5.2",
-				"node-addon-api": "^2.0.0",
-				"node-gyp-build": "^4.2.0"
-			}
-		},
-		"semaphore": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
-			"integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
-			"dev": true
-		},
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 			"dev": true
 		},
-		"semver-diff": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
-			"integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
-			"dev": true,
-			"requires": {
-				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
-			}
-		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
-		},
-		"set-immediate-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
 			"dev": true
 		},
 		"set-value": {
@@ -14479,22 +7175,6 @@
 				}
 			}
 		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
-		},
-		"sha.js": {
-			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -14517,78 +7197,11 @@
 			"dev": true,
 			"optional": true
 		},
-		"shortid": {
-			"version": "2.2.16",
-			"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
-			"integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
-			"dev": true,
-			"requires": {
-				"nanoid": "^2.1.0"
-			},
-			"dependencies": {
-				"nanoid": {
-					"version": "2.1.11",
-					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-					"integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
-					"dev": true
-				}
-			}
-		},
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
-		},
-		"signed-varint": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
-			"integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
-			"dev": true,
-			"requires": {
-				"varint": "~5.0.0"
-			}
-		},
-		"sinon": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.0.tgz",
-			"integrity": "sha512-eSNXz1XMcGEMHw08NJXSyTHIu6qTCOiN8x9ODACmZpNQpr0aXTBXBnI4xTzQzR+TEpOmLiKowGf9flCuKIzsbw==",
-			"dev": true,
-			"requires": {
-				"@sinonjs/commons": "^1.8.1",
-				"@sinonjs/fake-timers": "^6.0.1",
-				"@sinonjs/formatio": "^5.0.1",
-				"@sinonjs/samsam": "^5.2.0",
-				"diff": "^4.0.2",
-				"nise": "^4.0.4",
-				"supports-color": "^7.1.0"
-			},
-			"dependencies": {
-				"@sinonjs/commons": {
-					"version": "1.8.1",
-					"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
-					"integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
-					"dev": true,
-					"requires": {
-						"type-detect": "4.0.8"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
 		},
 		"sisteransi": {
 			"version": "1.0.5",
@@ -14620,12 +7233,6 @@
 					"dev": true
 				}
 			}
-		},
-		"smart-buffer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
-			"dev": true
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -14749,213 +7356,6 @@
 				}
 			}
 		},
-		"socket.io": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.3.0.tgz",
-			"integrity": "sha512-2A892lrj0GcgR/9Qk81EaY2gYhCBxurV0PfmmESO6p27QPrUK1J3zdns+5QPqvUYK2q657nSj0guoIil9+7eFg==",
-			"dev": true,
-			"requires": {
-				"debug": "~4.1.0",
-				"engine.io": "~3.4.0",
-				"has-binary2": "~1.0.2",
-				"socket.io-adapter": "~1.1.0",
-				"socket.io-client": "2.3.0",
-				"socket.io-parser": "~3.4.0"
-			},
-			"dependencies": {
-				"base64-arraybuffer": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-					"integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
-					"dev": true
-				},
-				"component-emitter": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-					"dev": true
-				},
-				"isarray": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-					"dev": true
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"socket.io-client": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
-					"integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
-					"dev": true,
-					"requires": {
-						"backo2": "1.0.2",
-						"base64-arraybuffer": "0.1.5",
-						"component-bind": "1.0.0",
-						"component-emitter": "1.2.1",
-						"debug": "~4.1.0",
-						"engine.io-client": "~3.4.0",
-						"has-binary2": "~1.0.2",
-						"has-cors": "1.1.0",
-						"indexof": "0.0.1",
-						"object-component": "0.0.3",
-						"parseqs": "0.0.5",
-						"parseuri": "0.0.5",
-						"socket.io-parser": "~3.3.0",
-						"to-array": "0.1.4"
-					},
-					"dependencies": {
-						"socket.io-parser": {
-							"version": "3.3.1",
-							"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
-							"integrity": "sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==",
-							"dev": true,
-							"requires": {
-								"component-emitter": "~1.3.0",
-								"debug": "~3.1.0",
-								"isarray": "2.0.1"
-							},
-							"dependencies": {
-								"component-emitter": {
-									"version": "1.3.0",
-									"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-									"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-									"dev": true
-								},
-								"debug": {
-									"version": "3.1.0",
-									"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-									"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-									"dev": true,
-									"requires": {
-										"ms": "2.0.0"
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"socket.io-adapter": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
-			"integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==",
-			"dev": true
-		},
-		"socket.io-client": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.1.tgz",
-			"integrity": "sha512-YXmXn3pA8abPOY//JtYxou95Ihvzmg8U6kQyolArkIyLd0pgVhrfor/iMsox8cn07WCOOvvuJ6XKegzIucPutQ==",
-			"dev": true,
-			"requires": {
-				"backo2": "1.0.2",
-				"component-bind": "1.0.0",
-				"component-emitter": "~1.3.0",
-				"debug": "~3.1.0",
-				"engine.io-client": "~3.4.0",
-				"has-binary2": "~1.0.2",
-				"indexof": "0.0.1",
-				"parseqs": "0.0.6",
-				"parseuri": "0.0.6",
-				"socket.io-parser": "~3.3.0",
-				"to-array": "0.1.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"isarray": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-					"dev": true
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"parseqs": {
-					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-					"integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
-					"dev": true
-				},
-				"parseuri": {
-					"version": "0.0.6",
-					"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-					"integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
-					"dev": true
-				},
-				"socket.io-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
-					"integrity": "sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==",
-					"dev": true,
-					"requires": {
-						"component-emitter": "~1.3.0",
-						"debug": "~3.1.0",
-						"isarray": "2.0.1"
-					}
-				}
-			}
-		},
-		"socket.io-parser": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.1.tgz",
-			"integrity": "sha512-11hMgzL+WCLWf1uFtHSNvliI++tcRUWdoeYuwIl+Axvwy9z2gQM+7nJyN3STj1tLj5JyIUH8/gpDGxzAlDdi0A==",
-			"dev": true,
-			"requires": {
-				"component-emitter": "1.2.1",
-				"debug": "~4.1.0",
-				"isarray": "2.0.1"
-			},
-			"dependencies": {
-				"component-emitter": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-					"dev": true
-				},
-				"isarray": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-					"dev": true
-				}
-			}
-		},
-		"sonic-boom": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.0.tgz",
-			"integrity": "sha512-4nX6OYvOYr6R76xfQKi6cZpTO3YSWe/vd+QdIfoH0lBy0MnPkeAbb2rRWgmgADkXUeCKPwO1FZAKlAVWAadELw==",
-			"dev": true,
-			"requires": {
-				"atomic-sleep": "^1.0.0",
-				"flatstr": "^1.0.12"
-			}
-		},
-		"sort-keys": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.1.0.tgz",
-			"integrity": "sha512-/sRdxzkkPFUYiCrTr/2t+104nDc9AgDmEpeVYuvOWYQe3Djk1GWO6lVw3Vx2jfh1SsR0eehhd1nvFYlzt5e99w==",
-			"dev": true,
-			"requires": {
-				"is-plain-obj": "^2.0.0"
-			}
-		},
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -14999,12 +7399,6 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
 			"dev": true
 		},
-		"sparse-array": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
-			"integrity": "sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg==",
-			"dev": true
-		},
 		"spdx-correct": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -15046,15 +7440,6 @@
 				"extend-shallow": "^3.0.0"
 			}
 		},
-		"split2": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-			"integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^3.0.0"
-			}
-		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -15092,12 +7477,6 @@
 				}
 			}
 		},
-		"stable": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-			"dev": true
-		},
 		"stack-utils": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
@@ -15129,33 +7508,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-			"dev": true
-		},
-		"store": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/store/-/store-2.0.12.tgz",
-			"integrity": "sha1-jFNOKguDH3K3X8XxEZhXxE711ZM=",
-			"dev": true
-		},
-		"stream-to-it": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.2.tgz",
-			"integrity": "sha512-waULBmQpVdr6TkDzci6t1P7dIaSZ0bHC1TaPXDUeJC5PpSK7U3T0H0Zeo/LWUnd6mnhXOmGGDKAkjUCHw5IOng==",
-			"dev": true,
-			"requires": {
-				"get-iterator": "^1.0.2"
-			}
-		},
-		"streaming-iterables": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-5.0.3.tgz",
-			"integrity": "sha512-1AgrKjHTvaaK+iA+N3BuTXQWVb7Adyb6+v8yIW3SCTwlBVYEbm76mF8Mf0/IVo+DOk7hoeELOURBKTCMhe/qow==",
-			"dev": true
-		},
-		"strftime": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.0.tgz",
-			"integrity": "sha1-s/D6QZKVICpaKJ9ta+n0kJphcZM=",
 			"dev": true
 		},
 		"string-length": {
@@ -15240,31 +7592,11 @@
 			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
 			"dev": true
 		},
-		"strip-hex-prefix": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-			"integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-			"dev": true,
-			"requires": {
-				"is-hex-prefixed": "1.0.0"
-			}
-		},
 		"strip-json-comments": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
 			"integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
 			"dev": true
-		},
-		"strtok3": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.4.tgz",
-			"integrity": "sha512-rqWMKwsbN9APU47bQTMEYTPcwdpKDtmf1jVhHzNW2cL1WqAxaM9iBb9t5P2fj+RV2YsErUWgQzHD5JwV0uCTEQ==",
-			"dev": true,
-			"requires": {
-				"@tokenizer/token": "^0.1.1",
-				"@types/debug": "^4.1.5",
-				"peek-readable": "^3.1.0"
-			}
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -15345,31 +7677,6 @@
 				}
 			}
 		},
-		"tdigest": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
-			"integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
-			"dev": true,
-			"requires": {
-				"bintrees": "1.0.1"
-			}
-		},
-		"temp": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/temp/-/temp-0.9.2.tgz",
-			"integrity": "sha512-KLVd6CXeUYsqmI/LBWDLg3bFkdZPg0Xr/Gn79GUuPNiISzp6v/EKUaCOrxqeH1w/wVNmrljyDRgKxhZV9JzyJA==",
-			"dev": true,
-			"requires": {
-				"mkdirp": "^0.5.1",
-				"rimraf": "~2.6.2"
-			}
-		},
-		"term-size": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
-			"integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
-			"dev": true
-		},
 		"terminal-link": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -15409,56 +7716,6 @@
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
-		"thunky": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
-			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
-			"dev": true
-		},
-		"time-cache": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/time-cache/-/time-cache-0.3.0.tgz",
-			"integrity": "sha1-7Q388P2kXNyV+9YB/agw6/G9XYs=",
-			"dev": true,
-			"requires": {
-				"lodash.throttle": "^4.1.1"
-			}
-		},
-		"timeout-abort-controller": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-1.1.1.tgz",
-			"integrity": "sha512-BsF9i3NAJag6T0ZEjki9j654zoafI2X6ayuNd6Tp8+Ul6Tr5s4jo973qFeiWrRSweqvskC+AHDKUmIW4b7pdhQ==",
-			"dev": true,
-			"requires": {
-				"abort-controller": "^3.0.0",
-				"retimer": "^2.0.0"
-			}
-		},
-		"timestamp-nano": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.0.tgz",
-			"integrity": "sha512-NO/1CZigzlCWQiWdIGv8ebXt6Uk77zdLz2NE7KcZRU5Egj2+947lzUpk30xQUQlq5dRY25j7ZulG4RfA2DHYfA==",
-			"dev": true
-		},
-		"tiny-each-async": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
-			"integrity": "sha1-jru/1tYpXxNwAD+7NxYq/loKUdE=",
-			"dev": true
-		},
-		"tiny-secp256k1": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
-			"integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
-			"dev": true,
-			"requires": {
-				"bindings": "^1.3.0",
-				"bn.js": "^4.11.8",
-				"create-hmac": "^1.1.7",
-				"elliptic": "^6.4.0",
-				"nan": "^2.13.2"
-			}
-		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -15494,12 +7751,6 @@
 			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
 			"dev": true
 		},
-		"to-array": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-			"integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
-			"dev": true
-		},
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -15526,12 +7777,6 @@
 				}
 			}
 		},
-		"to-readable-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-			"dev": true
-		},
 		"to-regex": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -15551,16 +7796,6 @@
 			"dev": true,
 			"requires": {
 				"is-number": "^7.0.0"
-			}
-		},
-		"token-types": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/token-types/-/token-types-2.0.0.tgz",
-			"integrity": "sha512-WWvu8sGK8/ZmGusekZJJ5NM6rRVTTDO7/bahz4NGiSDb/XsmdYBn6a1N/bymUHuWYTWeuLUg98wUzvE4jPdCZw==",
-			"dev": true,
-			"requires": {
-				"@tokenizer/token": "^0.1.0",
-				"ieee754": "^1.1.13"
 			}
 		},
 		"tough-cookie": {
@@ -15589,15 +7824,6 @@
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
-			}
-		},
-		"truncate-utf8-bytes": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-			"integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-			"dev": true,
-			"requires": {
-				"utf8-byte-length": "^1.0.1"
 			}
 		},
 		"tslib": {
@@ -15654,18 +7880,6 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
-		"typeforce": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-			"integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
-			"dev": true
-		},
-		"typical": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/typical/-/typical-6.0.1.tgz",
-			"integrity": "sha512-+g3NEp7fJLe9DPa1TArHm9QAA7YciZmWnfAqEaFrBihQ7epOv9i99rjtgb6Iz0wh3WuQDjsCTDfgRoGnmHN81A==",
-			"dev": true
-		},
 		"uint8arrays": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
@@ -15715,21 +7929,6 @@
 				"set-value": "^2.0.1"
 			}
 		},
-		"unique-string": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-			"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-			"dev": true,
-			"requires": {
-				"crypto-random-string": "^2.0.0"
-			}
-		},
-		"universalify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-			"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-			"dev": true
-		},
 		"unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -15770,78 +7969,6 @@
 				}
 			}
 		},
-		"update-notifier": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz",
-			"integrity": "sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==",
-			"dev": true,
-			"requires": {
-				"boxen": "^4.2.0",
-				"chalk": "^3.0.0",
-				"configstore": "^5.0.1",
-				"has-yarn": "^2.1.0",
-				"import-lazy": "^2.1.0",
-				"is-ci": "^2.0.0",
-				"is-installed-globally": "^0.3.1",
-				"is-npm": "^4.0.0",
-				"is-yarn-global": "^0.3.0",
-				"latest-version": "^5.0.0",
-				"pupa": "^2.0.1",
-				"semver-diff": "^3.1.1",
-				"xdg-basedir": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -15851,40 +7978,11 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"uri-to-multiaddr": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/uri-to-multiaddr/-/uri-to-multiaddr-4.0.0.tgz",
-			"integrity": "sha512-6zQ1uBlE+F//46CBA3lx3vBMhybSvdGJqgNyQPobSDsWGrDDdmJM/f95GPaswXAGFlRHPqOjrGKT11IcKmIfaA==",
-			"dev": true,
-			"requires": {
-				"is-ip": "^3.1.0",
-				"multiaddr": "^8.0.0"
-			}
-		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
 			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
 			"dev": true
-		},
-		"url-parse-lax": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"dev": true,
-			"requires": {
-				"prepend-http": "^2.0.0"
-			}
-		},
-		"ursa-optional": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.10.1.tgz",
-			"integrity": "sha512-/pgpBXVJut57dHNrdGF+1/qXi+5B7JrlmZDWPSyoivEcbwFWRZJBJGkWb6ivknMBA3bnFA7lqsb6iHiFfp79QQ==",
-			"dev": true,
-			"requires": {
-				"bindings": "^1.5.0",
-				"nan": "^2.14.0"
-			}
 		},
 		"use": {
 			"version": "3.1.1",
@@ -15892,21 +7990,10 @@
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
 		},
-		"utf8-byte-length": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-			"integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
-			"dev": true
-		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
-		"uuid": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-			"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
 		},
 		"v8-compile-cache": {
 			"version": "2.1.1",
@@ -15947,24 +8034,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
 			"integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
-		},
-		"varint-decoder": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-1.0.0.tgz",
-			"integrity": "sha512-JkOvdztASWGUAsXshCFHrB9f6AgR2Q8W08CEyJ+43b1qtFocmI8Sp1R/M0E/hDOY2FzVIqk63tOYLgDYWuJ7IQ==",
-			"dev": true,
-			"requires": {
-				"varint": "^5.0.0"
-			}
-		},
-		"varuint-bitcoin": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
-			"integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.1.1"
-			}
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -16010,16 +8079,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.3.tgz",
 			"integrity": "sha512-Ajn64qJ0Z3oMwOIwBtxajFPA+4guB12n4EfmY1Mtlgb9296WJxwH1q/ykedmQrBNpjcKCM207S5OM2wpJfl4VA=="
-		},
-		"webcrypto": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/webcrypto/-/webcrypto-0.1.1.tgz",
-			"integrity": "sha512-BAvoatS38TbHdyt42ECLroi27NmDh5iea5l5rHC6nZTZjlbJlndrT0FoIiEq7fmPHpmNtP0lMFKVMEKZQFIrGA==",
-			"dev": true,
-			"requires": {
-				"crypto-browserify": "^3.10.0",
-				"detect-node": "^2.0.3"
-			}
 		},
 		"webidl-conversions": {
 			"version": "4.0.2",
@@ -16067,24 +8126,6 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
-		},
-		"widest-line": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-			"dev": true,
-			"requires": {
-				"string-width": "^4.0.0"
-			}
-		},
-		"wif": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-			"integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
-			"dev": true,
-			"requires": {
-				"bs58check": "<3.0.0"
-			}
 		},
 		"word-wrap": {
 			"version": "1.2.3",
@@ -16172,12 +8213,6 @@
 			"integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
 			"dev": true
 		},
-		"xdg-basedir": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-			"dev": true
-		},
 		"xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -16190,40 +8225,10 @@
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
 		},
-		"xmlhttprequest-ssl": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-			"integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
-			"dev": true
-		},
-		"xor-distance": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/xor-distance/-/xor-distance-2.0.0.tgz",
-			"integrity": "sha512-AsAqZfPAuWx7qB/0kyRDUEvoU3QKsHWzHU9smFlkaiprEpGfJ/NBbLze2Uq0rdkxCxkNM9uOLvz/KoNBCbZiLQ==",
-			"dev": true
-		},
-		"xsalsa20": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.1.0.tgz",
-			"integrity": "sha512-zd3ytX2cm+tcSndRU+krm0eL4TMMpZE7evs5hLRAoOy6gviqLfe3qOlkjF3i5SeAkQUCeJk0lJZrEU56kHRfWw==",
-			"dev": true
-		},
-		"xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true
-		},
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-			"dev": true
-		},
-		"yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
 		"yargs": {
@@ -16304,27 +8309,6 @@
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
-			}
-		},
-		"yargs-promise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/yargs-promise/-/yargs-promise-1.1.0.tgz",
-			"integrity": "sha1-l+u1GY33NLs7EXRRM65bUBsWqx8=",
-			"dev": true
-		},
-		"yeast": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-			"integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
-			"dev": true
-		},
-		"zcash-block": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/zcash-block/-/zcash-block-2.0.0.tgz",
-			"integrity": "sha512-I6pv5b+eGE8CJFmltR+ILHnGcnBO8olV78VicQIaWulMhkomlwDmaMeMshJRLPcnd0FBs58QQVcVNBOT9ojH6Q==",
-			"dev": true,
-			"requires": {
-				"multihashing": "~0.3.3"
 			}
 		}
 	}

--- a/packages/doctype-tile/package.json
+++ b/packages/doctype-tile/package.json
@@ -34,7 +34,7 @@
     "cids": "^1.0.2",
     "did-jwt": "^4.6.3",
     "did-resolver": "^2.1.1",
-    "dids": "^0.8.0",
+    "dids": "^1.0.0",
     "fast-json-patch": "^2.2.1",
     "fast-json-stable-stringify": "^2.1.0"
   },

--- a/packages/doctype-tile/src/__tests__/three-id.test.ts
+++ b/packages/doctype-tile/src/__tests__/three-id.test.ts
@@ -121,7 +121,7 @@ describe('ThreeIdHandler', () => {
     did = new DID()
     did.createJWS = jest.fn(async () => {
       // fake jws
-      return 'eyJraWQiOiJkaWQ6a2V5OnpRM3Nod3NDZ0ZhbkJheDZVaWFMdTFvR3ZNN3ZodXFvVzg4VkJVaVVUQ2VIYlRlVFYiLCJhbGciOiJFUzI1NksifQ.bbbb.cccc'
+      return { payload: 'bbbb', signatures: [{ protected: 'eyJraWQiOiJkaWQ6a2V5OnpRM3Nod3NDZ0ZhbkJheDZVaWFMdTFvR3ZNN3ZodXFvVzg4VkJVaVVUQ2VIYlRlVFYiLCJhbGciOiJFUzI1NksifQ', signature: 'cccc'}]}
     })
     did._id = 'did:key:zQ3shwsCgFanBax6UiaLu1oGvM7vhuqoW88VBUiUTCeHbTeTV'
 

--- a/packages/doctype-tile/src/__tests__/tile-doctype.test.ts
+++ b/packages/doctype-tile/src/__tests__/tile-doctype.test.ts
@@ -34,7 +34,6 @@ const RECORDS = {
       "payload": "bbbb",
       "signatures": [
         {
-          
           "protected": "eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9",
           "signature": "cccc"
         }
@@ -117,7 +116,7 @@ describe('TileDoctypeHandler', () => {
     did = new DID()
     did.createJWS = jest.fn(async () => {
       // fake jws
-      return 'eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9.bbbb.cccc'
+      return { payload: 'bbbb', signatures: [{ protected: 'eyJraWQiOiJkaWQ6MzprMnQ2d3lmc3U0cGcwdDJuNGo4bXMzczMzeHNncWpodHRvMDRtdnE4dzVhMnY1eG80OGlkeXozOGw3eWRraT92ZXJzaW9uPTAjc2lnbmluZyIsImFsZyI6IkVTMjU2SyJ9', signature: 'cccc'}]}
     })
     did._id = 'did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki'
 

--- a/packages/http-client/package-lock.json
+++ b/packages/http-client/package-lock.json
@@ -1,22 +1,9 @@
 {
-	"name": "@ceramicnetwork/ceramic-http-client",
+	"name": "@ceramicnetwork/http-client",
 	"version": "0.8.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"3id-blockchain-utils": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/3id-blockchain-utils/-/3id-blockchain-utils-1.0.0.tgz",
-			"integrity": "sha512-+6128bRssiaPGY08cxdQpYdKacB82X2S5ydTm06qiV+ERWH4ywrmNXypc2/U6+EyBd9HM4Qf/Z5E95I01CGSHA==",
-			"requires": {
-				"@babel/runtime": "^7.9.2",
-				"@ethersproject/contracts": "^5.0.1",
-				"@ethersproject/providers": "^5.0.4",
-				"@ethersproject/wallet": "^5.0.1",
-				"caip": "^0.9.2",
-				"js-sha256": "^0.9.0"
-			}
-		},
 		"@babel/code-frame": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -1127,6 +1114,7 @@
 			"version": "7.9.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
 			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -1176,70 +1164,50 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true
 		},
-		"@ceramicnetwork/ceramic-common": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-common/-/ceramic-common-0.12.0.tgz",
-			"integrity": "sha512-C43IMV2N4J3LOyF9Tvu3xI2oEFv8Fv7o5tca7bEklay8wUo4oeA47j7JBD7rO9bzbx3vQbH7FEk4NsQHVUAryQ==",
+		"@ceramicnetwork/3id-did-resolver": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@ceramicnetwork/3id-did-resolver/-/3id-did-resolver-0.5.0.tgz",
+			"integrity": "sha512-VcEVp5dRzyi/iRB7FtJhDGokaZGaP/wykSYY1x4koMMCF6j9cezA/zDEI8IJV+t+vQWGsOjUgppQLO1w6wtUJA==",
 			"requires": {
-				"@ceramicnetwork/docid": "^0.2.0",
-				"cids": "^1.0.0",
-				"dag-jose": "^0.3.0",
-				"did-resolver": "^2.1.1",
-				"lodash.clonedeep": "^4.5.0",
-				"loglevel": "^1.7.0",
-				"loglevel-plugin-prefix": "^0.8.4",
+				"@ceramicnetwork/common": "^0.13.0",
+				"@ceramicnetwork/docid": "^0.3.0",
+				"cids": "^1.0.2",
+				"cross-fetch": "^3.0.6",
 				"uint8arrays": "^1.1.0"
-			}
-		},
-		"@ceramicnetwork/ceramic-doctype-account-link": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-account-link/-/ceramic-doctype-account-link-0.10.0.tgz",
-			"integrity": "sha512-pud0g5pJL3zQ4FMYPo9RxMQAJ1DqBqEKYI9QVA8XnIv9n3XDem7T+67JZt9qOGxu4juP3z/Se6OOplVzpJTc0Q==",
-			"requires": {
-				"3id-blockchain-utils": "^1.0.0",
-				"@ceramicnetwork/ceramic-common": "^0.12.0",
-				"@types/lodash.clonedeep": "^4.5.6",
-				"cids": "^1.0.0",
-				"did-resolver": "^2.1.1"
-			}
-		},
-		"@ceramicnetwork/ceramic-doctype-tile": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/ceramic-doctype-tile/-/ceramic-doctype-tile-0.10.0.tgz",
-			"integrity": "sha512-IvKpRYCN0Q20PIub2r2ZjFlwy6sQgKGC7VBVj1HEQEttd+VxyapioHzwMEBzSmosiW/7k6SgBsB7XlKU2TdEAA==",
-			"requires": {
-				"3id-blockchain-utils": "^1.0.0",
-				"@ceramicnetwork/ceramic-common": "^0.12.0",
-				"@ceramicnetwork/key-did-resolver": "^0.1.2",
-				"@ethersproject/base64": "^5.0.2",
-				"@ethersproject/random": "^5.0.2",
-				"@types/lodash.clonedeep": "^4.5.6",
-				"base64url": "^3.0.1",
-				"cids": "^1.0.0",
-				"did-jwt": "^4.0.0",
-				"did-resolver": "^2.1.1",
-				"dids": "^0.7.0",
-				"fast-json-patch": "^2.2.1",
-				"fast-json-stable-stringify": "^2.1.0"
-			}
-		},
-		"@ceramicnetwork/docid": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/docid/-/docid-0.2.0.tgz",
-			"integrity": "sha512-s4YXOFM7CNSYGkfnts9XB6EOmp37uPnc7Q2hF3M5SZDNQhtDzYpuCdY30CFNJ291JOfMlfLQovQv4+k7ytkE6A==",
-			"requires": {
-				"cids": "^1.0.0",
-				"multibase": "^3.0.1",
-				"varint": "^6.0.0"
 			},
 			"dependencies": {
+				"@ceramicnetwork/common": {
+					"version": "0.13.0",
+					"resolved": "https://registry.npmjs.org/@ceramicnetwork/common/-/common-0.13.0.tgz",
+					"integrity": "sha512-YxJjYY8PN4Doke+bgWk8Sce2olf7gm62oyVb8TseISbraTVda+ZDTbxyET2YP0POaP0WCqzPWjssK2vYMCcA7Q==",
+					"requires": {
+						"@ceramicnetwork/docid": "^0.3.0",
+						"cids": "^1.0.2",
+						"dag-jose": "^0.3.0",
+						"did-resolver": "^2.1.1",
+						"lodash.clonedeep": "^4.5.0",
+						"loglevel": "^1.7.0",
+						"loglevel-plugin-prefix": "^0.8.4",
+						"uint8arrays": "^1.1.0"
+					}
+				},
+				"@ceramicnetwork/docid": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/@ceramicnetwork/docid/-/docid-0.3.0.tgz",
+					"integrity": "sha512-o9sDp0u44H+UyGONDQwEbvR0FL9AdDJmTyoJTr9DpMJVAbgEtDZ7LR4C5iDN2zfLUzaw4S7k9d7JuvZBbn2FUQ==",
+					"requires": {
+						"cids": "^1.0.2",
+						"multibase": "^3.0.1",
+						"varint": "^6.0.0"
+					}
+				},
 				"multibase": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
-					"integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.0.tgz",
+					"integrity": "sha512-Z+pThrpbS7ckQ2DwW5mPiwCGe1a94f8DWi/OxmbyeRednVOyUKmLSE+60kL/WHFYwWnaD1OakXGk3PYI1NkMFw==",
 					"requires": {
 						"@multiformats/base-x": "^4.0.1",
-						"web-encoding": "^1.0.2"
+						"web-encoding": "^1.0.4"
 					}
 				},
 				"varint": {
@@ -1250,22 +1218,23 @@
 			}
 		},
 		"@ceramicnetwork/key-did-resolver": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@ceramicnetwork/key-did-resolver/-/key-did-resolver-0.1.2.tgz",
-			"integrity": "sha512-FUPiJTQ4mSnieqoafL0Bt0gT+wMBscW198zCAz/AX9UEejgfvfQNdKYEph9vclsJ+obAvwJQfq4aZq40oH/b0w==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@ceramicnetwork/key-did-resolver/-/key-did-resolver-0.2.0.tgz",
+			"integrity": "sha512-wQFgO/ZPkUV2SUECJrn/XsjkYPlZHG4Jse7CYza1xLExgn7yQmJuKSuWSbf0Xvt+CvXy6SamOgsYZ9d/lnZT2Q==",
 			"requires": {
+				"@stablelib/ed25519": "^1.0.1",
 				"multibase": "^3.0.1",
 				"uint8arrays": "^1.1.0",
 				"varint": "^6.0.0"
 			},
 			"dependencies": {
 				"multibase": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
-					"integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.0.tgz",
+					"integrity": "sha512-Z+pThrpbS7ckQ2DwW5mPiwCGe1a94f8DWi/OxmbyeRednVOyUKmLSE+60kL/WHFYwWnaD1OakXGk3PYI1NkMFw==",
 					"requires": {
 						"@multiformats/base-x": "^4.0.1",
-						"web-encoding": "^1.0.2"
+						"web-encoding": "^1.0.4"
 					}
 				},
 				"varint": {
@@ -1283,368 +1252,6 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
-			}
-		},
-		"@ethersproject/abi": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
-			"integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
-			"requires": {
-				"@ethersproject/address": "^5.0.4",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.4",
-				"@ethersproject/hash": "^5.0.4",
-				"@ethersproject/keccak256": "^5.0.3",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/strings": "^5.0.4"
-			}
-		},
-		"@ethersproject/abstract-provider": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.5.tgz",
-			"integrity": "sha512-i/CjElAkzV7vQBAeoz+IpjGfcFYEP9eD7j3fzZ0fzTq03DO7PPnR+xkEZ1IoDXGwDS+55aLM1xvLDwB/Lx6IOQ==",
-			"requires": {
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/networks": "^5.0.3",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/transactions": "^5.0.5",
-				"@ethersproject/web": "^5.0.6"
-			}
-		},
-		"@ethersproject/abstract-signer": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.7.tgz",
-			"integrity": "sha512-8W8gy/QutEL60EoMEpvxZ8MFAEWs/JvH5nmZ6xeLXoZvmBCasGmxqHdYjo2cxg0nevkPkq9SeenSsBBZSCx+SQ==",
-			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.4",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3"
-			}
-		},
-		"@ethersproject/address": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.5.tgz",
-			"integrity": "sha512-DpkQ6rwk9jTefrRsJzEm6nhRiJd9pvhn1xN0rw5N/jswXG5r7BLk/GVA0mMAVWAsYfvi2xSc5L41FMox43RYEA==",
-			"requires": {
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/keccak256": "^5.0.3",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/rlp": "^5.0.3",
-				"bn.js": "^4.4.0"
-			}
-		},
-		"@ethersproject/base64": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.4.tgz",
-			"integrity": "sha512-4KRykQ7BQMeOXfvio1YITwHjxwBzh92UoXIdzxDE1p53CK28bbHPdsPNYo0wl0El7lJAMpT2SOdL0hhbWRnyIA==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4"
-			}
-		},
-		"@ethersproject/basex": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.4.tgz",
-			"integrity": "sha512-ixIr/kKiAoSzOnSc777AGIOAhKai5Ivqr4HO/Gz+YG+xkfv6kqD6AW4ga9vM20Wwb0QBhh3LoRWTu4V1K+x9Ew==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/properties": "^5.0.3"
-			}
-		},
-		"@ethersproject/bignumber": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.8.tgz",
-			"integrity": "sha512-KXFVAFKS1jdTXYN8BE5Oj+ZfPMh28iRdFeNGBVT6cUFdtiPVqeXqc0ggvBqA3A1VoFFGgM7oAeaagA393aORHA==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"bn.js": "^4.4.0"
-			}
-		},
-		"@ethersproject/bytes": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.5.tgz",
-			"integrity": "sha512-IEj9HpZB+ACS6cZ+QQMTqmu/cnUK2fYNE6ms/PVxjoBjoxc6HCraLpam1KuRvreMy0i523PLmjN8OYeikRdcUQ==",
-			"requires": {
-				"@ethersproject/logger": "^5.0.5"
-			}
-		},
-		"@ethersproject/constants": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.5.tgz",
-			"integrity": "sha512-foaQVmxp2+ik9FrLUCtVrLZCj4M3Ibgkqvh+Xw/vFRSerkjVSYePApaVE5essxhoSlF1U9oXfWY09QI2AXtgKA==",
-			"requires": {
-				"@ethersproject/bignumber": "^5.0.7"
-			}
-		},
-		"@ethersproject/contracts": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.5.tgz",
-			"integrity": "sha512-tFI255lFbmbqMkgnuyhDWHl3yWqttPlReplYuVvDCT/SuvBjLR4ad2uipBlh1fh5X1ipK9ettAoV4S0HKim4Kw==",
-			"requires": {
-				"@ethersproject/abi": "^5.0.5",
-				"@ethersproject/abstract-provider": "^5.0.4",
-				"@ethersproject/abstract-signer": "^5.0.4",
-				"@ethersproject/address": "^5.0.4",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3"
-			}
-		},
-		"@ethersproject/hash": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.6.tgz",
-			"integrity": "sha512-Gvh57v6BWhwnud6l7tMfQm32PRQ2DYx2WaAAQmAxAfYvmzUkpQCBstnGeNMXIL8/2wdkvcB2u+WZRWaZtsFuUQ==",
-			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.6",
-				"@ethersproject/address": "^5.0.5",
-				"@ethersproject/bignumber": "^5.0.8",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/keccak256": "^5.0.3",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.4",
-				"@ethersproject/strings": "^5.0.4"
-			}
-		},
-		"@ethersproject/hdnode": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.5.tgz",
-			"integrity": "sha512-Ho4HZaK+KijE5adayvjAGusWMnT0mgwGa5hGMBofBOgX9nqiKf6Wxx68SXBGI1/L3rmKo6mlAjxUd8gefs0teQ==",
-			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.4",
-				"@ethersproject/basex": "^5.0.3",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/pbkdf2": "^5.0.3",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/sha2": "^5.0.3",
-				"@ethersproject/signing-key": "^5.0.4",
-				"@ethersproject/strings": "^5.0.4",
-				"@ethersproject/transactions": "^5.0.5",
-				"@ethersproject/wordlists": "^5.0.4"
-			}
-		},
-		"@ethersproject/json-wallets": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.7.tgz",
-			"integrity": "sha512-dgOn9JtGgjT28mDXs4LYY2rT4CzS6bG/rxoYuPq3TLHIf6nmvBcr33Fee6RrM/y8UAx4gyIkf6wb2cXsOctvQQ==",
-			"requires": {
-				"@ethersproject/abstract-signer": "^5.0.4",
-				"@ethersproject/address": "^5.0.4",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/hdnode": "^5.0.4",
-				"@ethersproject/keccak256": "^5.0.3",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/pbkdf2": "^5.0.3",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/random": "^5.0.3",
-				"@ethersproject/strings": "^5.0.4",
-				"@ethersproject/transactions": "^5.0.5",
-				"aes-js": "3.0.0",
-				"scrypt-js": "3.0.1"
-			}
-		},
-		"@ethersproject/keccak256": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.4.tgz",
-			"integrity": "sha512-GNpiOUm9PGUxFNqOxYKDQBM0u68bG9XC9iOulEQ8I0tOx/4qUpgVzvgXL6ugxr0RY554Gz/NQsVqknqPzUcxpQ==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"js-sha3": "0.5.7"
-			},
-			"dependencies": {
-				"js-sha3": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-					"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-				}
-			}
-		},
-		"@ethersproject/logger": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.6.tgz",
-			"integrity": "sha512-FrX0Vnb3JZ1md/7GIZfmJ06XOAA8r3q9Uqt9O5orr4ZiksnbpXKlyDzQtlZ5Yv18RS8CAUbiKH9vwidJg1BPmQ=="
-		},
-		"@ethersproject/networks": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.4.tgz",
-			"integrity": "sha512-/wHDTRms5mpJ09BoDrbNdFWINzONe05wZRgohCXvEv39rrH/Gd/yAnct8wC0RsW3tmFOgjgQxuBvypIxuUynTw==",
-			"requires": {
-				"@ethersproject/logger": "^5.0.5"
-			}
-		},
-		"@ethersproject/pbkdf2": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.4.tgz",
-			"integrity": "sha512-9jVBjHXQKfr9+3bkCg01a8Cd1H9e+7Kw3ZMIvAxD0lZtuzrXsJxm1hVwY9KA+PRUvgS/9tTP4viXQYwLAax7zg==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/sha2": "^5.0.3"
-			}
-		},
-		"@ethersproject/properties": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.4.tgz",
-			"integrity": "sha512-UdyX3GqBxFt15B0uSESdDNmhvEbK3ACdDXl2soshoPcneXuTswHDeA0LoPlnaZzhbgk4p6jqb4GMms5C26Qu6A==",
-			"requires": {
-				"@ethersproject/logger": "^5.0.5"
-			}
-		},
-		"@ethersproject/providers": {
-			"version": "5.0.14",
-			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.14.tgz",
-			"integrity": "sha512-K9QRRkkHWyprm3g4L8U9aPx5uyivznL4RYemkN2shCQumyGqFJ5SO+OtQrgebVm0JpGwFAUGugnhRUh49sjErw==",
-			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.4",
-				"@ethersproject/abstract-signer": "^5.0.4",
-				"@ethersproject/address": "^5.0.4",
-				"@ethersproject/basex": "^5.0.3",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.4",
-				"@ethersproject/hash": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/networks": "^5.0.3",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/random": "^5.0.3",
-				"@ethersproject/rlp": "^5.0.3",
-				"@ethersproject/sha2": "^5.0.3",
-				"@ethersproject/strings": "^5.0.4",
-				"@ethersproject/transactions": "^5.0.5",
-				"@ethersproject/web": "^5.0.6",
-				"bech32": "1.1.4",
-				"ws": "7.2.3"
-			}
-		},
-		"@ethersproject/random": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.4.tgz",
-			"integrity": "sha512-AIZJhqs6Ba4/+U3lOjt3QZbP6b/kuuGLJUYFUonAgWmkTHwqsCwYnFvnHKQSUuHbXHvErp7WFXFlztx+yMn3kQ==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5"
-			}
-		},
-		"@ethersproject/rlp": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.4.tgz",
-			"integrity": "sha512-5qrrZad7VTjofxSsm7Zg/7Dr4ZOln4S2CqiDdOuTv6MBKnXj0CiBojXyuDy52M8O3wxH0CyE924hXWTDV1PQWQ==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5"
-			}
-		},
-		"@ethersproject/sha2": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.4.tgz",
-			"integrity": "sha512-0yFhf1mspxAfWdXXoPtK94adUeu1R7/FzAa+DfEiZTc76sz/vHXf0LSIazoR3znYKFny6haBxME+usbvvEcF3A==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"hash.js": "1.1.3"
-			},
-			"dependencies": {
-				"hash.js": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-					"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"minimalistic-assert": "^1.0.0"
-					}
-				}
-			}
-		},
-		"@ethersproject/signing-key": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.5.tgz",
-			"integrity": "sha512-Z1wY7JC1HVO4CvQWY2TyTTuAr8xK3bJijZw1a9G92JEmKdv1j255R/0YLBBcFTl2J65LUjtXynNJ2GbArPGi5g==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3",
-				"elliptic": "6.5.3"
-			}
-		},
-		"@ethersproject/strings": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
-			"integrity": "sha512-JED6WaIV00xM/gvj8vSnd+0VWtDYdidTmavFRCTQakqfz+4tDo6Jz5LHgG+dd45h7ah7ykCHW0C7ZXWEDROCXQ==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5"
-			}
-		},
-		"@ethersproject/transactions": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.6.tgz",
-			"integrity": "sha512-htsFhOD+NMBxx676A8ehSuwVV49iqpSB+CkjPZ02tpNew0K6p8g0CZ46Z1ZP946gIHAU80xQ0NACHYrjIUaCFA==",
-			"requires": {
-				"@ethersproject/address": "^5.0.4",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/constants": "^5.0.4",
-				"@ethersproject/keccak256": "^5.0.3",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/rlp": "^5.0.3",
-				"@ethersproject/signing-key": "^5.0.4"
-			}
-		},
-		"@ethersproject/wallet": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.7.tgz",
-			"integrity": "sha512-n2GX1+2Tc0qV8dguUcLkjNugINKvZY7u/5fEsn0skW9rz5+jHTR5IKMV6jSfXA+WjQT8UCNMvkI3CNcdhaPbTQ==",
-			"requires": {
-				"@ethersproject/abstract-provider": "^5.0.4",
-				"@ethersproject/abstract-signer": "^5.0.4",
-				"@ethersproject/address": "^5.0.4",
-				"@ethersproject/bignumber": "^5.0.7",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/hash": "^5.0.4",
-				"@ethersproject/hdnode": "^5.0.4",
-				"@ethersproject/json-wallets": "^5.0.6",
-				"@ethersproject/keccak256": "^5.0.3",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/random": "^5.0.3",
-				"@ethersproject/signing-key": "^5.0.4",
-				"@ethersproject/transactions": "^5.0.5",
-				"@ethersproject/wordlists": "^5.0.4"
-			}
-		},
-		"@ethersproject/web": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.9.tgz",
-			"integrity": "sha512-//QNlv1MSkOII1hv3+HQwWoiVFS+BMVGI0KYeUww4cyrEktnx1QIez5bTSab9s9fWTFaWKNmQNBwMbxAqPuYDw==",
-			"requires": {
-				"@ethersproject/base64": "^5.0.3",
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/strings": "^5.0.4"
-			}
-		},
-		"@ethersproject/wordlists": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.5.tgz",
-			"integrity": "sha512-XA3ycFltVrCTQt04w5nHu3Xq5Z6HjqWsXaAYQHFdqtugyUsIumaO9S5MOwFFuUYTNkZUoT3jCRa/OBS+K4tLfA==",
-			"requires": {
-				"@ethersproject/bytes": "^5.0.4",
-				"@ethersproject/hash": "^5.0.4",
-				"@ethersproject/logger": "^5.0.5",
-				"@ethersproject/properties": "^5.0.3",
-				"@ethersproject/strings": "^5.0.4"
 			}
 		},
 		"@istanbuljs/load-nyc-config": {
@@ -2325,11 +1932,6 @@
 				"@stablelib/wipe": "^1.0.0"
 			}
 		},
-		"@stablelib/utf8": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.0.tgz",
-			"integrity": "sha512-Y8QWrK4T0yW0HMFfSI3ZaMHKV37q27hX5ilsmKV358x01mzYfj5fwIf2LjzTlF+UIemHEXSlSN9XJnv1ML4znQ=="
-		},
 		"@stablelib/wipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
@@ -2433,12 +2035,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/eslint-visitor-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
-			"dev": true
-		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -2501,12 +2097,14 @@
 		"@types/lodash": {
 			"version": "4.14.149",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-			"integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
+			"integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+			"dev": true
 		},
 		"@types/lodash.clonedeep": {
 			"version": "4.5.6",
 			"resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
 			"integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+			"dev": true,
 			"requires": {
 				"@types/lodash": "*"
 			}
@@ -2578,53 +2176,6 @@
 			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
 			"dev": true
 		},
-		"@typescript-eslint/eslint-plugin": {
-			"version": "2.31.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.31.0.tgz",
-			"integrity": "sha512-iIC0Pb8qDaoit+m80Ln/aaeu9zKQdOLF4SHcGLarSeY1gurW6aU4JsOPMjKQwXlw70MvWKZQc6S2NamA8SJ/gg==",
-			"dev": true,
-			"requires": {
-				"@typescript-eslint/experimental-utils": "2.31.0",
-				"functional-red-black-tree": "^1.0.1",
-				"regexpp": "^3.0.0",
-				"tsutils": "^3.17.1"
-			},
-			"dependencies": {
-				"@typescript-eslint/experimental-utils": {
-					"version": "2.31.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.31.0.tgz",
-					"integrity": "sha512-MI6IWkutLYQYTQgZ48IVnRXmLR/0Q6oAyJgiOror74arUMh7EWjJkADfirZhRsUMHeLJ85U2iySDwHTSnNi9vA==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.3",
-						"@typescript-eslint/typescript-estree": "2.31.0",
-						"eslint-scope": "^5.0.0",
-						"eslint-utils": "^2.0.0"
-					}
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "2.31.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.31.0.tgz",
-					"integrity": "sha512-vxW149bXFXXuBrAak0eKHOzbcu9cvi6iNcJDzEtOkRwGHxJG15chiAQAwhLOsk+86p9GTr/TziYvw+H9kMaIgA==",
-					"dev": true,
-					"requires": {
-						"debug": "^4.1.1",
-						"eslint-visitor-keys": "^1.1.0",
-						"glob": "^7.1.6",
-						"is-glob": "^4.0.1",
-						"lodash": "^4.17.15",
-						"semver": "^6.3.0",
-						"tsutils": "^3.17.1"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
-			}
-		},
 		"@typescript-eslint/experimental-utils": {
 			"version": "2.26.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.26.0.tgz",
@@ -2635,53 +2186,6 @@
 				"@typescript-eslint/typescript-estree": "2.26.0",
 				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^2.0.0"
-			}
-		},
-		"@typescript-eslint/parser": {
-			"version": "2.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.33.0.tgz",
-			"integrity": "sha512-AUtmwUUhJoH6yrtxZMHbRUEMsC2G6z5NSxg9KsROOGqNXasM71I8P2NihtumlWTUCRld70vqIZ6Pm4E5PAziEA==",
-			"dev": true,
-			"requires": {
-				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "2.33.0",
-				"@typescript-eslint/typescript-estree": "2.33.0",
-				"eslint-visitor-keys": "^1.1.0"
-			},
-			"dependencies": {
-				"@typescript-eslint/experimental-utils": {
-					"version": "2.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.33.0.tgz",
-					"integrity": "sha512-qzPM2AuxtMrRq78LwyZa8Qn6gcY8obkIrBs1ehqmQADwkYzTE1Pb4y2W+U3rE/iFkSWcWHG2LS6MJfj6SmHApg==",
-					"dev": true,
-					"requires": {
-						"@types/json-schema": "^7.0.3",
-						"@typescript-eslint/typescript-estree": "2.33.0",
-						"eslint-scope": "^5.0.0",
-						"eslint-utils": "^2.0.0"
-					}
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "2.33.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.33.0.tgz",
-					"integrity": "sha512-d8rY6/yUxb0+mEwTShCQF2zYQdLlqihukNfG9IUlLYz5y1CH6G/9XYbrxQLq3Z14RNvkCC6oe+OcFlyUpwUbkg==",
-					"dev": true,
-					"requires": {
-						"debug": "^4.1.1",
-						"eslint-visitor-keys": "^1.1.0",
-						"glob": "^7.1.6",
-						"is-glob": "^4.0.1",
-						"lodash": "^4.17.15",
-						"semver": "^7.3.2",
-						"tsutils": "^3.17.1"
-					}
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-					"dev": true
-				}
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
@@ -2748,11 +2252,6 @@
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
 			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
 			"dev": true
-		},
-		"aes-js": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
 		},
 		"ajv": {
 			"version": "6.12.0",
@@ -3094,14 +2593,9 @@
 			}
 		},
 		"base64-js": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-		},
-		"base64url": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-			"integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -3111,11 +2605,6 @@
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
-		},
-		"bech32": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-			"integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
 		},
 		"bignumber.js": {
 			"version": "9.0.1",
@@ -3215,9 +2704,9 @@
 			}
 		},
 		"buffer": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.1.tgz",
-			"integrity": "sha512-2z15UUHpS9/3tk9mY/q+Rl3rydOi7yMp5XWNQnRvoz+mJwiv8brqYwp9a+nOCtma6dwuEIxljD8W3ysVBZ05Vg==",
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
 			"requires": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
@@ -3245,11 +2734,6 @@
 				"union-value": "^1.0.0",
 				"unset-value": "^1.0.0"
 			}
-		},
-		"caip": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/caip/-/caip-0.9.2.tgz",
-			"integrity": "sha512-o4aIUSR9lkn7B9lIw8Xgkj+hDh+S1PtsBphoSqP2Dt95gRWPniaqEpnPwiUEhaPQr84JzWIEm4Cck3lMZtIkTA=="
 		},
 		"callsites": {
 			"version": "3.1.0",
@@ -3709,15 +3193,14 @@
 			"dev": true
 		},
 		"did-jwt": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-4.6.2.tgz",
-			"integrity": "sha512-T77RnUjhhEvwusQ8gxaMqGekyYjpgaZoq6HM3zEkVH7LA5otasqa5XZpbsxeaGgyT7e9sXeofNNzBWvSZM3G2g==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-4.7.0.tgz",
+			"integrity": "sha512-tkiZk4gukBAtnhqooBSBW0XYrjXIxEhk/bIHvr6VIwilFL9gQrceJOuJqZuE8s5/UbiUClINv6nOJ+DGPio0DQ==",
 			"requires": {
 				"@babel/runtime": "^7.11.2",
 				"@stablelib/ed25519": "^1.0.1",
 				"@stablelib/random": "^1.0.0",
 				"@stablelib/sha256": "^1.0.0",
-				"@stablelib/utf8": "^1.0.0",
 				"@stablelib/x25519": "^1.0.0",
 				"@stablelib/xchacha20poly1305": "^1.0.0",
 				"did-resolver": "^2.1.1",
@@ -3727,9 +3210,9 @@
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
-					"integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
+					"version": "7.12.5",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+					"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
 					"requires": {
 						"regenerator-runtime": "^0.13.4"
 					}
@@ -3742,13 +3225,14 @@
 			"integrity": "sha512-FYLTkNWofjYNDGV1HTQlyVu1OqZiFxR4I8KM+oxGVOkbXva15NfWzbzciqdXUDqOhe6so5aroAdrVip6gSAYSA=="
 		},
 		"dids": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/dids/-/dids-0.7.0.tgz",
-			"integrity": "sha512-v0KQBE0UoB15n8cDZ5uxdTpadm3LnICP7RkpHIZ79zoDfB8/yPneeu7Xnvzd3PSfkHRnoOWkuJtQ8IoVC37OMA==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dids/-/dids-1.0.0.tgz",
+			"integrity": "sha512-z9bjdMmf3xzDymRQJvX8L1RYIKiz+NRSoewu3EXM9aZ/fNncUBEyYnZnJN6NSpN0SbLSElgiPjxVucAGskRIcQ==",
 			"requires": {
+				"@stablelib/random": "^1.0.0",
 				"cids": "^1.0.0",
 				"dag-jose-utils": "^0.1.0",
-				"did-jwt": "^4.6.2",
+				"did-jwt": "^4.6.3",
 				"did-resolver": "^2.1.1",
 				"rpc-utils": "^0.1.3",
 				"uint8arrays": "^1.1.0"
@@ -4264,25 +3748,11 @@
 			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
 			"dev": true
 		},
-		"fast-json-patch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-			"integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
-			"requires": {
-				"fast-deep-equal": "^2.0.1"
-			},
-			"dependencies": {
-				"fast-deep-equal": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-				}
-			}
-		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -4623,9 +4093,9 @@
 			}
 		},
 		"ieee754": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
 		},
 		"ignore": {
 			"version": "4.0.6",
@@ -6361,11 +5831,6 @@
 				}
 			}
 		},
-		"js-sha256": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-			"integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-		},
 		"js-sha3": {
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -6793,9 +6258,9 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.1.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.16.tgz",
-			"integrity": "sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w=="
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.18.tgz",
+			"integrity": "sha512-rndlDjbbHbcV3xi+R2fpJ+PbGMdfBxz5v1fATIQFq0DP64FsicQdwnKLy47K4kZHdRpmQXtz24eGsxQqamzYTA=="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -7457,12 +6922,6 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"regexpp": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-			"integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
-			"dev": true
-		},
 		"regexpu-core": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
@@ -7869,11 +7328,6 @@
 			"requires": {
 				"xmlchars": "^2.1.1"
 			}
-		},
-		"scrypt-js": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
 		},
 		"semver": {
 			"version": "5.7.1",
@@ -8915,7 +8369,8 @@
 		"ws": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+			"integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -26,13 +26,16 @@
     "clean": "rm -rf ./lib"
   },
   "dependencies": {
+    "@ceramicnetwork/3id-did-resolver": "^0.5.0",
     "@ceramicnetwork/common": "^0.13.0",
     "@ceramicnetwork/docid": "^0.3.0",
     "@ceramicnetwork/doctype-caip10-link": "^0.11.0",
     "@ceramicnetwork/doctype-tile": "^0.11.0",
+    "@ceramicnetwork/key-did-resolver": "^0.2.0",
     "cids": "^1.0.2",
     "cross-fetch": "^3.0.6",
-    "dids": "^0.8.0",
+    "did-resolver": "^2.1.1",
+    "dids": "^1.0.0",
     "lodash.clonedeep": "^4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump DIDs to the latest version. Also bumps `key-did-provider-ed25519`.

In addition we also set the resolvers to the DID instance, in both http-client and core.