### PR TITLE
Use specific versions for multiformats dependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "ipfs-core": "^0.3.0",
     "ipfs-http-client": "^48.1.1",
     "key-did-provider-ed25519": "^1.0.0",
-    "multiformats": "^3.0.3",
+    "multiformats": "3.0.3",
     "uint8arrays": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "ipfs-http-client": "^48.1.1",
     "level-ts": "^2.0.5",
     "lodash.clonedeep": "^4.5.0",
-    "multiformats": "^3.0.3",
+    "multiformats": "3.0.3",
     "p-queue": "^6.6.1",
     "typestub-multihashes": "^0.0.4"
   },

--- a/packages/docid/package.json
+++ b/packages/docid/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "cids": "1.0.2",
-    "multibase": "^3.0.1",
+    "multibase": "3.0.1",
     "varint": "^6.0.0"
   },
   "publishConfig": {

--- a/packages/docid/package.json
+++ b/packages/docid/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "cids": "1.0.2",
     "multibase": "3.0.1",
+    "multicodec": "2.0.4",
     "varint": "^6.0.0"
   },
   "publishConfig": {

--- a/packages/key-did-resolver/package.json
+++ b/packages/key-did-resolver/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@stablelib/ed25519": "^1.0.1",
-    "multibase": "^3.0.1",
+    "multibase": "3.0.1",
     "uint8arrays": "^1.1.0",
     "varint": "^6.0.0"
   },
@@ -38,7 +38,7 @@
     "@babel/preset-typescript": "^7.9.0",
     "@types/bs58": "^4.0.1",
     "@types/events": "^3.0.0",
-    "@types/multibase": "^0.6.0",
+    "@types/multibase": "0.6.0",
     "@types/node": "^13.13.15",
     "@types/secp256k1": "^4.0.1",
     "@types/varint": "^5.0.0",


### PR DESCRIPTION
- use specific versions for `multiformats` dependencies
--`multiformats: 3.0.3`
--`multibase: 3.0.1`