### PR TITLE
fix: surface express errors properly

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -70,13 +70,6 @@ class CeramicDaemon {
     this.registerAPIPaths(app, opts.gateway)
 
     if (this.debug) {
-      app.use((err: Error, req: Request, res: Response, next: NextFunction): void => {
-        const requestStart = Date.now()
-        const httpLog = this._buildHttpLog(requestStart, req, res)
-        const logString = JSON.stringify(httpLog)
-        this.logger.error(logString)
-        next(err)
-      })
       app.use((req: Request, res: Response, next: NextFunction): void => {
         const requestStart = Date.now()
 
@@ -103,7 +96,10 @@ class CeramicDaemon {
     }
 
     app.use((err: Error, req: Request, res: Response, next: NextFunction): void => {
-      res.json({ error: err.message })
+      const requestStart = Date.now()
+      const httpLog = this._buildHttpLog(requestStart, req, res)
+      const logString = JSON.stringify(httpLog)
+      this.logger.error(logString)
       next(err)
     })
 


### PR DESCRIPTION
Closes #705 

### Motivation

When a request is made to the daemon that causes an error the server should respond with an error status code and message. Right not it always responds with 200

### Changes

- Moved custom error handler to be the last Express handler
  - per the [express docs](https://expressjs.com/en/guide/error-handling.html): "you define error-handling middleware last, after other app.use() and routes calls;"
- Removed the `res.json` call so Express can handle the error properly