### PR TITLE
Daemon error handling

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,7 +67,6 @@
     "logfmt": "^1.3.2",
     "morgan": "^1.10.0",
     "multiformats": "~4.6.1",
-    "os-utils": "0.0.14",
     "s3leveldown": "^2.2.1",
     "stream-to-array": "^2.3.0",
     "uint8arrays": "^2.0.5"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,7 @@
     }
   },
   "dependencies": {
+    "@awaitjs/express": "^0.7.2",
     "@ceramicnetwork/3id-did-resolver": "^1.2.0-rc.1",
     "@ceramicnetwork/common": "^0.18.0-rc.0",
     "@ceramicnetwork/core": "^0.22.0-rc.0",

--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -39,8 +39,6 @@ program
         logDirectory,
         network,
         pubsubTopic,
-        maxHealthyCpu,
-        maxHealthyMemory,
         corsAllowedOrigins
     }) => {
         if (stateStoreDirectory && stateStoreS3Bucket) {
@@ -62,8 +60,6 @@ program
             logDirectory,
             network,
             pubsubTopic,
-            maxHealthyCpu,
-            maxHealthyMemory,
             corsAllowedOrigins
         )
     })

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -54,8 +54,6 @@ export class CeramicCliUtils {
      * @param logDirectory - Store log files in this directory
      * @param network - The Ceramic network to connect to
      * @param pubsubTopic - Pub/sub topic to use for protocol messages.
-     * @param maxHealthyCpu - Max fraction of total CPU usage considered healthy. Default is 0.7
-     * @param maxHealthyMemory - Max fraction of total memory usage considered healthy. Default is 0.7
      * @param corsAllowedOrigins - Origins for Access-Control-Allow-Origin header. Default is all
      */
     static async createDaemon(
@@ -74,8 +72,6 @@ export class CeramicCliUtils {
         logDirectory: string,
         network = DEFAULT_NETWORK,
         pubsubTopic: string,
-        maxHealthyCpu = 0.7,
-        maxHealthyMemory = 0.7,
         corsAllowedOrigins: string
     ): Promise<CeramicDaemon> {
         let _corsAllowedOrigins: string | RegExp[] = '*'
@@ -101,8 +97,6 @@ export class CeramicCliUtils {
             loggerConfig,
             network,
             pubsubTopic,
-            maxHealthyCpu,
-            maxHealthyMemory,
             corsAllowedOrigins: _corsAllowedOrigins,
             ipfsHost: ipfsApi,
         }

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -282,7 +282,7 @@ class CeramicDaemon {
   }
 
   async _notSupported (req: Request, res: Response): Promise<void> {
-    res.status(400).json({ status: 'error', message: 'Method not supported by read only Ceramic Gateway' })
+    res.status(400).json({ error: 'Method not supported by read only Ceramic Gateway' })
   }
 
   async getSupportedChains (req: Request, res: Response): Promise<void> {

--- a/packages/cli/src/daemon/error-handler.ts
+++ b/packages/cli/src/daemon/error-handler.ts
@@ -6,7 +6,7 @@ import { DiagnosticsLogger } from '@ceramicnetwork/common';
  */
 export function errorHandler(logger: DiagnosticsLogger): ErrorRequestHandler {
   return (err: Error, req: Request, res: Response, next: NextFunction) => {
-    (req as any).error = err // Allow other middlewares access the error
+    res.locals.error = err; // Allow other middlewares access the error
     logger.err(err);
     if (res.headersSent) {
       return next(err);

--- a/packages/cli/src/daemon/error-handler.ts
+++ b/packages/cli/src/daemon/error-handler.ts
@@ -1,0 +1,20 @@
+import { ErrorRequestHandler, NextFunction, Request, Response } from 'express';
+import { DiagnosticsLogger } from '@ceramicnetwork/common';
+
+/**
+ * Generic error handling middleware for the daemon.
+ */
+export function errorHandler(logger: DiagnosticsLogger): ErrorRequestHandler {
+  return (err: Error, req: Request, res: Response, next: NextFunction) => {
+    (req as any).error = err // Allow other middlewares access the error
+    logger.err(err);
+    if (res.headersSent) {
+      return next(err);
+    }
+    if (res.statusCode < 300) {
+      // 2xx indicates error has not yet been handled
+      res.status(500);
+    }
+    res.send({ error: err.message });
+  };
+}

--- a/packages/cli/src/daemon/log-requests.ts
+++ b/packages/cli/src/daemon/log-requests.ts
@@ -23,5 +23,5 @@ export function logRequests(loggerProvider: LoggerProvider): any[] {
 
   const logger = loggerProvider.makeServiceLogger('http-access');
 
-  return [morgan(ACCESS_LOG_FMT, { stream: logger })];
+  return morgan(ACCESS_LOG_FMT, { stream: logger });
 }

--- a/packages/cli/src/daemon/log-requests.ts
+++ b/packages/cli/src/daemon/log-requests.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from 'express';
+import { LoggerProvider } from '@ceramicnetwork/common';
+import morgan from 'morgan';
+
+const ACCESS_LOG_FMT = 'ip=:remote-addr ts=:date[iso] method=:method original_url=:original-url base_url=:base-url path=:path http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=:user-agent elapsed_ms=:total-time[3] error_message=:error-message error_code=:error-code';
+
+export function logRequests(loggerProvider: LoggerProvider): any[] {
+  morgan.token<Request, Response>('error-message', (req) => {
+    return req.error?.message;
+  });
+  morgan.token<Request, Response>('error-code', (req) => {
+    return req.error?.code;
+  });
+  morgan.token<Request, Response>('original-url', (req) => {
+    return req.originalUrl;
+  });
+  morgan.token<Request, Response>('base-url', (req) => {
+    return req.baseUrl;
+  });
+  morgan.token<Request, Response>('path', (req) => {
+    return req.path;
+  });
+
+  const logger = loggerProvider.makeServiceLogger('http-access');
+
+  return [morgan(ACCESS_LOG_FMT, { stream: logger })];
+}

--- a/packages/cli/src/daemon/log-requests.ts
+++ b/packages/cli/src/daemon/log-requests.ts
@@ -5,11 +5,11 @@ import morgan from 'morgan';
 const ACCESS_LOG_FMT = 'ip=:remote-addr ts=:date[iso] method=:method original_url=:original-url base_url=:base-url path=:path http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=:user-agent elapsed_ms=:total-time[3] error_message=:error-message error_code=:error-code';
 
 export function logRequests(loggerProvider: LoggerProvider): any[] {
-  morgan.token<Request, Response>('error-message', (req) => {
-    return req.error?.message;
+  morgan.token<Request, Response>('error-message', (req, res: Response) => {
+    return res.locals.error?.message;
   });
-  morgan.token<Request, Response>('error-code', (req) => {
-    return req.error?.code;
+  morgan.token<Request, Response>('error-code', (req, res: Response) => {
+    return res.locals.error?.code;
   });
   morgan.token<Request, Response>('original-url', (req) => {
     return req.originalUrl;

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -169,6 +169,7 @@ class Ceramic implements CeramicApi {
   readonly repository: Repository;
 
   readonly _doctypeHandlers: HandlersMap
+  readonly loggerProvider: LoggerProvider;
   private readonly _ipfsTopology: IpfsTopology
   private readonly _logger: DiagnosticsLogger
   private readonly _networkOptions: CeramicNetworkOptions
@@ -178,6 +179,7 @@ class Ceramic implements CeramicApi {
 
   constructor (modules: CeramicModules, params: CeramicParameters) {
     this._ipfsTopology = modules.ipfsTopology
+    this.loggerProvider = modules.loggerProvider;
     this._logger = modules.loggerProvider.getDiagnosticsLogger()
     this.repository = modules.repository
     this.pin = new LocalPinApi(this.repository, this._loadDoc.bind(this), this._logger)

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -38,8 +38,7 @@
     "ipfs": "~0.54.2",
     "ipfs-http-gateway": "~0.3.2",
     "ipfs-http-server": "~0.3.3",
-    "multiformats": "~4.6.1",
-    "os-utils": "^0.0.14"
+    "multiformats": "~4.6.1"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
- LoggerProvider is exposed as a field of Ceramic core node (Context ≠ DI)
- Beautification for async request handlers. This makes all the errors fall to the generic error handler.
- Generic error handler dumps error message to DiagnosticsLogger and response back with 500 error
- Morgan now exposes caught error as `error_message` and `error_code` tokens.
- Drop health checks

<img width="1433" alt="Screenshot 2021-04-06 at 21 56 44" src="https://user-images.githubusercontent.com/193527/113764298-6ccdac80-9723-11eb-9eb4-6923bdbb37b6.png">
