### PR TITLE
feat(core): Limit total number of the tasks executed concurrently

### DIFF
--- a/packages/core/src/__tests__/create-ceramic.ts
+++ b/packages/core/src/__tests__/create-ceramic.ts
@@ -4,10 +4,10 @@ import * as uint8arrays from 'uint8arrays';
 import * as sha256 from '@stablelib/sha256';
 import tmp from 'tmp-promise';
 import { Ed25519Provider } from 'key-did-provider-ed25519';
-import ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
-import KeyDidResolver from 'key-did-resolver'
-import { Resolver } from "did-resolver"
-import { DID } from 'dids'
+import ThreeIdResolver from '@ceramicnetwork/3id-did-resolver';
+import KeyDidResolver from 'key-did-resolver';
+import { Resolver } from 'did-resolver';
+import { DID } from 'dids';
 
 export async function createCeramic(ipfs: IpfsApi, config?: CeramicConfig & { seed?: string }): Promise<Ceramic> {
   const appliedConfig = {
@@ -24,7 +24,8 @@ export async function createCeramic(ipfs: IpfsApi, config?: CeramicConfig & { se
   const keyDidResolver = KeyDidResolver.getResolver();
   const threeIdResolver = ThreeIdResolver.getResolver(ceramic);
   const resolver = new Resolver({
-    ...threeIdResolver, ...keyDidResolver,
+    ...threeIdResolver,
+    ...keyDidResolver,
   });
   const did = new DID({ provider, resolver });
   await ceramic.setDID(did);

--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -64,7 +64,7 @@ describe('Dispatcher', () => {
     const levelPath = await tmp.tmpName();
     const stateStore = new LevelStateStore(levelPath);
     stateStore.open('test');
-    repository = new Repository(100, loggerProvider.getDiagnosticsLogger());
+    repository = new Repository(100, 100, loggerProvider.getDiagnosticsLogger());
     const pinStore = ({
       stateStore,
     } as unknown) as PinStore;

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -63,7 +63,7 @@ test('handleTip', async () => {
   expect(doc2.content).toEqual(doc1.content);
   expect(doc2.state).toEqual(expect.objectContaining({ signature: SignatureStatus.SIGNED, anchorStatus: 0 }));
 
-  await ceramic2.repository.stateManager.handleTip(docState2, doc1.state.log[1].cid);
+  await (ceramic2.repository.stateManager as any).handleTip(docState2, doc1.state.log[1].cid);
 
   expect(doc2.state).toEqual(doc1.state);
   await ceramic2.close();
@@ -221,7 +221,7 @@ test('handles basic conflict', async () => {
     .then((doc) => doc.state);
   const state$ = new RunningState(initialState);
   ceramic.repository.add(state$);
-  await ceramic.repository.stateManager.handleTip(state$, tipPreUpdate);
+  await (ceramic.repository.stateManager as any).handleTip(state$, tipPreUpdate);
   await new Promise((resolve) => setTimeout(resolve, 1000));
 
   const conflictingNewContent = { asdf: 2342 };
@@ -235,12 +235,12 @@ test('handles basic conflict', async () => {
   expect(doc2.content).toEqual(conflictingNewContent);
   // loading tip from valid log to doc with invalid
   // log results in valid state
-  await ceramic.repository.stateManager.handleTip(state$, tipValidUpdate);
+  await (ceramic.repository.stateManager as any).handleTip(state$, tipValidUpdate);
   expect(doc2.content).toEqual(newContent);
 
   // loading tip from invalid log to doc with valid
   // log results in valid state
-  await ceramic.repository.stateManager.handleTip(docState1, tipInvalidUpdate);
+  await (ceramic.repository.stateManager as any).handleTip(docState1, tipInvalidUpdate);
   expect(doc1.content).toEqual(newContent);
 
   // Loading valid commit works

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -95,6 +95,7 @@ export interface CeramicConfig {
   pubsubTopic?: string;
 
   docCacheLimit?: number;
+  concurrentTasksLimit?: number;
   cacheDocCommits?: boolean; // adds 'docCacheLimit' additional cache entries if commits can be cached as well
 
   useCentralizedPeerDiscovery?: boolean;
@@ -126,6 +127,7 @@ export interface CeramicModules {
 export interface CeramicParameters {
   cacheDocumentCommits: boolean,
   docCacheLimit: number,
+  concurrentTasksLimit: number,
   networkOptions: CeramicNetworkOptions,
   supportedChains: string[],
   validateDocs: boolean,
@@ -374,15 +376,17 @@ class Ceramic implements CeramicApi {
     }
 
     const docCacheLimit = config.docCacheLimit ?? DEFAULT_DOC_CACHE_LIMIT
+    const concurrentTasksLimit = config.concurrentTasksLimit ?? docCacheLimit
 
     const ipfsTopology = new IpfsTopology(ipfs, networkOptions.name, logger)
     const pinStoreFactory = new PinStoreFactory(ipfs, pinStoreOptions)
-    const repository = new Repository(docCacheLimit, logger)
+    const repository = new Repository(docCacheLimit, logger, concurrentTasksLimit)
     const dispatcher = new Dispatcher(ipfs, networkOptions.pubsubTopic, repository, logger, pubsubLogger)
 
-    const params = {
+    const params: CeramicParameters = {
       cacheDocumentCommits: config.cacheDocCommits ?? true,
       docCacheLimit: docCacheLimit,
+      concurrentTasksLimit: concurrentTasksLimit,
       networkOptions,
       supportedChains,
       validateDocs: config.validateDocs ?? true,

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -483,8 +483,7 @@ class Ceramic implements CeramicApi {
    */
   async applyCommit<T extends Doctype>(docId: string | DocID, commit: CeramicCommit, opts: CreateOpts | UpdateOpts = {}): Promise<T> {
     opts = { ...DEFAULT_APPLY_COMMIT_OPTS, ...opts };
-    const state$ = await this._loadDoc(normalizeDocID(docId), opts as CreateOpts)
-    await this.repository.stateManager.applyCommit(state$, commit, opts)
+    const state$ = await this.repository.stateManager.applyCommit(normalizeDocID(docId), commit, opts as CreateOpts)
     return doctypeFromState<T>(this.context, this._doctypeHandlers, state$.value, this.repository.updates$)
   }
 

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -95,7 +95,7 @@ export interface CeramicConfig {
   pubsubTopic?: string;
 
   docCacheLimit?: number;
-  concurrentTasksLimit?: number;
+  concurrentRequestsLimit?: number;
   cacheDocCommits?: boolean; // adds 'docCacheLimit' additional cache entries if commits can be cached as well
 
   useCentralizedPeerDiscovery?: boolean;
@@ -126,8 +126,6 @@ export interface CeramicModules {
  */
 export interface CeramicParameters {
   cacheDocumentCommits: boolean,
-  docCacheLimit: number,
-  concurrentTasksLimit: number,
   networkOptions: CeramicNetworkOptions,
   supportedChains: string[],
   validateDocs: boolean,
@@ -376,17 +374,15 @@ class Ceramic implements CeramicApi {
     }
 
     const docCacheLimit = config.docCacheLimit ?? DEFAULT_DOC_CACHE_LIMIT
-    const concurrentTasksLimit = config.concurrentTasksLimit ?? docCacheLimit
+    const concurrentRequestsLimit = config.concurrentRequestsLimit ?? docCacheLimit
 
     const ipfsTopology = new IpfsTopology(ipfs, networkOptions.name, logger)
     const pinStoreFactory = new PinStoreFactory(ipfs, pinStoreOptions)
-    const repository = new Repository(docCacheLimit, logger, concurrentTasksLimit)
+    const repository = new Repository(docCacheLimit, concurrentRequestsLimit, logger)
     const dispatcher = new Dispatcher(ipfs, networkOptions.pubsubTopic, repository, logger, pubsubLogger)
 
     const params: CeramicParameters = {
       cacheDocumentCommits: config.cacheDocCommits ?? true,
-      docCacheLimit: docCacheLimit,
-      concurrentTasksLimit: concurrentTasksLimit,
       networkOptions,
       supportedChains,
       validateDocs: config.validateDocs ?? true,

--- a/packages/core/src/pubsub/task-queue.ts
+++ b/packages/core/src/pubsub/task-queue.ts
@@ -6,8 +6,23 @@ export const noop = () => {
 
 export type Task<TaskResultType> = () => Promise<TaskResultType>;
 
+/**
+ * TaskQueue aspect.
+ */
 export interface TaskQueueLike {
+  /**
+   * Add task to the queue, and disregard its result. Fire-and-forget semantics.
+   *
+   * @param task - task to run
+   * @param onFinally - function to call when the task is finished, optional
+   */
   add(task: Task<void>, onFinally?: () => void | Promise<void>): void;
+
+  /**
+   * Add task to the queue. Return its result in Promise.
+   * The point of `run` (as opposed to `add`) is to pass an error to the caller if it is throw inside a task.
+   * Note "fire-and-forget" comment for the `add` method.
+   */
   run<T>(task: Task<T>): Promise<T>;
 }
 

--- a/packages/core/src/state-management/__tests__/cache-eviction.test.ts
+++ b/packages/core/src/state-management/__tests__/cache-eviction.test.ts
@@ -32,7 +32,7 @@ test('Doctype not subscribed, RunningState in cache', async () => {
   const document = await TileDoctype.create(ceramic, INITIAL);
   const state$ = await ceramic.repository.load(document.id, {});
   const updateRecord = await document.makeCommit(ceramic, UPDATED);
-  await ceramic.repository.stateManager.applyCommit(state$, updateRecord, { anchor: false, publish: false });
+  await ceramic.repository.stateManager.applyCommit(state$.id, updateRecord, { anchor: false, publish: false });
   // Doctype does not see the change
   expect(document.state.content).toEqual(INITIAL);
   expect(document.state.next).toBeUndefined();
@@ -48,7 +48,7 @@ test('Doctype not subscribed, RunningState evicted', async () => {
 
   const state2$ = await ceramic.repository.load(document.id, {});
   const updateRecord = await new TileDoctype(state$, ceramic.context).makeCommit(ceramic, UPDATED);
-  await ceramic.repository.stateManager.applyCommit(state2$, updateRecord, { anchor: false, publish: false });
+  await ceramic.repository.stateManager.applyCommit(state2$.id, updateRecord, { anchor: false, publish: false });
 
   // Doctype does not see the change
   expect(document.state.content).toEqual(INITIAL);
@@ -63,7 +63,7 @@ test('Doctype subscribed, RunningState in cache', async () => {
   document.subscribe();
   const state$ = await ceramic.repository.load(document.id, {});
   const updateRecord = await document.makeCommit(ceramic, UPDATED);
-  await ceramic.repository.stateManager.applyCommit(state$, updateRecord, { anchor: false, publish: false });
+  await ceramic.repository.stateManager.applyCommit(state$.id, updateRecord, { anchor: false, publish: false });
   // Doctype sees the change
   expect(document.state.content).toEqual(INITIAL);
   expect(document.state.next.content).toEqual(UPDATED);
@@ -81,7 +81,7 @@ test('Doctype subscribed, RunningState not evicted', async () => {
   const state2$ = await ceramic.repository.load(document.id, {});
   expect(state2$).toBe(state$);
   const updateRecord = await new TileDoctype(state$, ceramic.context).makeCommit(ceramic, UPDATED);
-  await ceramic.repository.stateManager.applyCommit(state2$, updateRecord, { anchor: false, publish: false });
+  await ceramic.repository.stateManager.applyCommit(state2$.id, updateRecord, { anchor: false, publish: false });
 
   // Doctype sees change
   expect(document.state.content).toEqual(INITIAL);

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -66,7 +66,7 @@ export class Repository {
     this.loadingQ = new NamedTaskQueue((error) => {
       logger.err(error);
     });
-    this.executionQ = new ExecutionQueue(concurrencyLimit, logger, (docId) => this.get(docId));
+    this.executionQ = new ExecutionQueue(concurrencyLimit, logger);
     this.inmemory = new StateCache(cacheLimit, (state$) => state$.complete());
     this.updates$ = this.updates$.bind(this);
   }
@@ -81,6 +81,8 @@ export class Repository {
       deps.anchorService,
       deps.conflictResolution,
       this.logger,
+      (docId) => this.get(docId),
+      (docId) => this.load(docId),
     );
   }
 

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -62,12 +62,11 @@ export class Repository {
    * @param logger - Where we put diagnostics messages.
    * @param concurrencyLimit - Maximum number of concurrently running tasks on the documents.
    */
-  constructor(cacheLimit: number, private readonly logger: DiagnosticsLogger, concurrencyLimit?: number) {
+  constructor(cacheLimit: number, concurrencyLimit: number, private readonly logger: DiagnosticsLogger) {
     this.loadingQ = new NamedTaskQueue((error) => {
       logger.err(error);
     });
-    const effectiveConcurrencyLimit = cacheLimit || concurrencyLimit;
-    this.executionQ = new ExecutionQueue(effectiveConcurrencyLimit, logger, (docId) => this.get(docId));
+    this.executionQ = new ExecutionQueue(concurrencyLimit, logger, (docId) => this.get(docId));
     this.inmemory = new StateCache(cacheLimit, (state$) => state$.complete());
     this.updates$ = this.updates$.bind(this);
   }

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -2,10 +2,10 @@ import DocID from '@ceramicnetwork/docid';
 import {
   AnchorService,
   AnchorStatus,
-  Context,
+  Context, CreateOpts,
   DocState,
   DocStateHolder,
-  LoadOpts
+  LoadOpts,
 } from '@ceramicnetwork/common';
 import { PinStore } from '../store/pin-store';
 import { NamedTaskQueue } from './named-task-queue';
@@ -82,7 +82,7 @@ export class Repository {
       deps.conflictResolution,
       this.logger,
       (docId) => this.get(docId),
-      (docId) => this.load(docId),
+      (docId, opts) => this.load(docId, opts),
     );
   }
 
@@ -127,7 +127,7 @@ export class Repository {
    * Returns a document from wherever we can get information about it.
    * Starts by checking if the document state is present in the in-memory cache, if not then then checks the state store, and finally loads the document from pubsub.
    */
-  async load(docId: DocID, opts: LoadOpts): Promise<RunningState> {
+  async load(docId: DocID, opts: LoadOpts | CreateOpts): Promise<RunningState> {
     return this.loadingQ.run(docId.toString(), async () => {
       const fromMemory = this.fromMemory(docId);
       if (fromMemory) return fromMemory;

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -39,7 +39,7 @@ export class StateManager {
     public conflictResolution: ConflictResolution,
     private readonly logger: DiagnosticsLogger,
     private readonly fromMemoryOrStore: (docId: DocID) => Promise<RunningState | undefined>,
-    private readonly load: (docId: DocID, opts?: LoadOpts | CreateOpts | UpdateOpts) => Promise<RunningState>,
+    private readonly load: (docId: DocID, opts?: LoadOpts | CreateOpts) => Promise<RunningState>,
   ) {}
 
   /**
@@ -134,7 +134,7 @@ export class StateManager {
    */
   update(docId: DocID, tip: CID): void {
     this.executionQ.forDocument(docId).add(async () => {
-      const state$ = await this.get(docId);
+      const state$ = await this.fromMemoryOrStore(docId);
       if (state$) await this.handleTip(state$, tip);
     });
   }

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -20,6 +20,17 @@ import { SnapshotState } from './snapshot-state';
 import { CommitID, DocID } from '@ceramicnetwork/docid';
 
 export class StateManager {
+
+  /**
+   * @param dispatcher - currently used instance of Dispatcher
+   * @param pinStore - currently used instance of PinStore
+   * @param executionQ - currently used instance of ExecutionQueue
+   * @param anchorService - currently used instance of AnchorService
+   * @param conflictResolution - currently used instance of ConflictResolution
+   * @param logger - Logger
+   * @param fromMemoryOrStore - load RunningState from in-memory cache or from state store, see `Repository#get`.
+   * @param load - `Repository#load`
+   */
   constructor(
     private readonly dispatcher: Dispatcher,
     private readonly pinStore: PinStore,
@@ -27,7 +38,7 @@ export class StateManager {
     public anchorService: AnchorService,
     public conflictResolution: ConflictResolution,
     private readonly logger: DiagnosticsLogger,
-    private readonly get: (docId: DocID) => Promise<RunningState | undefined>,
+    private readonly fromMemoryOrStore: (docId: DocID) => Promise<RunningState | undefined>,
     private readonly load: (docId: DocID, opts?: LoadOpts | CreateOpts | UpdateOpts) => Promise<RunningState>,
   ) {}
 

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -95,7 +95,7 @@ export class StateManager {
     }
   }
 
-  async handleTip(state$: RunningState, cid: CID): Promise<void> {
+  private async handleTip(state$: RunningState, cid: CID): Promise<void> {
     const next = await this.conflictResolution.applyTip(state$.value, cid);
     if (next) {
       state$.next(next);


### PR DESCRIPTION
Add one more config parameter: `concurrentTasksLimit`. By default it is the same as `docCacheLimit`.
Sets the upper bound of concurrently processing documents.