### PR TITLE
Fix gateway endpoints

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -243,7 +243,7 @@ class CeramicDaemon {
    */
   async createReadOnlyDocFromGenesis (req: Request, res: Response, next: NextFunction): Promise<void> {
     const { doctype, genesis, docOpts } = req.body
-    const readOnlyDocOpts = {...docOpts, anchor: false, publish: false}
+    const readOnlyDocOpts = { ...docOpts, anchor: false, publish: false }
     try {
       const doc = await this.ceramic.createDocumentFromGenesis(doctype, DoctypeUtils.deserializeRecord(genesis), readOnlyDocOpts)
       res.json({ docId: doc.id.toString(), state: DoctypeUtils.serializeState(doc.state) })

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -226,6 +226,7 @@ class CeramicDaemon {
 
   /**
    * Create document from genesis record
+   * @dev Useful when the docId is unknown, but you have the genesis contents
    */
   async createDocFromGenesis (req: Request, res: Response, next: NextFunction): Promise<void> {
     const { doctype, genesis, docOpts } = req.body
@@ -240,6 +241,10 @@ class CeramicDaemon {
 
   /**
    * Create read-only document from genesis record
+   * @dev Useful when the docId is unknown, but you have the genesis contents
+   * @TODO Should return null if document does not already exist instead of
+   * current behavior, publishing to IPFS. With that change it will make sense
+   * to rename this, e.g. `loadDocFromGenesis`
    */
   async createReadOnlyDocFromGenesis (req: Request, res: Response, next: NextFunction): Promise<void> {
     const { doctype, genesis, docOpts } = req.body


### PR DESCRIPTION
Closes #703 

### Motivation

In gateway mode ceramic should not be able to publish or anchor documents

### Changes

- Replaced handler for `/documents` endpoint when in gateway mode to use `createDocumentFromGenesis` with publish and anchor set to false