### PR TITLE
Log Async

### DIFF
--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 lib/
+logs/

--- a/packages/cli/src/__mocks__/fs.ts
+++ b/packages/cli/src/__mocks__/fs.ts
@@ -63,6 +63,26 @@ function createWriteStream(filePath: string, options: { flags: string }): MockSt
     return new MockStream(filePath, options.flags)
 }
 
+function writeFile(filePath: string, data: any, options: { flag: string }): Promise<void> {
+    const prevFile = mockFs[filePath] || {
+        name: filePath,
+        birthtime: new Date(),
+        message: ''
+    }
+
+    if (options.flag === 'w') {
+        mockFs[filePath] = {
+            ...prevFile,
+            message: data
+        }
+    } else if (options.flag === 'a') {
+        mockFs[filePath] = {
+            ...prevFile,
+            message: prevFile.message.concat(data)
+        }
+    }
+}
+
 async function rename(filePath: string, nextFilePath: string): Promise<void> {
     const file = mockFs[filePath]
     delete mockFs[filePath]
@@ -78,5 +98,6 @@ fs.__getMockFs = __getMockFs
 fs.createWriteStream = createWriteStream
 fs.promises.rename = rename
 fs.promises.stat = stat
+fs.promises.writeFile = writeFile
 
 module.exports = fs

--- a/packages/cli/src/__mocks__/fs.ts
+++ b/packages/cli/src/__mocks__/fs.ts
@@ -46,9 +46,6 @@ class MockStream {
                 message: prevFile.message.concat(message)
             }
         }
-        setTimeout(() => {
-            // delay
-        }, 1000);
         if (mockFs[this.filePath].__blocking) return false // Can not write again
         return true
     }

--- a/packages/cli/src/__mocks__/fs.ts
+++ b/packages/cli/src/__mocks__/fs.ts
@@ -24,8 +24,7 @@ class MockStream {
         this.filePath = filePath
         this.writeFlag = writeFlag
     }
