### PR TITLE
chore(core): Update state store path in S3 to include ceramic prefix

### DIFF
--- a/packages/cli/src/s3-state-store.ts
+++ b/packages/cli/src/s3-state-store.ts
@@ -20,7 +20,7 @@ export class S3StateStore implements StateStore {
    * Open pinning service
    */
   async open(networkName: string): Promise<void> {
-    const location = this.#bucketName + '/' + networkName + '/state-store'
+    const location = this.#bucketName + '/ceramic/' + networkName + '/state-store'
     this.#store = new LevelUp(new S3LevelDOWN(location));
   }
 


### PR DESCRIPTION
It was mentioned the other day that we wanted the ceramic-related stuff in S3 under a `ceramic/` prefix to parallel the `ipfs/` prefix for the ipfs data