### PR TITLE
CID version fix

### DIFF
--- a/packages/3id-did-resolver/package.json
+++ b/packages/3id-did-resolver/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@ceramicnetwork/common": "^0.14.1",
     "@ceramicnetwork/docid": "^0.3.0",
-    "cids": "^1.0.2",
+    "cids": "1.0.2",
     "cross-fetch": "^3.0.6",
     "uint8arrays": "^1.1.0"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@ceramicnetwork/docid": "^0.3.0",
-    "cids": "^1.0.2",
+    "cids": "1.0.2",
     "dag-jose": "^0.3.0",
     "did-resolver": "^2.1.1",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "@ethersproject/random": "^5.0.2",
     "ajv": "^6.12.3",
     "base64url": "^3.0.1",
-    "cids": "^1.0.2",
+    "cids": "1.0.2",
     "cross-fetch": "^3.0.6",
     "did-jwt": "^4.6.3",
     "did-resolver": "^2.1.1",

--- a/packages/docid/package.json
+++ b/packages/docid/package.json
@@ -24,7 +24,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "cids": "^1.0.2",
+    "cids": "1.0.2",
     "multibase": "^3.0.1",
     "varint": "^6.0.0"
   },

--- a/packages/doctype-caip10-link/package.json
+++ b/packages/doctype-caip10-link/package.json
@@ -29,7 +29,7 @@
     "3id-blockchain-utils": "^1.1.0",
     "@ceramicnetwork/common": "^0.14.1",
     "@types/lodash.clonedeep": "^4.5.6",
-    "cids": "^1.0.2"
+    "cids": "1.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/doctype-tile/package.json
+++ b/packages/doctype-tile/package.json
@@ -31,7 +31,7 @@
     "@ethersproject/random": "^5.0.2",
     "@types/lodash.clonedeep": "^4.5.6",
     "base64url": "^3.0.1",
-    "cids": "^1.0.2",
+    "cids": "1.0.2",
     "did-jwt": "^4.6.3",
     "did-resolver": "^2.1.1",
     "dids": "^1.1.0",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -32,7 +32,7 @@
     "@ceramicnetwork/doctype-caip10-link": "^0.12.1",
     "@ceramicnetwork/doctype-tile": "^0.12.3",
     "@ceramicnetwork/key-did-resolver": "^0.2.1",
-    "cids": "^1.0.2",
+    "cids": "1.0.2",
     "cross-fetch": "^3.0.6",
     "did-resolver": "^2.1.1",
     "dids": "^1.1.0",

--- a/packages/pinning-aggregation/package.json
+++ b/packages/pinning-aggregation/package.json
@@ -32,7 +32,7 @@
     "@ceramicnetwork/pinning-powergate-backend": "^0.1.4",
     "@stablelib/base64": "^1.0.0",
     "@stablelib/sha256": "^1.0.0",
-    "cids": "^1.0.2"
+    "cids": "1.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pinning-ipfs-backend/package.json
+++ b/packages/pinning-ipfs-backend/package.json
@@ -31,7 +31,7 @@
     "ipfs-http-client": "^48.1.1"
   },
   "devDependencies": {
-    "cids": "^1.0.2",
+    "cids": "1.0.2",
     "ts-jest": "^26.4.4"
   },
   "publishConfig": {

--- a/packages/pinning-powergate-backend/package.json
+++ b/packages/pinning-powergate-backend/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.162",
-    "cids": "^1.0.2"
+    "cids": "1.0.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
- use `1.0.2` version of `cids` dependency until IPFS update (IPFS depends on earlier version of `cids`)