### PR TITLE
fix(blockchain-utils-linking): Pin @ethersproject/providers to previous version

### DIFF
--- a/packages/blockchain-utils-linking/package.json
+++ b/packages/blockchain-utils-linking/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@stablelib/sha256": "^1.0.0",
     "caip": "^0.9.2",
+    "@ethersproject/providers": "5.0.23",
     "uint8arrays": "^2.0.5"
   },
   "devDependencies": {

--- a/packages/blockchain-utils-validation/package.json
+++ b/packages/blockchain-utils-validation/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ceramicnetwork/blockchain-utils-linking": "^0.2.0-rc.3",
     "@ethersproject/contracts": "^5.0.9",
-    "@ethersproject/providers": "^5.0.18",
+    "@ethersproject/providers": "5.0.23",
     "@ethersproject/wallet": "^5.0.10",
     "@polkadot/util-crypto": "^5.2.3",
     "@smontero/eosio-signing-tools": "^0.0.6",


### PR DESCRIPTION
Looks like our test depends on internal state from the `providers` package: https://github.com/ceramicnetwork/js-ceramic/blob/develop/packages/blockchain-utils-linking/src/__tests__/ethereum.test.ts#L89-L95.  That state seems to have been updated in a recent release from `@ethersproject`.  Ideally we would fix the way this test works, but in the interest of time, this is a quick fix that just pins us to the second-to-most recent version of the `providers` package