### PR TITLE
fix(docid): Add missing uint8array dep

### DIFF
--- a/packages/docid/package.json
+++ b/packages/docid/package.json
@@ -27,6 +27,7 @@
     "cids": "1.0.2",
     "multibase": "3.0.1",
     "multicodec": "2.0.4",
+    "uint8arrays": "^1.1.0",
     "varint": "^6.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
This is causing issues when importing some ceramic packages.