### PR TITLE
Chore(core): Replace logger used in Document and Dispatcher

### DIFF
--- a/packages/common/src/logger-provider.ts
+++ b/packages/common/src/logger-provider.ts
@@ -39,11 +39,12 @@ export class LoggerProvider {
     }
 
     static makeServiceLogger(serviceName: string, config: LoggerConfig): ServiceLogger {
+        const logToFiles = config.logToFiles ?? DEFAULT_LOG_CONFIG.logToFiles
         const logDir = config.logPath ?? DEFAULT_LOG_CONFIG.logPath
         let logLevel = typeof config.logLevel == "string" ? logLevelMapping[config.logLevel] : config.logLevel
         logLevel = logLevel ?? DEFAULT_LOG_CONFIG.logLevel
         const logPath = path.join(logDir, `${serviceName}.log`)
 
-        return new ServiceLogger(serviceName, logPath, logLevel)
+        return new ServiceLogger(serviceName, logPath, logLevel, logToFiles)
     }
 }

--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -3,6 +3,7 @@ import CID from 'cids'
 import Document from "../document"
 import { TileDoctype } from "@ceramicnetwork/doctype-tile"
 import DocID from "@ceramicnetwork/docid";
+import { LoggerProvider } from "@ceramicnetwork/common";
 
 const TOPIC = '/ceramic'
 const FAKE_CID = new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
@@ -47,7 +48,7 @@ describe('Dispatcher', () => {
     ipfs.pubsub.unsubscribe.mockClear()
     ipfs.pubsub.publish.mockClear()
 
-    dispatcher = new Dispatcher(ipfs, TOPIC)
+    dispatcher = new Dispatcher(ipfs, TOPIC, LoggerProvider.makeDiagnosticLogger({}), LoggerProvider.makeServiceLogger("pubsub", {}))
     await dispatcher.init()
   })
 

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -283,7 +283,9 @@ class Ceramic implements CeramicApi {
     }
 
     // Initialize ceramic loggers
-    const logger = LoggerProvider.makeDiagnosticLogger({logLevel: config.logLevel, logToFiles: config.logToFiles, logPath: config.logPath})
+    const loggerConfig = {logLevel: config.logLevel, logToFiles: config.logToFiles, logPath: config.logPath}
+    const logger = LoggerProvider.makeDiagnosticLogger(loggerConfig)
+    const pubsubLogger = LoggerProvider.makeServiceLogger("pubsub", loggerConfig)
 
     const anchorService = config.anchorServiceUrl ? new EthereumAnchorService(config) : new InMemoryAnchorService(config as any)
     await anchorService.init()
@@ -295,7 +297,7 @@ class Ceramic implements CeramicApi {
 
     const networkOptions = await Ceramic._generateNetworkOptions(config, anchorService)
 
-    const dispatcher = new Dispatcher(ipfs, networkOptions.pubsubTopic)
+    const dispatcher = new Dispatcher(ipfs, networkOptions.pubsubTopic, logger, pubsubLogger)
     await dispatcher.init()
 
     const pinStoreProperties = {

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -16,8 +16,6 @@ import {
   Context,
   DoctypeUtils,
   DocMetadata,
-  RootLogger,
-  Logger,
   DocStateHolder,
   UnreachableCaseError
 } from '@ceramicnetwork/common'
@@ -25,6 +23,7 @@ import DocID from '@ceramicnetwork/docid'
 import { PinStore } from './store/pin-store';
 import { SubscriptionSet } from "./subscription-set";
 import { concatMap } from "rxjs/operators";
+import { DiagnosticsLogger } from "@ceramicnetwork/logger";
 
 // DocOpts defaults for document load operations
 const DEFAULT_LOAD_DOCOPTS = {anchor: false, publish: false, sync: true}
@@ -40,7 +39,7 @@ class Document extends EventEmitter implements DocStateHolder {
 
   public readonly commit: CID
 
-  private _logger: Logger
+  private _logger: DiagnosticsLogger
   private _isProcessing: boolean
   private readonly subscriptionSet = new SubscriptionSet();
 
@@ -54,7 +53,7 @@ class Document extends EventEmitter implements DocStateHolder {
     super()
     this.commit = id.commit
 
-    this._logger = RootLogger.getLogger(Document.name)
+    this._logger = _context.logger
 
     this._applyQueue = new PQueue({ concurrency: 1 })
     this._genesisCid = id.cid
@@ -295,7 +294,7 @@ class Document extends EventEmitter implements DocStateHolder {
     try {
       await this._handleTip(cid)
     } catch (e) {
-      this._logger.error(e)
+      this._logger.err(e)
     } finally {
       this._isProcessing = false
     }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@overnightjs/logger": "^1.2.0",
     "@types/logfmt": "^1.2.1",
+    "flat": "^5.0.2",
     "logfmt": "^1.3.2",
     "rotating-file-stream": "^2.1.3"
   },


### PR DESCRIPTION
Current log output:
```
timestamp=1612816371277 peer=QmdA7MsuBQoYcfnFXTfeUjNGLEFtBzC3A2yTK16Anrz4wT event=received topic=/ceramic/testnet-clay message.from=QmNTneAkkct2PMzJR73gARRPtKjVsBZEHa3wBkX6xCCo5h message.data.typ=2 message.data.
id=18,32,33,49,36,54,38,117,118,200,226,126,15,213,247,91,70,82,131,117,96,71,197,251,220,93,90,103,129,193,181,32,150,89 message.data.tips.kjzl6cwe1jw148i5dltejg923qq8ukoeco3t3y9xcasozji4f4v3e68h9xa1859=bagcqce
raqgkhhpnnfpobtsuk4aqkcoirc64bfoaarpzhejreysgja7pkdv6q message.seqno.0=12 message.seqno.1=247 message.seqno.2=30 message.seqno.3=55 message.seqno.4=66 message.seqno.5=114 message.seqno.6=166 message.seqno.7=183 
message.topicIDs.0=/ceramic/testnet-clay
```

New log output:
```
[Mon, 08 Feb 2021 22:22:20 GMT] service=pubsub peer=QmdA7MsuBQoYcfnFXTfeUjNGLEFtBzC3A2yTK16Anrz4wT event=received topic=/ceramic/testnet-clay message.from=QmP5Xahw3efWYhi8Wm4zbPJVcqN1wfCwCbqsojEDmkfHxq message.data.typ=2 message.data.id=18,32,33,49,36,54,38,117,118,200,226,126,15,213,247,91,70,82,131,117,96,71,197,251,220,93,90,103,129,193,181,32,150,89 message.data.tips.kjzl6cwe1jw148i5dltejg923qq8ukoeco3t3y9xcasozji4f4v3e68h9xa1859=bagcqceraqgkhhpnnfpobtsuk4aqkcoirc64bfoaarpzhejreysgja7pkdv6q message.seqno=238,246,72,74,35,33,192,68 message.topicIDs.0=/ceramic/testnet-clay
```

Interestingly, it looks like this changes the way the `message.seqno` array gets serialized the log.  Not sure why that is, but I think the new way is probably better?  @valmack 

This also removes the `dispatcher-docids.log` file