### PR TITLE
chore(core): Remove unused 'unique' field

### DIFF
--- a/packages/common/src/doctype.ts
+++ b/packages/common/src/doctype.ts
@@ -23,8 +23,6 @@ export interface RecordHeader {
     schema?: string
     tags?: Array<string>
 
-    unique?: string
-
     [index: string]: any // allow support for future changes
 }
 


### PR DESCRIPTION
The `unique` field exists in GenesisRecord.  It doesn't show up in arbitrary record headers, and this field is currently unused