### PR TITLE
feat: Add support for cosmos blockchain

### DIFF
--- a/packages/blockchain-utils-linking/package.json
+++ b/packages/blockchain-utils-linking/package.json
@@ -40,7 +40,8 @@
     "@smontero/eosio-local-provider": "^0.0.3",
     "@zondax/filecoin-signing-tools": "^0.13.0",
     "eth-sig-util": "^3.0.0",
-    "ganache-core": "^2.13.1"
+    "ganache-core": "^2.13.1",
+    "@tendermint/sig": "^0.6.0"
   },
   "jest": {
     "testEnvironment": "jest-environment-uint8array",

--- a/packages/blockchain-utils-linking/src/__tests__/__snapshots__/cosmos.test.ts.snap
+++ b/packages/blockchain-utils-linking/src/__tests__/__snapshots__/cosmos.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Blockchain: Cosmos authenticate create proof for cosmoshub3 1`] = `"0x3e779670d353ea4826096f99ba6ba6a23ac4efb67de9cffb03909e6017245965"`;
+
+exports[`Blockchain: Cosmos createLink create proof for cosmoshub3 1`] = `
+Object {
+  "account": "cosmos1gs6gu0w9xvqcfhm3nlhnmqkf8aphnsxyjlgpqd@cosmos:cosmoshub-3",
+  "message": "Create a new account link to your identity.
+
+did:3:bafysdfwefwe 
+Timestamp: 666",
+  "signature": "eyJzaWduYXR1cmUiOiJUUFJqd0JIdCtMRDloQkFXZndMSVhPMnRnWWUwdnZlZjVqdTVlRGcrcEpSbkdIMkEyRzc3ZE1Ec0U3ekR0Z2RXZCsyTFFOQjM4NzROL2xzcXh2Mnk0UT09IiwicHViX2tleSI6eyJ0eXBlIjoidGVuZGVybWludC9QdWJLZXlTZWNwMjU2azEiLCJ2YWx1ZSI6IkE0MVhFTUx0TnhvbmhlU2FwNTg5Nzdkc0ZhSTh5VWt3NHdWSytiR3dPNElyIn19",
+  "timestamp": 666,
+  "type": "cosmos",
+  "version": 1,
+}
+`;

--- a/packages/blockchain-utils-linking/src/__tests__/__snapshots__/cosmos.test.ts.snap
+++ b/packages/blockchain-utils-linking/src/__tests__/__snapshots__/cosmos.test.ts.snap
@@ -11,7 +11,6 @@ did:3:bafysdfwefwe
 Timestamp: 666",
   "signature": "eyJzaWduYXR1cmUiOiJUUFJqd0JIdCtMRDloQkFXZndMSVhPMnRnWWUwdnZlZjVqdTVlRGcrcEpSbkdIMkEyRzc3ZE1Ec0U3ekR0Z2RXZCsyTFFOQjM4NzROL2xzcXh2Mnk0UT09IiwicHViX2tleSI6eyJ0eXBlIjoidGVuZGVybWludC9QdWJLZXlTZWNwMjU2azEiLCJ2YWx1ZSI6IkE0MVhFTUx0TnhvbmhlU2FwNTg5Nzdkc0ZhSTh5VWt3NHdWSytiR3dPNElyIn19",
   "timestamp": 666,
-  "type": "cosmos",
   "version": 1,
 }
 `;

--- a/packages/blockchain-utils-linking/src/__tests__/cosmos.test.ts
+++ b/packages/blockchain-utils-linking/src/__tests__/cosmos.test.ts
@@ -4,6 +4,7 @@ import { CosmosAuthProvider } from '../cosmos';
 const did = 'did:3:bafysdfwefwe';
 const mnemonic = 'test salon husband push melody usage fine ensure blade deal miss twin';
 const local_provider = createWalletFromMnemonic(mnemonic);
+const chainRef = 'cosmoshub-3';
 
 class CosmosMockSigner {
   readonly provider: Wallet;
@@ -34,7 +35,8 @@ describe('Blockchain: Cosmos', () => {
       const provider = new CosmosMockSigner(local_provider);
       const authProvider = new CosmosAuthProvider(
         provider,
-        local_provider.address
+        local_provider.address,
+        chainRef
       );
       const proof = await authProvider.createLink(did);
       expect(proof).toMatchSnapshot();
@@ -46,7 +48,8 @@ describe('Blockchain: Cosmos', () => {
       const provider = new CosmosMockSigner(local_provider);
       const authProvider = new CosmosAuthProvider(
         provider,
-        local_provider.address
+        local_provider.address,
+        chainRef
       );
       const result = await authProvider.authenticate('msg');
       expect(result).toMatchSnapshot();

--- a/packages/blockchain-utils-linking/src/__tests__/cosmos.test.ts
+++ b/packages/blockchain-utils-linking/src/__tests__/cosmos.test.ts
@@ -1,0 +1,56 @@
+import { signTx, Tx, SignMeta, createWalletFromMnemonic, Wallet, StdTx } from '@tendermint/sig';
+import { CosmosAuthProvider } from '../cosmos';
+
+const did = 'did:3:bafysdfwefwe';
+const mnemonic = 'test salon husband push melody usage fine ensure blade deal miss twin';
+const local_provider = createWalletFromMnemonic(mnemonic);
+
+class CosmosMockSigner {
+  readonly provider: Wallet;
+
+  constructor(local_provider: Wallet) {
+    this.provider = local_provider;
+  }
+
+  public async sign(msg : Tx, metadata : SignMeta) : Promise<StdTx>{
+    return new Promise((resolve): void => {
+      const signature = signTx(msg, metadata, this.provider);
+      resolve(signature);
+    }); 
+  }
+}
+
+beforeAll(() => {
+  global.Date.now = jest.fn().mockImplementation(() => 666000);
+});
+
+afterAll(() => {
+  jest.clearAllMocks();
+});
+
+describe('Blockchain: Cosmos', () => {
+  describe('createLink', () => {
+    test('create proof for cosmoshub3', async () => {
+      const provider = new CosmosMockSigner(local_provider);
+      const authProvider = new CosmosAuthProvider(
+        provider,
+        local_provider.address
+      );
+      const proof = await authProvider.createLink(did);
+      expect(proof).toMatchSnapshot();
+    });
+  });
+
+  describe('authenticate', () => {
+    test('create proof for cosmoshub3', async () => {
+      const provider = new CosmosMockSigner(local_provider);
+      const authProvider = new CosmosAuthProvider(
+        provider,
+        local_provider.address
+      );
+      const result = await authProvider.authenticate('msg');
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+});

--- a/packages/blockchain-utils-linking/src/cosmos.ts
+++ b/packages/blockchain-utils-linking/src/cosmos.ts
@@ -5,8 +5,6 @@ import { Tx, SignMeta } from '@tendermint/sig';
 import { hash } from '@stablelib/sha256';
 import * as uint8arrays from 'uint8arrays';
 
-const CHAIN_ID = "cosmos:cosmoshub-3";
-
 const stringEncode = (str: string): string => uint8arrays.toString(uint8arrays.fromString(str), 'base64pad');
 
 // return data in the cosmos unsigned transaction format
@@ -44,7 +42,8 @@ export class CosmosAuthProvider implements AuthProvider {
 
   constructor(
     private readonly provider: any, 
-    private readonly address: string) {}
+    private readonly address: string,
+    private readonly chainRef: string) {}
 
   async authenticate(message: string): Promise<string> {
     const accountID = await this.accountId();
@@ -73,11 +72,11 @@ export class CosmosAuthProvider implements AuthProvider {
   async accountId(): Promise<AccountID> {
     return new AccountID({
       address: this.address,
-      chainId: CHAIN_ID,
+      chainId: `cosmos:${this.chainRef}`,
     });
   }
 
   withAddress(address: string): AuthProvider {
-    return new CosmosAuthProvider(this.provider, address);
+    return new CosmosAuthProvider(this.provider, address, this.chainRef);
   }
 }

--- a/packages/blockchain-utils-linking/src/cosmos.ts
+++ b/packages/blockchain-utils-linking/src/cosmos.ts
@@ -1,0 +1,84 @@
+import { AccountID } from 'caip';
+import { AuthProvider } from './auth-provider';
+import { getConsentMessage, LinkProof } from './util';
+import { Tx, SignMeta } from '@tendermint/sig';
+import { hash } from '@stablelib/sha256';
+import * as uint8arrays from 'uint8arrays';
+
+const CHAIN_ID = "cosmos:cosmoshub-3";
+
+const stringEncode = (str: string): string => uint8arrays.toString(uint8arrays.fromString(str), 'base64pad');
+
+// return data in the cosmos unsigned transaction format
+function asTransaction(address: string, message: string): Tx {
+  return {
+    fee: {
+      amount: [{ amount: '0', denom: '' }],
+      gas: '0',
+    },
+    memo: message,
+    msg: [
+      {
+        type: 'cosmos-sdk/MsgSend',
+        value: {
+          from_address: address,
+          to_address: address,
+          amount: [{ amount: '0', denom: '0' }],
+        },
+      },
+    ],
+  };
+}
+
+// generate metadata for signing the transaction
+function getMetaData(): SignMeta {
+  return {
+    account_number: '1',
+    chain_id: 'cosmos',
+    sequence: '0',
+  };
+}
+
+export class CosmosAuthProvider implements AuthProvider {
+  readonly isAuthProvider = true;
+
+  constructor(
+    private readonly provider: any, 
+    private readonly address: string) {}
+
+  async authenticate(message: string): Promise<string> {
+    const accountID = await this.accountId();
+    const encodedMsg = stringEncode(message);
+    const res = await this.provider.sign(asTransaction(accountID.address, encodedMsg), getMetaData());
+    const digest = hash(uint8arrays.fromString(JSON.stringify(res.signatures[0])))
+    return `0x${uint8arrays.toString(digest, 'base16')}`
+  }
+
+  async createLink(did: string): Promise<LinkProof> {
+    const { message, timestamp } = getConsentMessage(did);
+    const accountID = await this.accountId();
+    const encodedMsg = stringEncode(message);
+    const res = await this.provider.sign(asTransaction(accountID.address, encodedMsg), getMetaData());
+    const signature = stringEncode(JSON.stringify(res.signatures[0]));
+    const proof: LinkProof = {
+      version: 1,
+      type: 'cosmos',
+      message,
+      signature,
+      account: accountID.toString(),
+      timestamp,
+    };
+    return proof;
+  }
+
+  async accountId(): Promise<AccountID> {
+    return new AccountID({
+      address: this.address,
+      chainId: CHAIN_ID,
+    });
+  }
+
+  withAddress(address: string): AuthProvider {
+    return new CosmosAuthProvider(this.provider, address);
+  }
+}

--- a/packages/blockchain-utils-linking/src/cosmos.ts
+++ b/packages/blockchain-utils-linking/src/cosmos.ts
@@ -62,7 +62,6 @@ export class CosmosAuthProvider implements AuthProvider {
     const signature = stringEncode(JSON.stringify(res.signatures[0]));
     const proof: LinkProof = {
       version: 1,
-      type: 'cosmos',
       message,
       signature,
       account: accountID.toString(),

--- a/packages/blockchain-utils-linking/src/cosmos.ts
+++ b/packages/blockchain-utils-linking/src/cosmos.ts
@@ -8,7 +8,7 @@ import * as uint8arrays from 'uint8arrays';
 const stringEncode = (str: string): string => uint8arrays.toString(uint8arrays.fromString(str), 'base64pad');
 
 // return data in the cosmos unsigned transaction format
-function asTransaction(address: string, message: string): Tx {
+export function asTransaction(address: string, message: string): Tx {
   return {
     fee: {
       amount: [{ amount: '0', denom: '' }],
@@ -29,7 +29,7 @@ function asTransaction(address: string, message: string): Tx {
 }
 
 // generate metadata for signing the transaction
-function getMetaData(): SignMeta {
+export function getMetaData(): SignMeta {
   return {
     account_number: '1',
     chain_id: 'cosmos',

--- a/packages/blockchain-utils-linking/src/index.ts
+++ b/packages/blockchain-utils-linking/src/index.ts
@@ -4,3 +4,4 @@ export * from "./util";
 export * as filecoin from "./filecoin";
 export * as polkadot from "./polkadot";
 export * as eosio from "./eosio";
+export * as cosmos from "./cosmos";

--- a/packages/blockchain-utils-validation/package.json
+++ b/packages/blockchain-utils-validation/package.json
@@ -32,7 +32,8 @@
     "@smontero/eosio-signing-tools": "^0.0.6",
     "@zondax/filecoin-signing-tools": "^0.12.0",
     "caip": "^0.9.2",
-    "uint8arrays": "^2.0.5"
+    "uint8arrays": "^2.0.5",
+    "@tendermint/sig": "^0.6.0"
   },
   "devDependencies": {
     "@glif/filecoin-address": "^1.1.0-beta.15",
@@ -44,8 +45,7 @@
     "@polkadot/util-crypto": "^5.0.1",
     "@smontero/eosio-local-provider": "^0.0.3",
     "eth-sig-util": "^3.0.0",
-    "ganache-core": "^2.13.1",
-    "@tendermint/sig": "^0.6.0"
+    "ganache-core": "^2.13.1"
   },
   "gitHead": "34eeee25597b0a60def72906c26d3afd6230aaf1"
 }

--- a/packages/blockchain-utils-validation/package.json
+++ b/packages/blockchain-utils-validation/package.json
@@ -44,7 +44,8 @@
     "@polkadot/util-crypto": "^5.0.1",
     "@smontero/eosio-local-provider": "^0.0.3",
     "eth-sig-util": "^3.0.0",
-    "ganache-core": "^2.13.1"
+    "ganache-core": "^2.13.1",
+    "@tendermint/sig": "^0.6.0"
   },
   "gitHead": "34eeee25597b0a60def72906c26d3afd6230aaf1"
 }

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/cosmos.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/cosmos.test.ts
@@ -1,0 +1,36 @@
+import { signTx, Tx, SignMeta, createWalletFromMnemonic, Wallet, StdTx } from '@tendermint/sig';
+import { validateLink } from '../cosmos';
+import * as linking from "@ceramicnetwork/blockchain-utils-linking";
+
+const did = 'did:3:bafysdfwefwe';
+const mnemonic = 'test salon husband push melody usage fine ensure blade deal miss twin';
+const local_provider = createWalletFromMnemonic(mnemonic);
+
+class CosmosMockSigner {
+  readonly provider: Wallet;
+
+  constructor(local_provider: Wallet) {
+    this.provider = local_provider;
+  }
+
+  public async sign(msg : Tx, metadata : SignMeta) : Promise<StdTx>{
+    return new Promise((resolve): void => {
+      const signature = signTx(msg, metadata, this.provider);
+      resolve(signature);
+    }); 
+  }
+}
+
+describe('Blockchain: Cosmos', () => {
+  describe('validateLink', () => {
+    test('validate proof for cosmoshub3', async () => {
+      const provider = new CosmosMockSigner(local_provider);
+      const authProvider = new linking.cosmos.CosmosAuthProvider(
+        provider,
+        local_provider.address
+      );
+      const proof = await authProvider.createLink(did);
+      await expect(validateLink(proof)).resolves.toEqual(proof);
+    });
+  });
+});

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/cosmos.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/cosmos.test.ts
@@ -5,6 +5,7 @@ import * as linking from "@ceramicnetwork/blockchain-utils-linking";
 const did = 'did:3:bafysdfwefwe';
 const mnemonic = 'test salon husband push melody usage fine ensure blade deal miss twin';
 const local_provider = createWalletFromMnemonic(mnemonic);
+const chainRef = 'cosmoshub-3';
 
 class CosmosMockSigner {
   readonly provider: Wallet;
@@ -27,7 +28,8 @@ describe('Blockchain: Cosmos', () => {
       const provider = new CosmosMockSigner(local_provider);
       const authProvider = new linking.cosmos.CosmosAuthProvider(
         provider,
-        local_provider.address
+        local_provider.address,
+        chainRef
       );
       const proof = await authProvider.createLink(did);
       await expect(validateLink(proof)).resolves.toEqual(proof);

--- a/packages/blockchain-utils-validation/src/blockchains/cosmos.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/cosmos.ts
@@ -1,7 +1,7 @@
 import { AccountID } from "caip";
-import { Tx, SignMeta, verifyTx } from '@tendermint/sig';
+import { verifyTx } from '@tendermint/sig';
 import { BlockchainHandler } from "../blockchain-handler";
-import type { LinkProof } from "@ceramicnetwork/blockchain-utils-linking";
+import { LinkProof, cosmos } from "@ceramicnetwork/blockchain-utils-linking";
 import * as uint8arrays from "uint8arrays";
 
 const namespace = "cosmos";
@@ -9,45 +9,15 @@ const namespace = "cosmos";
 const stringEncode = (str: string): string => uint8arrays.toString(uint8arrays.fromString(str), 'base64pad');
 const stringDecode = (str: string): string => uint8arrays.toString(uint8arrays.fromString(str, 'base64pad'));
 
-// return data in the cosmos unsigned transaction format
-function asTransaction(address: string, message: string): Tx {
-  return {
-    fee: {
-      amount: [{ amount: '0', denom: '' }],
-      gas: '0',
-    },
-    memo: message,
-    msg: [
-      {
-        type: 'cosmos-sdk/MsgSend',
-        value: {
-          from_address: address,
-          to_address: address,
-          amount: [{ amount: '0', denom: '0' }],
-        },
-      },
-    ],
-  };
-}
-
-// generate metadata for signing the transaction
-function getMetaData(): SignMeta {
-  return {
-    account_number: '1',
-    chain_id: 'cosmos',
-    sequence: '0',
-  };
-}
-
 export async function validateLink(
   proof: LinkProof
 ): Promise<LinkProof | null> {
     const account = new AccountID(proof.account);
     const encodedMsg = stringEncode(proof.message);
-    const payload = asTransaction(account.address, encodedMsg);
+    const payload = cosmos.asTransaction(account.address, encodedMsg);
     const sigObj = JSON.parse(stringDecode(proof.signature));
-    const Tx = { ...payload, ...getMetaData(), signatures: [sigObj] };
-    const is_sig_valid = verifyTx(Tx, getMetaData());
+    const Tx = { ...payload, ...cosmos.getMetaData(), signatures: [sigObj] };
+    const is_sig_valid = verifyTx(Tx, cosmos.getMetaData());
     return is_sig_valid ? proof : null;
 }
 

--- a/packages/blockchain-utils-validation/src/blockchains/cosmos.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/cosmos.ts
@@ -1,0 +1,59 @@
+import { AccountID } from "caip";
+import { Tx, SignMeta, verifyTx } from '@tendermint/sig';
+import { BlockchainHandler } from "../blockchain-handler";
+import * as linking from "@ceramicnetwork/blockchain-utils-linking";
+import * as uint8arrays from "uint8arrays";
+
+const namespace = "cosmos";
+
+const stringEncode = (str: string): string => uint8arrays.toString(uint8arrays.fromString(str), 'base64pad');
+const stringDecode = (str: string): string => uint8arrays.toString(uint8arrays.fromString(str, 'base64pad'));
+
+// return data in the cosmos unsigned transaction format
+function asTransaction(address: string, message: string): Tx {
+  return {
+    fee: {
+      amount: [{ amount: '0', denom: '' }],
+      gas: '0',
+    },
+    memo: message,
+    msg: [
+      {
+        type: 'cosmos-sdk/MsgSend',
+        value: {
+          from_address: address,
+          to_address: address,
+          amount: [{ amount: '0', denom: '0' }],
+        },
+      },
+    ],
+  };
+}
+
+// generate metadata for signing the transaction
+function getMetaData(): SignMeta {
+  return {
+    account_number: '1',
+    chain_id: 'cosmos',
+    sequence: '0',
+  };
+}
+
+export async function validateLink(
+  proof: linking.LinkProof
+): Promise<linking.LinkProof | null> {
+    const account = new AccountID(proof.account);
+    const encodedMsg = stringEncode(proof.message);
+    const payload = asTransaction(account.address, encodedMsg);
+    const sigObj = JSON.parse(stringDecode(proof.signature));
+    const Tx = { ...payload, ...getMetaData(), signatures: [sigObj] };
+    const is_sig_valid = verifyTx(Tx, getMetaData());
+    return is_sig_valid ? proof : null;
+}
+
+const Handler: BlockchainHandler = {
+  namespace,
+  validateLink,
+};
+
+export default Handler;

--- a/packages/blockchain-utils-validation/src/blockchains/cosmos.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/cosmos.ts
@@ -40,8 +40,8 @@ function getMetaData(): SignMeta {
 }
 
 export async function validateLink(
-  proof: linking.LinkProof
-): Promise<linking.LinkProof | null> {
+  proof: LinkProof
+): Promise<LinkProof | null> {
     const account = new AccountID(proof.account);
     const encodedMsg = stringEncode(proof.message);
     const payload = asTransaction(account.address, encodedMsg);

--- a/packages/blockchain-utils-validation/src/blockchains/cosmos.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/cosmos.ts
@@ -1,7 +1,7 @@
 import { AccountID } from "caip";
 import { Tx, SignMeta, verifyTx } from '@tendermint/sig';
 import { BlockchainHandler } from "../blockchain-handler";
-import * as linking from "@ceramicnetwork/blockchain-utils-linking";
+import type { LinkProof } from "@ceramicnetwork/blockchain-utils-linking";
 import * as uint8arrays from "uint8arrays";
 
 const namespace = "cosmos";

--- a/packages/blockchain-utils-validation/src/index.ts
+++ b/packages/blockchain-utils-validation/src/index.ts
@@ -3,6 +3,7 @@ import ethereum from "./blockchains/ethereum";
 import filecoin from "./blockchains/filecoin";
 import polkadot from "./blockchains/polkadot";
 import eosio from "./blockchains/eosio";
+import cosmos from "./blockchains/cosmos";
 import { AccountID } from "caip";
 
 const handlers = {
@@ -10,6 +11,7 @@ const handlers = {
   [filecoin.namespace]: filecoin,
   [polkadot.namespace]: polkadot,
   [eosio.namespace]: eosio,
+  [cosmos.namespace]: cosmos,
 };
 
 const findDID = (did: string): string | undefined => did.match(/(did:[a-zA-Z0-9]+:[a-zA-Z0-9]+)/)?.[0]


### PR DESCRIPTION
This PR is a migration of [#44](https://github.com/ceramicnetwork/js-3id-blockchain-utils/pull/44)

**Summary** :
Add support for `cosmos:cosmoshub-3` chain to the library

**Dependencies added** :
Tendermint Signer

**Changes**:
- [X] Add cosmos linking
- [X] Add cosmos validation