### PR TITLE
feat: add networks enum and elp

### DIFF
--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -17,7 +17,7 @@ program
     .option('--verbose', 'Enable verbose logging level. Default is false')
     .option('--log-to-files', 'If debug is true, write logs to files. Default is false')
     .option('--log-directory <dir>', 'Store logs in this directory. Defaults to HOME_DIR/.ceramic/logs')
-    .option('--network <name>', 'Name of the ceramic network to connect to. One of: "mainnet", "testnet-clay", "local", or "inmemory". Defaults to "testnet-clay"')
+    .option('--network <name>', 'Name of the ceramic network to connect to. One of: "mainnet", "testnet-clay", "dev-unstable", "local", or "inmemory". Defaults to "testnet-clay"')
     .option('--pubsubTopic <string>', 'Pub/sub topic to use for protocol messages')
     .option('--max-healthy-cpu <decimal>', 'Fraction of total CPU usage considered healthy. Defaults to 0.7')
     .option('--max-healthy-memory <decimal>', 'Fraction of total memory usage considered healthy. Defaults to 0.7')

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -1,21 +1,20 @@
-import os from "os"
-import path from "path"
+import os from 'os'
+import path from 'path'
 import { randomBytes } from '@stablelib/random'
 import * as u8a from 'uint8arrays'
 
 import { promises as fs } from 'fs'
 
 import { Ed25519Provider } from 'key-did-provider-ed25519'
-import CeramicClient from "@ceramicnetwork/http-client"
-import { CeramicApi, DoctypeUtils, LoggerConfig } from "@ceramicnetwork/common"
-import { LogLevel } from '@ceramicnetwork/common';
+import CeramicClient from '@ceramicnetwork/http-client'
+import { CeramicApi, DoctypeUtils, LoggerConfig, LogLevel, Networks } from '@ceramicnetwork/common'
 import DocID from '@ceramicnetwork/docid'
 
-import CeramicDaemon, { CreateOpts } from "./ceramic-daemon"
+import CeramicDaemon, { CreateOpts } from './ceramic-daemon'
 
 const DEFAULT_CLI_CONFIG_FILE = 'config.json'
 const DEFAULT_CLI_CONFIG_PATH = path.join(os.homedir(), '.ceramic')
-const DEFAULT_NETWORK = 'testnet-clay'
+const DEFAULT_NETWORK = Networks.TESTNET_CLAY
 
 /**
  * CLI configuration

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -7,6 +7,7 @@ export * from './utils/test-utils'
 export * from './logger-provider'
 export * from './logger-provider-old' // TODO remove this
 export * from './loggers'
+export * from './networks'
 export * from './pinning'
 export * from './doc-cache'
 export * from './unreachable-case-error'

--- a/packages/common/src/networks.ts
+++ b/packages/common/src/networks.ts
@@ -1,0 +1,8 @@
+export enum Networks {
+    MAINNET = 'mainnet',
+    ELP = 'elp', // early launch program
+    TESTNET_CLAY = 'testnet-clay',
+    DEV_UNSTABLE = 'dev-unstable',
+    LOCAL = 'local',
+    INMEMORY = 'inmemory'
+}

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -84,15 +84,6 @@ describe('Ceramic integration', () => {
     await ceramic.close()
   })
 
-  it('can create Ceramic instance explicitly on elp network', async () => {
-    const stateStoreDirectory = await tmp.tmpName()
-    const ceramic = await Ceramic.create(ipfs1, { networkName: 'elp', stateStoreDirectory, restoreDocuments: false })
-    await delay(1000)
-    const supportedChains = await ceramic.getSupportedChains()
-    expect(supportedChains).toEqual(['eip155:1'])
-    await ceramic.close()
-  })
-
   it('cannot create Ceramic instance on network not supported by our anchor service', async () => {
     await expect(Ceramic._loadSupportedChains("local", new InMemoryAnchorService({}))).rejects.toThrow(
         "No usable chainId for anchoring was found.  The ceramic network 'local' supports the chains: ['eip155:1337'], but the configured anchor service '<inmemory>' only supports the chains: ['inmemory:12345']")

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -84,6 +84,15 @@ describe('Ceramic integration', () => {
     await ceramic.close()
   })
 
+  it('can create Ceramic instance explicitly on elp network', async () => {
+    const stateStoreDirectory = await tmp.tmpName()
+    const ceramic = await Ceramic.create(ipfs1, { networkName: 'elp', stateStoreDirectory, restoreDocuments: false })
+    await delay(1000)
+    const supportedChains = await ceramic.getSupportedChains()
+    expect(supportedChains).toEqual(['eip155:1'])
+    await ceramic.close()
+  })
+
   it('cannot create Ceramic instance on network not supported by our anchor service', async () => {
     await expect(Ceramic._loadSupportedChains("local", new InMemoryAnchorService({}))).rejects.toThrow(
         "No usable chainId for anchoring was found.  The ceramic network 'local' supports the chains: ['eip155:1337'], but the configured anchor service '<inmemory>' only supports the chains: ['inmemory:12345']")


### PR DESCRIPTION
### Motivation

We have some infra up for ELP but now need a way to run the Ceramic nodes!

### Changes

- Added "elp" network
- Created enum for different networks (will punt this change if there's hesitancy because just want to get this running asap ideally)

### Notes

Do we need a test for this? If so will sync with @stbrody about how because I didn't really understand if/how we are testing these networks.