### PR TITLE
fix(doctype-caip10-link): solidify data structure

### DIFF
--- a/packages/common/src/utils/doctype-utils.ts
+++ b/packages/common/src/utils/doctype-utils.ts
@@ -164,18 +164,6 @@ export class DoctypeUtils {
     }
 
     /**
-     * Converts Doctype metadata to record header
-     * @param docMetadata - DocMetadata instance
-     */
-    static metadataToRecordHeader(docMetadata: DocMetadata): RecordHeader {
-        return {
-            ...docMetadata.controllers && { controllers: docMetadata.controllers },
-            ...docMetadata.schema && { schema: docMetadata.schema },
-            ...docMetadata.tags && { tags: docMetadata.tags },
-        }
-    }
-
-    /**
      * Checks if record is signed DTO ({jws: {}, linkedBlock: {}})
      * @param record - Record
      */

--- a/packages/doctype-caip10-link/src/__tests__/__snapshots__/caip10-link-doctype.test.ts.snap
+++ b/packages/doctype-caip10-link/src/__tests__/__snapshots__/caip10-link-doctype.test.ts.snap
@@ -144,6 +144,7 @@ Object {
     "controllers": Array [
       "0x25954ef14cebbc9af3d71132489a9cfe87043f20@eip155:1",
     ],
+    "family": "caip10-eip155:1",
   },
   "next": Object {
     "content": undefined,
@@ -206,6 +207,7 @@ Object {
     "controllers": Array [
       "0x25954ef14cebbc9af3d71132489a9cfe87043f20@eip155:1",
     ],
+    "family": "caip10-eip155:1",
   },
   "next": Object {
     "content": null,
@@ -311,6 +313,7 @@ Object {
     "controllers": Array [
       "0x25954ef14cebbc9af3d71132489a9cfe87043f20@eip155:1",
     ],
+    "family": "caip10-eip155:1",
   },
   "next": Object {
     "content": undefined,

--- a/packages/doctype-caip10-link/src/__tests__/caip10-link-doctype.test.ts
+++ b/packages/doctype-caip10-link/src/__tests__/caip10-link-doctype.test.ts
@@ -20,7 +20,7 @@ const FAKE_CID_3 = new CID('bafybeig6xv5nwphfmvcnektpnojts55jqcuam7bmye2pb54adnr
 const FAKE_CID_4 = new CID('bafybeig6xv5nwphfmvcnektpnojts66jqcuam7bmye2pb54adnrtccjlsu')
 
 const RECORDS = {
-  genesis: { header: { controllers: [ '0x25954ef14cebbc9af3d71132489a9cfe87043f20@eip155:1' ] } },
+  genesis: { header: { controllers: [ '0x25954ef14cebbc9af3d71132489a9cfe87043f20@eip155:1' ], family: "caip10-eip155:1" } },
   r1: {
     desiredContent: {
       version: 1,
@@ -36,11 +36,6 @@ const RECORDS = {
         signature: '0xbb800bc9e65a21e239bdc9e5f740e66edda75810a5952ff3d78fe6b41f7613c44470f81c6e4153eaded99096099afab59c7d0b8a1b61ba1bd7cd4cd0d117794c1b',
         address: '0x25954ef14cebbc9af3d71132489a9cfe87043f20@eip155:1',
         timestamp: 1585919920
-      },
-      header: {
-        controllers: [
-          "0x25954ef14cebbc9af3d71132489a9cfe87043f20@eip155:1"
-        ]
       },
       id: FAKE_CID_1,
       prev: FAKE_CID_1

--- a/packages/doctype-caip10-link/src/caip10-link-doctype.ts
+++ b/packages/doctype-caip10-link/src/caip10-link-doctype.ts
@@ -5,8 +5,7 @@ import {
     DocOpts,
     DocParams,
     Context,
-    CeramicRecord,
-    DoctypeUtils
+    CeramicRecord
 } from "@ceramicnetwork/common"
 
 const DOCTYPE = 'caip10-link'
@@ -74,7 +73,8 @@ export class Caip10LinkDoctype extends Doctype {
         if (!linkedChainId) {
             throw new Error('Chain ID must be specified according to CAIP-10')
         }
-        return { header: DoctypeUtils.metadataToRecordHeader(metadata) }
+        // Add family here to enable easier indexing
+        return { header: { controllers: metadata.controllers, family: `caip10-${linkedChainId}` } }
     }
 
     /**
@@ -85,13 +85,12 @@ export class Caip10LinkDoctype extends Doctype {
      * @private
      */
     static async _makeRecord (doctype: Caip10LinkDoctype, newContent: any, newSchema: string = null): Promise<CeramicRecord> {
-        const { metadata } = doctype
         if (newSchema) {
-            metadata.schema = newSchema
+            throw new Error('Schema not allowed on caip10-link doctype')
         }
         if (newContent == null) {
-            newContent = doctype.content
+            throw new Error('Proof must be given in doctype')
         }
-        return { data: newContent, header: metadata, prev: doctype.tip, id: doctype.state.log[0].cid }
+        return { data: newContent, prev: doctype.tip, id: doctype.state.log[0].cid }
     }
 }


### PR DESCRIPTION
Some small changes to the `caip10-link` doctype:
* Don't allow arbitrary data in the genesis header
* Include a family to make indexing easier
* No need to include past header in the new record