### PR TITLE
Hotfix pubsub subscribe

### DIFF
--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -69,7 +69,6 @@ describe('Ceramic interop: core <> http-client', () => {
             ipfs.pubsub = {}
         }
         ipfs.pubsub.subscribe = jest.fn()
-        ipfs.pubsub.ls = jest.fn(() => Promise.resolve([topic]))
     })
 
     afterAll(async () => {

--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -28,6 +28,7 @@ const waitChange = (doc: EventEmitter, count = 1): Promise<void> => {
 }
 const port = 7777
 const apiUrl = 'http://localhost:' + port
+const topic = '/ceramic'
 
 /**
  * Create an IPFS instance
@@ -64,6 +65,11 @@ describe('Ceramic interop: core <> http-client', () => {
                 }, Bootstrap: []
             }
         })
+        if (!ipfs.pubsub) {
+            ipfs.pubsub = {}
+        }
+        ipfs.pubsub.subscribe = jest.fn()
+        ipfs.pubsub.ls = jest.fn(() => Promise.resolve([topic]))
     })
 
     afterAll(async () => {
@@ -76,7 +82,7 @@ describe('Ceramic interop: core <> http-client', () => {
         // performed yet by the time the test checks.  To eliminate this race condition we should set
         // anchorOnRequest to false in the config for the InMemoryAnchorService and anchor manually
         // throughout the tests.
-        core = await Ceramic.create(ipfs)
+        core = await Ceramic.create(ipfs, {pubsubTopic: topic})
 
         const doctypeHandler = new TileDoctypeHandler()
         doctypeHandler.verifyJWS = (): Promise<void> => { return }

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -68,6 +68,8 @@ const generateStringOfSize = (size): string => {
   return random_data.join('');
 }
 
+const TOPIC = '/ceramic'
+
 describe('Ceramic API', () => {
   jest.setTimeout(15000)
   let ipfs: IpfsApi;
@@ -87,6 +89,7 @@ describe('Ceramic API', () => {
 
   const createCeramic = async (c: CeramicConfig = {}): Promise<Ceramic> => {
     c.anchorOnRequest = false
+    c.pubsubTopic = TOPIC
     const ceramic = await Ceramic.create(ipfs, c)
 
     const provider = new Ed25519Provider(seed)
@@ -104,11 +107,22 @@ describe('Ceramic API', () => {
         Bootstrap: []
       }
     })
+    ipfs.pubsub.subscribe = jest.fn()
+    ipfs.pubsub.ls = jest.fn(
+        () => new Promise((resolve, reject) => {
+            resolve([TOPIC])
+            reject()
+        })
+    )
   })
 
   afterAll(async () => {
     await ipfs.stop(() => console.log('IPFS stopped'))
     await tmpFolder.cleanup()
+  })
+
+  afterEach(async () => {
+    await ceramic.close()
   })
 
   describe('API', () => {

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -68,8 +68,6 @@ const generateStringOfSize = (size): string => {
   return random_data.join('');
 }
 
-const TOPIC = '/ceramic'
-
 describe('Ceramic API', () => {
   jest.setTimeout(15000)
   let ipfs: IpfsApi;
@@ -89,7 +87,6 @@ describe('Ceramic API', () => {
 
   const createCeramic = async (c: CeramicConfig = {}): Promise<Ceramic> => {
     c.anchorOnRequest = false
-    c.pubsubTopic = TOPIC
     const ceramic = await Ceramic.create(ipfs, c)
 
     const provider = new Ed25519Provider(seed)
@@ -107,22 +104,11 @@ describe('Ceramic API', () => {
         Bootstrap: []
       }
     })
-    ipfs.pubsub.subscribe = jest.fn()
-    ipfs.pubsub.ls = jest.fn(
-        () => new Promise((resolve, reject) => {
-            resolve([TOPIC])
-            reject()
-        })
-    )
   })
 
   afterAll(async () => {
     await ipfs.stop(() => console.log('IPFS stopped'))
     await tmpFolder.cleanup()
-  })
-
-  afterEach(async () => {
-    await ceramic.close()
   })
 
   describe('API', () => {

--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -4,6 +4,7 @@ import Document from "../document"
 import { TileDoctype } from "@ceramicnetwork/doctype-tile"
 import DocID from "@ceramicnetwork/docid";
 
+const TOPIC = '/ceramic'
 const FAKE_CID = new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
 const FAKE_CID2 = new CID('bafybeig6xv5nwphfmvcnektpnojts44jqcuam7bmye2pb54adnrtccjlsu')
 const FAKE_DOC_ID = "kjzl6cwe1jw147dvq16zluojmraqvwdmbh61dx9e0c59i344lcrsgqfohexp60s"
@@ -12,6 +13,10 @@ const ipfs = {
   pubsub: {
     subscribe: jest.fn(),
     unsubscribe: jest.fn(),
+    ls: jest.fn(() => new Promise((resolve, reject) => {
+        resolve([TOPIC])
+        reject()
+    })),
     publish: jest.fn()
   },
   dag: {
@@ -23,7 +28,6 @@ const ipfs = {
   },
   id: (): any => ({ id: 'ipfsid' })
 }
-const TOPIC = '/ceramic'
 
 class TileDoctypeMock extends TileDoctype {
   get doctype() {

--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -13,9 +13,6 @@ const ipfs = {
   pubsub: {
     subscribe: jest.fn(),
     unsubscribe: jest.fn(),
-    ls: jest.fn(() => new Promise((resolve) => {
-        resolve([TOPIC])
-    })),
     publish: jest.fn()
   },
   dag: {

--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -13,9 +13,8 @@ const ipfs = {
   pubsub: {
     subscribe: jest.fn(),
     unsubscribe: jest.fn(),
-    ls: jest.fn(() => new Promise((resolve, reject) => {
+    ls: jest.fn(() => new Promise((resolve) => {
         resolve([TOPIC])
-        reject()
     })),
     publish: jest.fn()
   },

--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -60,7 +60,7 @@ describe('Dispatcher', () => {
 
   it('is constructed correctly', async () => {
     expect(dispatcher._documents).toEqual({})
-    expect(ipfs.pubsub.subscribe).toHaveBeenCalledWith(TOPIC, expect.anything())
+    expect(ipfs.pubsub.subscribe).toHaveBeenCalledWith(TOPIC, expect.anything(), expect.anything())
   })
 
   it('closes correctly', async () => {

--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -50,6 +50,10 @@ describe('Dispatcher', () => {
     await dispatcher.init()
   })
 
+  afterEach(async () => {
+    await dispatcher.close()
+  })
+
   it('is constructed correctly', async () => {
     expect(dispatcher._documents).toEqual({})
     expect(ipfs.pubsub.subscribe).toHaveBeenCalledWith(TOPIC, expect.anything())
@@ -62,8 +66,16 @@ describe('Dispatcher', () => {
   })
 
   it('makes registration correctly', async () => {
-    const doc = new Document(DocID.fromString(FAKE_DOC_ID), dispatcher, null)
-    doc._doctype = new TileDoctypeMock()
+    const doc = new Document(
+      DocID.fromString(FAKE_DOC_ID),
+      dispatcher,
+      null,
+      false,
+      {},
+      null,
+      null
+    )
+    doc['_doctype'] = new TileDoctypeMock(null, {})
     await dispatcher.register(doc)
 
     const publishArgs = ipfs.pubsub.publish.mock.calls[0]
@@ -94,8 +106,16 @@ describe('Dispatcher', () => {
   })
 
   it('handle message correctly', async () => {
-    const doc = new Document(DocID.fromString(FAKE_DOC_ID), dispatcher, null)
-    doc._doctype = new TileDoctypeMock()
+    const doc = new Document(
+      DocID.fromString(FAKE_DOC_ID),
+      dispatcher,
+      null,
+      false,
+      {},
+      null,
+      null
+    )
+    doc['_doctype'] = new TileDoctypeMock(null, {})
     await dispatcher.register(doc)
 
     // Store the query ID sent when the doc is registered so we can use it as the response ID later

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -65,7 +65,7 @@ export default class Dispatcher extends EventEmitter {
   }
 
   async _subscribe(): Promise<void> {
-    let alreadySubscribed = this._isSubscribed
+    const alreadySubscribed = this._isSubscribed
 
     try {
       !alreadySubscribed && await this._ipfs.pubsub.subscribe(this.topic, this.handleMessage.bind(this))

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -47,6 +47,7 @@ export default class Dispatcher extends EventEmitter {
 
   private logger: Logger
   private _isRunning = true
+  private _messageHandler = this.handleMessage.bind(this)
   private _resubscribeInterval: any
 
   constructor (public _ipfs: IpfsApi, public topic: string) {
@@ -76,7 +77,7 @@ export default class Dispatcher extends EventEmitter {
     try {
       await this._ipfs.pubsub.subscribe(
         this.topic,
-        this.handleMessage.bind(this),
+        this._messageHandler,
         {timeout: TESTING ? null : IPFS_GET_TIMEOUT}
       )
       this._log({peer: this._peerId, event: 'subscribed', topic: this.topic })

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -13,6 +13,7 @@ import DocID from "@ceramicnetwork/docid";
 const IPFS_GET_TIMEOUT = 30000 // 30 seconds
 const IPFS_MAX_RECORD_SIZE = 256000 // 256 KB
 const IPFS_RESUBSCRIBE_INTERVAL_DELAY = 1000 * 60 // 1 minute
+const TESTING = process.env.NODE_ENV == 'test'
 
 /**
  * Ceramic Pub/Sub message type.
@@ -62,7 +63,7 @@ export default class Dispatcher extends EventEmitter {
   async init(): Promise<void> {
     this._peerId = this._peerId || (await this._ipfs.id()).id
     await this._subscribe()
-    process.env.NODE_ENV != 'test' && this._resubscribeOnDisconnect()
+    !TESTING && this._resubscribeOnDisconnect()
   }
 
   /**
@@ -76,7 +77,7 @@ export default class Dispatcher extends EventEmitter {
         await this._ipfs.pubsub.subscribe(
           this.topic,
           this.handleMessage.bind(this),
-          {timeout: process.env.NODE_ENV != 'test' && IPFS_GET_TIMEOUT}
+          {timeout: !TESTING && IPFS_GET_TIMEOUT}
         )
 
         const { isSubscribed, error } = await this._confirmIsSubscribed()

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -82,6 +82,9 @@ export default class Dispatcher extends EventEmitter {
       this._log({peer: this._peerId, event: 'subscribed', topic: this.topic })
     } catch (error) {
       // TODO: use logger
+      if (error.message.includes('Already subscribed')) {
+        console.log(error.message)
+      }
       console.error(error)
     }
   }

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -77,7 +77,7 @@ export default class Dispatcher extends EventEmitter {
         await this._ipfs.pubsub.subscribe(
           this.topic,
           this.handleMessage.bind(this),
-          {timeout: !TESTING && IPFS_GET_TIMEOUT}
+          {timeout: TESTING ? null : IPFS_GET_TIMEOUT}
         )
 
         const { isSubscribed, error } = await this._confirmIsSubscribed()

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -62,7 +62,9 @@ export default class Dispatcher extends EventEmitter {
   async init(): Promise<void> {
     this._peerId = this._peerId || (await this._ipfs.id()).id
     await this._subscribe()
-    !TESTING && this._resubscribe()
+    if (!TESTING) {
+      this._resubscribe()
+    }
   }
 
   /**
@@ -75,7 +77,7 @@ export default class Dispatcher extends EventEmitter {
       await this._ipfs.pubsub.subscribe(
         this.topic,
         this.handleMessage.bind(this),
-        {timeout: !TESTING && IPFS_GET_TIMEOUT}
+        {timeout: TESTING ? null : IPFS_GET_TIMEOUT}
       )
       this._log({peer: this._peerId, event: 'subscribed', topic: this.topic })
     } catch (error) {

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -83,9 +83,10 @@ export default class Dispatcher extends EventEmitter {
     } catch (error) {
       // TODO: use logger
       if (error.message.includes('Already subscribed')) {
-        console.log(error.message)
+        this.logger.debug(error.message)
+      } else {
+        console.error(error)
       }
-      console.error(error)
     }
   }
 

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -62,7 +62,7 @@ export default class Dispatcher extends EventEmitter {
   async init(): Promise<void> {
     this._peerId = this._peerId || (await this._ipfs.id()).id
     await this._subscribe()
-    this._resubscribeOnDisconnect()
+    process.env.NODE_ENV != 'test' && this._resubscribeOnDisconnect()
   }
 
   /**
@@ -76,7 +76,7 @@ export default class Dispatcher extends EventEmitter {
         await this._ipfs.pubsub.subscribe(
           this.topic,
           this.handleMessage.bind(this),
-          { timeout: IPFS_GET_TIMEOUT }
+          {timeout: process.env.NODE_ENV != 'test' && IPFS_GET_TIMEOUT}
         )
 
         const { isSubscribed, error } = await this._confirmIsSubscribed()

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -116,16 +116,15 @@ export default class Dispatcher extends EventEmitter {
     let error = null
 
     const requestTimeout = 1000 * 5 // five seconds
-    await this._ipfs.pubsub.ls({ timeout: requestTimeout })
-      .then((subscriptions: any) => {
-        if (!subscriptions.includes(this.topic)) {
-          isSubscribed = false
-        }
-      })
-      .catch((_error: Error) => {
+    try {
+      const subscriptions = await this._ipfs.pubsub.ls({ timeout: requestTimeout })
+      if (!subscriptions.includes(this.topic)) {
         isSubscribed = false
-        error = _error
-      })
+      }
+    } catch (_error) {
+      isSubscribed = false
+      error = _error
+    }
     this._isSubscribed = isSubscribed
 
     return { isSubscribed: this._isSubscribed, error }

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -47,7 +47,6 @@ export default class Dispatcher extends EventEmitter {
 
   private logger: Logger
   private _isRunning = true
-  private _messageHandler = this.handleMessage.bind(this)
   private _resubscribeInterval: any
 
   constructor (public _ipfs: IpfsApi, public topic: string) {
@@ -77,7 +76,7 @@ export default class Dispatcher extends EventEmitter {
     try {
       await this._ipfs.pubsub.subscribe(
         this.topic,
-        this._messageHandler,
+        this.handleMessage,
         {timeout: TESTING ? null : IPFS_GET_TIMEOUT}
       )
       this._log({peer: this._peerId, event: 'subscribed', topic: this.topic })
@@ -227,7 +226,7 @@ export default class Dispatcher extends EventEmitter {
    *
    * @param message - Message data
    */
-  async handleMessage (message: any): Promise<void> {
+  handleMessage = async (message: any): Promise<void> => {
     if (!this._isRunning) {
       this.logger.error('Dispatcher has been closed')
       return

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -746,7 +746,7 @@ class Document extends EventEmitter {
 
     await this._applyQueue.onEmpty()
 
-    this._context.anchorService.removeAllListeners(this.id.toString())
+    this._context.anchorService && this._context.anchorService.removeAllListeners(this.id.toString())
     await Utils.awaitCondition(() => this._isProcessing, () => false, 500)
   }
 


### PR DESCRIPTION
### Motivation

Our ipfs node on infra is going down periodically (reason tbd) and when it reboots we stop receiving pubsub messages.
Created an issue on js-ipfs repo here https://github.com/ipfs/js-ipfs/issues/3465 -- the error handler for pubsub is broken in Node.js

### Changes

- Check if we are subscribed every 60 seconds and resubscribe if we are not
- Also updated infra https://github.com/3box/ceramic-infra/commit/164ba63a21b82d5aba6da27dee457079930eb292 to not subscribe from the IPFS API node itself because it was causing this issue https://github.com/ipfs/js-ipfs/issues/3467
- Small change to check that document context includes `anchorService` before removing listeners (which was breaking tests)