### PR TITLE
fix(doctype-tile): make controllers default to current user

### DIFF
--- a/packages/doctype-tile/src/tile-doctype.ts
+++ b/packages/doctype-tile/src/tile-doctype.ts
@@ -70,7 +70,7 @@ export class TileDoctype extends Doctype {
         const unique = params.deterministic ? '0' : base64Encode(randomBytes(12))
 
         const metadata: GenesisHeader = params.metadata || { controllers: [] }
-        if (metadata.controllers.length === 0) {
+        if (!metadata.controllers || metadata.controllers.length === 0) {
             if (params.content && context.did) {
                 metadata.controllers = [context.did.id]
             } else {


### PR DESCRIPTION
This fixes the recent regression where documents can't be created from the cli.