### PR TITLE
Recover anchors on startup

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -55,6 +55,7 @@
     "ipfs-core": "0.3.0",
     "jest": "^26.6.3",
     "json-schema-to-typescript": "^9.1.1",
+    "rxjs": "^6.6.3",
     "tmp-promise": "^2.0.2",
     "ts-node": "^9.0.0",
     "tsc-watch": "^4.2.9",

--- a/packages/common/src/anchor-service.ts
+++ b/packages/common/src/anchor-service.ts
@@ -1,43 +1,80 @@
 import CID from "cids";
+import type { Observable } from "rxjs";
+import { AnchorProof, AnchorStatus } from "./doctype";
+import { CeramicApi } from "./ceramic-api";
+import DocID from "@ceramicnetwork/docid";
 
-import { EventEmitter } from "events";
-import { AnchorProof } from "./doctype"
-import { CeramicApi } from "./ceramic-api"
+export interface AnchorServicePending {
+  readonly status: AnchorStatus.PENDING;
+  readonly docId: DocID;
+  readonly cid: CID;
+  readonly message: string;
+  readonly anchorScheduledFor: number;
+}
+
+export interface AnchorServiceProcessing {
+  readonly status: AnchorStatus.PROCESSING;
+  readonly docId: DocID;
+  readonly cid: CID;
+  readonly message: string;
+}
+
+export interface AnchorServiceAnchored {
+  readonly status: AnchorStatus.ANCHORED;
+  readonly docId: DocID;
+  readonly cid: CID;
+  readonly message: string;
+  readonly anchorRecord: CID;
+}
+
+export interface AnchorServiceFailed {
+  readonly status: AnchorStatus.FAILED;
+  readonly docId: DocID;
+  readonly cid: CID;
+  readonly message: string;
+}
+
+/**
+ * Describes anchor service response
+ */
+export type AnchorServiceResponse =
+  | AnchorServicePending
+  | AnchorServiceProcessing
+  | AnchorServiceAnchored
+  | AnchorServiceFailed;
 
 /**
  * Describes anchoring service behavior
  */
