### PR TITLE
Ipfs daemon docker

### DIFF
--- a/Dockerfile.ipfs-daemon
+++ b/Dockerfile.ipfs-daemon
@@ -1,0 +1,39 @@
+FROM node:14
+
+RUN apt-get update && apt-get install -y netcat
+
+WORKDIR /js-ceramic
+
+COPY package.json package-lock.json ./
+RUN npm install
+
+COPY lerna.json tsconfig.json ./
+
+COPY packages/3id-did-resolver/package*.json ./packages/3id-did-resolver/
+COPY packages/cli/package*.json ./packages/cli/
+COPY packages/common/package*.json ./packages/common/
+COPY packages/core/package*.json ./packages/core/
+COPY packages/docid/package*.json ./packages/docid/
+COPY packages/doctype-caip10-link/package*.json ./packages/doctype-caip10-link/
+COPY packages/doctype-tile/package*.json ./packages/doctype-tile/
+COPY packages/http-client/package*.json ./packages/http-client/
+COPY packages/ipfs-daemon/package*.json ./packages/ipfs-daemon/
+COPY packages/ipfs-topology/package*.json ./packages/ipfs-topology/
+COPY packages/key-did-resolver/package*.json ./packages/key-did-resolver/
+COPY packages/logger/package*.json ./packages/logger/
+COPY packages/pinning-aggregation/package*.json ./packages/pinning-aggregation/
+COPY packages/pinning-ipfs-backend/package*.json ./packages/pinning-ipfs-backend/
+COPY packages/pinning-powergate-backend/package*.json ./packages/pinning-powergate-backend/
+
+RUN npx lerna bootstrap --hoist
+
+COPY packages ./packages
+COPY types ./types
+
+RUN npm run build
+
+EXPOSE 5011
+EXPOSE 9011
+
+ENTRYPOINT ["./packages/ipfs-daemon/bin/ipfs-daemon.js"]
+

--- a/packages/ipfs-daemon/.dockerignore
+++ b/packages/ipfs-daemon/.dockerignore
@@ -1,3 +1,0 @@
-node_modules
-.git
-.github

--- a/packages/ipfs-daemon/Dockerfile
+++ b/packages/ipfs-daemon/Dockerfile
@@ -1,8 +1,0 @@
-FROM node:14.10.1
-
-RUN npm --global config set user root && \
-    npm install --global @ceramicnetwork/ipfs-daemon
-
-EXPOSE 4011 4012 5011 9011 8011
-
-CMD ipfs-daemon

--- a/packages/ipfs-daemon/src/index.ts
+++ b/packages/ipfs-daemon/src/index.ts
@@ -1,3 +1,2 @@
 export * from './ipfs-daemon'
-export * from './ipfs-daemon'
 export * from './healthcheck-server'

--- a/packages/ipfs-daemon/src/ipfs-daemon.ts
+++ b/packages/ipfs-daemon/src/ipfs-daemon.ts
@@ -86,7 +86,7 @@ export class IpfsDaemon {
             bucket: configuration.awsBucketName,
             accessKeyId: configuration.awsAccessKeyId,
             secretAccessKey: configuration.awsSecretAccessKey,
-        }) : null
+        }) : configuration.ipfsPath
 
         const ipfs = await IPFS.create({
             start: false,


### PR DESCRIPTION
### Motivation

On infra the migration from 9 to 10 is failing. The very odd thing here is the the image built from `develop` branch results in v9. Images built from `master` are properly using v10. The docker image we are using for the build just pulls from npm so this PR addresses that issue. No guarantees it will fix the migration problem unfortunately but submitted an issue here: https://github.com/ipfs/js-ipfs-repo/issues/299

### Changes
- Replaces Dockerfile with Dockerfile.ipfs-daemon in root
- Builds ipfs-daemon with lerna
- Uses ipfs path specified in config by default