### PR TITLE
chore(cli): Add new express logger to ceramic daemon

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,7 @@
     "ipfs-http-client": "48.1.1",
     "key-did-provider-ed25519": "^1.0.0",
     "logfmt": "^1.3.2",
+    "morgan": "^1.10.0",
     "multiformats": "3.0.3",
     "os-utils": "0.0.14",
     "uint8arrays": "^2.0.5"

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -60,7 +60,7 @@ interface MultiQueries {
 const ACCESS_LOG_FMT = 'ip=:remote-addr ts=:date[iso] method=:method path=:url http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=:user-agent elapsed_ms=:total-time[3]';
 
 const makeExpressMiddleware = function (config: LoggerConfig) {
-  const logger = LoggerProvider.makeServiceLogger("http", config)
+  const logger = LoggerProvider.makeServiceLogger("http-access", config)
 
   return [morgan(ACCESS_LOG_FMT, { stream: logger })]
 };

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -57,9 +57,19 @@ interface MultiQueries {
   queries: Array<MultiQuery>
 }
 
-const ACCESS_LOG_FMT = 'ip=:remote-addr ts=:date[iso] method=:method path=:url http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=:user-agent elapsed_ms=:total-time[3]';
+const ACCESS_LOG_FMT = 'ip=:remote-addr ts=:date[iso] method=:method original_url=:original-url base_url=:base-url path=:path http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=:user-agent elapsed_ms=:total-time[3]';
 
 const makeExpressMiddleware = function (config: LoggerConfig) {
+  morgan.token<Request, Response>('original-url', function (req, res): any {
+    return req.originalUrl;
+  });
+  morgan.token<Request, Response>('base-url', function (req, res): any {
+    return req.baseUrl;
+  });
+  morgan.token<Request, Response>('path', function (req, res): any {
+    return req.path;
+  });
+
   const logger = LoggerProvider.makeServiceLogger("http-access", config)
 
   return [morgan(ACCESS_LOG_FMT, { stream: logger })]

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -127,7 +127,7 @@ class CeramicDaemon {
 
     const logConfig: LoggerConfig = { logPath: opts.logPath,
                                       logToFiles: opts.logToFiles,
-                                      logLevel: opts.debug ? "debug" : "important" } // todo use LogLevel
+                                      logLevel: opts.debug ? "debug" : "important" }
     const expressMiddleware = makeExpressMiddleware(logConfig)
     app.use(expressMiddleware)
 


### PR DESCRIPTION
As implemented, this doesn't actually replace or remove the existing logging behavior from the ceramic daemon, it simply adds the new logger in place in addition to the old.  So now we'll have two log files containing the http logs, with the following output formats.  Note in the below log samples I added a line `throw new Error("FAILED TO LOAD DOC!!")` right before [this line](https://github.com/ceramicnetwork/js-ceramic/blob/01562c92ea1b837530f751d5737ec6ade0305608/packages/cli/src/ceramic-daemon.ts#L272), to simulate a failed response.

*ceramicdaemon.log*:
```
request.timestamp=1612906056137 request.headers.content-type=application/json request.headers.accept=*/* request.headers.content-length=706 request.headers.user-agent="node-fetch/1.0 (+https://github.com/bitinn/
node-fetch)" request.headers.accept-encoding=gzip,deflate request.headers.connection=close request.headers.host=localhost:7007 request.httpVersion=1.1 request.method=POST request.remoteAddress=::ffff:127.0.0.1 r
equest.remoteFamily=IPv6 request.url=/api/v0/documents response.timestamp=1612906056137 response.processingTime=1 response.body="" response.statusCode=200 response.statusMessage=OK response.requestError=
Error: FAILED TO LOAD DOC!!
request.timestamp=1612906061976 request.headers.accept=*/* request.headers.user-agent="node-fetch/1.0 (+https://github.com/bitinn/node-fetch)" request.headers.accept-encoding=gzip,deflate request.headers.connect
ion=close request.headers.host=localhost:7007 request.httpVersion=1.1 request.method=GET request.remoteAddress=::ffff:127.0.0.1 request.remoteFamily=IPv6 request.url=/api/v0/documents/kjzl6cwe1jw14atbi2xajrecsyr
02ub3oazhrxbtafga1wu5kseqrzg8qr5vdgu response.timestamp=1612906061976 response.processingTime=0 response.body= response.statusCode=500 response.statusMessage="Internal Server Error" response.requestError=
```

*http.log*:
```
[Tue, 09 Feb 2021 21:27:36 GMT] service=http ip=::ffff:127.0.0.1 ts=2021-02-09T21:27:36.136Z method=POST path=/api/v0/documents http_version=1.1 req_header- status=200 content_length=361 content_type="applicatio
n/json; charset=utf-8" ref=- user_agent=node-fetch/1.0 (+https://github.com/bitinn/node-fetch) elapsed_ms=53.983
 
[Tue, 09 Feb 2021 21:27:41 GMT] service=http ip=::ffff:127.0.0.1 ts=2021-02-09T21:27:41.977Z method=GET path=/api/v0/documents/kjzl6cwe1jw14atbi2xajrecsyr02ub3oazhrxbtafga1wu5kseqrzg8qr5vdgu http_version=1.1 req
_header- status=500 content_length=32 content_type="application/json; charset=utf-8" ref=- user_agent=node-fetch/1.0 (+https://github.com/bitinn/node-fetch) elapsed_ms=3.375
 ```

Note that the new `http.log` file seems to contain less information than the existing `ceramicdaemon.log` file does, namely the `statusMessage` and the actually exception contents seem to be lost.  I'm not sure if this is something that could be easily added right now, or if it requires the larger project to rethink how error handling in the daemon happens @valmack.  This is why I decided to leave the old log handling in place for now.  I'm wondering if you think this is good enough for now to get in and let me move on to other stuff, and then we can revisit this as part of the daemon refactor project?