### PR TITLE
chore(core): Move 'unique' field into GenesisHeader

### DIFF
--- a/packages/3id-did-resolver/src/__tests__/index.test.ts
+++ b/packages/3id-did-resolver/src/__tests__/index.test.ts
@@ -6,11 +6,11 @@ jest.mock('cross-fetch', () => {
       json: async () => {
         const call = mockedCalls[url]
         if (opts.method === 'post') {
-          const { response } = call.find(({ expectedBody }) => opts.body === JSON.stringify(expectedBody))
-          if (response) {
-            return response
+          const result = call.find(({ expectedBody }) => opts.body === JSON.stringify(expectedBody))
+          if (result?.response) {
+            return result.response
           } else {
-            throw new Error('invalid http request for mock')
+            throw new Error('Could not find response for http body: ' + opts.body)
           }
         }
         return call.response

--- a/packages/3id-did-resolver/src/__tests__/vectors.json
+++ b/packages/3id-did-resolver/src/__tests__/vectors.json
@@ -159,13 +159,13 @@
       }
     },
     "http://localhost:7007/api/v0/documents": [{
-      "expectedBody": {"doctype":"tile","genesis":{"header":{"controllers":["did:key:zQ3shcMwX6vEZkbCWrZqL5W47yditTzauxC5x4WNbgo5r2PbW"],"family":"3id"},"unique":"0"},"docOpts":{"anchor":false,"publish":false}},
+      "expectedBody": {"doctype":"tile","genesis":{"header":{"controllers":["did:key:zQ3shcMwX6vEZkbCWrZqL5W47yditTzauxC5x4WNbgo5r2PbW"],"family":"3id"}},"docOpts":{"anchor":false,"publish":false}},
       "response": {
         "docId":"k2t6wyfsu4pfzxkvkqs4sxhgk2vy60icvko3jngl56qzmdewud4lscf5p93wna",
         "state":{"doctype":"tile","content":{"publicKeys":{"ALmMYTWJ5UKJ4CM":"zQ3shi9zKgi8T5x8gD41cGUbXfnvextDoVALmMYTWJ5UKJ4CM","ybNYrGwCnFBSJza":"z6LSrJMTEUvAWvnv63NmvN9zZ54HMR15TybNYrGwCnFBSJza"}},"metadata":{"family":"3id","controllers":["did:key:z6Mkte2hed9vh5xaKPhxF8EpA5jj71BF4Gk1efkuRvNPmgRN"]},"signature":2,"anchorStatus":"ANCHORED","log":[{"cid":"bafyreiecg6f5fcfkyhtrcwn6v2k3gtoyrshxbm5lqua4s337huq2meefay","type":0},{"cid":"bagcqcera3jzvu6lfkstkgr5ykabaaikf5uu2dqum4n2q33c2mj4v6byanria","type":1},{"cid":"bafyreie7ova3gtkvkgla6cslvism7kjn4uzhtngahyir5dng2pfa4vouja","type":2,"timestamp":1615908910},{"cid":"bagcqcera4nkr2zsd55zozxllhdoacn7qwz47xj23cecjub3mcrx35uf2zz5q","type":1},{"cid":"bafyreihlb5brxifcy3eb7v4vqw27r56clvizkt5x5gricdh77w45kwvq4y","type":2,"timestamp":1615909089}],"anchorProof":{"root":"bagcqcera4nkr2zsd55zozxllhdoacn7qwz47xj23cecjub3mcrx35uf2zz5q","txHash":"bagjqcgzazuikj3gdyfbghkknahtuavveqnft6rnjr4u7bbijohbczzsmr6ha","chainId":"eip155:3","blockNumber":9849831,"blockTimestamp":1615909089}}
       }
     }, {
-      "expectedBody": {"doctype":"tile","genesis":{"header":{"controllers":["did:key:zQ3shcMwX6vEZkhBgM38F4erHWNDfsHQhxtHrJdUDqh515pT2"],"family":"3id"},"unique":"0"},"docOpts":{"anchor":false,"publish":false}},
+      "expectedBody": {"doctype":"tile","genesis":{"header":{"controllers":["did:key:zQ3shcMwX6vEZkhBgM38F4erHWNDfsHQhxtHrJdUDqh515pT2"],"family":"3id"}},"docOpts":{"anchor":false,"publish":false}},
       "response": {
         "docId":"k2t6wyfsu4pfxkwr4xlff0joqfejg1b42ujhzo4xcf0ujw2upuko0mf5b7834q",
         "state":{"doctype":"tile","content":{},"metadata":{"family":"3id","controllers":["did:key:zQ3shcMwX6vEZkhBgM38F4erHWNDfsHQhxtHrJdUDqh515pT2"]},"signature":0,"anchorStatus":"NOT_REQUESTED","log":[{"cid":"bafyreibd3imfprrpgsvm7qciu7pszyaevvy5acg74ksckbfpjkxhqnke3i","type":0}]}

--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -130,6 +130,8 @@ describe('Ceramic interop: core <> http-client', () => {
         // TODO fix: logs are different because of the kid version (0 != anchored CID)
         delete state1.log
         delete state2.log
+        delete state1.metadata.unique
+        delete state2.metadata.unique
 
         expect(state1).toEqual(state2)
     })

--- a/packages/common/src/doctype.ts
+++ b/packages/common/src/doctype.ts
@@ -27,12 +27,13 @@ export interface CommitHeader {
     [index: string]: any // allow support for future changes
 }
 
-export type GenesisHeader = CommitHeader
+export interface GenesisHeader extends CommitHeader {
+  unique?: string
+}
 
 export type GenesisCommit = {
     header: GenesisHeader
     data?: any
-    unique?: string
 }
 
 export interface UnsignedCommit {

--- a/packages/doctype-tile-handler/src/__tests__/three-id.test.ts
+++ b/packages/doctype-tile-handler/src/__tests__/three-id.test.ts
@@ -39,7 +39,7 @@ const RECORDS = {
                     signature: "cccc"
                 }
             ],
-            link: new CID("bafyreia4yhrqevqys35mvccnfmgcrpne6fxrdpqaonif7njq3gh7so633e")
+            link: new CID("bafyreig7dosektvux6a55mphri6piy3g5k4otxinanfevjeehix6rqfeym")
         },
         linkedBlock: {
             data: {
@@ -55,7 +55,6 @@ const RECORDS = {
                     "3id",
                 ]
             },
-            unique: "0",
         }
     },
     r1: {
@@ -212,7 +211,8 @@ it('applies genesis record correctly', async () => {
 
     const record = await TileDoctype.makeGenesis({
         content: RECORDS.genesis.data,
-        metadata: {controllers: [did.id], tags: ['3id']}
+        metadata: {controllers: [did.id], tags: ['3id']},
+        deterministic: true,
     }, context) as SignedCommitContainer
     await context.ipfs.dag.put(record, FAKE_CID_1)
 
@@ -245,7 +245,8 @@ it('applies signed record correctly', async () => {
 
     const genesisRecord = await TileDoctype.makeGenesis({
         content: RECORDS.genesis.data,
-        metadata: {controllers: [did.id], tags: ['3id']}
+        metadata: {controllers: [did.id], tags: ['3id']},
+        deterministic: true,
     }, context) as SignedCommitContainer
     await context.ipfs.dag.put(genesisRecord, FAKE_CID_1)
 
@@ -288,7 +289,8 @@ it('applies anchor record correctly', async () => {
 
     const genesisRecord = await TileDoctype.makeGenesis({
         content: RECORDS.genesis.data,
-        metadata: {controllers: [did.id], tags: ['3id']}
+        metadata: {controllers: [did.id], tags: ['3id']},
+        deterministic: true,
     }, context) as SignedCommitContainer
     await context.ipfs.dag.put(genesisRecord, FAKE_CID_1)
 

--- a/packages/doctype-tile-handler/src/__tests__/tile-doctype.test.ts
+++ b/packages/doctype-tile-handler/src/__tests__/tile-doctype.test.ts
@@ -35,7 +35,7 @@ const FAKE_CID_4 = new CID('bafybeig6xv5nwphfmvcnektpnojts66jqcuam7bmye2pb54adnr
 // did:3:bafyasdfasdf
 
 const RECORDS = {
-    genesis: { header: { controllers: [ 'did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki' ] }, data: { much: 'data' }, unique: '0' },
+    genesis: { header: { controllers: [ 'did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki' ] }, data: { much: 'data' } },
     genesisGenerated: {
         "jws": {
             "payload": "bbbb",
@@ -56,7 +56,6 @@ const RECORDS = {
                     "did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki"
                 ]
             },
-            "unique": "0",
         }
     },
     r1: {
@@ -257,7 +256,7 @@ describe('TileDoctypeHandler', () => {
     it('applies genesis record correctly', async () => {
         const tileHandler = new TileDoctypeHandler()
 
-        const record = await TileDoctype.makeGenesis({ content: RECORDS.genesis.data, metadata: { controllers: [did.id] } }, context) as SignedCommitContainer
+        const record = await TileDoctype.makeGenesis({ content: RECORDS.genesis.data, metadata: { controllers: [did.id] }, deterministic: true }, context) as SignedCommitContainer
         await context.ipfs.dag.put(record, FAKE_CID_1)
 
         const payload = dagCBOR.util.deserialize(record.linkedBlock)
@@ -288,7 +287,7 @@ describe('TileDoctypeHandler', () => {
     it('applies signed record correctly', async () => {
         const tileDoctypeHandler = new TileDoctypeHandler()
 
-        const genesisRecord = await TileDoctype.makeGenesis({ content: RECORDS.genesis.data, metadata: { controllers: [did.id] } }, context) as SignedCommitContainer
+        const genesisRecord = await TileDoctype.makeGenesis({ content: RECORDS.genesis.data, metadata: { controllers: [did.id] }, deterministic: true }, context) as SignedCommitContainer
         await context.ipfs.dag.put(genesisRecord, FAKE_CID_1)
 
         const payload = dagCBOR.util.deserialize(genesisRecord.linkedBlock)
@@ -314,7 +313,7 @@ describe('TileDoctypeHandler', () => {
         const deepCopy = o => DoctypeUtils.deserializeState(DoctypeUtils.serializeState(o))
         const tileDoctypeHandler = new TileDoctypeHandler()
 
-        const genesisRecord = await TileDoctype.makeGenesis({ content: { test: 'data' }, metadata: { controllers: [did.id] } }, context) as SignedCommitContainer
+        const genesisRecord = await TileDoctype.makeGenesis({ content: { test: 'data' }, metadata: { controllers: [did.id] }, deterministic: true }, context) as SignedCommitContainer
         await context.ipfs.dag.put(genesisRecord, FAKE_CID_1)
         const payload = dagCBOR.util.deserialize(genesisRecord.linkedBlock)
         await context.ipfs.dag.put(payload, genesisRecord.jws.link)
@@ -375,7 +374,7 @@ describe('TileDoctypeHandler', () => {
     it('applies anchor record correctly', async () => {
         const tileDoctypeHandler = new TileDoctypeHandler()
 
-        const genesisRecord = await TileDoctype.makeGenesis({ content: RECORDS.genesis.data, metadata: { controllers: [did.id] } }, context) as SignedCommitContainer
+        const genesisRecord = await TileDoctype.makeGenesis({ content: RECORDS.genesis.data, metadata: { controllers: [did.id] }, deterministic: true }, context) as SignedCommitContainer
         await context.ipfs.dag.put(genesisRecord, FAKE_CID_1)
 
         const payload = dagCBOR.util.deserialize(genesisRecord.linkedBlock)
@@ -404,7 +403,7 @@ describe('TileDoctypeHandler', () => {
     it('Does not apply anchor record on unsupported chain', async () => {
         const tileDoctypeHandler = new TileDoctypeHandler()
 
-        const genesisRecord = await TileDoctype.makeGenesis({ content: RECORDS.genesis.data, metadata: { controllers: [did.id] } }, context) as SignedCommitContainer
+        const genesisRecord = await TileDoctype.makeGenesis({ content: RECORDS.genesis.data, metadata: { controllers: [did.id] }, deterministic: true }, context) as SignedCommitContainer
         await context.ipfs.dag.put(genesisRecord, FAKE_CID_1)
 
         const payload = dagCBOR.util.deserialize(genesisRecord.linkedBlock)

--- a/packages/doctype-tile/src/tile-doctype.ts
+++ b/packages/doctype-tile/src/tile-doctype.ts
@@ -66,9 +66,6 @@ export class TileDoctype extends Doctype {
      * @param context - Ceramic context
      */
     static async makeGenesis<T extends CeramicCommit>(params: DocParams, context: Context): Promise<T> {
-        // If 'deterministic' is undefined, default to creating document uniquely
-        const unique = params.deterministic ? '0' : uint8arrays.toString(randomBytes(12), 'base64')
-
         const metadata: GenesisHeader = params.metadata || { controllers: [] }
         if (!metadata.controllers || metadata.controllers.length === 0) {
             if (context.did) {
@@ -82,7 +79,12 @@ export class TileDoctype extends Doctype {
             throw new Error('Exactly one controller must be specified')
         }
 
-        const commit: GenesisCommit = { data: params.content, header: metadata, unique }
+        // If 'deterministic' is undefined, default to creating document uniquely
+        if (!params.deterministic) {
+            metadata.unique = uint8arrays.toString(randomBytes(12), 'base64')
+        }
+
+        const commit: GenesisCommit = { data: params.content, header: metadata }
         return (params.content ? await TileDoctype._signDagJWS(commit, context.did, metadata.controllers[0]): commit) as T
     }
 


### PR DESCRIPTION
With this change now if a deterministic document is created then the `unique` field simply doesn't show up in the doc state at all (unlike today where it's there with the value `"0"`).  When a non-deterministic document is made, the unique field and its random string value are now a part of the document metadata (and thus will now show up on the cli when running `ceramic state`, which isn't currently the case)