### PR TITLE
chore(key-did-resolver): rename package

### DIFF
--- a/packages/key-did-resolver/package.json
+++ b/packages/key-did-resolver/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ceramicnetwork/key-did-resolver",
+  "name": "key-did-resolver",
   "version": "0.2.2",
   "description": "Ceramic did:key method resolver",
   "keywords": [


### PR DESCRIPTION
This PR renames the `@ceramicnetwork/key-did-resolver` package to `key-did-resolver`. The reason for this is to make the name symmetrical with packages like `key-did-provider-ed25519`, `3id-did-provider`. Also in the future we might want to move this package into a separate repo that is more focused on DID related things.