### PR TITLE
CORS

### DIFF
--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -18,7 +18,7 @@ program
     .option('--network <name>', 'Name of the ceramic network to connect to. One of: "mainnet", "testnet-clay", "local", or "inmemory". Defaults to "testnet-clay"')
     .option('--max-healthy-cpu <decimal>', 'Fraction of total CPU usage considered healthy. Defaults to 0.7')
     .option('--max-healthy-memory <decimal>', 'Fraction of total memory usage considered healthy. Defaults to 0.7')
-    .option('--cors-allowed-origins <array>', 'List of strings and/or regex expressions to set for Access-Control-Allow-Origin . Defaults to all: ["*"]')
+    .option('--cors-allowed-origins <array>', 'Space-separated list of strings and/or regex expressions to set for Access-Control-Allow-Origin . Defaults to all: "*"')
     .description('Start the daemon')
     .action(async ({
         ipfsApi,

--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -18,6 +18,7 @@ program
     .option('--network <name>', 'Name of the ceramic network to connect to. One of: "mainnet", "testnet-clay", "local", or "inmemory". Defaults to "testnet-clay"')
     .option('--max-healthy-cpu <decimal>', 'Fraction of total CPU usage considered healthy. Defaults to 0.7')
     .option('--max-healthy-memory <decimal>', 'Fraction of total memory usage considered healthy. Defaults to 0.7')
+    .option('--cors-allowed-origins <array>', 'List of strings and/or regex expressions to set for Access-Control-Allow-Origin . Defaults to all: ["*"]')
     .description('Start the daemon')
     .action(async ({
         ipfsApi,
@@ -33,7 +34,8 @@ program
         logPath,
         network,
         maxHealthyCpu,
-        maxHealthyMemory
+        maxHealthyMemory,
+        corsAllowedOrigins
     }) => {
         await CeramicCliUtils.createDaemon(
             ipfsApi,
@@ -49,7 +51,8 @@ program
             logPath,
             network,
             maxHealthyCpu,
-            maxHealthyMemory
+            maxHealthyMemory,
+            corsAllowedOrigins
         )
     })
 

--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -18,7 +18,7 @@ program
     .option('--network <name>', 'Name of the ceramic network to connect to. One of: "mainnet", "testnet-clay", "local", or "inmemory". Defaults to "testnet-clay"')
     .option('--max-healthy-cpu <decimal>', 'Fraction of total CPU usage considered healthy. Defaults to 0.7')
     .option('--max-healthy-memory <decimal>', 'Fraction of total memory usage considered healthy. Defaults to 0.7')
-    .option('--cors-allowed-origins <array>', 'Space-separated list of strings and/or regex expressions to set for Access-Control-Allow-Origin . Defaults to all: "*"')
+    .option('--cors-allowed-origins <list>', 'Space-separated list of strings and/or regex expressions to set for Access-Control-Allow-Origin . Defaults to all: "*"')
     .description('Start the daemon')
     .action(async ({
         ipfsApi,

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -58,6 +58,7 @@ export class CeramicCliUtils {
      * @param network - The Ceramic network to connect to
      * @param maxHealthyCpu - Max fraction of total CPU usage considered healthy. Default is 0.7
      * @param maxHealthyMemory - Max fraction of total memory usage considered healthy. Default is 0.7
+     * @param corsAllowedOrigins - Origins for Access-Control-Allow-Origin header. Default is all
      */
     static async createDaemon(
         ipfsApi: string,
@@ -73,7 +74,8 @@ export class CeramicCliUtils {
         logPath: string,
         network: string,
         maxHealthyCpu = 0.7,
-        maxHealthyMemory = 0.7
+        maxHealthyMemory = 0.7,
+        corsAllowedOrigins: any[] = ["*"]
     ): Promise<CeramicDaemon> {
         if (stateStorePath == null) {
             stateStorePath = DEFAULT_PINNING_STORE_PATH
@@ -92,7 +94,8 @@ export class CeramicCliUtils {
             logPath,
             network,
             maxHealthyCpu,
-            maxHealthyMemory
+            maxHealthyMemory,
+            corsAllowedOrigins
         }
 
         multiformats.multicodec.add(dagJose)

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -75,10 +75,15 @@ export class CeramicCliUtils {
         network: string,
         maxHealthyCpu = 0.7,
         maxHealthyMemory = 0.7,
-        corsAllowedOrigins: any[] = ["*"]
+        corsAllowedOrigins: string
     ): Promise<CeramicDaemon> {
         if (stateStorePath == null) {
             stateStorePath = DEFAULT_PINNING_STORE_PATH
+        }
+
+        let _corsAllowedOrigins: string | RegExp[] = '*'
+        if (corsAllowedOrigins != null && corsAllowedOrigins != '*') {
+            _corsAllowedOrigins = corsAllowedOrigins.split(' ').map((origin) => new RegExp(origin))
         }
 
         const config: CreateOpts = {
@@ -95,7 +100,7 @@ export class CeramicCliUtils {
             network,
             maxHealthyCpu,
             maxHealthyMemory,
-            corsAllowedOrigins
+            corsAllowedOrigins: _corsAllowedOrigins
         }
 
         multiformats.multicodec.add(dagJose)

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -21,7 +21,7 @@ export interface CreateOpts {
   ipfsHost?: string;
   ipfs?: IpfsApi;
   port?: number;
-  corsAllowedOrigins: any[];
+  corsAllowedOrigins: string | RegExp[];
 
   ethereumRpcUrl?: string;
   anchorServiceUrl?: string;
@@ -67,7 +67,6 @@ class CeramicDaemon {
     const app: core.Express = express()
     app.use(express.json())
     app.use(cors({ origin: opts.corsAllowedOrigins }))
-    // app.use(cors({ origin: [ "http://localhost", /\.3boxlabs\.com$/, /\.ceramic\.network$/, /\.self\.id$/, /\.3idconnect\.org$/  ] }))
 
     this.registerAPIPaths(app, opts.gateway)
 

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -21,6 +21,7 @@ export interface CreateOpts {
   ipfsHost?: string;
   ipfs?: IpfsApi;
   port?: number;
+  corsAllowedOrigins: any[];
 
   ethereumRpcUrl?: string;
   anchorServiceUrl?: string;
@@ -65,7 +66,8 @@ class CeramicDaemon {
 
     const app: core.Express = express()
     app.use(express.json())
-    app.use(cors())
+    app.use(cors({ origin: opts.corsAllowedOrigins }))
+    // app.use(cors({ origin: [ "http://localhost", /\.3boxlabs\.com$/, /\.ceramic\.network$/, /\.self\.id$/, /\.3idconnect\.org$/  ] }))
 
     this.registerAPIPaths(app, opts.gateway)
 


### PR DESCRIPTION
### Motivation

We want the ability to set CORS headers so that only clients on whitelisted domains can make requests to the Ceramic api.

### Changes

- Added a flag `--cors-allowed-origins` which accepts a space separated list of values to use as a whitelist
  - e.g. `".3boxlabs.com$ ://3boxlabs.com$"` will whitelist all subdomains and the base domain for 3boxlabs.com