### PR TITLE
chore(core): Remove Context from PinStoreFactory and PinningBackend

### DIFF
--- a/packages/common/src/pinning.ts
+++ b/packages/common/src/pinning.ts
@@ -1,5 +1,5 @@
 import type CID from "cids";
-import type { Context } from "./context";
+import { IpfsApi } from "./index";
 
 export interface PinningBackend {
     id: string;
@@ -20,7 +20,7 @@ export interface PinningBackend {
 export interface PinningBackendStatic {
     designator: string;
 
-    new(connectionString: string, context: Context): PinningBackend;
+    new(connectionString: string, ipfs: IpfsApi): PinningBackend;
 }
 
 export type CidString = string;

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -297,7 +297,7 @@ class Ceramic implements CeramicApi {
       pinningEndpoints: config.ipfsPinningEndpoints,
       pinningBackends: config.pinningBackends
     }
-    const pinStoreFactory = new PinStoreFactory(context, pinStoreProperties)
+    const pinStoreFactory = new PinStoreFactory(ipfs, pinStoreProperties)
     const pinStore = await pinStoreFactory.open()
     const topology = new IpfsTopology(ipfs, networkOptions.name)
     const ceramic = new Ceramic(dispatcher, pinStore, context, topology, networkOptions, config.validateDocs, config.docCacheLimit, config.cacheDocCommits)

--- a/packages/core/src/store/__tests__/state-store-integration.test.ts
+++ b/packages/core/src/store/__tests__/state-store-integration.test.ts
@@ -213,7 +213,7 @@ describe('Level data store', () => {
     doctypeHandler.verifyJWS = async (): Promise<void> => { return }
 
     const levelPath = (await tmp.dir({unsafeCleanup: true})).path
-    const storeFactory = new PinStoreFactory(context, {
+    const storeFactory = new PinStoreFactory(context.ipfs, {
       pinsetDirectory: levelPath,
       pinningEndpoints: ['ipfs+context'],
       networkName: 'inmemory',
@@ -349,7 +349,7 @@ describe('Level data store', () => {
     await anchorUpdate(doc.doctype)
 
     const levelPath = (await tmp.dir({unsafeCleanup: true})).path
-    const storeFactoryLocal = new PinStoreFactory(context, {
+    const storeFactoryLocal = new PinStoreFactory(context.ipfs, {
       pinsetDirectory: levelPath,
       pinningEndpoints: ['ipfs+context'],
       networkName: "local",
@@ -363,7 +363,7 @@ describe('Level data store', () => {
     await localStore.close()
 
     // Now create a net pin store for a different ceramic network
-    const storeFactoryInMemory = new PinStoreFactory(context, {
+    const storeFactoryInMemory = new PinStoreFactory(context.ipfs, {
       pinsetDirectory: levelPath,
       pinningEndpoints: ['ipfs+context'],
       networkName: "inmemory",

--- a/packages/core/src/store/pin-store-factory.ts
+++ b/packages/core/src/store/pin-store-factory.ts
@@ -1,4 +1,4 @@
-import { Context, PinningBackendStatic } from "@ceramicnetwork/common";
+import { IpfsApi, PinningBackendStatic } from "@ceramicnetwork/common";
 import { LevelStateStore } from "./level-state-store";
 import { PinningAggregation } from "@ceramicnetwork/pinning-aggregation";
 import { PinStore } from "./pin-store";
@@ -23,7 +23,7 @@ export class PinStoreFactory {
     readonly pinningEndpoints: string[]
     readonly pinningBackends: PinningBackendStatic[];
 
-    constructor(readonly context: Context, props: Props) {
+    constructor(readonly ipfs: IpfsApi, props: Props) {
         const directoryRoot = props.pinsetDirectory || DEFAULT_PINSET_DIRECTORY
         // Always store the pinning state in a network-specific directory
         this.stateStorePath = path.join(directoryRoot, props.networkName)
@@ -34,8 +34,8 @@ export class PinStoreFactory {
     async open(): Promise<PinStore> {
         await fs.mkdir(this.stateStorePath, { recursive: true }) // create dir if it doesn't exist
         const stateStore = new LevelStateStore(this.stateStorePath)
-        const pinning = PinningAggregation.build(this.context, this.pinningEndpoints, this.pinningBackends)
-        const ipfs = this.context.ipfs
+        const ipfs = this.ipfs
+        const pinning = PinningAggregation.build(ipfs, this.pinningEndpoints, this.pinningBackends)
         const retrieve = async (cid: CID): Promise<any> => {
             const blob = await ipfs.dag.get(cid, { timeout: IPFS_GET_TIMEOUT })
             return blob?.value

--- a/packages/pinning-aggregation/src/index.ts
+++ b/packages/pinning-aggregation/src/index.ts
@@ -1,6 +1,7 @@
+
 import type CID from "cids";
 import type {
-    CidList, PinningBackend, PinningBackendStatic, PinningInfo, Context,
+  CidList, PinningBackend, PinningBackendStatic, PinningInfo, IpfsApi,
 } from "@ceramicnetwork/common";
 import * as base64 from "@stablelib/base64";
 import * as sha256 from "@stablelib/sha256";
@@ -24,7 +25,7 @@ export class PinningAggregation implements PinningBackend {
     readonly id: string;
     readonly backends: PinningBackend[];
 
-    static build(context: Context, connectionStrings: string[], pinners: Array<PinningBackendStatic> = []): PinningAggregation {
+    static build(ipfs: IpfsApi, connectionStrings: string[], pinners: Array<PinningBackendStatic> = []): PinningAggregation {
         const backends = connectionStrings.map<PinningBackend>((s) => {
             const protocol = s.match(`://`) ? new URL(s).protocol.replace(":", "") : s;
             const match = protocol.match(/^(\w+)\+?/);
@@ -32,7 +33,7 @@ export class PinningAggregation implements PinningBackend {
 
             const found = pinners.find((pinner) => pinner.designator === designator);
             if (found) {
-                return new found(s, context);
+                return new found(s, ipfs);
             } else {
                 throw new UnknownPinningService(designator);
             }

--- a/packages/pinning-ipfs-backend/src/__tests__/ipfs-pinning.test.ts
+++ b/packages/pinning-ipfs-backend/src/__tests__/ipfs-pinning.test.ts
@@ -26,15 +26,15 @@ describe("constructor", () => {
 });
 
 describe("#open", () => {
-    test("use IPFS from context if __context", async () => {
-        const context = ({ ipfs: jest.fn() } as unknown) as Context;
-        const pinning = new IpfsPinning("ipfs+context", context);
+    test("use provided IPFS", async () => {
+        const ipfs = jest.fn()
+        const pinning = new IpfsPinning("ipfs+context", ipfs);
         await pinning.open();
-        expect(pinning.ipfs).toBe(context.ipfs);
+        expect(pinning.ipfs).toBe(ipfs);
     });
-    test("throw if no IPFS instance in context", async () => {
-        const context = {};
-        const pinning = new IpfsPinning("ipfs+context", context);
+    test("throw if no IPFS instance", async () => {
+        const ipfs = null;
+        const pinning = new IpfsPinning("ipfs+context", ipfs);
         await expect(pinning.open.bind(pinning)).rejects.toThrow(NoIpfsInstanceError);
     });
     test("use IPFS client pointed to #ipfsAddress", async () => {
@@ -47,14 +47,13 @@ describe("#open", () => {
 describe("#pin", () => {
     test("call ipfs instance", async () => {
         const add = jest.fn();
-        const context = ({
-            ipfs: {
-                pin: {
-                    add: add,
-                },
-            },
-        } as unknown) as Context;
-        const pinning = new IpfsPinning("ipfs+context", context);
+        const ipfs = {
+          pin: {
+            add: add,
+          },
+        };
+
+        const pinning = new IpfsPinning("ipfs+context", ipfs);
         await pinning.open();
         const cid = new CID("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D");
         await pinning.pin(cid);
@@ -62,8 +61,8 @@ describe("#pin", () => {
     });
 
     test("silently pass if no IPFS instance", async () => {
-        const context = {} as Context;
-        const pinning = new IpfsPinning("ipfs+context", context);
+        const ipfs = null
+        const pinning = new IpfsPinning("ipfs+context", ipfs);
         const cid = new CID("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D");
         await expect(pinning.pin(cid)).resolves.toBeUndefined();
     });
@@ -72,14 +71,13 @@ describe("#pin", () => {
 describe("#unpin", () => {
     test("call ipfs instance", async () => {
         const rm = jest.fn();
-        const context = ({
-            ipfs: {
-                pin: {
-                    rm: rm,
-                },
-            },
-        } as unknown) as Context;
-        const pinning = new IpfsPinning("ipfs+context", context);
+        const ipfs = {
+          pin: {
+            rm: rm,
+          },
+        };
+
+        const pinning = new IpfsPinning("ipfs+context", ipfs);
         await pinning.open();
         const cid = new CID("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D");
         await pinning.unpin(cid);
@@ -87,8 +85,8 @@ describe("#unpin", () => {
     });
 
     test("silently pass if no IPFS instance", async () => {
-        const context = {} as Context;
-        const pinning = new IpfsPinning("ipfs+context", context);
+        const ipfs = null
+        const pinning = new IpfsPinning("ipfs+context", ipfs);
         const cid = new CID("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D");
         await expect(pinning.unpin(cid)).resolves.toBeUndefined();
     });
@@ -99,14 +97,12 @@ describe("#ls", () => {
         const cids = [new CID("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D"), new CID("QmWXShtJXt6Mw3FH7hVCQvR56xPcaEtSj4YFSGjp2QxA4v"),];
         const lsResult = cids.map((cid) => ({ cid: cid, type: "direct" }));
         const ls = jest.fn(() => asyncIterableFromArray(lsResult));
-        const context = ({
-            ipfs: {
-                pin: {
-                    ls: ls,
-                },
-            },
-        } as unknown) as Context;
-        const pinning = new IpfsPinning("ipfs+context", context);
+        const ipfs = {
+          pin: {
+            ls: ls,
+          },
+        };
+        const pinning = new IpfsPinning("ipfs+context", ipfs);
         await pinning.open();
         const result = await pinning.ls();
         cids.forEach((cid) => {
@@ -115,8 +111,8 @@ describe("#ls", () => {
     });
 
     test("return empty array if no ipfs", async () => {
-        const context = ({} as unknown) as Context;
-        const pinning = new IpfsPinning("ipfs+context", context);
+        const ipfs = null
+        const pinning = new IpfsPinning("ipfs+context", ipfs);
         const result = await pinning.ls();
         expect(result).toEqual({});
     });

--- a/packages/pinning-ipfs-backend/src/index.ts
+++ b/packages/pinning-ipfs-backend/src/index.ts
@@ -31,10 +31,9 @@ export class IpfsPinning implements PinningBackend {
     readonly ipfsAddress: string;
     readonly id: string;
 
-    readonly #context: Context;
     #ipfs: IpfsApi | undefined;
 
-    constructor(readonly connectionString: string, context: Context) {
+    constructor(readonly connectionString: string, ipfs: IpfsApi) {
         if (connectionString == 'ipfs+context') {
             this.ipfsAddress = FROM_CONTEXT_HOST
         } else {
@@ -51,7 +50,7 @@ export class IpfsPinning implements PinningBackend {
                 this.ipfsAddress = `${protocol}://${ipfsHost}:${ipfsPort}`
             }
         }
-        this.#context = context;
+        this.#ipfs = ipfs;
 
         const bytes = textEncoder.encode(this.connectionString);
         const digest = base64.encodeURLSafe(sha256.hash(bytes));
@@ -64,9 +63,7 @@ export class IpfsPinning implements PinningBackend {
 
     async open(): Promise<void> {
         if (this.ipfsAddress === FROM_CONTEXT_HOST) {
-            if (this.#context.ipfs) {
-                this.#ipfs = this.#context.ipfs;
-            } else {
+            if (!this.#ipfs) {
                 throw new NoIpfsInstanceError();
             }
         } else {


### PR DESCRIPTION
Requiring the `Context` object to already exist before the PinStore is initialized creates some circular initialization dependencies that are getting in the way of cleaning up Ceramic initialization