### PR TITLE
fix(core): Improve pubsub resubscribe logic

### DIFF
--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -11,8 +11,9 @@ const FAKE_DOC_ID = "kjzl6cwe1jw147dvq16zluojmraqvwdmbh61dx9e0c59i344lcrsgqfohex
 
 const ipfs = {
   pubsub: {
+    ls: jest.fn(async () => Promise.resolve(TOPIC)),
     subscribe: jest.fn(),
-    unsubscribe: jest.fn(),
+    unsubscribe: jest.fn(async () => Promise.resolve()),
     publish: jest.fn()
   },
   dag: {
@@ -61,7 +62,7 @@ describe('Dispatcher', () => {
 
   it('closes correctly', async () => {
     await dispatcher.close()
-    expect(ipfs.pubsub.unsubscribe).toHaveBeenCalledTimes(1)
+    expect(ipfs.pubsub.unsubscribe).toHaveBeenCalledTimes(2)
     expect(ipfs.pubsub.unsubscribe).toHaveBeenCalledWith(TOPIC)
   })
 


### PR DESCRIPTION
Only tries to resubscribe if we are not currently subscribed to the pubsub topic. Will unsubscribe before trying to subscribe. 

Have tested this locally by running an external ipfs node with ceramic. Closed the ipfs node, then restarted it and confirmed that I still receive pubsub messages.