### PR TITLE
fix(core): Generate Query id differently

### DIFF
--- a/packages/core/src/pubsub/pubsub-message.ts
+++ b/packages/core/src/pubsub/pubsub-message.ts
@@ -52,7 +52,7 @@ export function buildQueryMessage(docId: DocID): QueryMessage {
     typ: MsgType.QUERY as MsgType.QUERY,
     doc: docId,
   };
-  const id = messageHash(payload);
+  const id = messageHash({...payload, doc: docId.toString()});
   return {
     ...payload,
     id: id,


### PR DESCRIPTION
Apparently dag-cbor can not serialize custom JS symbols