### PR TITLE
fix(cli): Disable DHT

### DIFF
--- a/packages/cli/src/build-ipfs-connection.util.ts
+++ b/packages/cli/src/build-ipfs-connection.util.ts
@@ -38,7 +38,7 @@ export async function buildIpfsConnection(network: string, ipfsEndpoint?: string
             libp2p: {
                 config: {
                     dht: {
-                        enabled: true,
+                        enabled: false,
                         clientMode: !IPFS_DHT_SERVER_MODE,
                         randomWalk: false,
                     },


### PR DESCRIPTION
**This PR disables the use of the DHT in the js-ipfs node used by the cli.**

Having the DHT enabled in it's current configuration is causing quite severe degradation issues when making method calls to ceramic. It doesn't only slow things down, but makes request times very variable (sometimes up to minutes). With the DHT disabled the same calls work much more consistently.