### PR TITLE
chore(http-client): optimize bundle size

### DIFF
--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -50,12 +50,6 @@ export interface CeramicApi {
     addDoctypeHandler<T extends Doctype>(doctypeHandler: DoctypeHandler<T>): void;
 
     /**
-     * Finds document handler for the doctype
-     * @param doctype - Doctype
-     */
-    findDoctypeHandler<T extends Doctype>(doctype: string): DoctypeHandler<T>;
-
-    /**
      * Create Doctype instance
      * @param doctype - Doctype name
      * @param params - Create parameters

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -296,18 +296,6 @@ class Ceramic implements CeramicApi {
   }
 
   /**
-   * Finds doctype handler
-   * @param doctype - Doctype
-   */
-  findDoctypeHandler<T extends Doctype>(doctype: string): DoctypeHandler<T> {
-    const doctypeHandler = this._doctypeHandlers[doctype]
-    if (doctypeHandler == null) {
-      throw new Error(`Failed to find doctype handler for doctype ${doctype}`)
-    }
-    return doctypeHandler as DoctypeHandler<T>
-  }
-
-  /**
    * Applies record on a given document
    * @param docId - Document ID
    * @param record - Record to be applied

--- a/packages/http-client/src/document.ts
+++ b/packages/http-client/src/document.ts
@@ -1,5 +1,5 @@
 import {
-  CeramicRecord, Context, DocOpts, DocParams, DocState, Doctype, DoctypeHandler, DoctypeUtils
+  CeramicRecord, Context, DocOpts, DocParams, DocState, Doctype, DoctypeConstructor, DoctypeUtils
 } from "@ceramicnetwork/common"
 
 import DocID from '@ceramicnetwork/docid'
@@ -12,7 +12,7 @@ class Document extends Doctype {
   private _syncEnabled: boolean
   private readonly _syncInterval: number
 
-  public doctypeHandler: DoctypeHandler<Doctype>
+  public doctypeConstructor: DoctypeConstructor<Doctype>
 
   constructor (state: DocState, context: Context, private _apiUrl: string, config: CeramicClientConfig = { docSyncEnabled: false }) {
     super(state, context)
@@ -96,7 +96,7 @@ class Document extends Doctype {
   }
 
   async change(params: DocParams, opts: DocOpts): Promise<void> {
-    const doctype = new this.doctypeHandler.doctype(this.state, this.context)
+    const doctype = new this.doctypeConstructor(this.state, this.context)
 
     await doctype.change(params, opts)
     this.state = doctype.state


### PR DESCRIPTION
This is an attempt at trying to minimize the build size of the http-client. The http-client shouldn't need the doctypeHandlers, just the doctypes themselves. The caip10-link handlers bundle size is quite large so the hope is that this will reduce the package  size dramatically.

Still need to confirm this though. Could potentially release an alpha to test it on bundlephobia.

Would love your thoughts @PaulLeCam!