### PR TITLE
feat(core, http-client): Remove default DID Resolver and make apps provide via CeramicAPI.setDID()

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,7 @@
     }
   },
   "dependencies": {
+    "@ceramicnetwork/3id-did-resolver": "^1.2.0-rc.1",
     "@ceramicnetwork/common": "^0.18.0-rc.0",
     "@ceramicnetwork/core": "^0.22.0-rc.0",
     "@ceramicnetwork/docid": "^0.5.1",
@@ -55,10 +56,13 @@
     "commander": "^7.0.0",
     "cors": "^2.8.5",
     "dag-jose": "^0.3.0",
+    "dids": "^2.0.0",
+    "did-resolver": "^3.0.1",
     "express": "^4.17.1",
     "flat": "^5.0.2",
     "ipfs-http-client": "~49.0.3",
     "key-did-provider-ed25519": "^1.0.1",
+    "key-did-resolver": "^1.1.1",
     "levelup": "^4.4.0",
     "logfmt": "^1.3.2",
     "morgan": "^1.10.0",

--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -101,10 +101,11 @@ export interface CeramicApi {
     applyCommit<T extends Doctype>(docId: DocID | string, commit: CeramicCommit, opts?: DocOpts): Promise<T>;
 
     /**
-     * Set DID provider
-     * @param provider - DID provider instance
+     * Sets the DID instance that will be used to author commits to documents. The DID instance
+     * also includes the DID Resolver that will be used to verify commits from others.
+     * @param did
      */
-    setDIDProvider (provider: DIDProvider): Promise<void>;
+    setDID(did: DID): Promise<void>;
 
     /**
      * @returns An array of the CAIP-2 chain IDs of the blockchains that are supported for anchoring

--- a/packages/common/src/context.ts
+++ b/packages/common/src/context.ts
@@ -11,8 +11,6 @@ import { IpfsApi, LoggerProvider } from "./index"
 export interface Context {
     did?: DID;
     ipfs?: IpfsApi; // an ipfs instance
-    resolver?: Resolver; // a DID resolver instance
-    provider?: DIDProvider; // a DID provider (3ID provider initially)
     anchorService?: AnchorService;
     loggerProvider?: LoggerProvider;
 

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -193,8 +193,6 @@ describe('Ceramic API', () => {
     })
 
     it('can update schema and then assign to doc with now valid content', async () => {
-      const controller = ceramic.context.did.id
-
       // Create doc with content that has type 'number'.
       const doc = await TileDoctype.create(ceramic, {a: 1})
       await anchorUpdate(ceramic, doc)

--- a/packages/core/src/__tests__/ceramic-pinning.test.ts
+++ b/packages/core/src/__tests__/ceramic-pinning.test.ts
@@ -5,8 +5,23 @@ import { IpfsApi, CeramicApi } from '@ceramicnetwork/common';
 import * as u8a from 'uint8arrays'
 import { createIPFS } from './ipfs-util';
 import { TileDoctype } from '@ceramicnetwork/doctype-tile';
+import ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
+import KeyDidResolver from 'key-did-resolver'
+import { Resolver } from "did-resolver"
+import { DID } from 'dids'
 
 const seed = u8a.fromString('6e34b2e1a9624113d81ece8a8a22e6e97f0e145c25c1d4d2d0e62753b4060c83', 'base16')
+
+const makeDID = function(seed: Uint8Array, ceramic: Ceramic): DID {
+  const provider = new Ed25519Provider(seed)
+
+  const keyDidResolver = KeyDidResolver.getResolver()
+  const threeIdResolver = ThreeIdResolver.getResolver(ceramic)
+  const resolver = new Resolver({
+    ...threeIdResolver, ...keyDidResolver,
+  })
+  return new DID({ provider, resolver })
+}
 
 const createCeramic = async (ipfs: IpfsApi, stateStoreDirectory, anchorOnRequest = false): Promise<Ceramic> => {
   const ceramic = await Ceramic.create(ipfs, {
@@ -14,8 +29,7 @@ const createCeramic = async (ipfs: IpfsApi, stateStoreDirectory, anchorOnRequest
     anchorOnRequest,
     pubsubTopic: "/ceramic/inmemory/test" // necessary so Ceramic instances can talk to each other
   })
-  const provider = new Ed25519Provider(seed)
-  await ceramic.setDIDProvider(provider)
+  await ceramic.setDID(makeDID(seed, ceramic))
 
   return ceramic
 }

--- a/packages/core/src/__tests__/ceramic-pinning.test.ts
+++ b/packages/core/src/__tests__/ceramic-pinning.test.ts
@@ -30,6 +30,7 @@ const createCeramic = async (ipfs: IpfsApi, stateStoreDirectory, anchorOnRequest
     pubsubTopic: "/ceramic/inmemory/test" // necessary so Ceramic instances can talk to each other
   })
   await ceramic.setDID(makeDID(seed, ceramic))
+  await ceramic.did.authenticate()
 
   return ceramic
 }

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -7,6 +7,10 @@ import * as u8a from 'uint8arrays'
 import { createIPFS, swarmConnect } from './ipfs-util';
 import InMemoryAnchorService from "../anchor/memory/in-memory-anchor-service";
 import { anchorUpdate } from '../state-management/__tests__/anchor-update';
+import ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
+import KeyDidResolver from 'key-did-resolver'
+import { Resolver } from "did-resolver"
+import { DID } from 'dids'
 
 jest.mock('../store/level-state-store')
 
@@ -14,6 +18,17 @@ const seed = u8a.fromString('6e34b2e1a9624113d81ece8a8a22e6e97f0e145c25c1d4d2d0e
 
 async function delay(mills: number): Promise<void> {
   await new Promise<void>(resolve => setTimeout(() => resolve(), mills))
+}
+
+const makeDID = function(seed: Uint8Array, ceramic: Ceramic): DID {
+  const provider = new Ed25519Provider(seed)
+
+  const keyDidResolver = KeyDidResolver.getResolver()
+  const threeIdResolver = ThreeIdResolver.getResolver(ceramic)
+  const resolver = new Resolver({
+    ...threeIdResolver, ...keyDidResolver,
+  })
+  return new DID({ provider, resolver })
 }
 
 const createCeramic = async (ipfs: IpfsApi, anchorOnRequest = false, docCacheLimit = 100, cacheDocumentCommits = true): Promise<Ceramic> => {
@@ -25,8 +40,7 @@ const createCeramic = async (ipfs: IpfsApi, anchorOnRequest = false, docCacheLim
     restoreDocuments: false,
     pubsubTopic: "/ceramic/inmemory/test" // necessary so Ceramic instances can talk to each other
   })
-  const provider = new Ed25519Provider(seed)
-  await ceramic.setDIDProvider(provider)
+  await ceramic.setDID(makeDID(seed, ceramic))
 
   return ceramic
 }
@@ -40,8 +54,6 @@ describe('Ceramic integration', () => {
   let ipfs1: IpfsApi;
   let ipfs2: IpfsApi;
   let ipfs3: IpfsApi;
-
-  const DOCTYPE_TILE = 'tile'
 
   beforeEach(async () => {
     [ipfs1, ipfs2, ipfs3] = await Promise.all(Array.from({length: 3}).map(() => createIPFS()));

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -304,7 +304,6 @@ describe('Ceramic integration', () => {
     await swarmConnect(ipfs1, ipfs2)
     const ceramic1 = await createCeramic(ipfs1, false, 2)
     const ceramic2 = await createCeramic(ipfs2, false, 1)
-    const controller = ceramic1.context.did.id
 
     const repository1 = ceramic1.repository
     const addSpy1 = jest.spyOn(repository1, 'add');
@@ -345,7 +344,6 @@ describe('Ceramic integration', () => {
     await swarmConnect(ipfs1, ipfs2)
     const ceramic1 = await createCeramic(ipfs1, false, 2)
     const ceramic2 = await createCeramic(ipfs2, false, 1, false)
-    const controller = ceramic1.context.did.id
 
     const repository1 = ceramic1.repository
     const addSpy1 = jest.spyOn(repository1, 'add');

--- a/packages/core/src/__tests__/create-ceramic.ts
+++ b/packages/core/src/__tests__/create-ceramic.ts
@@ -28,6 +28,7 @@ export async function createCeramic(ipfs: IpfsApi, config?: CeramicConfig & { se
   });
   const did = new DID({ provider, resolver });
   await ceramic.setDID(did);
+  await did.authenticate();
 
   return ceramic;
 }

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -454,10 +454,7 @@ class Ceramic implements CeramicApi {
    */
   async setDID(did: DID): Promise<void> {
     this.context.did = did
-    if (!did.authenticated) {
-      await this.did.authenticate()
-    }
-    this._logger.imp(`Now authenticated as DID ${did}`)
+    this._logger.imp(`Now using DID ${did}`)
   }
 
   /**

--- a/packages/doctype-tile/src/tile-doctype.ts
+++ b/packages/doctype-tile/src/tile-doctype.ts
@@ -98,6 +98,9 @@ async function _makeGenesis<T>(did: DID, content: T | null, metadata?: TileMetad
 
     if (!metadata.controllers || metadata.controllers.length === 0) {
         if (did) {
+            if (!did.authenticated) {
+                await did.authenticate()
+            }
             metadata.controllers = [did.id]
         } else {
             throw new Error('No controllers specified')
@@ -217,6 +220,9 @@ export class TileDoctype<T = Record<string, any>> extends Doctype {
         const metadata: GenesisHeader = params.metadata || { controllers: [] }
         if (!metadata.controllers || metadata.controllers.length === 0) {
             if (context.did) {
+                if (!context.did.authenticated) {
+                    await context.did.authenticate()
+                }
                 metadata.controllers = [context.did.id]
             } else {
                 throw new Error('No controllers specified')

--- a/packages/doctype-tile/src/tile-doctype.ts
+++ b/packages/doctype-tile/src/tile-doctype.ts
@@ -73,10 +73,13 @@ function headerFromMetadata(metadata?: TileMetadataArgs | DocMetadata): CommitHe
  * @param controller - Controller
  * @private
  */
-function _signDagJWS(commit: CeramicCommit, did: DID, controller: string): Promise<SignedCommitContainer> {
+async function _signDagJWS(commit: CeramicCommit, did: DID, controller: string): Promise<SignedCommitContainer> {
     // check for DID and authentication
-    if (did == null || !did.authenticated) {
+    if (did == null) {
         throw new Error('No DID authenticated')
+    }
+    if (!did.authenticated) {
+        await did.authenticate()
     }
     return did.createDagJWS(commit, { did: controller })
 }

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -27,16 +27,13 @@
     "test": "./node_modules/.bin/jest --coverage --passWithNoTests"
   },
   "dependencies": {
-    "@ceramicnetwork/3id-did-resolver": "^1.2.0-rc.1",
     "@ceramicnetwork/common": "^0.18.0-rc.0",
     "@ceramicnetwork/docid": "^0.5.1",
     "@ceramicnetwork/doctype-caip10-link": "^0.14.0-rc.1",
     "@ceramicnetwork/doctype-tile": "^0.15.0-rc.1",
     "cids": "~1.1.6",
     "cross-fetch": "^3.0.6",
-    "did-resolver": "^3.0.1",
     "dids": "^2.0.0",
-    "key-did-resolver": "^1.1.1",
     "lru_map": "^0.4.1",
     "rxjs": "^6.6.6"
   },

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -6,7 +6,6 @@ import {
   CeramicApi,
   CeramicCommit,
   Context,
-  DIDProvider,
   DocOpts,
   DocParams,
   Doctype,
@@ -19,9 +18,6 @@ import {
 import { TileDoctype } from "@ceramicnetwork/doctype-tile"
 import { Caip10LinkDoctype } from "@ceramicnetwork/doctype-caip10-link"
 import { DocID, CommitID, DocRef } from '@ceramicnetwork/docid';
-import ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
-import KeyDidResolver from 'key-did-resolver'
-import { Resolver } from "did-resolver"
 
 const API_PATH = '/api/v0'
 const CERAMIC_HOST = 'http://localhost:7007'
@@ -37,10 +33,6 @@ export const DEFAULT_CLIENT_CONFIG: CeramicClientConfig = {
  * Ceramic client configuration
  */
 export interface CeramicClientConfig {
-  /**
-   * DID Resolver. Would add one to did:3 and did:key resolver.
-   */
-  didResolver?: Resolver
   /**
    * Period of synchronisation, in milliseconds. Active when subscribing document.
    */
@@ -78,12 +70,6 @@ export default class CeramicClient implements CeramicApi {
     this.context = { api: this }
 
     this.pin = this._initPinApi()
-
-    const keyDidResolver = KeyDidResolver.getResolver()
-    const threeIdResolver = ThreeIdResolver.getResolver(this)
-    this.context.resolver = new Resolver({
-      ...this._config.didResolver, ...threeIdResolver, ...keyDidResolver,
-    })
 
     this._doctypeConstructors = {
       'tile': TileDoctype,
@@ -230,12 +216,10 @@ export default class CeramicClient implements CeramicApi {
     return new doctypeConstructor(document, this.context)
   }
 
-  async setDIDProvider(provider: DIDProvider): Promise<void> {
-    this.context.provider = provider;
-    this.context.did = new DID( { provider, resolver: this.context.resolver })
-
-    if (!this.context.did.authenticated) {
-      await this.context.did.authenticate()
+  async setDID(did: DID): Promise<void> {
+    this.context.did = did
+    if (!did.authenticated) {
+      await this.did.authenticate()
     }
   }
 

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -218,9 +218,6 @@ export default class CeramicClient implements CeramicApi {
 
   async setDID(did: DID): Promise<void> {
     this.context.did = did
-    if (!did.authenticated) {
-      await this.did.authenticate()
-    }
   }
 
   async getSupportedChains(): Promise<Array<string>> {


### PR DESCRIPTION
This breaks a circular dependency between the http-client and the 3id-did-resolver