-
-    on(event: string, cb: Function): void {}
+    on(event: string, cb: any): void { /* eslint-disable-line */ }
 
     write(message: string): boolean {
         const prevFile = mockFs[this.filePath] || {
@@ -54,9 +53,7 @@ class MockStream {
         return true
     }
 
-    end(): void {
-        // pass
-    }
+    end(): void { /* eslint-disable-line */ }
 }
 
 function __initMockFs(files: Array<MockFile>): void {

--- a/packages/cli/src/__mocks__/fs.ts
+++ b/packages/cli/src/__mocks__/fs.ts
@@ -6,6 +6,7 @@ interface MockFile {
     name: string;
     birthtime: Date;
     message: string;
+    size: number;
 }
 
 interface MockFs {
@@ -27,7 +28,8 @@ class MockStream {
         const prevFile = mockFs[this.filePath] || {
             name: this.filePath,
             birthtime: new Date(),
-            message: ''
+            message: '',
+            size: 0
         }
 
         if (this.writeFlag === 'w') {
@@ -67,7 +69,8 @@ function writeFile(filePath: string, data: any, options: { flag: string }): Prom
     const prevFile = mockFs[filePath] || {
         name: filePath,
         birthtime: new Date(),
-        message: ''
+        message: '',
+        size: 0
     }
 
     if (options.flag === 'w') {

--- a/packages/cli/src/__tests__/ceramic-logger-plugins.test.ts
+++ b/packages/cli/src/__tests__/ceramic-logger-plugins.test.ts
@@ -52,7 +52,7 @@ describe('Ceramic Logger Plugins', () => {
             })
         })
 
-        describe('_writeStream', () => {
+        describe('_writeFile', () => {
             it('should rotate expired files before overwriting', async () => {
                 dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => today.getTime())
                 const prevFilePath = mockFiles[0].name
@@ -62,7 +62,7 @@ describe('Ceramic Logger Plugins', () => {
                 expect(isExpired).toBe(true)
 
                 const nextFileMessage = 'nextmessage'
-                await LogToFiles['_writeStream'](prevFilePath, nextFileMessage, 'w')
+                await LogToFiles['_writeFile'](prevFilePath, nextFileMessage, 'w')
                 const nextFilePath = prevFilePath + '.old'
 
                 expect(mockFs[prevFilePath].message).toBe(nextFileMessage + '\n')
@@ -77,7 +77,7 @@ describe('Ceramic Logger Plugins', () => {
                 expect(isExpired).toBe(true)
 
                 const nextFileMessage = 'nextmessage'
-                await LogToFiles['_writeStream'](prevFilePath, nextFileMessage, 'a')
+                await LogToFiles['_writeFile'](prevFilePath, nextFileMessage, 'a')
                 const nextFilePath = prevFilePath + '.old'
 
                 expect(mockFs[prevFilePath].message).toBe(nextFileMessage + '\n')
@@ -92,7 +92,7 @@ describe('Ceramic Logger Plugins', () => {
                 expect(isExpired).toBe(false)
 
                 const message = 'message'
-                await LogToFiles['_writeStream'](filePath, message, 'a')
+                await LogToFiles['_writeFile'](filePath, message, 'a')
                 const nextFilePath = filePath + '.old'
 
                 expect(mockFs[filePath].message).toBe(prevMessage + message + '\n')
@@ -106,7 +106,7 @@ describe('Ceramic Logger Plugins', () => {
                 expect(isExpired).toBe(false)
 
                 const message = 'message'
-                await LogToFiles['_writeStream'](filePath, message, 'w')
+                await LogToFiles['_writeFile'](filePath, message, 'w')
                 const nextFilePath = filePath + '.old'
 
                 expect(mockFs[filePath].message).toBe(message + '\n')

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -137,10 +137,10 @@ class CeramicDaemon {
     }
 
     if (opts.logToFiles) {
-        const fileLogger = new LogToFiles()
         ceramicConfig.logToFiles = opts.logToFiles
         ceramicConfig.logToFilesPlugin = {
-            plugin: fileLogger.main,
+            plugin: LogToFiles.main,
+            state: {blockedFiles: {}},
             options: {logPath: opts.logPath}
         }
     }

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -137,9 +137,10 @@ class CeramicDaemon {
     }
 
     if (opts.logToFiles) {
+        const fileLogger = new LogToFiles()
         ceramicConfig.logToFiles = opts.logToFiles
         ceramicConfig.logToFilesPlugin = {
-            plugin: LogToFiles.main,
+            plugin: fileLogger.main,
             options: {logPath: opts.logPath}
         }
     }

--- a/packages/cli/src/ceramic-logger-plugins.ts
+++ b/packages/cli/src/ceramic-logger-plugins.ts
@@ -15,7 +15,7 @@ interface LogToFilesState {
     blockedFiles: BlockedFiles
 }
 
-interface BlockedFiles {
+export interface BlockedFiles {
     [filePath: string]: boolean
 }
 

--- a/packages/cli/src/ceramic-logger-plugins.ts
+++ b/packages/cli/src/ceramic-logger-plugins.ts
@@ -19,6 +19,11 @@ interface BlockedFiles {
     [filePath: string]: boolean
 }
 
+interface WriteResult {
+    blocked: boolean
+    filePath: string
+}
+
 /**
  * Plugin for the root logger from the `loglevel` library to write logs to files
  */
@@ -39,6 +44,7 @@ export class LogToFiles {
         pluginOptions: LoggerPluginOptions
     ): void {
         const originalFactory = rootLogger.methodFactory;
+
         let basePath = pluginOptions.logPath
         if ((basePath === undefined) || (basePath === '')) {
             basePath = '/usr/local/var/log/ceramic/'
@@ -54,11 +60,9 @@ export class LogToFiles {
                 fs.mkdir(basePath, { recursive: true }, async (err) => {
                     if (err && (err.code != 'EEXIST')) console.warn('WARNING: Can not write logs to files', err)
                     else {
-                        const filePrefix = basePath + loggerName.toLowerCase()
-                        const filePath = `${filePrefix}.log`
-
-                        await LogToFiles._writeFile(pluginState.blockedFiles, filePath, message, 'a')
-                        await LogToFiles._writeDocId(pluginState.blockedFiles, filePrefix, message)
+                        const filePrefix = loggerName.toLowerCase()
+                        await LogToFiles._write(pluginState.blockedFiles, basePath, filePrefix, message)
+                        await LogToFiles._writeDocId(pluginState.blockedFiles, basePath, filePrefix, message)
                     }
                 })
                 rawMethod(...args)
@@ -68,22 +72,86 @@ export class LogToFiles {
     }
 
     /**
-   * Writes `message` to a file
-   * @notice If the file is currently being written to by an open stream or if
-   * its buffer is full, the call to this method will return without writing
-   * @param filePath Full path of file to write to
-   * @param message Message to write to `filePath`
-   * @param writeFlag Specifies writing method (e.g. "a" for append, "w" for overwrite)
-   */
-    private static async _writeFile (
+     * Appends `message` to file `${basePath}${filePrefix}.log`
+     * @param basePath Base directory for file
+     * @param filePrefix Prefix of file name to write to
+     * @param message Message to write to file
+     */
+    private static async _write (
+        blockedFiles: BlockedFiles,
+        basePath: string,
+        filePrefix: string,
+        message: string
+    ): Promise<void> {
+        const filePath = `${basePath}${filePrefix}.log`
+        const result = await LogToFiles._writeStream(blockedFiles, filePath, message, 'a')
+        if (result.blocked) await LogToFiles._writeBlockedWarning(blockedFiles, basePath, filePath)
+    }
+
+    /**
+     * Writes the docId in `message` to file, if `message` contains a docId
+     * @notice The write operation overwrites the existing file at `${basePath}${filePrefix}.log`
+     * @param basePath Base directory for file
+     * @param filePrefix Prefix of file name to write to
+     * @param message Message to write to file
+     */
+    private static async _writeDocId (
+        blockedFiles: BlockedFiles,
+        basePath: string,
+        filePrefix: string,
+        message: string
+    ): Promise<void> {
+        const lookup = '/ceramic/'
+        const docIdIndex = message.indexOf(lookup)
+
+        if (docIdIndex > -1) {
+            const docIdSubstring = message.substring(docIdIndex)
+            const match = docIdSubstring.match(/\/ceramic\/\w+/)
+
+            if (match !== null) {
+                const docId = match[0]
+                const filePath = `${basePath}${filePrefix}-docids.log`
+                const result = await LogToFiles._writeStream(blockedFiles, filePath, docId, 'w')
+                if (result.blocked) await LogToFiles._writeBlockedWarning(blockedFiles, basePath, filePath)
+            }
+        }
+    }
+
+    /**
+     * Logs and writes warning message about `filePath` being blocked.
+     * @notice If the file that this tries to write to itself is blocked,
+     * its message will be dropped and only appear in the console
+     * @param basePath Base directory for file to write to
+     * @param filePath Path to file that is blocked
+     */
+    private static async _writeBlockedWarning (
+        blockedFiles: BlockedFiles,
+        basePath: string,
+        filePath: string
+    ): Promise<void> {
+        const loggerFilePath = basePath + 'logger.log'
+        const message = `Stream blocked for file: ${filePath}\n`
+        await LogToFiles._writeStream(blockedFiles, loggerFilePath, message, 'a')
+    }
+
+    /**
+      * Writes `message` to a file and returns whether it is blocked or not
+      * @notice If the file is currently being written to by an open stream or if
+      * its buffer is full, the call to this method will return without writing
+      * @param filePath Full path of file to write to
+      * @param message Message to write to `filePath`
+      * @param writeFlag Specifies writing method (e.g. "a" for append, "w" for overwrite)
+      * @returns True if the stream is blocked and false otherwise
+      */
+    private static async _writeStream (
         blockedFiles: BlockedFiles,
         filePath: string,
         message: string,
         writeFlag: string
-    ): Promise<void> {
+    ): Promise<WriteResult> {
         if (blockedFiles[filePath]) {
             console.warn(`Stream busy for ${filePath}. Some logs may be dropped.`)
-            return
+            return { blocked: blockedFiles[filePath], filePath }
         }
 
         blockedFiles[filePath] = true
@@ -108,28 +176,7 @@ export class LogToFiles {
             stream.end()
             return
         })
-    }
-
-    /**
-     * Writes the docId in `message` to `filePath`, if `message` contains a docId.
-     * @notice The write operation overwrites any existing file.
-     * @param filePrefix Prefix of file name to write to
-     * @param message Message to write to `filePath`
-     */
-    private static async _writeDocId (blockedFiles: BlockedFiles, filePrefix: string, message: string): Promise<void> {
-        const lookup = '/ceramic/'
-        const docIdIndex = message.indexOf(lookup)
-
-        if (docIdIndex > -1) {
-            const docIdSubstring = message.substring(docIdIndex)
-            const match = docIdSubstring.match(/\/ceramic\/\w+/)
-
-            if (match !== null) {
-                const docId = match[0]
-                const filePath = filePrefix + '-docids.log'
-                LogToFiles._writeFile(blockedFiles, filePath, docId, 'w')
-            }
-        }
+        return { blocked: blockedFiles[filePath], filePath }
     }
 
     /**
@@ -137,6 +184,7 @@ export class LogToFiles {
      * @notice Returns false if file is not found.
      * Returns true if unable to get file creation datetime for some other reason.
      * @param filePath Full path of file
+     * @returns If the file is expired
      */
     private static async _isExpired (filePath: string): Promise<boolean> {
         try {

--- a/packages/cli/src/ceramic-logger-plugins.ts
+++ b/packages/cli/src/ceramic-logger-plugins.ts
@@ -110,7 +110,8 @@ export class LogToFiles {
 
         if (docIdIndex > -1) {
             const docIdSubstring = message.substring(docIdIndex)
-            const match = docIdSubstring.match(/\/ceramic\/\w+/)
+            // TODO: Exclude topics without docIds
+            const match = docIdSubstring.match(/\/ceramic\/[^"]+/)
 
             if (match !== null) {
                 const docId = match[0]

--- a/packages/cli/src/ceramic-logger-plugins.ts
+++ b/packages/cli/src/ceramic-logger-plugins.ts
@@ -161,8 +161,7 @@ export class LogToFiles {
 
         const stream = fs.createWriteStream(filePath, { flags: writeFlag })
         stream.on('error', (err) => {
-            console.warn(err)
-            return
+            throw err
         })
         stream.on('drain', () => {
             blockedFiles[filePath] = false

--- a/packages/cli/src/ceramic-logger-plugins.ts
+++ b/packages/cli/src/ceramic-logger-plugins.ts
@@ -43,7 +43,7 @@ export class LogToFiles {
                         const filePrefix = basePath + loggerName.toLowerCase()
                         const filePath = `${filePrefix}.log`
 
-                        await LogToFiles._writeStream(filePath, message, 'a')
+                        await LogToFiles._writeFile(filePath, message, 'a')
                         await LogToFiles._writeDocId(filePrefix, message)
                     }
                 })
@@ -54,20 +54,19 @@ export class LogToFiles {
     }
 
     /**
-     * Opens a filesystem stream and writes `message` to it
+     * Writes `message` to a file
      * @param filePath Full path of file to write to
      * @param message Message to write to `filePath`
      * @param writeFlag Specifies writing method (e.g. "a" for append, "w" for overwrite)
      */
-    private static async _writeStream (filePath: string, message: string, writeFlag: string): Promise<void> {
+    private static async _writeFile (filePath: string, message: string, writeFlag: string): Promise<void> {
         const fileExpired = await LogToFiles._isExpired(filePath)
         fileExpired && await LogToFiles._rotate(filePath)
-        const stream = fs.createWriteStream(
+        await fsPromises.writeFile(
             filePath,
-            { flags: writeFlag }
+            util.format(message) + '\n',
+            { flag: writeFlag }
         )
-        stream.write(util.format(message) + '\n')
-        stream.end()
     }
 
     /**
@@ -87,7 +86,7 @@ export class LogToFiles {
             if (match !== null) {
                 const docId = match[0]
                 const filePath = filePrefix + '-docids.log'
-                LogToFiles._writeStream(filePath, docId, 'w')
+                LogToFiles._writeFile(filePath, docId, 'w')
             }
         }
     }

--- a/packages/cli/src/ceramic-logger-plugins.ts
+++ b/packages/cli/src/ceramic-logger-plugins.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import path from 'path'
 import util from 'util'
 
 import {
@@ -48,7 +49,7 @@ export class LogToFiles {
 
         let basePath = pluginOptions.logPath
         if ((basePath === undefined) || (basePath === '')) {
-            basePath = '/usr/local/var/log/ceramic/'
+            basePath = path.join(path.resolve(__dirname, '../'), 'logs/')
         }
         if (!basePath.endsWith('/')) {
             basePath = basePath + '/'

--- a/packages/cli/src/ceramic-logger-plugins.ts
+++ b/packages/cli/src/ceramic-logger-plugins.ts
@@ -198,9 +198,9 @@ export class LogToFiles {
 
         if (!fileStats) {
             return true
-        } else if (await LogToFiles._isExpired(fileStats)) {
+        } else if (LogToFiles._isExpired(fileStats)) {
             return true
-        } else if (await LogToFiles._isMaxSize(fileStats)) {
+        } else if (LogToFiles._isMaxSize(fileStats)) {
             return true
         }
 
@@ -213,7 +213,7 @@ export class LogToFiles {
      * @param fileStats `fs.Stats` of file
      * @returns If the file is expired
      */
-    private static async _isExpired (fileStats: fs.Stats): Promise<boolean> {
+    private static _isExpired (fileStats: fs.Stats): boolean {
         const { birthtime } = fileStats
         if (birthtime.getTime() == 0) {
             console.warn('WARNING: Unable to retrieve file birthtime')
@@ -228,7 +228,7 @@ export class LogToFiles {
      * @param fileStats `fs.Stats` of file
      * @returns If the file is at max size
      */
-    private static async _isMaxSize (fileStats: fs.Stats): Promise<boolean> {
+    private static _isMaxSize (fileStats: fs.Stats): boolean {
         const { size } = fileStats
         return size >= LogToFiles.MAX_FILE_BYTES
     }

--- a/packages/common/src/logger-provider.ts
+++ b/packages/common/src/logger-provider.ts
@@ -40,7 +40,12 @@ interface PluginOptions {
  * Function type for plugins
  * @dev Must call `setLevel` on `rootLogger` to be enabled
  */
-type Plugin = (rootLogger: log.RootLogger, loggerOptions?: Options, pluginOptions?: PluginOptions) => void;
+type Plugin = (
+    rootLogger: log.RootLogger,
+    pluginState?: any,
+    loggerOptions?: Options,
+    pluginOptions?: PluginOptions
+) => void;
 
 /**
  * Global Logger factory
@@ -70,11 +75,17 @@ class LoggerProvider {
     /**
      * Adds `plugin` to the logger instance
      * @param plugin Plugin function to add
+     * @param pluginState Shared state specific to `plugin`
      * @param loggerOptions Options returned from LoggerProvider.init
      * @param pluginOptions Options specific to `plugin`
      */
-    static addPlugin(plugin: Plugin, loggerOptions?: Options, pluginOptions?: PluginOptions): void {
-        plugin(log, loggerOptions, pluginOptions)
+    static addPlugin(
+        plugin: Plugin,
+        pluginState?: any,
+        loggerOptions?: Options,
+        pluginOptions?: PluginOptions
+    ): void {
+        plugin(log, pluginState, loggerOptions, pluginOptions)
     }
 
     /**

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -51,6 +51,7 @@ export interface CeramicConfig {
   logToFiles?: boolean;
   logToFilesPlugin?: {
     plugin: LoggerPlugin;
+    state: any;
     options: LoggerPluginOptions;
   };
   gateway?: boolean;
@@ -232,6 +233,7 @@ class Ceramic implements CeramicApi {
     if (config.logToFiles) {
         LoggerProvider.addPlugin(
             config.logToFilesPlugin.plugin,
+            config.logToFilesPlugin.state,
             null,
             config.logToFilesPlugin.options
         )


### PR DESCRIPTION
### Motivation

I noticed some warnings in our hosted node about files not being rotated so looking into this I found that using `fs.promises` alone is not the best way to handle writing to files because it can lead to memory leaks and race conditions if we are doing a lot of logging.

### Changes

- Use `Writable` stream to handle writing logs to files -- In most cases this should work fine but in the event that the stream buffer gets full or is busy, it will prevent additional writes until it is flushed/finished, which may cause some logs to be dropped.