### PR TITLE
fix: add missing jest pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",
     "eslint": "^6.8.0",
-    "eslint-plugin-jest": "^23.8.2"
+    "eslint-plugin-jest": "^23.8.2",
+    "jest-environment-uint8array": "^1.0.0"
   }
 }


### PR DESCRIPTION
Resolves #823 

- Adds missing required pkg `jest-environment-uint8array`