### PR TITLE
chore(core): Stabilize ceramic-anchor.test.ts

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,6 +3,7 @@ export * from './ceramic-api'
 export * from './context'
 export * from './doctype'
 export * from './utils/doctype-utils'
+export * from './utils/test-utils'
 export * from './logger-provider'
 export * from './logger-provider-old' // TODO remove this
 export * from './pinning'

--- a/packages/common/src/utils/test-utils.ts
+++ b/packages/common/src/utils/test-utils.ts
@@ -1,0 +1,42 @@
+import {DocState, Doctype} from "../doctype";
+
+export class TestUtils {
+
+    /**
+     * Returns a Promise that resolves when there is an update to the given document's state.
+     * @param doc
+     */
+    static registerChangeListener(doc: Doctype): Promise<void> {
+        return new Promise(resolve => {
+            doc.on('change', () => {
+                resolve()
+            })
+        })
+    }
+
+    /**
+     * Given a document and a predicate that operates on the document state, continuously waits for
+     * changes to the document until the predicate returns true.
+     * @param doc
+     * @param timeout - how long to wait for
+     * @param predicate - function that takes the document's DocState as input and returns true when this function can stop waiting
+     * @param onFailure - function called if we time out before the predicate becomes true
+     */
+    static async waitForState(doc: Doctype,
+                              timeout: number,
+                              predicate: (state: DocState) => boolean,
+                              onFailure: () => void): Promise<void> {
+        const timeoutPromise = new Promise(resolve => setTimeout(resolve, timeout))
+        const completionPromise = async function () {
+            let changeHandle = TestUtils.registerChangeListener(doc)
+            while (!predicate(doc.state)) {
+                await changeHandle
+                changeHandle = TestUtils.registerChangeListener(doc)
+            }
+        }
+        await Promise.race([timeoutPromise, completionPromise()])
+        if (!predicate(doc.state)) {
+            onFailure()
+        }
+    }
+}

--- a/packages/core/src/__tests__/ceramic-anchor.test.ts
+++ b/packages/core/src/__tests__/ceramic-anchor.test.ts
@@ -1,6 +1,6 @@
 import Ceramic from '../ceramic'
 import { Ed25519Provider } from 'key-did-provider-ed25519'
-import { AnchorStatus, Doctype, IpfsApi } from "@ceramicnetwork/common"
+import {AnchorStatus, DocState, Doctype, IpfsApi, TestUtils} from "@ceramicnetwork/common"
 import tmp from 'tmp-promise'
 import IPFS from 'ipfs-core'
 import * as u8a from 'uint8arrays'
@@ -44,14 +44,6 @@ const createCeramic = async (ipfs: IpfsApi, anchorManual: boolean): Promise<Cera
   return ceramic
 }
 
-const registerChangeListener = function (doc: Doctype): Promise<void> {
-  return new Promise(resolve => {
-    doc.on('change', () => {
-      resolve()
-    })
-  })
-}
-
 /**
  * Registers a listener for change notifications on a document, instructs the anchor service to
  * perform an anchor, then waits for the change listener to resolve, indicating that the document
@@ -60,7 +52,7 @@ const registerChangeListener = function (doc: Doctype): Promise<void> {
  * @param doc
  */
 const anchorDoc = async (ceramic: Ceramic, doc: any): Promise<void> => {
-  const changeHandle = registerChangeListener(doc)
+  const changeHandle = TestUtils.registerChangeListener(doc)
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   await ceramic.context.anchorService.anchor()
@@ -312,7 +304,11 @@ describe('Ceramic anchoring', () => {
     expect(doctype1.state.log.length).toEqual(8)
 
     const doctype2 = await ceramic2.loadDocument(doctype1.id)
-    expect(doctype1.content).toEqual(doctype2.content)
+    await TestUtils.waitForState(
+        doctype2,
+        5000, // 5 second timeout
+        (state) => state.content == doctype1.content,
+        () => expect(doctype1.content).toEqual(doctype2.content))
     expect(doctype1.state.log.length).toEqual(doctype2.state.log.length)
 
     await ceramic1.close()
@@ -346,8 +342,8 @@ describe('Ceramic anchoring', () => {
     const update1ShouldWin = doctype1.state.log[doctype1.state.log.length - 1].cid.bytes < doctype2.state.log[doctype2.state.log.length - 1].cid.bytes
     const winningContent = update1ShouldWin ? newContent1 : newContent2
 
-    const handle1 = registerChangeListener(doctype1)
-    const handle2 = registerChangeListener(doctype2)
+    const handle1 = TestUtils.registerChangeListener(doctype1)
+    const handle2 = TestUtils.registerChangeListener(doctype2)
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/packages/core/src/__tests__/ceramic-anchor.test.ts
+++ b/packages/core/src/__tests__/ceramic-anchor.test.ts
@@ -1,6 +1,6 @@
 import Ceramic from '../ceramic'
 import { Ed25519Provider } from 'key-did-provider-ed25519'
-import {AnchorStatus, DocState, Doctype, IpfsApi, TestUtils} from "@ceramicnetwork/common"
+import {AnchorStatus, IpfsApi, TestUtils} from "@ceramicnetwork/common"
 import tmp from 'tmp-promise'
 import IPFS from 'ipfs-core'
 import * as u8a from 'uint8arrays'


### PR DESCRIPTION
I'm curious for thoughts on this approach.  If we like this we can roll out the `waitForState` helper in more of our tests over time