### PR TITLE
feat(core): Cleanup and fix conflict resolution

### DIFF
--- a/packages/core/src/__tests__/document.test.ts
+++ b/packages/core/src/__tests__/document.test.ts
@@ -516,10 +516,10 @@ describe('Document', () => {
         metadata: {},
       }
 
-      // When neither log is anchored and log lengths are the same we should pick the log whose first entry has the
+      // When neither log is anchored and log lengths are the same we should pick the log whose last entry has the
       // smaller CID.
-      expect(await Document._pickLogToAccept(state1, state2)).toEqual(state1)
-      expect(await Document._pickLogToAccept(state2, state1)).toEqual(state1)
+      expect(await Document._pickLogToAccept(state1, state2)).toEqual(state2)
+      expect(await Document._pickLogToAccept(state2, state1)).toEqual(state2)
     })
 
     it("Neither log is anchored, different log lengths", async () => {
@@ -649,9 +649,9 @@ describe('Document', () => {
       }
 
       // When anchored in the same blockchain, same block, and with same log lengths, we should use
-      // the fallback mechanism of picking the log whose first entry has the smaller CID
-      expect(await Document._pickLogToAccept(state1, state2)).toEqual(state1)
-      expect(await Document._pickLogToAccept(state2, state1)).toEqual(state1)
+      // the fallback mechanism of picking the log whose last entry has the smaller CID
+      expect(await Document._pickLogToAccept(state1, state2)).toEqual(state2)
+      expect(await Document._pickLogToAccept(state2, state1)).toEqual(state2)
     })
   })
 

--- a/packages/core/src/__tests__/document.test.ts
+++ b/packages/core/src/__tests__/document.test.ts
@@ -518,8 +518,8 @@ describe('Document', () => {
 
       // When neither log is anchored and log lengths are the same we should pick the log whose first entry has the
       // smaller CID.
-      expect(await Document._pickLogToAccept(state1, state2)).toEqual(false)
-      expect(await Document._pickLogToAccept(state2, state1)).toEqual(true)
+      expect(await Document._pickLogToAccept(state1, state2)).toEqual(state1)
+      expect(await Document._pickLogToAccept(state2, state1)).toEqual(state1)
     })
 
     it("Neither log is anchored, different log lengths", async () => {
@@ -536,8 +536,8 @@ describe('Document', () => {
       }
 
       // When neither log is anchored and log lengths are different we should pick the log with greater length
-      expect(await Document._pickLogToAccept(state1, state2)).toEqual(false)
-      expect(await Document._pickLogToAccept(state2, state1)).toEqual(true)
+      expect(await Document._pickLogToAccept(state1, state2)).toEqual(state1)
+      expect(await Document._pickLogToAccept(state2, state1)).toEqual(state1)
     })
 
     it("One log anchored before the other", async () => {
@@ -550,8 +550,8 @@ describe('Document', () => {
       }
 
       // When only one of the logs has been anchored, we pick the anchored one
-      expect(await Document._pickLogToAccept(state1, state2)).toEqual(true)
-      expect(await Document._pickLogToAccept(state2, state1)).toEqual(false)
+      expect(await Document._pickLogToAccept(state1, state2)).toEqual(state2)
+      expect(await Document._pickLogToAccept(state2, state1)).toEqual(state2)
     })
 
     it("Both logs anchored in different blockchains", async () => {
@@ -598,8 +598,8 @@ describe('Document', () => {
       }
 
       // When anchored in the same blockchain, should take log with earlier block number
-      expect(await Document._pickLogToAccept(state1, state2)).toEqual(true)
-      expect(await Document._pickLogToAccept(state2, state1)).toEqual(false)
+      expect(await Document._pickLogToAccept(state1, state2)).toEqual(state2)
+      expect(await Document._pickLogToAccept(state2, state1)).toEqual(state2)
     })
 
     it("Both logs anchored in same blockchains in the same block with different log lengths", async () => {
@@ -624,8 +624,8 @@ describe('Document', () => {
 
       // When anchored in the same blockchain, same block, and with same log lengths, we should choose the one with
       // longer log length
-      expect(await Document._pickLogToAccept(state1, state2)).toEqual(false)
-      expect(await Document._pickLogToAccept(state2, state1)).toEqual(true)
+      expect(await Document._pickLogToAccept(state1, state2)).toEqual(state1)
+      expect(await Document._pickLogToAccept(state2, state1)).toEqual(state1)
     })
 
     it("Both logs anchored in same blockchains in the same block with same log lengths", async () => {
@@ -650,8 +650,8 @@ describe('Document', () => {
 
       // When anchored in the same blockchain, same block, and with same log lengths, we should use
       // the fallback mechanism of picking the log whose first entry has the smaller CID
-      expect(await Document._pickLogToAccept(state1, state2)).toEqual(false)
-      expect(await Document._pickLogToAccept(state2, state1)).toEqual(true)
+      expect(await Document._pickLogToAccept(state1, state2)).toEqual(state1)
+      expect(await Document._pickLogToAccept(state2, state1)).toEqual(state1)
     })
   })
 

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -438,8 +438,8 @@ class Document extends EventEmitter {
     // decision about which log to choose.  The most common way this can happen is that neither log
     // is anchored, although it can also happen if both are anchored but in the same blockNumber or
     // blockTimestamp. At this point, the decision of which log to take is arbitrary, but we want it
-    // to still be deterministic. Therefore, we take the log whose first entry has the lowest CID.
-    return state1.log[0].cid.bytes < state2.log[0].cid.bytes ? state1 : state2
+    // to still be deterministic. Therefore, we take the log whose last entry has the lowest CID.
+    return state1.log[state1.log.length - 1].cid.bytes < state2.log[state2.log.length - 1].cid.bytes ? state1 : state2
   }
 
   /**


### PR DESCRIPTION
This does 2 things. First it cleans up the conflict resolution code so _pickLogToAccept returns which log it chose rather than a boolean, to increase code readability.  It also changes the conflict resolution fallback to compare the CIDs of the last log entries rather than the first, to match what the CAS does.

This PR should not be considered a blocker to releasing tomorrow