### PR TITLE
feat: get origin in logs

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -124,6 +124,7 @@ class CeramicDaemon {
     this.logger = ceramic.context.loggerProvider.getDiagnosticsLogger()
 
     const app: core.Express = express()
+    app.set('trust proxy', true)
     app.use(express.json())
     app.use(cors({ origin: opts.corsAllowedOrigins }))
 


### PR DESCRIPTION
This gives us the ip that makes a request to our load balancer so in the metrics dashboard we can track requests per origin properly