### PR TITLE
fix(http-client): reload cached documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repo is made up of several different packages.
 | @ceramicnetwork/doctype-caip10-link | [![npm](https://img.shields.io/npm/v/@ceramicnetwork/doctype-caip10-link)](https://www.npmjs.com/package/@ceramicnetwork/doctype-caip10-link) | Ceramic caip10 link doctype |
 | @ceramicnetwork/doctype-tile | [![npm](https://img.shields.io/npm/v/@ceramicnetwork/doctype-tile)](https://www.npmjs.com/package/@ceramicnetwork/doctype-tile) | Ceramic tile doctype |
 | @ceramicnetwork/3id-did-resolver | [![npm](https://img.shields.io/npm/v/@ceramicnetwork/3id-did-resolver)](https://www.npmjs.com/package/@ceramicnetwork/3id-did-resolver) | DID resolver for 3IDs |
-| @ceramicnetwork/key-did-resolver | [![npm](https://img.shields.io/npm/v/@ceramicnetwork/key-did-resolver)](https://www.npmjs.com/package/@ceramicnetwork/key-did-resolver) | did:key method resolver |
+| key-did-resolver | [![npm](https://img.shields.io/npm/v/key-did-resolver)](https://www.npmjs.com/package/key-did-resolver) | did:key method resolver |
 
 ## APIs
 [APIs documentation](https://docs.ceramic.network)

--- a/packages/common/src/utils/doctype-utils.ts
+++ b/packages/common/src/utils/doctype-utils.ts
@@ -135,6 +135,11 @@ export class DoctypeUtils {
         return cloned
     }
 
+    static statesEqual(state1: DocState, state2: DocState): boolean {
+        return JSON.stringify(DoctypeUtils.serializeState(state1)) !==
+        JSON.stringify(DoctypeUtils.serializeState(state2))
+    }
+
     /**
      * Make doctype readonly
      * @param doctype - Doctype instance

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "@ceramicnetwork/docid": "^0.4.1",
     "@ceramicnetwork/doctype-caip10-link": "^0.12.3",
     "@ceramicnetwork/doctype-tile": "^0.12.5",
-    "@ceramicnetwork/key-did-resolver": "^0.2.2",
+    "key-did-resolver": "^0.2.3",
     "@ceramicnetwork/pinning-aggregation": "^0.1.6",
     "@ceramicnetwork/pinning-ipfs-backend": "^0.1.6",
     "@ethersproject/base64": "^5.0.2",

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -1,7 +1,7 @@
 import Dispatcher from './dispatcher'
 import Document from './document'
 import ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
-import KeyDidResolver from '@ceramicnetwork/key-did-resolver'
+import KeyDidResolver from 'key-did-resolver'
 import DocID from '@ceramicnetwork/docid'
 import { AnchorService, CeramicApi, CeramicRecord, DIDProvider, IpfsApi, PinApi, MultiQuery } from "@ceramicnetwork/common"
 

--- a/packages/doctype-tile/package.json
+++ b/packages/doctype-tile/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@ceramicnetwork/common": "^0.15.1",
-    "@ceramicnetwork/key-did-resolver": "^0.2.2",
     "@ethersproject/base64": "^5.0.2",
     "@ethersproject/random": "^5.0.2",
     "@types/lodash.clonedeep": "^4.5.6",
@@ -49,6 +48,7 @@
     "@types/node": "^13.13.15",
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",
+    "key-did-resolver": "^0.2.3",
     "babel-jest": "^25.1.0",
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.8.2",

--- a/packages/doctype-tile/src/__tests__/three-id.test.ts
+++ b/packages/doctype-tile/src/__tests__/three-id.test.ts
@@ -4,7 +4,7 @@ import { Resolver } from "did-resolver"
 
 import dagCBOR from "ipld-dag-cbor"
 
-import KeyDidResolver from '@ceramicnetwork/key-did-resolver'
+import KeyDidResolver from 'key-did-resolver'
 import ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
 
 import { DID } from 'dids'

--- a/packages/doctype-tile/src/__tests__/tile-doctype.test.ts
+++ b/packages/doctype-tile/src/__tests__/tile-doctype.test.ts
@@ -5,7 +5,7 @@ import dagCBOR from "ipld-dag-cbor"
 import { DID } from 'dids'
 import { Resolver } from "did-resolver"
 import ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
-import KeyDidResolver from '@ceramicnetwork/key-did-resolver'
+import KeyDidResolver from 'key-did-resolver'
 import { TileDoctypeHandler } from '../tile-doctype-handler'
 
 import { TileDoctype } from "../tile-doctype"

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -31,7 +31,7 @@
     "@ceramicnetwork/docid": "^0.4.1",
     "@ceramicnetwork/doctype-caip10-link": "^0.12.3",
     "@ceramicnetwork/doctype-tile": "^0.12.5",
-    "@ceramicnetwork/key-did-resolver": "^0.2.2",
+    "key-did-resolver": "^0.2.3",
     "cids": "1.0.2",
     "cross-fetch": "^3.0.6",
     "did-resolver": "^2.1.1",

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -47,6 +47,13 @@ export interface CeramicClientConfig {
  */
 export default class CeramicClient implements CeramicApi {
   private readonly _apiUrl: string
+  /**
+   * _docmap stores handles to Documents that been handed out. This allows us
+   * to update the state within the Document object when we learn about changes
+   * to the document. This means that client code with Document references
+   * always have access to the most recent known-about version, without needing
+   * to explicitly re-load the document.
+   */
   private readonly _docmap: Record<string, Document>
   private _supportedChains: Array<string>
 
@@ -125,10 +132,7 @@ export default class CeramicClient implements CeramicApi {
     const docIdStr = doc.id.toString()
     if (!this._docmap[docIdStr]) {
       this._docmap[docIdStr] = doc
-    } else if (
-      JSON.stringify(DoctypeUtils.serializeState(doc.state)) !==
-      JSON.stringify(DoctypeUtils.serializeState(this._docmap[docIdStr].state))
-    ) {
+    } else if (DoctypeUtils.statesEqual(doc.state, this._docmap[docIdStr].state)) {
       this._docmap[docIdStr].state = doc.state
       this._docmap[docIdStr].emit('change')
     }

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -127,6 +127,7 @@ export default class CeramicClient implements CeramicApi {
       this._docmap[docIdStr] = doc
     } else {
       this._docmap[docIdStr].state = doc.state
+      this._docmap[docIdStr].emit('change')
     }
     this._docmap[docIdStr].doctypeHandler = this.findDoctypeHandler(this._docmap[docIdStr].state.doctype)
     return this._docmap[docIdStr] as unknown as T
@@ -138,7 +139,7 @@ export default class CeramicClient implements CeramicApi {
     if (!this._docmap[docIdStr]) {
       this._docmap[docIdStr] = await Document.load(docId, this._apiUrl, this.context, this._config)
     } else {
-      this._docmap[docIdStr]._syncState()
+      await this._docmap[docIdStr]._syncState()
     }
     this._docmap[docIdStr].doctypeHandler = this.findDoctypeHandler(this._docmap[docIdStr].state.doctype)
     return this._docmap[docIdStr] as unknown as T

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -125,7 +125,10 @@ export default class CeramicClient implements CeramicApi {
     const docIdStr = doc.id.toString()
     if (!this._docmap[docIdStr]) {
       this._docmap[docIdStr] = doc
-    } else {
+    } else if (
+      JSON.stringify(DoctypeUtils.serializeState(doc.state)) !==
+      JSON.stringify(DoctypeUtils.serializeState(this._docmap[docIdStr].state))
+    ) {
       this._docmap[docIdStr].state = doc.state
       this._docmap[docIdStr].emit('change')
     }

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -19,7 +19,7 @@ import { TileDoctypeHandler } from "@ceramicnetwork/doctype-tile"
 import { Caip10LinkDoctypeHandler } from "@ceramicnetwork/doctype-caip10-link"
 import DocID from '@ceramicnetwork/docid'
 import ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
-import KeyDidResolver from '@ceramicnetwork/key-did-resolver'
+import KeyDidResolver from 'key-did-resolver'
 import { Resolver } from "did-resolver"
 
 const API_PATH = '/api/v0'
@@ -125,6 +125,8 @@ export default class CeramicClient implements CeramicApi {
     const docIdStr = doc.id.toString()
     if (!this._docmap[docIdStr]) {
       this._docmap[docIdStr] = doc
+    } else {
+      this._docmap[docIdStr].state = doc.state
     }
     this._docmap[docIdStr].doctypeHandler = this.findDoctypeHandler(this._docmap[docIdStr].state.doctype)
     return this._docmap[docIdStr] as unknown as T
@@ -135,6 +137,8 @@ export default class CeramicClient implements CeramicApi {
     const docIdStr = docId.toString()
     if (!this._docmap[docIdStr]) {
       this._docmap[docIdStr] = await Document.load(docId, this._apiUrl, this.context, this._config)
+    } else {
+      this._docmap[docIdStr]._syncState()
     }
     this._docmap[docIdStr].doctypeHandler = this.findDoctypeHandler(this._docmap[docIdStr].state.doctype)
     return this._docmap[docIdStr] as unknown as T

--- a/packages/http-client/src/document.ts
+++ b/packages/http-client/src/document.ts
@@ -26,22 +26,26 @@ class Document extends Doctype {
   }
 
   /**
+   * Sync document state
+   * @private
+   */
+  async _syncState() {
+    const { state } = await fetchJson(this._apiUrl + '/documents/' + this.id.toString())
+
+    if (JSON.stringify(DoctypeUtils.serializeState(this.state)) !== JSON.stringify(state)) {
+      this.state = DoctypeUtils.deserializeState(state)
+      this.emit('change')
+    }
+  }
+
+  /**
    * Sync document states periodically
    * @private
    */
   async _syncPeriodically() {
-    const _syncState = async () => {
-      const { state } = await fetchJson(this._apiUrl + '/documents/' + this.id.toString())
-
-      if (JSON.stringify(DoctypeUtils.serializeState(this.state)) !== JSON.stringify(state)) {
-        this.state = DoctypeUtils.deserializeState(state)
-        this.emit('change')
-      }
-    }
-
     while (this._syncEnabled) {
       try {
-        await _syncState()
+        await this._syncState()
       } catch (e) {
         // failed to sync state
       }

--- a/packages/key-did-resolver/README.md
+++ b/packages/key-did-resolver/README.md
@@ -4,7 +4,7 @@
 
 ### Installation
 ```
-$ npm install @ceramicnetwork/key-did-resolver
+$ npm install key-did-resolver
 ```
 
 ## Contributing


### PR DESCRIPTION
Also includes a commit that fixes the package name used for `key-did-resolver`. 

Packages published as `next`:
```
 - @ceramicnetwork/3id-did-resolver@0.6.2-alpha.2
 - @ceramicnetwork/cli@0.18.1-alpha.2
 - @ceramicnetwork/common@0.15.2-alpha.2
 - @ceramicnetwork/core@0.17.2-alpha.2
 - @ceramicnetwork/docid@0.4.2-alpha.2
 - @ceramicnetwork/doctype-caip10-link@0.12.4-alpha.2
 - @ceramicnetwork/doctype-tile@0.12.6-alpha.2
 - @ceramicnetwork/http-client@0.8.10-alpha.2
 - key-did-resolver@0.2.4-alpha.2
 - @ceramicnetwork/pinning-aggregation@0.1.7-alpha.2
 - @ceramicnetwork/pinning-ipfs-backend@0.1.7-alpha.2
 - @ceramicnetwork/pinning-powergate-backend@0.1.7-alpha.2
 ```