### PR TITLE
chore(core): Set defaults based on ceramic network

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -21,8 +21,6 @@ import morgan from 'morgan';
 const DEFAULT_PORT = 7007
 const toApiPath = (ending: string): string => '/api/v0' + ending
 
-const DEFAULT_ANCHOR_SERVICE_URL = "https://cas-clay.3boxlabs.com"
-
 /**
  * Daemon create options
  */
@@ -85,8 +83,6 @@ const makeCeramicConfig = function (opts: CreateOpts): CeramicConfig {
   if (opts.anchorServiceUrl) {
     ceramicConfig.ethereumRpcUrl = opts.ethereumRpcUrl
     ceramicConfig.anchorServiceUrl = opts.anchorServiceUrl
-  } else if (ceramicConfig.networkName === "testnet-clay" || ceramicConfig.networkName === "dev-unstable") {
-    ceramicConfig.anchorServiceUrl = DEFAULT_ANCHOR_SERVICE_URL
   }
 
   if (opts.pubsubTopic) {

--- a/packages/common/src/anchor-service.ts
+++ b/packages/common/src/anchor-service.ts
@@ -60,6 +60,11 @@ export interface AnchorService {
   ceramic: CeramicApi;
 
   /**
+   * URL of the connected anchor service
+   */
+  url: string;
+
+  /**
    * Request anchor commit on blockchain
    * @param docId - Document ID
    * @param tip - CID tip

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -5,6 +5,7 @@ import { DoctypeUtils, DocState, Doctype, IpfsApi } from "@ceramicnetwork/common
 import { TileDoctype } from "@ceramicnetwork/doctype-tile"
 import * as u8a from 'uint8arrays'
 import { createIPFS, swarmConnect } from './ipfs-util';
+import InMemoryAnchorService from "../anchor/memory/in-memory-anchor-service";
 
 jest.mock('../store/level-state-store')
 
@@ -85,8 +86,8 @@ describe('Ceramic integration', () => {
 
   it('cannot create Ceramic instance on network not supported by our anchor service', async () => {
     const stateStoreDirectory = await tmp.tmpName()
-    await expect(Ceramic.create(ipfs1, { networkName: 'local', stateStoreDirectory, restoreDocuments: false })).rejects.toThrow(
-        "No usable chainId for anchoring was found.  The ceramic network 'local' supports the chains: ['eip155:1337'], but the configured anchor service 'inmemory' only supports the chains: ['inmemory:12345']")
+    await expect(Ceramic._loadSupportedChains("local", new InMemoryAnchorService({}))).rejects.toThrow(
+        "No usable chainId for anchoring was found.  The ceramic network 'local' supports the chains: ['eip155:1337'], but the configured anchor service '<inmemory>' only supports the chains: ['inmemory:12345']")
     await delay(1000)
   })
 

--- a/packages/core/src/__tests__/document.test.ts
+++ b/packages/core/src/__tests__/document.test.ts
@@ -194,7 +194,6 @@ describe('Document', () => {
       const networkOptions = {
         name: 'inmemory',
         pubsubTopic: '/ceramic/inmemory',
-        supportedChains: ['inmemory:12345']
       }
 
       const topology = new FakeTopology(dispatcher._ipfs, networkOptions.name, loggerProvider.getDiagnosticsLogger())
@@ -220,6 +219,7 @@ describe('Document', () => {
         cacheDocumentCommits: true,
         docCacheLimit: 100,
         networkOptions,
+        supportedChains: ['inmemory:12345'],
         validateDocs: true,
       }
 
@@ -783,7 +783,6 @@ describe('Document', () => {
       const networkOptions = {
         name: 'inmemory',
         pubsubTopic: '/ceramic/inmemory',
-        supportedChains: ['inmemory:12345']
       }
       const topology = new FakeTopology(dispatcher._ipfs, networkOptions.name, loggerProvider.getDiagnosticsLogger())
 
@@ -808,6 +807,7 @@ describe('Document', () => {
         cacheDocumentCommits: true,
         docCacheLimit: 100,
         networkOptions,
+        supportedChains: ['inmemory:12345'],
         pinStoreOptions: null,
         validateDocs: true,
       }

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -55,17 +55,16 @@ const BASE_CHAIN_ID = "eip155"
 export default class EthereumAnchorService implements AnchorService {
   private readonly requestsApiEndpoint: string;
   private readonly chainIdApiEndpoint: string;
-  private readonly ethereumRpcEndpoint: string | undefined;
   private _chainId: string;
 
   /**
-   * @param config - service configuration (polling interval, etc.)
+   * @param anchorServiceUrl
+   * @param ethereumRpcEndpoint
    */
-  constructor(config: CeramicConfig) {
-    this.requestsApiEndpoint = config.anchorServiceUrl + "/api/v0/requests";
+  constructor(readonly anchorServiceUrl: string, readonly ethereumRpcEndpoint: string) {
+    this.requestsApiEndpoint = this.anchorServiceUrl + "/api/v0/requests";
     this.chainIdApiEndpoint =
-      config.anchorServiceUrl + "/api/v0/service-info/supported_chains";
-    this.ethereumRpcEndpoint = config.ethereumRpcUrl;
+      this.anchorServiceUrl + "/api/v0/service-info/supported_chains";
   }
 
   /**
@@ -75,6 +74,10 @@ export default class EthereumAnchorService implements AnchorService {
    */
   set ceramic(ceramic: CeramicApi) {
     // Do Nothing
+  }
+
+  get url() {
+    return this.anchorServiceUrl
   }
 
     async init(): Promise<void> {

--- a/packages/core/src/anchor/memory/in-memory-anchor-service.ts
+++ b/packages/core/src/anchor/memory/in-memory-anchor-service.ts
@@ -223,6 +223,10 @@ class InMemoryAnchorService implements AnchorService {
     this.#logger = this.#ceramic?.context?.loggerProvider.getDiagnosticsLogger();
   }
 
+  get url() {
+    return "<inmemory>"
+  }
+
   /**
    * Send request to the anchoring service
    * @param docId - Document ID


### PR DESCRIPTION
Now you can run `ceramic daemon --network<network>` with any of `testnet-clay`, `dev-unstable`, `local` or `inmemory` and it just works