### PR TITLE
fix: remove cpu and memory from healthcheck

### DIFF
--- a/packages/ipfs-daemon/src/healthcheck-server.ts
+++ b/packages/ipfs-daemon/src/healthcheck-server.ts
@@ -1,4 +1,3 @@
-import os from 'os-utils'
 import express from "express"
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -20,21 +19,6 @@ export class HealthcheckServer {
                 const message = "Service offline"
                 this.logger.err(message)
                 return res.status(503).send(message)
-            }
-
-            const maxHealthyCpu = 0.95
-            const maxHealthyMemory = 0.80
-
-            const freeCpu: any = await new Promise((resolve) => os.cpuFree(resolve))
-            const cpuUsage: number = 1 - freeCpu
-
-            const freeMemory = os.freememPercentage()
-            const memUsage: number = 1 - freeMemory
-
-            if (cpuUsage > maxHealthyCpu || memUsage > maxHealthyMemory) {
-                const stats = `cpuUsage=${cpuUsage} maxHealthyCpu=${maxHealthyCpu} freeCpu=${freeCpu} memoryUsage=${memUsage} maxHealthyMemory=${maxHealthyMemory} freeMemory=${freeMemory}`
-                this.logger.err(stats)
-                return res.status(503).send("Insufficient resources")
             }
             return res.status(200).send("Alive")
         })


### PR DESCRIPTION
The readings are off on 3Box Ceramic infra--maybe it doesn't work properly when running the process in a container. CPU usage said it was over .95 but we have been around 25% consistently per cloudwatch/grafana dashboards. Also potentially caused 502 gateway errors.

*Anyone can merge!*