### PR TITLE
fix(core): Use seconds for unix timstamp for inmemory anchors

### DIFF
--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -435,15 +435,18 @@ describe('Ceramic API', () => {
       })
 
       // test data for the atTime feature
+      const delay = () => new Promise(resolve => setTimeout(resolve, 1000))
       docFStates.push(docF.state)
-      docFTimestamps.push(Date.now())
+      docFTimestamps.push(Math.floor(Date.now() / 1000))
       await docF.change({ content: { ...docF.content, update: 'new stuff' }})
       await anchorDoc(ceramic, docF)
-      docFTimestamps.push(Date.now())
+      docFTimestamps.push(Math.floor(Date.now() / 1000))
+      await delay()
       docFStates.push(docF.state)
       await docF.change({ content: { ...docF.content, update: 'newer stuff' }})
       await anchorDoc(ceramic, docF)
-      docFTimestamps.push(Date.now())
+      docFTimestamps.push(Math.floor(Date.now() / 1000))
+      await delay()
       docFStates.push(docF.state)
     })
 

--- a/packages/core/src/anchor/memory/in-memory-anchor-service.ts
+++ b/packages/core/src/anchor/memory/in-memory-anchor-service.ts
@@ -269,10 +269,11 @@ class InMemoryAnchorService implements AnchorService {
    */
   async _process(leaf: Candidate): Promise<void> {
     // creates fake anchor commit
+    const timestamp = Math.floor(Date.now() / 1000)
     const proofData: AnchorProof = {
       chainId: CHAIN_ID,
-      blockNumber: Date.now(),
-      blockTimestamp: Date.now(),
+      blockNumber: timestamp,
+      blockTimestamp: timestamp,
       txHash: new CID(SAMPLE_ETH_TX_HASH),
       root: leaf.cid,
     };

--- a/packages/doctype-tile-handler/src/__tests__/__snapshots__/three-id.test.ts.snap
+++ b/packages/doctype-tile-handler/src/__tests__/__snapshots__/three-id.test.ts.snap
@@ -4,7 +4,7 @@ exports[`applies anchor record correctly 1`] = `
 Object {
   "anchorProof": Object {
     "blockNumber": 123456,
-    "blockTimestamp": 29872349872,
+    "blockTimestamp": 1615799679,
     "chainId": "fakechain:123",
   },
   "anchorStatus": 3,
@@ -143,7 +143,7 @@ Object {
         ],
         "version": 1,
       },
-      "timestamp": 29872349872,
+      "timestamp": 1615799679,
       "type": 2,
     },
   ],

--- a/packages/doctype-tile-handler/src/__tests__/__snapshots__/tile-doctype.test.ts.snap
+++ b/packages/doctype-tile-handler/src/__tests__/__snapshots__/tile-doctype.test.ts.snap
@@ -4,7 +4,7 @@ exports[`TileDoctypeHandler applies anchor record correctly 1`] = `
 Object {
   "anchorProof": Object {
     "blockNumber": 123456,
-    "blockTimestamp": 29872349872,
+    "blockTimestamp": 1615799679,
     "chainId": "fakechain:123",
   },
   "anchorStatus": 3,
@@ -141,7 +141,7 @@ Object {
         ],
         "version": 1,
       },
-      "timestamp": 29872349872,
+      "timestamp": 1615799679,
       "type": 2,
     },
   ],

--- a/packages/doctype-tile-handler/src/__tests__/three-id.test.ts
+++ b/packages/doctype-tile-handler/src/__tests__/three-id.test.ts
@@ -88,7 +88,7 @@ const RECORDS = {
     r2: {record: {proof: FAKE_CID_4}},
     proof: {
         blockNumber: 123456,
-        blockTimestamp: 29872349872,
+        blockTimestamp: 1615799679,
         chainId: 'fakechain:123',
     }
 }

--- a/packages/doctype-tile-handler/src/__tests__/tile-doctype.test.ts
+++ b/packages/doctype-tile-handler/src/__tests__/tile-doctype.test.ts
@@ -88,7 +88,7 @@ const RECORDS = {
     r2: { record: { proof: FAKE_CID_4 } },
     proof: {
         blockNumber: 123456,
-        blockTimestamp: 29872349872,
+        blockTimestamp: 1615799679,
         chainId: 'fakechain:123',
     }
 }


### PR DESCRIPTION
Javascript and ms -.-

The blockTimestamp from Eth is correctly denoted in `s`.