### PR TITLE
fix: use npm package for ipfs-daemon in docker

### DIFF
--- a/packages/ipfs-daemon/Dockerfile
+++ b/packages/ipfs-daemon/Dockerfile
@@ -1,13 +1,8 @@
 FROM node:14.10.1
 
-WORKDIR /ipfs
-
-COPY . /ipfs
-
-RUN npm install
-
-RUN npm run build
+RUN npm --global config set user root && \
+    npm install --global @ceramicnetwork/ipfs-daemon
 
 EXPOSE 4011 4012 5011 9011 8011
 
-CMD npm start
+CMD ipfs-daemon


### PR DESCRIPTION
### Motivation

We want to use @ceramicnetwork/ipfs-daemon instead of js-ipfs-ceramic on our infra nodes so this updates the Dockerfile that will be used to run the former.

### Changes

- Updates Dockerfile to pull ipfs-daemon from npm and run the binary