### PR TITLE
Feat/multiquery ceramic api

### DIFF
--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -109,3 +109,8 @@ export interface CeramicApi {
      */
     close(): Promise<void>; // gracefully close the ceramic instance
 }
+
+export interface MultiQuery {
+    docId: DocID | string
+    paths?: Array<string>
+}

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -542,7 +542,6 @@ describe('Ceramic API', () => {
       expect(docs[docF.id.toString()]).toBeTruthy()
     })
 
-
     it('can load docs for array of overlapping multiqueries', async () => {
       const queries = [
         {
@@ -558,23 +557,20 @@ describe('Ceramic API', () => {
       expect(Object.keys(docs).length).toEqual(6)
     })
 
-    // it('can load docs for array of multiqueries even if docid or path throws error', async () => {
-    //   console.log('error')
-    //   const queries = [
-    //     {
-    //       docId: docA.id,
-    //       paths: ['/b/d', '/notExistDocId']
-    //     }, 
-    //     {
-    //       docId: notExistDocId,
-    //       paths: ['/e/f' , '/d']
-    //     }
-    //   ]
-    //   const docs = await ceramic.multiQuery(queries)
-    //   expect(Object.keys(docs).length).toEqual(3)
-    //   console.log('error not')
-    // })
-
+    it('can load docs for array of multiqueries even if docid or path throws error', async () => {
+      const queries = [
+        {
+          docId: docA.id,
+          paths: ['/b/d', '/notExistDocId']
+        }, 
+        {
+          docId: notExistDocId,
+          paths: ['/e/f' , '/d']
+        }
+      ]
+      const docs = await ceramic.multiQuery(queries, 1000)
+      expect(Object.keys(docs).length).toEqual(3)
+    })
 
     it('can load docs for array of multiqueries including paths that dont exist', async () => {
       const queries = [

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -551,7 +551,7 @@ describe('Ceramic API', () => {
         }, 
         {
           docId: docB.id,
-          paths: ['/e/f' , '/d']
+          paths: ['/e/f', '/d']
         }
       ]
       const docs = await ceramic.multiQuery(queries)
@@ -586,7 +586,6 @@ describe('Ceramic API', () => {
           docId: docE.id,
           paths: ['/1', '2/3/4', '5/6']
         },
-        , 
         {
           docId: docB.id,
           paths: ['/1', '2/3/4', '5/6']

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -58,5 +58,31 @@ export default class Utils {
         }
     }
 
-
 }
+
+export class TrieNode {
+    public key: string
+    public children:  Record<string, TrieNode>
+  
+    constructor(key = '') {
+      this.key = key
+      this.children = {}
+    }
+  }
+  
+  export class PathTrie {
+    public root: TrieNode
+  
+    constructor() {
+      this.root = new TrieNode()
+    }
+  
+    add(path: string) {
+      const nextNodeAdd = (node: TrieNode, key: string): TrieNode => {
+        if (!node.children[key]) node.children[key] = new TrieNode(key)
+        return node.children[key]
+      }
+      if (path.startsWith('/')) path = path.substring(1)
+      path.split('/').reduce(nextNodeAdd, this.root)
+    }
+  }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -68,21 +68,21 @@ export class TrieNode {
       this.key = key
       this.children = {}
     }
-  }
+}
   
-  export class PathTrie {
+export class PathTrie {
     public root: TrieNode
-  
+
     constructor() {
-      this.root = new TrieNode()
+        this.root = new TrieNode()
     }
-  
+
     add(path: string) {
-      const nextNodeAdd = (node: TrieNode, key: string): TrieNode => {
+        const nextNodeAdd = (node: TrieNode, key: string): TrieNode => {
         if (!node.children[key]) node.children[key] = new TrieNode(key)
-        return node.children[key]
-      }
-      if (path.startsWith('/')) path = path.substring(1)
-      path.split('/').reduce(nextNodeAdd, this.root)
+            return node.children[key]
+        }
+        if (path.startsWith('/')) path = path.substring(1)
+        path.split('/').reduce(nextNodeAdd, this.root)
     }
-  }
+}

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -86,3 +86,10 @@ export class PathTrie {
         path.split('/').reduce(nextNodeAdd, this.root)
     }
 }
+
+export const promiseTimeout = (ms: number, promise:Promise<any>): Promise<any> => {
+    const timeout = new Promise((resolve, reject) => {
+        setTimeout(() => reject(), ms)
+    })
+    return Promise.race([timeout, promise])
+}


### PR DESCRIPTION
~~In progress~~

re earlier (not changed here yet) 

does seem to make sense to implement a `multiQuery' function in core along with loadLinkedDocuments 
```
async multiQuery(queries: StateQuery):  Promise<Record<string, Doctype>>
```

then it will be easier to test there and the http daemon handler can just mostly deal with (de)serialize as it should instead of the extra logic included there now

http client can then implement multiQuery as well 

also with both func in core, it can be optimized when handling many queries, especially if there is likely to be any redundant paths between docids/queries (ie docid1 included already in path of docid2 and then they may have subpaths overlapping as well)