### PR TITLE
chore(core): Allow exceptions to escape from blockchain validateLink functions

### DIFF
--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/eosio.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/eosio.test.ts
@@ -55,7 +55,7 @@ describe("validateLink", () => {
 
     testAccount = new AccountID(`${jungleAccount}@eosio:${invalidCAIPChainId}`);
     proof.account = testAccount.toString();
-    await expect(validateLink(proof)).resolves.toEqual(null);
+    await expect(validateLink(proof)).rejects.toThrow(`No node found for chainId: ${invalidCAIPChainId}`)
   });
 
   test("Jungle", async () => {
@@ -82,6 +82,6 @@ describe("validateLink", () => {
       `${telosTestnetAccount}@eosio:${invalidCAIPChainId}`
     );
     proof.account = testAccount.toString();
-    await expect(validateLink(proof)).resolves.toEqual(null);
+    await expect(validateLink(proof)).rejects.toThrow(`No node found for chainId: ${invalidCAIPChainId}`)
   });
 });

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/ethereum.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/ethereum.test.ts
@@ -99,7 +99,7 @@ test("invalid ethereumEOA proof should return null", async () => {
   // wrong address
   const account = new AccountID({ address: addresses[1], chainId: "eip155:1" });
   const invalidProof = { account } as unknown as LinkProof;
-  expect(await ethereum.validateLink(invalidProof)).toBeFalsy();
+  await expect(ethereum.validateLink(invalidProof)).rejects.toThrow()
   // invalid signature
   const invalidSignatureProof = Object.assign(
     {},
@@ -108,7 +108,7 @@ test("invalid ethereumEOA proof should return null", async () => {
         "0xfa69ccf4a94db6132542abcabcabcab234b73f439700fbb748209890a5780f3365a5335f82d424d7f9a63ee41b637c116e64ef2f32c761bb065e4409f978c4babc",
     }
   ) as unknown as LinkProof;
-  expect(await ethereum.validateLink(invalidSignatureProof)).toBeFalsy();
+  await expect(ethereum.validateLink(invalidSignatureProof)).rejects.toThrow()
 });
 
 test("validateLink: valid ethereumEOA proof should return proof", async () => {
@@ -122,7 +122,7 @@ test("validateLink: valid ethereumEOA proof should return proof", async () => {
 
 test("validate v0 and v1 proofs", async () => {
   expect(await ethereum.validateLink(proofs.v0.valid as unknown as LinkProof)).toMatchSnapshot();
-  await expect(ethereum.validateLink(proofs.v0.invalid as unknown as LinkProof)).resolves.toEqual(null);
+  await expect(ethereum.validateLink(proofs.v0.invalid as unknown as LinkProof)).rejects.toThrow('invalid point')
   expect(await ethereum.validateLink(proofs.v1.valid as unknown as LinkProof)).toMatchSnapshot();
   expect(await ethereum.validateLink(proofs.v1.invalid as unknown as LinkProof)).toEqual(null);
 });
@@ -135,7 +135,7 @@ test("invalid erc1271 proof should return null", async () => {
     chainId: "eip155:" + GANACHE_CHAIN_ID,
   });
   const erc1271Proof = { account, type: "erc1271" } as unknown as LinkProof
-  expect(await ethereum.validateLink(erc1271Proof)).toBeFalsy();
+  await expect(ethereum.validateLink(erc1271Proof)).rejects.toThrow()
 });
 
 test("validateLink: valid erc1271 proof should return proof", async () => {

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/filecoin.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/filecoin.test.ts
@@ -41,6 +41,6 @@ describe('validateLink', () => {
     const testAddr = await testnetProvider.getAccounts()
     const testAcc = new AccountID(`${testAddr[0]}@fil:t`)
     proof.account = testAcc.toString()
-    await expect(validateLink(proof)).resolves.toEqual(null)
+    await expect(validateLink(proof)).rejects.toEqual('Error verifying signature: BLS error | Size mismatch')
   })
 })

--- a/packages/blockchain-utils-validation/src/blockchains/eosio.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/eosio.ts
@@ -11,18 +11,13 @@ export async function validateLink(
   const { message, signature, account } = proof;
   const accountID = new AccountID(account);
   const { address, chainId } = accountID;
-  try {
-    const success = await SigningTools.verifySignature({
-      chainId: chainId.reference,
-      account: address,
-      signature,
-      data: linking.eosio.toPayload(message, accountID),
-    });
-    return success ? proof : null;
-  } catch (error) {
-    console.warn(error);
-    return null;
-  }
+  const success = await SigningTools.verifySignature({
+    chainId: chainId.reference,
+    account: address,
+    signature,
+    data: linking.eosio.toPayload(message, accountID),
+  });
+  return success ? proof : null;
 }
 
 const Handler: BlockchainHandler = {

--- a/packages/blockchain-utils-validation/src/blockchains/ethereum.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/ethereum.ts
@@ -70,14 +70,10 @@ async function validateErc1271Link(
 }
 
 async function validateLink(proof: LinkProof): Promise<LinkProof | null> {
-  try {
-    if (proof.type === ADDRESS_TYPES.erc1271) {
-      return await validateErc1271Link(proof);
-    } else {
-      return await validateEoaLink(proof);
-    }
-  } catch {
-    return null;
+  if (proof.type === ADDRESS_TYPES.erc1271) {
+    return await validateErc1271Link(proof);
+  } else {
+    return await validateEoaLink(proof);
   }
 }
 

--- a/packages/blockchain-utils-validation/src/blockchains/filecoin.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/filecoin.ts
@@ -14,14 +14,10 @@ export async function validateLink(
     proof.message
   );
   const transaction = signingTools.transactionSerialize(payload);
-  try {
-    const recover = signingTools.verifySignature(proof.signature, transaction);
-    if (recover) {
-      return proof;
-    } else {
-      return null;
-    }
-  } catch {
+  const recover = signingTools.verifySignature(proof.signature, transaction);
+  if (recover) {
+    return proof;
+  } else {
     return null;
   }
 }

--- a/packages/doctype-caip10-link-handler/src/caip10-link-doctype-handler.ts
+++ b/packages/doctype-caip10-link-handler/src/caip10-link-doctype-handler.ts
@@ -96,7 +96,12 @@ export class Caip10LinkDoctypeHandler implements DoctypeHandler<Caip10LinkDoctyp
      */
     async _applySigned (commit: any, cid: CID, state: DocState): Promise<DocState> {
         // TODO: Assert that the 'prev' of the commit being applied is the end of the log in 'state'
-        const validProof = await validateLink(commit.data)
+        let validProof = null
+        try {
+          validProof = await validateLink(commit.data)
+        } catch (e) {
+          throw new Error("Error while validating link proof for caip10-link signed commit: " + e.toString())
+        }
         if (!validProof) {
             throw new Error('Invalid proof for signed commit')
         }


### PR DESCRIPTION
See [this comment](https://github.com/ceramicnetwork/js-ceramic/issues/829#issuecomment-777056611) for more context