-export abstract class AnchorService extends EventEmitter {
+export abstract class AnchorService {
+  /**
+   * Performs whatever initialization work is required by the specific anchor service implementation
+   */
+  abstract init(): Promise<void>;
 
-    /**
-     * Performs whatever initialization work is required by the specific anchor service implementation
-     */
-    abstract init(): Promise<void>;
+  /**
+   * Set Ceramic API instance
+   *
+   * @param ceramic - Ceramic API used for various purposes
+   */
+  abstract set ceramic(ceramic: CeramicApi);
 
-    /**
-     * Set Ceramic API instance
-     *
-     * @param ceramic - Ceramic API used for various purposes
-     */
-    abstract set ceramic(ceramic: CeramicApi);
+  /**
+   * Request anchor commit on blockchain
+   * @param docId - Document ID
+   * @param tip - CID tip
+   */
+  abstract requestAnchor(docId: DocID, tip: CID): Observable<AnchorServiceResponse>;
 
-    /**
-     * Request anchor commit on blockchain
-     * @param docId - Document ID
-     * @param tip - CID tip
-     */
-    abstract requestAnchor(docId: string, tip: CID): Promise<void>;
+  /**
+   * Validate anchor proof commit
+   * @param anchorProof - Proof of blockchain inclusion
+   */
+  abstract validateChainInclusion(anchorProof: AnchorProof): Promise<void>;
 
-    /**
-     * Validate anchor proof commit
-     * @param anchorProof - Proof of blockchain inclusion
-     */
-    abstract validateChainInclusion(anchorProof: AnchorProof): Promise<void>;
-
-    /**
-     * @returns An array of the CAIP-2 chain IDs of the blockchains that are supported by this
-     * anchor service.
-     */
-    abstract getSupportedChains(): Promise<Array<string>>;
-
+  /**
+   * @returns An array of the CAIP-2 chain IDs of the blockchains that are supported by this
+   * anchor service.
+   */
+  abstract getSupportedChains(): Promise<Array<string>>;
 }

--- a/packages/common/src/anchor-service.ts
+++ b/packages/common/src/anchor-service.ts
@@ -46,35 +46,35 @@ export type AnchorServiceResponse =
 /**
  * Describes anchoring service behavior
  */
-export abstract class AnchorService {
+export interface AnchorService {
   /**
    * Performs whatever initialization work is required by the specific anchor service implementation
    */
-  abstract init(): Promise<void>;
+  init(): Promise<void>;
 
   /**
    * Set Ceramic API instance
    *
    * @param ceramic - Ceramic API used for various purposes
    */
-  abstract set ceramic(ceramic: CeramicApi);
+  ceramic: CeramicApi;
 
   /**
    * Request anchor commit on blockchain
    * @param docId - Document ID
    * @param tip - CID tip
    */
-  abstract requestAnchor(docId: DocID, tip: CID): Observable<AnchorServiceResponse>;
+  requestAnchor(docId: DocID, tip: CID): Observable<AnchorServiceResponse>;
 
   /**
    * Validate anchor proof commit
    * @param anchorProof - Proof of blockchain inclusion
    */
-  abstract validateChainInclusion(anchorProof: AnchorProof): Promise<void>;
+  validateChainInclusion(anchorProof: AnchorProof): Promise<void>;
 
   /**
    * @returns An array of the CAIP-2 chain IDs of the blockchains that are supported by this
    * anchor service.
    */
-  abstract getSupportedChains(): Promise<Array<string>>;
+  getSupportedChains(): Promise<Array<string>>;
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -6,6 +6,7 @@ export * from './utils/doctype-utils'
 export * from './logger-provider'
 export * from './pinning'
 export * from './doc-cache'
+export * from './unreachable-case-error'
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore

--- a/packages/common/src/unreachable-case-error.ts
+++ b/packages/common/src/unreachable-case-error.ts
@@ -1,0 +1,8 @@
+/**
+ * Ensure exhaustive matching for variants.
+ */
+export class UnreachableCaseError extends Error {
+  constructor(variant: never, message: string) {
+    super(`Unhandled ${variant}: ${message}`);
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,7 @@
     "lodash.clonedeep": "^4.5.0",
     "multihashes": "^3.1.2",
     "p-queue": "^6.6.1",
+    "rxjs": "^6.6.3",
     "uint8arrays": "^2.0.5"
   },
   "devDependencies": {

--- a/packages/core/src/__tests__/ceramic-anchor.test.ts
+++ b/packages/core/src/__tests__/ceramic-anchor.test.ts
@@ -35,6 +35,7 @@ const createCeramic = async (ipfs: IpfsApi, anchorManual: boolean): Promise<Cera
   const ceramic = await Ceramic.create(ipfs, {
     pinsetDirectory: await tmp.tmpName(),
     anchorOnRequest: !anchorManual,
+    restoreDocuments: false,
     pubsubTopic: "/ceramic/inmemory/test" // necessary so Ceramic instances can talk to each other
   })
   const provider = new Ed25519Provider(seed)

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -87,6 +87,7 @@ describe('Ceramic API', () => {
 
   const createCeramic = async (c: CeramicConfig = {}): Promise<Ceramic> => {
     c.anchorOnRequest = false
+    c.restoreDocuments = false
     const ceramic = await Ceramic.create(ipfs, c)
 
     const provider = new Ed25519Provider(seed)

--- a/packages/core/src/__tests__/ceramic-recover-documents.test.ts
+++ b/packages/core/src/__tests__/ceramic-recover-documents.test.ts
@@ -1,0 +1,154 @@
+import IPFS from "ipfs-core";
+import Ceramic from "../ceramic";
+import { Ed25519Provider } from "key-did-provider-ed25519";
+import tmp from "tmp-promise";
+import getPort from "get-port";
+import { DoctypeUtils, DocState, Doctype, IpfsApi, AnchorStatus } from "@ceramicnetwork/common";
+
+import dagJose from "dag-jose";
+import basicsImport from "multiformats/cjs/src/basics-import.js";
+import legacy from "multiformats/cjs/src/legacy.js";
+import * as u8a from "uint8arrays";
+
+const PUBSUB_TOPIC = "/ceramic/inmemory/test";
+const SEED = u8a.fromString("6e34b2e1a9624113d81ece8a8a22e6e97f0e145c25c1d4d2d0e62753b4060c83", "base16");
+
+/**
+ * Create an IPFS instance
+ * @param overrideConfig - IPFS config for override
+ */
+const createIPFS = (overrideConfig: Record<string, unknown> = {}): Promise<any> => {
+    basicsImport.multicodec.add(dagJose);
+    const format = legacy(basicsImport, dagJose.name);
+
+    const config = {
+        ipld: { formats: [format] },
+    };
+
+    Object.assign(config, overrideConfig);
+    return IPFS.create(config);
+};
+
+const expectEqualStates = (state1: DocState, state2: DocState): void => {
+    expect(DoctypeUtils.serializeState(state1)).toEqual(DoctypeUtils.serializeState(state2));
+};
+
+const anchor = async (ceramic: Ceramic): Promise<void> => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    await ceramic.context.anchorService.anchor();
+};
+
+const syncDoc = async (doctype: Doctype): Promise<void> => {
+    await new Promise<void>((resolve) => {
+        doctype.on("change", () => {
+            resolve();
+        });
+    });
+};
+
+async function createCeramic(ipfs: IpfsApi, pinsetDirectory: string) {
+    const ceramic = await Ceramic.create(ipfs, {
+        pinsetDirectory: pinsetDirectory,
+        anchorOnRequest: false,
+        pubsubTopic: PUBSUB_TOPIC, // necessary so Ceramic instances can talk to each other
+    });
+    const provider = new Ed25519Provider(SEED);
+    await ceramic.setDIDProvider(provider);
+    return ceramic;
+}
+
+jest.setTimeout(60000);
+let ipfs1: IpfsApi;
+let ipfs2: IpfsApi;
+let ipfs3: IpfsApi;
+let multaddr1: string;
+let multaddr2: string;
+let multaddr3: string;
+let tmpFolder: any;
+
+const DOCTYPE_TILE = "tile";
+
+let p1Start = 4000;
+let p2Start = 4100;
+let p3Start = 4200;
+
+const pOffset = 100;
+
+let port1: number;
+let port2: number;
+let port3: number;
+
+beforeEach(async () => {
+    tmpFolder = await tmp.dir({ unsafeCleanup: true });
+
+    const buildConfig = (path: string, port: number): Record<string, unknown> => {
+        return {
+            repo: `${path}/ipfs${port}/`,
+            config: {
+                Addresses: { Swarm: [`/ip4/127.0.0.1/tcp/${port}`] },
+                Bootstrap: [],
+            },
+        };
+    };
+
+    const findPort = async (start: number, offset: number): Promise<number> => {
+        return await getPort({ port: getPort.makeRange(start + 1, start + offset) });
+    };
+
+    [port1, port2, port3] = await Promise.all([p1Start, p2Start, p3Start].map((start) => findPort(start, pOffset)));
+    [ipfs1, ipfs2, ipfs3] = await Promise.all(
+        [port1, port2, port3].map((port) => createIPFS(buildConfig(tmpFolder.path, port)))
+    );
+    [p1Start, p2Start, p3Start] = [p1Start, p2Start, p3Start].map((start) => start + pOffset);
+
+    multaddr1 = (await ipfs1.id()).addresses[0].toString();
+    multaddr2 = (await ipfs2.id()).addresses[0].toString();
+    multaddr3 = (await ipfs3.id()).addresses[0].toString();
+
+    const id1 = await ipfs1.id();
+    const id2 = await ipfs2.id();
+    const id3 = await ipfs3.id();
+    multaddr1 = id1.addresses[0].toString();
+    multaddr2 = id2.addresses[0].toString();
+    multaddr3 = id3.addresses[0].toString();
+});
+
+afterEach(async () => {
+    await ipfs1.stop(() => console.log("IPFS1 stopped"));
+    await ipfs2.stop(() => console.log("IPFS2 stopped"));
+    await ipfs3.stop(() => console.log("IPFS3 stopped"));
+
+    await tmpFolder.cleanup();
+});
+
+it("re-request anchors on #recoverDocuments", async () => {
+    const pinsetDirectory = await tmp.tmpName();
+
+    // Store
+    const ceramic1 = await createCeramic(ipfs1, pinsetDirectory);
+    const controller = ceramic1.context.did.id;
+
+    const doc1 = await ceramic1.createDocument(
+        DOCTYPE_TILE,
+        { content: { test: 456 }, metadata: { controllers: [controller], tags: ["3id"] } },
+        { anchor: true }
+    );
+    await ceramic1.pin.add(doc1.id);
+    expect(doc1.state.anchorStatus).toEqual(AnchorStatus.PENDING);
+    await ceramic1.close();
+
+    // Retrieve after being closed
+    const ceramic2 = await createCeramic(ipfs2, pinsetDirectory);
+
+    const doc2 = await ceramic2.loadDocument(doc1.id);
+    expect(doc2.state.anchorStatus).toEqual(AnchorStatus.PENDING);
+    // doc2 is exact replica of doc1
+    expectEqualStates(doc1.state, doc2.state);
+    // Now CAS anchors
+    await anchor(ceramic2);
+    await syncDoc(doc2);
+    // And the document is anchored
+    expect(doc2.state.anchorStatus).toEqual(AnchorStatus.ANCHORED);
+    await ceramic2.close();
+});

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -46,6 +46,7 @@ const createCeramic = async (ipfs: IpfsApi, anchorOnRequest = false, docCacheLim
     anchorOnRequest,
     docCacheLimit,
     cacheDocCommits: cacheDocumentCommits,
+    restoreDocuments: false,
     pubsubTopic: "/ceramic/inmemory/test" // necessary so Ceramic instances can talk to each other
   })
   const provider = new Ed25519Provider(seed)
@@ -131,7 +132,7 @@ describe('Ceramic integration', () => {
 
   it('can create Ceramic instance on default network', async () => {
     const pinsetDirectory = await tmp.tmpName()
-    const ceramic = await Ceramic.create(ipfs1, {pinsetDirectory})
+    const ceramic = await Ceramic.create(ipfs1, {pinsetDirectory, restoreDocuments: false})
     await delay(1000)
     const supportedChains = await ceramic.getSupportedChains()
     expect(supportedChains).toEqual(['inmemory:12345'])
@@ -140,7 +141,7 @@ describe('Ceramic integration', () => {
 
   it('can create Ceramic instance explicitly on inmemory network', async () => {
     const pinsetDirectory = await tmp.tmpName()
-    const ceramic = await Ceramic.create(ipfs1, { networkName: 'inmemory', pinsetDirectory })
+    const ceramic = await Ceramic.create(ipfs1, { networkName: 'inmemory', pinsetDirectory, restoreDocuments: false })
     await delay(1000)
     const supportedChains = await ceramic.getSupportedChains()
     expect(supportedChains).toEqual(['inmemory:12345'])
@@ -149,14 +150,14 @@ describe('Ceramic integration', () => {
 
   it('cannot create Ceramic instance on network not supported by our anchor service', async () => {
     const pinsetDirectory = await tmp.tmpName()
-    await expect(Ceramic.create(ipfs1, { networkName: 'local', pinsetDirectory })).rejects.toThrow(
+    await expect(Ceramic.create(ipfs1, { networkName: 'local', pinsetDirectory, restoreDocuments: false })).rejects.toThrow(
         "No usable chainId for anchoring was found.  The ceramic network 'local' supports the chains: ['eip155:1337'], but the configured anchor service 'inmemory' only supports the chains: ['inmemory:12345']")
     await delay(1000)
   })
 
   it('cannot create Ceramic instance on invalid network', async () => {
     const pinsetDirectory = await tmp.tmpName()
-    await expect(Ceramic.create(ipfs1, { networkName: 'fakenetwork', pinsetDirectory })).rejects.toThrow("Unrecognized Ceramic network name: 'fakenetwork'. Supported networks are: 'mainnet', 'testnet-clay', 'dev-unstable', 'local', 'inmemory'")
+    await expect(Ceramic.create(ipfs1, { networkName: 'fakenetwork', pinsetDirectory, restoreDocuments: false })).rejects.toThrow("Unrecognized Ceramic network name: 'fakenetwork'. Supported networks are: 'mainnet', 'testnet-clay', 'dev-unstable', 'local', 'inmemory'")
     await delay(1000)
   })
 

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -1,27 +1,30 @@
 import CID from "cids"
 import fetch from "cross-fetch"
-
 import * as uint8arrays from 'uint8arrays'
 import { decode } from "multihashes"
 import * as providers from "@ethersproject/providers"
 import { CeramicConfig } from "../../ceramic"
-
-import AnchorServiceResponse from "../anchor-service-response"
-import { AnchorService, AnchorStatus } from "@ceramicnetwork/common"
-import { AnchorProof, CeramicApi } from "@ceramicnetwork/common"
+import {
+  AnchorProof,
+  CeramicApi,
+  AnchorServiceResponse,
+  AnchorService,
+  AnchorStatus,
+} from "@ceramicnetwork/common";
+import DocID from "@ceramicnetwork/docid";
+import { Observable, interval, from, concat, of } from "rxjs";
+import { concatMap, catchError } from "rxjs/operators";
 
 /**
  * CID-docId pair
  */
 interface CidDoc {
     readonly cid: CID
-    readonly docId: string
+    readonly docId: DocID
 }
 
 const DEFAULT_POLL_TIME = 60000 // 60 seconds
 const DEFAULT_MAX_POLL_TIME = 7200000 // 2 hours
-
-const MAX_NUMBER_OF_EVENT_LISTENERS = 100 // soft limit for maximum number of listeners ~ concurrent anchoring requests
 
 const HTTP_STATUS_NOT_FOUND = 404
 
@@ -50,34 +53,30 @@ const BASE_CHAIN_ID = "eip155"
  * Ethereum anchor service that stores root CIDs on Ethereum blockchain
  */
 export default class EthereumAnchorService extends AnchorService {
+  private readonly requestsApiEndpoint: string;
+  private readonly chainIdApiEndpoint: string;
+  private readonly ethereumRpcEndpoint: string | undefined;
+  private _chainId: string;
 
-    private _ceramic: CeramicApi
-    private readonly cidToResMap: Map<CidDoc, AnchorServiceResponse>
-    private readonly requestsApiEndpoint: string
-    private readonly chainIdApiEndpoint: string
-    private _chainId: string
+  /**
+   * @param config - service configuration (polling interval, etc.)
+   */
+  constructor(config: CeramicConfig) {
+    super();
+    this.requestsApiEndpoint = config.anchorServiceUrl + "/api/v0/requests";
+    this.chainIdApiEndpoint =
+      config.anchorServiceUrl + "/api/v0/service-info/supported_chains";
+    this.ethereumRpcEndpoint = config.ethereumRpcUrl;
+  }
 
-    /**
-     * @param _config - service configuration (polling interval, etc.)
-     */
-    constructor(private _config: CeramicConfig) {
-        super()
-
-        this.cidToResMap = new Map<CidDoc, AnchorServiceResponse>()
-        this.requestsApiEndpoint = this._config.anchorServiceUrl + '/api/v0/requests'
-        this.chainIdApiEndpoint = this._config.anchorServiceUrl + '/api/v0/service-info/supported_chains'
-
-        this.setMaxListeners(MAX_NUMBER_OF_EVENT_LISTENERS)
-    }
-
-    /**
-     * Set Ceramic API instance
-     *
-     * @param ceramic - Ceramic API used for various purposes
-     */
-    set ceramic(ceramic: CeramicApi) {
-        this._ceramic = ceramic
-    }
+  /**
+   * Set Ceramic API instance
+   *
+   * @param ceramic - Ceramic API used for various purposes
+   */
+  set ceramic(ceramic: CeramicApi) {
+    // Do Nothing
+  }
 
     async init(): Promise<void> {
         // Get the chainIds supported by our anchor service
@@ -97,179 +96,216 @@ export default class EthereumAnchorService extends AnchorService {
         }
     }
 
-    /**
-     * Requests anchoring service for current tip of the document
-     * @param docId - Document ID
-     * @param tip - Tip CID of the document
-     */
-    async requestAnchor(docId: string, tip: CID): Promise<void> {
-        const cidDocPair: CidDoc = { cid: tip, docId }
-
-        // send initial request
-        await this._sendReq(cidDocPair)
-        this._poll(cidDocPair) // start polling
-    }
-
-    /**
-     * @returns An array of the CAIP-2 chain IDs of the blockchains that are supported by this
-     * anchor service.
-     */
-    async getSupportedChains(): Promise<Array<string>> {
-        return [this._chainId]
-    }
-
-    /**
-     * Send requests to an external Ceramic Anchor Service
-     * @param cidDocPair - mapping
-     * @private
-     */
-    async _sendReq(cidDocPair: CidDoc): Promise<void> {
-        const response = await fetch(this.requestsApiEndpoint, {
-            method: "POST", body: JSON.stringify({
-                docId: cidDocPair.docId, cid: cidDocPair.cid.toString()
-            }), headers: {
-                "Content-Type": "application/json"
-            }
+  /**
+   * Requests anchoring service for current tip of the document
+   * @param docId - Document ID
+   * @param tip - Tip CID of the document
+   */
+  requestAnchor(docId: DocID, tip: CID): Observable<AnchorServiceResponse> {
+    const cidDocPair: CidDoc = { cid: tip, docId };
+    return concat(
+      this.announcePending(cidDocPair),
+      this.makeRequest(cidDocPair),
+      this.poll(cidDocPair)
+    ).pipe(
+      catchError((error) =>
+        of<AnchorServiceResponse>({
+          status: AnchorStatus.FAILED,
+          docId: docId,
+          cid: tip,
+          message: error.message,
         })
+      )
+    );
+  }
 
-        if (!response.ok) {
-            this.emit(cidDocPair.docId, {
-                cid: cidDocPair.cid,
-                status: 'FAILED',
-                message: `Failed to send request. Status ${response.statusText}`
-            })
-            return
+  /**
+   * @returns An array of the CAIP-2 chain IDs of the blockchains that are supported by this
+   * anchor service.
+   */
+  async getSupportedChains(): Promise<Array<string>> {
+    return [this._chainId];
+  }
+
+  private announcePending(cidDoc: CidDoc): Observable<AnchorServiceResponse> {
+    return of({
+      status: AnchorStatus.PENDING,
+      docId: cidDoc.docId,
+      cid: cidDoc.cid,
+      message: "Sending anchoring request",
+      anchorScheduledFor: null,
+    });
+  }
+
+  /**
+   * Send requests to an external Ceramic Anchor Service
+   * @param cidDocPair - mapping
+   * @private
+   */
+  private makeRequest(cidDocPair: CidDoc): Observable<AnchorServiceResponse> {
+    return from(
+      fetch(this.requestsApiEndpoint, {
+        method: "POST",
+        body: JSON.stringify({
+          docId: cidDocPair.docId.toString(),
+          cid: cidDocPair.cid.toString(),
+        }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+    ).pipe(
+      concatMap(async (response) => {
+        if (response.ok) {
+          const json = await response.json();
+          return this.parseResponse(cidDocPair, json);
+        } else {
+          throw new Error(
+            `Failed to send request. Status ${response.statusText}`
+          );
         }
-        const json = await response.json()
+      })
+    );
+  }
 
-        const res = { cid: cidDocPair.cid, status: json.status, message: json.message, anchorScheduledFor: json.scheduledAt }
-        this.cidToResMap.set(cidDocPair, res)
-        this.emit(cidDocPair.docId, res)
+  /**
+   * Start polling for CidDocPair mapping
+   * @param cidDoc - CID to Doc mapping
+   * @param pollTime - Single poll timeout
+   * @param maxPollingTime - Global timeout for max polling in milliseconds
+   * @private
+   */
+  private poll(
+    cidDoc: CidDoc,
+    pollTime?: number,
+    maxPollingTime?: number
+  ): Observable<AnchorServiceResponse> {
+    const started = new Date().getTime();
+    const maxTime = started + (maxPollingTime | DEFAULT_MAX_POLL_TIME);
+    const requestUrl = [this.requestsApiEndpoint, cidDoc.cid.toString()].join(
+      "/"
+    );
+
+    return interval(DEFAULT_POLL_TIME).pipe(
+      concatMap(async () => {
+        const now = new Date().getTime();
+        if (now > maxTime) {
+          throw new Error("Exceeded max timeout");
+        } else {
+          const response = await fetch(requestUrl);
+          if (response.status === HTTP_STATUS_NOT_FOUND) {
+            throw new Error("Request not found");
+          } else {
+            const json = await response.json();
+            return this.parseResponse(cidDoc, json);
+          }
+        }
+      })
+    );
+  }
+
+  /**
+   * Validate anchor proof on the chain
+   * @param anchorProof - Anchor proof instance
+   */
+  async validateChainInclusion(anchorProof: AnchorProof): Promise<void> {
+    const decoded = decode(anchorProof.txHash.multihash);
+    const txHash = uint8arrays.toString(decoded.digest, "base16");
+
+    // determine network based on a chain ID
+    const provider: providers.BaseProvider = this._getEthProvider(
+      anchorProof.chainId
+    );
+
+    const transaction = await provider.getTransaction("0x" + txHash);
+    const block = await provider.getBlock(transaction.blockHash);
+
+    const txValueHexNumber = parseInt(transaction.data, 16);
+    const rootValueHexNumber = parseInt(
+      "0x" + anchorProof.root.toBaseEncodedString("base16"),
+      16
+    );
+
+    if (txValueHexNumber !== rootValueHexNumber) {
+      throw new Error(
+        `The root CID ${anchorProof.root.toString()} is not in the transaction`
+      );
     }
 
-    /**
-     * Start polling for CidDocPair mapping
-     * @param cidDoc - CID to Doc mapping
-     * @param pollTime - Single poll timeout
-     * @param maxPollingTime - Global timeout for max polling in milliseconds
-     * @private
-     */
-    async _poll(cidDoc: CidDoc, pollTime?: number, maxPollingTime?: number): Promise<void> {
-        const started = new Date().getTime()
-        const maxTime = started + (maxPollingTime | DEFAULT_MAX_POLL_TIME)
-
-        let poll = true
-        while (poll) {
-            if (started > maxTime) {
-                const failedRes = { cid: cidDoc.cid, status: 'FAILED', message: 'exceeded max timeout' }
-                this.cidToResMap.set(cidDoc, failedRes)
-
-                this.emit(cidDoc.docId, failedRes)
-                return // exit loop
-            }
-
-            await new Promise(resolve => setTimeout(resolve, DEFAULT_POLL_TIME))
-
-            try {
-                const requestUrl = [this.requestsApiEndpoint, cidDoc.cid.toString()].join('/')
-                const response = await fetch(requestUrl)
-
-                if (response.status === HTTP_STATUS_NOT_FOUND) {
-                    // the anchor request does not exist, fail and stop polling
-                    // TODO
-                    this.emit(cidDoc.docId, {
-                        cid: cidDoc.cid, status: AnchorStatus[AnchorStatus.FAILED], message: 'Request not found.'
-                    })
-                    poll = false
-                    break
-                }
-
-                const json = await response.json()
-                switch (json.status) {
-                    case "PENDING": {
-                        // just log
-                        break
-                    }
-                    case "PROCESSING": {
-                        this.emit(cidDoc.docId, { cid: cidDoc.cid, status: json.status, message: json.message })
-                        break
-                    }
-                    case "FAILED": {
-                        this.emit(cidDoc.docId, { cid: cidDoc.cid, status: json.status, message: json.message })
-                        poll = false
-                        break
-                    }
-                    case "COMPLETED": {
-                        const { anchorRecord } = json
-                        const anchorRecordCid = new CID(anchorRecord.cid.toString())
-
-                        this.emit(cidDoc.docId, {
-                            cid: cidDoc.cid, status: json.status, message: json.message, anchorRecord: anchorRecordCid
-                        })
-                        poll = false
-                        break
-                    }
-                }
-            } catch (e) {
-                // just log
-            }
-        }
+    if (anchorProof.blockNumber !== transaction.blockNumber) {
+      throw new Error(`Block numbers are not the same`);
     }
 
-    /**
-     * Validate anchor proof on the chain
-     * @param anchorProof - Anchor proof instance
-     */
-    async validateChainInclusion(anchorProof: AnchorProof): Promise<void> {
-        const decoded = decode(anchorProof.txHash.multihash)
-        const txHash = uint8arrays.toString(decoded.digest, 'base16')
+    if (anchorProof.blockTimestamp !== block.timestamp) {
+      throw new Error(`Block timestamps are not the same`);
+    }
+  }
 
-        // determine network based on a chain ID
-        const provider: providers.BaseProvider = this._getEthProvider(anchorProof.chainId)
-
-        const transaction = await provider.getTransaction('0x' + txHash)
-        const block = await provider.getBlock(transaction.blockHash)
-
-        const txValueHexNumber = parseInt(transaction.data, 16)
-        const rootValueHexNumber = parseInt('0x' + anchorProof.root.toBaseEncodedString('base16'), 16)
-
-        if (txValueHexNumber !== rootValueHexNumber) {
-            throw new Error(`The root CID ${anchorProof.root.toString()} is not in the transaction`)
-        }
-
-        if (anchorProof.blockNumber !== transaction.blockNumber) {
-            throw new Error(`Block numbers are not the same`)
-        }
-
-        if (anchorProof.blockTimestamp !== block.timestamp) {
-            throw new Error(`Block timestamps are not the same`)
-        }
+  /**
+   * Gets Ethereum provider based on chain ID
+   * @param chain - CAIP-2 Chain ID
+   * @private
+   */
+  private _getEthProvider(chain: string): providers.BaseProvider {
+    if (!chain.startsWith("eip155")) {
+      throw new Error(
+        `Unsupported chainId '${chain}' - must be eip155 namespace`
+      );
     }
 
-    /**
-     * Gets Ethereum provider based on chain ID
-     * @param chain - CAIP-2 Chain ID
-     * @private
-     */
-    private _getEthProvider(chain: string): providers.BaseProvider {
-        if (!chain.startsWith('eip155')) {
-            throw new Error(`Unsupported chainId '${chain}' - must be eip155 namespace`)
-        }
-
-        if (this._chainId != chain) {
-            throw new Error(`Unsupported chainId '${chain}'. Configured anchor service only supports '${this._chainId}'`)
-        }
-
-        if (this._config.ethereumRpcUrl) {
-            return new providers.JsonRpcProvider(this._config.ethereumRpcUrl)
-        }
-
-        const ethNetwork: EthNetwork = ETH_CHAIN_ID_MAPPINGS[chain]
-        if (ethNetwork == null) {
-            throw new Error(`No ethereum provider available for chainId ${chain}`)
-        }
-
-        return providers.getDefaultProvider(ethNetwork.network)
+    if (this._chainId != chain) {
+      throw new Error(
+        `Unsupported chainId '${chain}'. Configured anchor service only supports '${this._chainId}'`
+      );
     }
 
+    if (this.ethereumRpcEndpoint) {
+      return new providers.JsonRpcProvider(this.ethereumRpcEndpoint);
+    }
+
+    const ethNetwork: EthNetwork = ETH_CHAIN_ID_MAPPINGS[chain];
+    if (ethNetwork == null) {
+      throw new Error(`No ethereum provider available for chainId ${chain}`);
+    }
+
+    return providers.getDefaultProvider(ethNetwork.network);
+  }
+
+  /**
+   * Parse JSON that CAS returns.
+   */
+  private parseResponse(cidDoc: CidDoc, json: any): AnchorServiceResponse {
+    switch (json.status) {
+      case "PENDING":
+        return {
+          status: AnchorStatus.PENDING,
+          docId: cidDoc.docId,
+          cid: cidDoc.cid,
+          message: json.message,
+          anchorScheduledFor: json.scheduledAt,
+        };
+      case "PROCESSING":
+        return {
+          status: AnchorStatus.PROCESSING,
+          docId: cidDoc.docId,
+          cid: cidDoc.cid,
+          message: json.message,
+        };
+      case "FAILED":
+        throw new Error(json.message);
+      case "COMPLETED": {
+        const { anchorRecord } = json;
+        const anchorRecordCid = new CID(anchorRecord.cid.toString());
+        return {
+          status: AnchorStatus.ANCHORED,
+          docId: cidDoc.docId,
+          cid: cidDoc.cid,
+          message: json.message,
+          anchorRecord: anchorRecordCid,
+        };
+      }
+      default:
+        throw new Error(`Unexpected status: ${json.status}`);
+    }
+  }
 }

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -103,9 +103,9 @@ export default class EthereumAnchorService implements AnchorService {
   requestAnchor(docId: DocID, tip: CID): Observable<AnchorServiceResponse> {
     const cidDocPair: CidDoc = { cid: tip, docId };
     return concat(
-      this.announcePending(cidDocPair),
-      this.makeRequest(cidDocPair),
-      this.poll(cidDocPair)
+      this._announcePending(cidDocPair),
+      this._makeRequest(cidDocPair),
+      this._poll(cidDocPair)
     ).pipe(
       catchError((error) =>
         of<AnchorServiceResponse>({
@@ -126,7 +126,7 @@ export default class EthereumAnchorService implements AnchorService {
     return [this._chainId];
   }
 
-  private announcePending(cidDoc: CidDoc): Observable<AnchorServiceResponse> {
+  private _announcePending(cidDoc: CidDoc): Observable<AnchorServiceResponse> {
     return of({
       status: AnchorStatus.PENDING,
       docId: cidDoc.docId,
@@ -141,7 +141,7 @@ export default class EthereumAnchorService implements AnchorService {
    * @param cidDocPair - mapping
    * @private
    */
-  private makeRequest(cidDocPair: CidDoc): Observable<AnchorServiceResponse> {
+  private _makeRequest(cidDocPair: CidDoc): Observable<AnchorServiceResponse> {
     return from(
       fetch(this.requestsApiEndpoint, {
         method: "POST",
@@ -174,7 +174,7 @@ export default class EthereumAnchorService implements AnchorService {
    * @param maxPollingTime - Global timeout for max polling in milliseconds
    * @private
    */
-  private poll(
+  private _poll(
     cidDoc: CidDoc,
     pollTime?: number,
     maxPollingTime?: number

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -52,7 +52,7 @@ const BASE_CHAIN_ID = "eip155"
 /**
  * Ethereum anchor service that stores root CIDs on Ethereum blockchain
  */
-export default class EthereumAnchorService extends AnchorService {
+export default class EthereumAnchorService implements AnchorService {
   private readonly requestsApiEndpoint: string;
   private readonly chainIdApiEndpoint: string;
   private readonly ethereumRpcEndpoint: string | undefined;
@@ -62,7 +62,6 @@ export default class EthereumAnchorService extends AnchorService {
    * @param config - service configuration (polling interval, etc.)
    */
   constructor(config: CeramicConfig) {
-    super();
     this.requestsApiEndpoint = config.anchorServiceUrl + "/api/v0/requests";
     this.chainIdApiEndpoint =
       config.anchorServiceUrl + "/api/v0/service-info/supported_chains";

--- a/packages/core/src/anchor/memory/in-memory-anchor-service.ts
+++ b/packages/core/src/anchor/memory/in-memory-anchor-service.ts
@@ -1,32 +1,36 @@
-import CID from 'cids'
-
-import * as didJwt from 'did-jwt'
-import { AnchorProof, AnchorService, CeramicApi, DoctypeUtils } from "@ceramicnetwork/common"
-
-import type Dispatcher from '../../dispatcher'
-import Ceramic from "../../ceramic"
+import CID from "cids";
 import * as uint8arrays from "uint8arrays";
+import { Observable, Subject, concat, of } from "rxjs";
+import { filter } from "rxjs/operators";
+import * as didJwt from "did-jwt";
+import {
+  AnchorProof,
+  AnchorService,
+  AnchorStatus,
+  CeramicApi,
+  DoctypeUtils,
+  AnchorServiceResponse,
+} from "@ceramicnetwork/common";
 
-const DID_MATCHER = '^(did:([a-zA-Z0-9_]+):([a-zA-Z0-9_.-]+(:[a-zA-Z0-9_.-]+)*)((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(/[^#?]*)?)([?][^#]*)?(#.*)?';
-const CHAIN_ID = 'inmemory:12345'
+import type Dispatcher from "../../dispatcher";
+import Ceramic from "../../ceramic";
+import DocID from "@ceramicnetwork/docid";
+import PQueue from "p-queue";
+
+const DID_MATCHER =
+  "^(did:([a-zA-Z0-9_]+):([a-zA-Z0-9_.-]+(:[a-zA-Z0-9_.-]+)*)((;[a-zA-Z0-9_.:%-]+=[a-zA-Z0-9_.:%-]*)*)(/[^#?]*)?)([?][^#]*)?(#.*)?";
+const CHAIN_ID = "inmemory:12345";
 
 class Candidate {
-  public cid: CID
-  public did?: string
-  public docId: string
-
-  public readonly log: CID[]
-
-  constructor(cid: CID, docId?: string, log?: CID[]) {
-    this.cid = cid
-    this.docId = docId
-    this.log = log
-  }
+  constructor(
+    readonly cid: CID,
+    readonly docId?: DocID,
+    readonly log?: CID[]
+  ) {}
 
   get key(): string {
-    return this.docId + this.did
+    return this.docId.toString();
   }
-
 }
 
 interface InMemoryAnchorConfig {
@@ -35,31 +39,36 @@ interface InMemoryAnchorConfig {
   verifySignatures?: boolean;
 }
 
+const SAMPLE_ETH_TX_HASH =
+  "bagjqcgzaday6dzalvmy5ady2m5a5legq5zrbsnlxfc2bfxej532ds7htpova";
+
+// Sequential execution of requestAnchor commands
+const requestAnchorQueue = new PQueue({ concurrency: 1 });
+
 /**
  * In-memory anchor service - used locally, not meant to be used in production code
  */
 class InMemoryAnchorService extends AnchorService {
-  private _ceramic: Ceramic
-  private _dispatcher: Dispatcher
+  #ceramic: Ceramic;
+  #dispatcher: Dispatcher;
 
-  private readonly _anchorDelay: number
-  private readonly _anchorOnRequest: boolean
-  private readonly _verifySignatures: boolean
+  readonly #anchorDelay: number;
+  readonly #anchorOnRequest: boolean;
+  readonly #verifySignatures: boolean;
+  readonly #feed: Subject<AnchorServiceResponse> = new Subject();
 
-  private _queue: Candidate[] = []
+  #queue: Candidate[] = [];
 
-  private SAMPLE_ETH_TX_HASH = 'bagjqcgzaday6dzalvmy5ady2m5a5legq5zrbsnlxfc2bfxej532ds7htpova'
+  constructor(_config: InMemoryAnchorConfig) {
+    super();
 
-  constructor (private _config: InMemoryAnchorConfig) {
-    super()
-
-    this._anchorDelay = _config?.anchorDelay ?? 0
-    this._anchorOnRequest = _config?.anchorOnRequest ?? true
-    this._verifySignatures = _config?.verifySignatures ?? true
+    this.#anchorDelay = _config?.anchorDelay ?? 0;
+    this.#anchorOnRequest = _config?.anchorOnRequest ?? true;
+    this.#verifySignatures = _config?.verifySignatures ?? true;
   }
 
   async init(): Promise<void> {
-    return
+    return;
   }
 
   /**
@@ -67,102 +76,108 @@ class InMemoryAnchorService extends AnchorService {
    * anchor service
    */
   async getSupportedChains(): Promise<Array<string>> {
-    return [CHAIN_ID]
+    return [CHAIN_ID];
   }
 
   /**
    * Anchor requests
    */
   async anchor(): Promise<void> {
-    const candidates = await this._findCandidates()
+    const candidates = await this._findCandidates();
     for (const candidate of candidates) {
-      await this._process(candidate)
+      await this._process(candidate);
     }
 
-    this._queue = [] // reset
+    this.#queue = []; // reset
   }
 
-
-    /**
+  /**
    * Filter candidates by document and DIDs
    * @private
    */
   async _findCandidates(): Promise<Candidate[]> {
-    const groupedCandidates = await this._groupCandidatesByDocId(this._queue)
-    return await this._selectValidCandidates(groupedCandidates)
+    const groupedCandidates = await this._groupCandidatesByDocId(this.#queue);
+    return this._selectValidCandidates(groupedCandidates);
   }
 
-  async _groupCandidatesByDocId(candidates: Candidate[]): Promise<Record<string, Candidate[]>> {
+  async _groupCandidatesByDocId(
+    candidates: Candidate[]
+  ): Promise<Record<string, Candidate[]>> {
     const result: Record<string, Candidate[]> = {};
+    await Promise.all(
+      candidates.map(async (req) => {
+        try {
+          const record = await this.#dispatcher.retrieveCommit(req.cid);
+          if (this.#verifySignatures) {
+            await this.verifySignedCommit(record);
+          }
 
-    let req: Candidate = null
-    for (let index = 0; index < this._queue.length; index++) {
-      try {
-        req = this._queue[index]
-        const record = (await this._ceramic.ipfs.dag.get(req.cid)).value
-        if (this._verifySignatures) {
-          await this.verifySignedCommit(record)
+          const log = await this._loadCommitHistory(req.cid);
+          const candidate = new Candidate(req.cid, req.docId, log);
+
+          if (!result[candidate.key]) {
+            result[candidate.key] = [];
+          }
+          result[candidate.key].push(candidate);
+        } catch (e) {
+          console.error(e.message);
+          this._failCandidate(req, e.message);
         }
-
-        const log = await this._loadCommitHistory(req.cid)
-        const candidate = new Candidate(new CID(req.cid), req.docId, log)
-
-        if (!result[candidate.key]) {
-          result[candidate.key] = []
-        }
-        result[candidate.key].push(candidate)
-      } catch (e) {
-        console.error(e.message)
-        await this._failCandidate(req, e.message)
-      }
-    }
-
-    return result
+      })
+    );
+    return result;
   }
 
-  async _selectValidCandidates(groupedCandidates: Record<string, Candidate[]>): Promise<Candidate[]> {
-    const result: Candidate[] = []
+  _selectValidCandidates(
+    groupedCandidates: Record<string, Candidate[]>
+  ): Candidate[] {
+    const result: Candidate[] = [];
     for (const compositeKey of Object.keys(groupedCandidates)) {
-      const candidates: Candidate[] = groupedCandidates[compositeKey]
+      const candidates = groupedCandidates[compositeKey];
 
       // When there are multiple valid candidate tips to anchor for the same docId, pick the one
       // with the largest log
-      let selected: Candidate = null
+      let selected: Candidate = null;
       for (const c of candidates) {
         if (selected == null) {
-          selected = c
-          continue
+          selected = c;
+          continue;
         }
 
         if (c.log.length < selected.log.length) {
-          await this._failCandidate(c)
+          this._failCandidate(c);
         } else if (c.log.length > selected.log.length) {
-          await this._failCandidate(selected)
-          selected = c
+          this._failCandidate(selected);
+          selected = c;
         } else {
           // If there are two conflicting candidates with the same log length, we must choose
           // which to anchor deterministically. We use the same arbitrary but deterministic strategy
           // that js-ceramic conflict resolution does: choosing the record whose CID is smaller
           if (c.cid.bytes < selected.cid.bytes) {
-            await this._failCandidate(selected)
-            selected = c
+            this._failCandidate(selected);
+            selected = c;
           } else {
-            await this._failCandidate(c)
+            this._failCandidate(c);
           }
         }
       }
 
-      result.push(selected)
+      result.push(selected);
     }
 
-    return result
+    return result;
   }
 
-  async _failCandidate(candidate: Candidate, message?: string): Promise<void> {
+  _failCandidate(candidate: Candidate, message?: string): void {
     if (!message) {
-      message = `Rejecting request to anchor CID ${candidate.cid.toString()} for document ${candidate.docId.toString()} because there is a better CID to anchor for the same document`
+      message = `Rejecting request to anchor CID ${candidate.cid.toString()} for document ${candidate.docId.toString()} because there is a better CID to anchor for the same document`;
     }
-    this.emit(candidate.docId, { cid: candidate.cid, status: 'FAILED', message: message })
+    this.#feed.next({
+      status: AnchorStatus.FAILED,
+      docId: candidate.docId,
+      cid: candidate.cid,
+      message,
+    });
   }
 
   /**
@@ -172,29 +187,33 @@ class InMemoryAnchorService extends AnchorService {
    * @private
    */
   async _loadCommitHistory(commitId: CID): Promise<CID[]> {
-    const history: CID[] = []
+    const history: CID[] = [];
 
-    let currentCommitId = commitId
-    for (; ;) {
-      const currentCommit = (await this._ceramic.ipfs.dag.get(currentCommitId)).value
+    let currentCommitId = commitId;
+    for (;;) {
+      const currentCommit = await this.#dispatcher.retrieveCommit(
+        currentCommitId
+      );
       if (DoctypeUtils.isAnchorCommit(currentCommit)) {
-        return history
+        return history;
       }
 
-      let prevCommitId: CID
+      let prevCommitId: CID;
       if (DoctypeUtils.isSignedCommit(currentCommit)) {
-        const payload = (await this._ceramic.ipfs.dag.get(currentCommit.link)).value
-        prevCommitId = payload.prev
+        const payload = await this.#dispatcher.retrieveCommit(
+          currentCommit.link
+        );
+        prevCommitId = payload.prev;
       } else {
-        prevCommitId = currentCommit.prev
+        prevCommitId = currentCommit.prev;
       }
 
       if (prevCommitId == null) {
-        return history
+        return history;
       }
 
-      history.push(prevCommitId)
-      currentCommitId = prevCommitId
+      history.push(prevCommitId);
+      currentCommitId = prevCommitId;
     }
   }
 
@@ -204,22 +223,46 @@ class InMemoryAnchorService extends AnchorService {
    * @param ceramic - Ceramic API used for various purposes
    */
   set ceramic(ceramic: CeramicApi) {
-    this._ceramic = ceramic as unknown as Ceramic
-    this._dispatcher = this._ceramic.dispatcher
+    this.#ceramic = (ceramic as unknown) as Ceramic;
+    this.#dispatcher = this.#ceramic.dispatcher;
   }
 
   /**
    * Send request to the anchoring service
    * @param docId - Document ID
-   * @param cid - Commit CID
+   * @param tip - Commit CID
    */
-  async requestAnchor(docId: string, cid: CID): Promise<void> {
-    const candidate: Candidate = new Candidate(cid, docId)
-
-    if (this._anchorOnRequest) {
-      await this._process(candidate)
+  requestAnchor(docId: DocID, tip: CID): Observable<AnchorServiceResponse> {
+    const candidate = new Candidate(tip, docId);
+    const feed$ = this.#feed.pipe(
+      filter((asr) => asr.docId.equals(docId) && asr.cid.equals(tip))
+    );
+    if (this.#anchorOnRequest) {
+      requestAnchorQueue
+        .add(() => {
+          return this._process(candidate);
+        })
+        .catch((error) => {
+          this.#feed.next({
+            status: AnchorStatus.FAILED,
+            docId: candidate.docId,
+            cid: candidate.cid,
+            message: error.message,
+          });
+        });
+      return feed$;
     } else {
-      this._queue.push(candidate)
+      this.#queue.push(candidate);
+      return concat(
+        of<AnchorServiceResponse>({
+          status: AnchorStatus.PENDING,
+          docId: docId,
+          cid: tip,
+          message: "Sending anchoring request",
+          anchorScheduledFor: null,
+        }),
+        feed$
+      );
     }
   }
 
@@ -233,18 +276,24 @@ class InMemoryAnchorService extends AnchorService {
       chainId: CHAIN_ID,
       blockNumber: Date.now(),
       blockTimestamp: Date.now(),
-      txHash: new CID(this.SAMPLE_ETH_TX_HASH),
+      txHash: new CID(SAMPLE_ETH_TX_HASH),
       root: leaf.cid,
-    }
-    const proof = await this._dispatcher.storeCommit(proofData)
-    const commit = { proof, path: '', prev: leaf.cid }
-    const cid = await this._dispatcher.storeCommit(commit)
+    };
+    const proof = await this.#dispatcher.storeCommit(proofData);
+    const commit = { proof, path: "", prev: leaf.cid };
+    const cid = await this.#dispatcher.storeCommit(commit);
 
     // add a delay
     const handle = setTimeout(() => {
-      this.emit(leaf.docId, { cid: leaf.cid, status: 'COMPLETED', message: 'CID successfully anchored.', anchorRecord: cid })
-      clearTimeout(handle)
-    }, this._anchorDelay)
+      this.#feed.next({
+        status: AnchorStatus.ANCHORED,
+        docId: leaf.docId,
+        cid: leaf.cid,
+        message: "CID successfully anchored",
+        anchorRecord: cid,
+      });
+      clearTimeout(handle);
+    }, this.#anchorDelay);
   }
 
   /**
@@ -254,24 +303,25 @@ class InMemoryAnchorService extends AnchorService {
    * @private
    */
   async verifySignedCommit(commit: Record<string, unknown>): Promise<string> {
-    const { payload, signatures } = commit
-    const { signature, protected: _protected } = signatures[0]
+    const { payload, signatures } = commit;
+    const { signature, protected: _protected } = signatures[0];
 
-    const decodedJsonString = uint8arrays.toString(uint8arrays.fromString(_protected, 'base64url'))
-    const decodedHeader = JSON.parse(decodedJsonString)
-    const { kid } = decodedHeader
+    const decodedJsonString = uint8arrays.toString(
+      uint8arrays.fromString(_protected, "base64url")
+    );
+    const decodedHeader = JSON.parse(decodedJsonString);
+    const { kid } = decodedHeader;
 
-    const didDoc = await this._ceramic.context.resolver.resolve(kid)
-    const jws = [_protected, payload, signature].join(".")
-    await didJwt.verifyJWS(jws, didDoc.publicKey)
-    return kid.match(RegExp(DID_MATCHER))[1]
+    const didDoc = await this.#ceramic.context.resolver.resolve(kid);
+    const jws = [_protected, payload, signature].join(".");
+    await didJwt.verifyJWS(jws, didDoc.publicKey);
+    return kid.match(RegExp(DID_MATCHER))[1];
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async validateChainInclusion (proof: AnchorProof): Promise<void> {
+  async validateChainInclusion(proof: AnchorProof): Promise<void> {
     // always valid
   }
-
 }
 
-export default InMemoryAnchorService
+export default InMemoryAnchorService;

--- a/packages/core/src/anchor/memory/in-memory-anchor-service.ts
+++ b/packages/core/src/anchor/memory/in-memory-anchor-service.ts
@@ -48,7 +48,7 @@ const requestAnchorQueue = new PQueue({ concurrency: 1 });
 /**
  * In-memory anchor service - used locally, not meant to be used in production code
  */
-class InMemoryAnchorService extends AnchorService {
+class InMemoryAnchorService implements AnchorService {
   #ceramic: Ceramic;
   #dispatcher: Dispatcher;
 
@@ -60,8 +60,6 @@ class InMemoryAnchorService extends AnchorService {
   #queue: Candidate[] = [];
 
   constructor(_config: InMemoryAnchorConfig) {
-    super();
-
     this.#anchorDelay = _config?.anchorDelay ?? 0;
     this.#anchorOnRequest = _config?.anchorOnRequest ?? true;
     this.#verifySignatures = _config?.verifySignatures ?? true;

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -3,7 +3,6 @@ import CID from 'cids'
 import { EventEmitter } from 'events'
 import PQueue from 'p-queue'
 import cloneDeep from 'lodash.clonedeep'
-import AnchorServiceResponse from './anchor/anchor-service-response'
 import Utils from './utils'
 import {
   AnchorProof,
@@ -20,10 +19,11 @@ import {
   RootLogger,
   Logger,
   DocStateHolder,
-  CommitType,
 } from '@ceramicnetwork/common'
 import DocID from '@ceramicnetwork/docid'
 import { PinStore } from './store/pin-store';
+import { SubscriptionSet } from "./subscription-set";
+import { concatMap } from "rxjs/operators";
 
 // DocOpts defaults for document load operations
 const DEFAULT_LOAD_DOCOPTS = {anchor: false, publish: false, sync: true}
@@ -41,6 +41,7 @@ class Document extends EventEmitter implements DocStateHolder {
 
   private _logger: Logger
   private _isProcessing: boolean
+  private readonly subscriptionSet = new SubscriptionSet();
 
   constructor (public readonly id: DocID,
                public dispatcher: Dispatcher,
@@ -261,7 +262,7 @@ class Document extends EventEmitter implements DocStateHolder {
     const publish = opts.publish ?? true
     const sync = opts.sync ?? true
     if (anchor) {
-      await this.anchor()
+      this.anchor();
     }
     if (publish) {
       await this._publishTip()
@@ -584,56 +585,55 @@ class Document extends EventEmitter implements DocStateHolder {
   /**
    * Request anchor for the latest document state
    */
-  async anchor (): Promise<void> {
+  anchor(): void {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const doc = this
     const requestTip: CID = this.tip
 
-    this._context.anchorService.on(this.id.toString(), async function listener (asr: AnchorServiceResponse) {
-      if (!asr.cid.equals(requestTip)) {
-        // This message is about a different tip for the same document
-        return
-      }
-      switch (asr.status) {
-        case 'PENDING': {
-          const state = doc._doctype.state
-          state.anchorScheduledFor = asr.anchorScheduledFor
-          doc._doctype.state = state
-          await doc._updateStateIfPinned()
-          return
-        }
-        case 'PROCESSING': {
-          const state = doc._doctype.state
-          state.anchorStatus = AnchorStatus.PROCESSING
-          doc._doctype.state = state
-          await doc._updateStateIfPinned()
-          return
-        }
-        case 'COMPLETED': {
-          doc._context.anchorService.removeListener(doc.id.toString(), listener)
-
-          await doc._handleTip(asr.anchorRecord)
-          await doc._updateStateIfPinned()
-          await doc._publishTip()
-          return
-        }
-        case 'FAILED': {
-          doc._context.anchorService.removeListener(doc.id.toString(), listener)
-          if (requestTip !== doc.tip) {
-            return
-          }
-
-          const state = doc._doctype.state
-          state.anchorStatus = AnchorStatus.FAILED
-          doc._doctype.state = state
-          return
-        }
-      }
-    })
-    await this._context.anchorService.requestAnchor(this.id.toString(), this.tip)
-    const state = this._doctype.state
-    state.anchorStatus = AnchorStatus.PENDING
-    this._doctype.state = state
+    const anchorStatus$ = this._context.anchorService.requestAnchor(this.id.baseID, this.tip);
+    const subscription = anchorStatus$
+        .pipe(
+            concatMap(async (asr) => {
+              if (!asr.cid.equals(requestTip)) {
+                // This message is about a different tip for the same document
+                return;
+              }
+              switch (asr.status) {
+                case AnchorStatus.PENDING: {
+                  const next = {
+                    ...doc._doctype.state,
+                    anchorStatus: AnchorStatus.PENDING,
+                  }
+                  if (asr.anchorScheduledFor) next.anchorScheduledFor = asr.anchorScheduledFor
+                  doc._doctype.state = next
+                  await doc._updateStateIfPinned();
+                  return;
+                }
+                case AnchorStatus.PROCESSING: {
+                  doc._doctype.state = { ...doc._doctype.state, anchorStatus: AnchorStatus.PROCESSING };
+                  await doc._updateStateIfPinned();
+                  return;
+                }
+                case AnchorStatus.ANCHORED: {
+                  await doc._handleTip(asr.anchorRecord);
+                  await doc._updateStateIfPinned();
+                  await doc._publishTip();
+                  subscription.unsubscribe();
+                  return;
+                }
+                case AnchorStatus.FAILED: {
+                  if (requestTip !== doc.tip) {
+                    return;
+                  }
+                  doc._doctype.state = { ...doc._doctype.state, anchorStatus: AnchorStatus.FAILED };
+                  subscription.unsubscribe();
+                  return;
+                }
+              }
+            })
+        )
+        .subscribe();
+    this.subscriptionSet.add(subscription);
   }
 
   /**
@@ -743,13 +743,13 @@ class Document extends EventEmitter implements DocStateHolder {
    * Gracefully closes the document instance.
    */
   async close (): Promise<void> {
+    this.subscriptionSet.close();
     this.off('update', this._update)
 
     this.dispatcher.unregister(this.id.toString())
 
     await this._applyQueue.onEmpty()
 
-    this._context.anchorService && this._context.anchorService.removeAllListeners(this.id.toString())
     await Utils.awaitCondition(() => this._isProcessing, () => false, 500)
   }
 

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -19,6 +19,7 @@ import {
   RootLogger,
   Logger,
   DocStateHolder,
+  UnreachableCaseError
 } from '@ceramicnetwork/common'
 import DocID from '@ceramicnetwork/docid'
 import { PinStore } from './store/pin-store';
@@ -629,6 +630,8 @@ class Document extends EventEmitter implements DocStateHolder {
                   subscription.unsubscribe();
                   return;
                 }
+                default:
+                  throw new UnreachableCaseError(asr, 'Unknown anchoring state')
               }
             })
         )

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -595,10 +595,6 @@ class Document extends EventEmitter implements DocStateHolder {
     const subscription = anchorStatus$
         .pipe(
             concatMap(async (asr) => {
-              if (!asr.cid.equals(requestTip)) {
-                // This message is about a different tip for the same document
-                return;
-              }
               switch (asr.status) {
                 case AnchorStatus.PENDING: {
                   const next = {

--- a/packages/core/src/subscription-set.ts
+++ b/packages/core/src/subscription-set.ts
@@ -1,0 +1,27 @@
+import { Subscription } from "rxjs";
+
+/**
+ * Track a set of active subscriptions. Unsubscribe them all at once.
+ *
+ * If a subscription gets unsubscribed, it auto-removes from the set.
+ */
+export class SubscriptionSet {
+  constructor(readonly subscriptions: Set<Subscription> = new Set()) {}
+
+  /**
+   * Start tracking a subscription, so that it is closed with others on +close+.
+   */
+  add(subscription: Subscription) {
+    subscription.add(() => {
+      this.subscriptions.delete(subscription);
+    });
+    this.subscriptions.add(subscription);
+  }
+
+  /**
+   * Unsubscribe all the subscriptions.
+   */
+  close() {
+    this.subscriptions.forEach((s) => s.unsubscribe());
+  }
+}


### PR DESCRIPTION
BTW, shaves 5-20 ms from `POST /documents` request as tested locally.

Replaces #860 