### PR TITLE
fix(common): Don't serialize null state fields

### DIFF
--- a/packages/common/src/utils/doctype-utils.ts
+++ b/packages/common/src/utils/doctype-utils.ts
@@ -86,17 +86,17 @@ export class DoctypeUtils {
         const cloned = cloneDeep(state)
 
         cloned.log = cloned.log.map((entry: LogEntry) => ({ ...entry, cid: entry.cid.toString() }))
-        if (cloned.anchorStatus) {
+        if (cloned.anchorStatus != null) {
             cloned.anchorStatus = AnchorStatus[cloned.anchorStatus];
         }
-        if (cloned.anchorScheduledFor) {
+        if (cloned.anchorScheduledFor != null) {
             cloned.anchorScheduledFor = new Date(cloned.anchorScheduledFor).toLocaleString()
         }
-        if (cloned.anchorProof) {
+        if (cloned.anchorProof != null) {
             cloned.anchorProof.txHash = cloned.anchorProof.txHash.toString();
             cloned.anchorProof.root = cloned.anchorProof.root.toString();
         }
-        if (cloned.lastAnchored) {
+        if (cloned.lastAnchored != null) {
             cloned.lastAnchored = cloned.lastAnchored.toString()
         }
         return cloned

--- a/packages/core/src/store/__tests__/level-state-store.test.ts
+++ b/packages/core/src/store/__tests__/level-state-store.test.ts
@@ -1,7 +1,7 @@
 import tmp from 'tmp-promise'
 import { LevelStateStore } from "../level-state-store";
 import Level from "level-ts";
-import { AnchorStatus, Doctype, CommitType, SignatureStatus } from "@ceramicnetwork/common";
+import { AnchorStatus, Doctype, CommitType, SignatureStatus, DoctypeUtils } from "@ceramicnetwork/common";
 import CID from 'cids'
 import DocID from '@ceramicnetwork/docid'
 
@@ -68,7 +68,7 @@ test('#save and #load', async () => {
         ...state,
         log: state.log.map(e => ({ ...e, cid: e.cid.toString() }))
     }
-    expect(mockPut).toBeCalledWith(docId.toString(), storedState)
+    expect(mockPut).toBeCalledWith(docId.toString(), DoctypeUtils.serializeState(state))
 
     const retrieved = await stateStore.load(docId)
     expect(mockGet).toBeCalledWith(docId.toString())


### PR DESCRIPTION
This was causing multi-node integration tests to fail when comparing their state objects as one node would have `anchorScheduledFor: null` and the other would just be missing that field entirely