### PR TITLE
chore: simplify installation process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-            - run: npm run bootstrap
+            - run: npm ci
             - run: npm run lint
             - run: npm run build
             - run: npm run test

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,7 @@ $ cd js-ceramic
 ```
 This project uses npm and lerna to manage packages and dependencies. To install dependencies for all packages in this repo:
 ```
-$ npm run bootstrap
+$ npm install
 ```
 Then build all packages:
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "scripts": {
-    "bootstrap": "npm ci && lerna bootstrap --hoist --ci",
+    "postinstall": "lerna bootstrap --hoist --ci",
     "test": "lerna exec npm t",
     "build": "lerna run build",
     "docs": "./node_modules/.bin/typedoc",


### PR DESCRIPTION
We can now install deps by simply running `npm i` or `npm ci`.

Feel free to merge when approved ✅ 