### PR TITLE
feat: seperate node and browser loggers

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,6 +18,10 @@
   "files": [
     "lib"
   ],
+  "browser": {
+    "./lib/logger-provider.js": "./lib/logger-provider-browser.js",
+    "./lib/loggers.js": "./lib/loggers-browser.js"
+  },
   "scripts": {
     "test": "./node_modules/.bin/jest --coverage --passWithNoTests",
     "build": "../../node_modules/.bin/tsc -p tsconfig.json",

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -8,6 +8,7 @@ export * from './logger-provider'
 export * from './logger-provider-old' // TODO remove this
 export * from './loggers'
 export * from './networks'
+export * from './logger-base'
 export * from './pinning'
 export * from './unreachable-case-error'
 export * from './running-state-like'

--- a/packages/common/src/logger-base.ts
+++ b/packages/common/src/logger-base.ts
@@ -1,0 +1,186 @@
+export enum LogStyle {
+  verbose = 'info',
+  info = 'info',
+  imp = 'imp',
+  warn = 'warn',
+  err = 'err'
+}
+
+export enum LogLevel {
+  verbose,
+  debug,
+  important,
+  warn,
+}
+
+export interface WriteableStream {
+  write: (message: string) => void
+}
+
+/**
+ * Logs to the console based on log level
+ */
+export class DiagnosticsLoggerBase {
+  public readonly logLevel: LogLevel;
+  protected logger: any;
+  protected readonly fileLogger: WriteableStream;
+  protected readonly includeStackTrace: boolean;
+  protected readonly logToFiles
+
+  constructor(logLevel: LogLevel, logToFiles: boolean, fileLogger?: WriteableStream) {
+    this.logLevel = logLevel;
+    this.includeStackTrace = this.logLevel <= LogLevel.debug ? true : false;
+    this.logToFiles = logToFiles
+    this.fileLogger = fileLogger
+  }
+
+  /**
+   * Calls `this.debug`. Used for stream interfaces.
+   * @param content Content to log
+   */
+  public write(content: string | Record<string, unknown> | Error): void {
+    this.debug(content);
+  }
+
+  public verbose(content: string | Record<string, unknown> | Error): void {
+    if (this.logLevel > LogLevel.verbose) {
+      return;
+    }
+    this.log(LogStyle.verbose, content);
+  }
+
+  public debug(content: string | Record<string, unknown> | Error): void {
+    if (this.logLevel > LogLevel.debug) {
+      return;
+    }
+    this.log(LogStyle.info, content);
+  }
+
+  public imp(content: string | Record<string, unknown> | Error): void {
+    if (this.logLevel > LogLevel.important) {
+      return;
+    }
+    this.log(LogStyle.imp, content);
+  }
+
+  public warn(content: string | Record<string, unknown> | Error): void {
+    this.log(LogStyle.warn, content);
+  }
+
+  public err(content: string | Record<string, unknown> | Error): void {
+    this.log(LogStyle.err, content);
+  }
+
+  public log(style: LogStyle, content: string | Record<string, unknown> | Error): void {
+    throw new Error('Not implmented in base class')
+  }
+}
+
+export interface ServiceLog {
+  [key: string]: any;
+}
+
+/**
+ * Logs content from app services to files and/or console
+ */
+export class ServiceLoggerBase {
+  public readonly service: string;
+  public readonly logToFiles: boolean
+  public readonly logToConsole: boolean
+  public readonly logLevel: LogLevel
+
+  protected readonly stream: WriteableStream;
+
+
+  constructor(service: string, logLevel: LogLevel, logToFiles: boolean, stream?: WriteableStream) {
+    this.service = service;
+    this.logLevel = logLevel
+    this.logToFiles = logToFiles
+    this.stream = stream
+
+    this.logToConsole = this.logLevel <= LogLevel.debug
+  }
+
+  /**
+   * Converts the service log to logfmt and writes it to `this.filePath`
+   * @param serviceLog Service log object
+   */
+  public log(serviceLog: ServiceLog): void {
+    this.write(this.format(serviceLog))
+  }
+
+  /**
+   * Writes the log message to the file stream and/or the console based on the config.
+   * @param message Content to log
+   */
+  public write(message: string): void {
+    const now = new Date();
+    // RFC1123 timestamp
+    message = `[${now.toUTCString()}] service=${this.service} ${message}`;
+
+    if (this.logToConsole) {
+      console.log(message);
+    }
+  }
+
+  /**
+   * Converts `serviceLog` key/value object to logfmt
+   * @param serviceLog Service log object
+   */
+  public format(serviceLog: ServiceLog): string {
+    throw new Error('Not implmented in base class')
+  }
+}
+
+export interface FileLoggerFactory {
+    (logPath: string): WriteableStream;
+}
+
+export interface LoggerConfig {
+    logDirectory?: string,
+    logLevel?: LogLevel,
+    logToFiles?: boolean,
+}
+
+// Can't have a default log directory as that would require using the `path` module before we know
+// for sure if it's safe to do so. If `logToFiles` is false we must avoid using any node-specific
+// functionality as we might be running in-browser
+const DEFAULT_LOG_CONFIG = {
+    logLevel: LogLevel.important,
+    logToFiles: false
+}
+
+/**
+//  * Global Logger factory
+//  */
+export class LoggerProviderBase {
+  public readonly config: LoggerConfig
+
+  protected readonly _diagnosticLogger: DiagnosticsLoggerBase
+  protected readonly _fileLoggerFactory: FileLoggerFactory
+
+  constructor(config: LoggerConfig = {}, fileLoggerFactory?: FileLoggerFactory) {
+    this.config = {
+      logLevel: config.logLevel !== undefined ? config.logLevel : DEFAULT_LOG_CONFIG.logLevel,
+      logToFiles: config.logToFiles !== undefined ? config.logToFiles : DEFAULT_LOG_CONFIG.logToFiles,
+      logDirectory: config.logDirectory,
+    }
+    this._fileLoggerFactory = fileLoggerFactory
+    if (this.config.logToFiles && !this._fileLoggerFactory) {
+      throw new Error("Must provide a FileLoggerFactory in order to log to files")
+    }
+    this._diagnosticLogger = this._makeDiagnosticLogger()
+  }
+
+  protected _makeDiagnosticLogger(): DiagnosticsLoggerBase {
+    throw new Error('Not implmented in base class')
+  }
+
+  public getDiagnosticsLogger(): DiagnosticsLoggerBase {
+    return this._diagnosticLogger
+  }
+
+  public makeServiceLogger(serviceName: string): ServiceLoggerBase {
+    throw new Error('Not implmented in base class')
+  }
+}

--- a/packages/common/src/logger-provider-browser.ts
+++ b/packages/common/src/logger-provider-browser.ts
@@ -1,0 +1,15 @@
+import { DiagnosticsLogger, ServiceLogger } from './loggers-browser';
+import { LoggerProviderBase } from './logger-base'
+
+/**
+ * Global Logger factory
+ */
+export class LoggerProvider extends LoggerProviderBase {
+    protected _makeDiagnosticLogger(): DiagnosticsLogger {
+        return new DiagnosticsLogger(this.config.logLevel);
+    }
+
+    public makeServiceLogger(serviceName: string): ServiceLogger {
+        return new ServiceLogger(serviceName, this.config.logLevel)
+    }
+}

--- a/packages/common/src/logger-provider.ts
+++ b/packages/common/src/logger-provider.ts
@@ -1,53 +1,12 @@
-import {
-    DiagnosticsLogger,
-    LogLevel,
-    ServiceLogger,
-    WriteableStream,
-} from './loggers';
+import { DiagnosticsLogger, ServiceLogger } from './loggers';
+import { LoggerProviderBase } from './logger-base'
 import path from "path";
 import os from "os";
-
-export interface FileLoggerFactory {
-    (logPath: string): WriteableStream;
-}
-
-export interface LoggerConfig {
-    logDirectory?: string,
-    logLevel?: LogLevel,
-    logToFiles?: boolean,
-}
-
-// Can't have a default log directory as that would require using the `path` module before we know
-// for sure if it's safe to do so. If `logToFiles` is false we must avoid using any node-specific
-// functionality as we might be running in-browser
-const DEFAULT_LOG_CONFIG = {
-    logLevel: LogLevel.important,
-    logToFiles: false
-}
-
 
 /**
  * Global Logger factory
  */
-export class LoggerProvider {
-    public readonly config: LoggerConfig
-
-    private readonly _diagnosticLogger: DiagnosticsLogger
-    private readonly _fileLoggerFactory: FileLoggerFactory
-
-    constructor(config: LoggerConfig = {}, fileLoggerFactory?: FileLoggerFactory) {
-      this.config = {
-        logLevel: config.logLevel !== undefined ? config.logLevel : DEFAULT_LOG_CONFIG.logLevel,
-        logToFiles: config.logToFiles !== undefined ? config.logToFiles : DEFAULT_LOG_CONFIG.logToFiles,
-        logDirectory: config.logDirectory,
-      }
-      this._fileLoggerFactory = fileLoggerFactory
-      if (this.config.logToFiles && !this._fileLoggerFactory) {
-          throw new Error("Must provide a FileLoggerFactory in order to log to files")
-      }
-      this._diagnosticLogger = this._makeDiagnosticLogger()
-    }
-
+export class LoggerProvider extends LoggerProviderBase {
     private _getLogPath(filename: string) {
         if (!this.config.logToFiles) {
             throw new Error("Tried to generate log path when logToFiles is false") // This indicates a programming error
@@ -56,17 +15,13 @@ export class LoggerProvider {
         return path.join(logDirectory, filename)
     }
 
-    private _makeDiagnosticLogger(): DiagnosticsLogger {
+    protected _makeDiagnosticLogger(): DiagnosticsLogger {
         let stream = null
         if (this.config.logToFiles) {
             stream = this._fileLoggerFactory(this._getLogPath("diagnostics.log"))
         }
 
         return new DiagnosticsLogger(this.config.logLevel, this.config.logToFiles, stream);
-    }
-
-    public getDiagnosticsLogger(): DiagnosticsLogger {
-      return this._diagnosticLogger
     }
 
     public makeServiceLogger(serviceName: string): ServiceLogger {

--- a/packages/common/src/loggers-browser.ts
+++ b/packages/common/src/loggers-browser.ts
@@ -1,0 +1,42 @@
+import { 
+  ServiceLoggerBase, 
+  DiagnosticsLoggerBase, 
+  LogStyle, 
+  LogLevel, 
+  ServiceLog } from './logger-base'
+import flatten from 'flat'
+
+const consoleLogger = {
+  'info': console.log,
+  'imp': console.log,
+  'warn': console.warn,
+  'err': console.error
+}
+
+/**
+ * Logs to the console based on log level
+ */
+export class DiagnosticsLogger extends DiagnosticsLoggerBase {
+
+  constructor(logLevel: LogLevel) {
+    super(logLevel, false)
+    this.logger = consoleLogger
+  }
+
+  public log(style: LogStyle, content: string | Record<string, unknown> | Error): void {
+    // simple, does not allow removeTimestamp and include stack trace option
+    this.logger[style](content)
+  }
+}
+
+/**
+ * Logs content from app services to console
+ */
+export class ServiceLogger extends ServiceLoggerBase{
+ constructor(service: string, logLevel: LogLevel) {
+    super(service, logLevel, false)
+  }
+  public format(serviceLog: ServiceLog): string {
+    return JSON.stringify(flatten(serviceLog))
+  }
+}

--- a/packages/common/src/loggers.ts
+++ b/packages/common/src/loggers.ts
@@ -2,84 +2,26 @@ import { Logger, LoggerModes } from '@overnightjs/logger';
 import * as logfmt from 'logfmt';
 import util from 'util';
 import flatten from 'flat'
-
-enum LogStyle {
-  verbose = 'info',
-  info = 'info',
-  imp = 'imp',
-  warn = 'warn',
-  err = 'err'
-}
-
-export enum LogLevel {
-  verbose,
-  debug,
-  important,
-  warn,
-}
-
-export interface WriteableStream {
-  write: (message: string) => void
-}
+import { 
+  ServiceLoggerBase, 
+  DiagnosticsLoggerBase, 
+  LogStyle, 
+  LogLevel, 
+  ServiceLog,
+WriteableStream } from './logger-base'
 
 /**
  * Logs to the console based on log level
  */
-export class DiagnosticsLogger {
-  public readonly logLevel: LogLevel;
-  private readonly logger: Logger;
-  private readonly fileLogger: WriteableStream;
-  private readonly includeStackTrace: boolean;
-  private readonly logToFiles
+export class DiagnosticsLogger extends DiagnosticsLoggerBase {
 
   constructor(logLevel: LogLevel, logToFiles: boolean, fileLogger?: WriteableStream) {
-    this.logLevel = logLevel;
-    this.includeStackTrace = this.logLevel <= LogLevel.debug ? true : false;
-    this.logToFiles = logToFiles
-    this.fileLogger = fileLogger
-
+    super(logLevel, logToFiles, fileLogger)
     const removeTimestamp = true;
     this.logger = new Logger(LoggerModes.Console, '', removeTimestamp);
   }
 
-  /**
-   * Calls `this.debug`. Used for stream interfaces.
-   * @param content Content to log
-   */
-  public write(content: string | Record<string, unknown> | Error): void {
-    this.debug(content);
-  }
-
-  public verbose(content: string | Record<string, unknown> | Error): void {
-    if (this.logLevel > LogLevel.verbose) {
-      return;
-    }
-    this.log(LogStyle.verbose, content);
-  }
-
-  public debug(content: string | Record<string, unknown> | Error): void {
-    if (this.logLevel > LogLevel.debug) {
-      return;
-    }
-    this.log(LogStyle.info, content);
-  }
-
-  public imp(content: string | Record<string, unknown> | Error): void {
-    if (this.logLevel > LogLevel.important) {
-      return;
-    }
-    this.log(LogStyle.imp, content);
-  }
-
-  public warn(content: string | Record<string, unknown> | Error): void {
-    this.log(LogStyle.warn, content);
-  }
-
-  public err(content: string | Record<string, unknown> | Error): void {
-    this.log(LogStyle.err, content);
-  }
-
-  private log(style: LogStyle, content: string | Record<string, unknown> | Error): void {
+  public log(style: LogStyle, content: string | Record<string, unknown> | Error): void {
     this.logger[style](content, this.includeStackTrace);
     if (this.logToFiles) {
       const now = new Date();
@@ -89,54 +31,19 @@ export class DiagnosticsLogger {
   }
 }
 
-interface ServiceLog {
-  [key: string]: any;
-}
-
 /**
  * Logs content from app services to files
  */
-export class ServiceLogger {
-  public readonly service: string;
-  public readonly logToFiles: boolean
-  public readonly logToConsole: boolean
-  public readonly logLevel: LogLevel
-
-  private readonly stream: WriteableStream;
-
-
-  constructor(service: string, logLevel: LogLevel, logToFiles: boolean, stream: WriteableStream) {
-    this.service = service;
-    this.logLevel = logLevel
-    this.logToFiles = logToFiles
-    this.stream = stream
-
-    this.logToConsole = this.logLevel <= LogLevel.debug
-  }
-
-  /**
-   * Converts the service log to logfmt and writes it to `this.filePath`
-   * @param serviceLog Service log object
-   */
-  public log(serviceLog: ServiceLog): void {
-    this.write(ServiceLogger.format(serviceLog))
-  }
-
+export class ServiceLogger extends ServiceLoggerBase {
   /**
    * Writes the log message to the file stream and/or the console based on the config.
    * @param message Content to log
    */
   public write(message: string): void {
-    const now = new Date();
-    // RFC1123 timestamp
-    message = `[${now.toUTCString()}] service=${this.service} ${message}`;
+    super.write(message)
 
     if (this.logToFiles) {
       this.stream.write(util.format(message, '\n'));
-    }
-
-    if (this.logToConsole) {
-      console.log(message);
     }
   }
 
@@ -144,7 +51,7 @@ export class ServiceLogger {
    * Converts `serviceLog` key/value object to logfmt
    * @param serviceLog Service log object
    */
-  public static format(serviceLog: ServiceLog): string {
+  public format(serviceLog: ServiceLog): string {
     return logfmt.stringify(flatten(serviceLog));
   }
 }


### PR DESCRIPTION
~~will revisit tmrrw, some cleanup/types, and had some trouble testing locally and getting dependencies to resolve properly~~

likely better long term solutions after, but can be revisited at same time as we work on core working in browser again, there may be other options for libraries as well, but wanted to minimize any changes there since we have a lot built on current log formats. 