### PR TITLE
feat(http-client,cli): Rename docOpts to opts in http api

### DIFF
--- a/packages/3id-did-resolver/src/__tests__/vectors.json
+++ b/packages/3id-did-resolver/src/__tests__/vectors.json
@@ -159,13 +159,13 @@
       }
     },
     "http://localhost:7007/api/v0/documents": [{
-      "expectedBody": {"doctype":"tile","genesis":{"header":{"controllers":["did:key:zQ3shcMwX6vEZkbCWrZqL5W47yditTzauxC5x4WNbgo5r2PbW"],"family":"3id"}},"docOpts":{"anchor":false,"publish":false}},
+      "expectedBody": {"doctype":"tile","genesis":{"header":{"controllers":["did:key:zQ3shcMwX6vEZkbCWrZqL5W47yditTzauxC5x4WNbgo5r2PbW"],"family":"3id"}},"opts":{"anchor":false,"publish":false}},
       "response": {
         "docId":"k2t6wyfsu4pfzxkvkqs4sxhgk2vy60icvko3jngl56qzmdewud4lscf5p93wna",
         "state":{"doctype":"tile","content":{"publicKeys":{"ALmMYTWJ5UKJ4CM":"zQ3shi9zKgi8T5x8gD41cGUbXfnvextDoVALmMYTWJ5UKJ4CM","ybNYrGwCnFBSJza":"z6LSrJMTEUvAWvnv63NmvN9zZ54HMR15TybNYrGwCnFBSJza"}},"metadata":{"family":"3id","controllers":["did:key:z6Mkte2hed9vh5xaKPhxF8EpA5jj71BF4Gk1efkuRvNPmgRN"]},"signature":2,"anchorStatus":"ANCHORED","log":[{"cid":"bafyreiecg6f5fcfkyhtrcwn6v2k3gtoyrshxbm5lqua4s337huq2meefay","type":0},{"cid":"bagcqcera3jzvu6lfkstkgr5ykabaaikf5uu2dqum4n2q33c2mj4v6byanria","type":1},{"cid":"bafyreie7ova3gtkvkgla6cslvism7kjn4uzhtngahyir5dng2pfa4vouja","type":2,"timestamp":1615908910},{"cid":"bagcqcera4nkr2zsd55zozxllhdoacn7qwz47xj23cecjub3mcrx35uf2zz5q","type":1},{"cid":"bafyreihlb5brxifcy3eb7v4vqw27r56clvizkt5x5gricdh77w45kwvq4y","type":2,"timestamp":1615909089}],"anchorProof":{"root":"bagcqcera4nkr2zsd55zozxllhdoacn7qwz47xj23cecjub3mcrx35uf2zz5q","txHash":"bagjqcgzazuikj3gdyfbghkknahtuavveqnft6rnjr4u7bbijohbczzsmr6ha","chainId":"eip155:3","blockNumber":9849831,"blockTimestamp":1615909089}}
       }
     }, {
-      "expectedBody": {"doctype":"tile","genesis":{"header":{"controllers":["did:key:zQ3shcMwX6vEZkhBgM38F4erHWNDfsHQhxtHrJdUDqh515pT2"],"family":"3id"}},"docOpts":{"anchor":false,"publish":false}},
+      "expectedBody": {"doctype":"tile","genesis":{"header":{"controllers":["did:key:zQ3shcMwX6vEZkhBgM38F4erHWNDfsHQhxtHrJdUDqh515pT2"],"family":"3id"}},"opts":{"anchor":false,"publish":false}},
       "response": {
         "docId":"k2t6wyfsu4pfxkwr4xlff0joqfejg1b42ujhzo4xcf0ujw2upuko0mf5b7834q",
         "state":{"doctype":"tile","content":{},"metadata":{"family":"3id","controllers":["did:key:zQ3shcMwX6vEZkhBgM38F4erHWNDfsHQhxtHrJdUDqh515pT2"]},"signature":0,"anchorStatus":"NOT_REQUESTED","log":[{"cid":"bafyreibd3imfprrpgsvm7qciu7pszyaevvy5acg74ksckbfpjkxhqnke3i","type":0}]}

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -177,8 +177,8 @@ class CeramicDaemon {
    * @dev Useful when the docId is unknown, but you have the genesis contents
    */
   async createDocFromGenesis (req: Request, res: Response): Promise<void> {
-    const { doctype, genesis, docOpts } = req.body
-    const doc = await this.ceramic.createDocumentFromGenesis(doctype, DoctypeUtils.deserializeCommit(genesis), docOpts)
+    const { doctype, genesis, opts } = req.body
+    const doc = await this.ceramic.createDocumentFromGenesis(doctype, DoctypeUtils.deserializeCommit(genesis), opts)
     res.json({ docId: doc.id.toString(), state: DoctypeUtils.serializeState(doc.state) })
   }
 
@@ -190,8 +190,8 @@ class CeramicDaemon {
    * to rename this, e.g. `loadDocFromGenesis`
    */
   async createReadOnlyDocFromGenesis (req: Request, res: Response): Promise<void> {
-    const { doctype, genesis, docOpts } = req.body
-    const readOnlyDocOpts = { ...docOpts, anchor: false, publish: false }
+    const { doctype, genesis, opts } = req.body
+    const readOnlyDocOpts = { ...opts, anchor: false, publish: false }
     const doc = await this.ceramic.createDocumentFromGenesis(doctype, DoctypeUtils.deserializeCommit(genesis), readOnlyDocOpts)
     res.json({ docId: doc.id.toString(), state: DoctypeUtils.serializeState(doc.state) })
   }
@@ -224,12 +224,12 @@ class CeramicDaemon {
    * Apply one commit to the existing document
    */
   async applyCommit (req: Request, res: Response): Promise<void> {
-    const { docId, commit, docOpts } = req.body
+    const { docId, commit, opts } = req.body
     if (!(docId && commit)) {
       throw new Error('docId and commit are required in order to apply commit')
     }
 
-    const doctype = await this.ceramic.applyCommit(docId, DoctypeUtils.deserializeCommit(commit), docOpts)
+    const doctype = await this.ceramic.applyCommit(docId, DoctypeUtils.deserializeCommit(commit), opts)
     res.json({ docId: doctype.id.toString(), state: DoctypeUtils.serializeState(doctype.state) })
   }
 

--- a/packages/http-client/src/document.ts
+++ b/packages/http-client/src/document.ts
@@ -43,25 +43,25 @@ export class Document extends Observable<DocState> implements RunningStateLike {
     return new DocID(this.state$.value.doctype, this.state$.value.log[0].cid)
   }
 
-  static async createFromGenesis (apiUrl: string, doctype: string, genesis: any, docOpts: DocOpts = {}, docSyncInterval: number): Promise<Document> {
+  static async createFromGenesis (apiUrl: string, doctype: string, genesis: any, opts: DocOpts = {}, docSyncInterval: number): Promise<Document> {
     const { state } = await fetchJson(apiUrl + '/documents', {
       method: 'post',
       body: {
         doctype,
         genesis: DoctypeUtils.serializeCommit(genesis),
-        docOpts,
+        opts,
       }
     })
     return new Document(DoctypeUtils.deserializeState(state), apiUrl, docSyncInterval)
   }
 
-  static async applyCommit(apiUrl: string, docId: DocID | string, commit: CeramicCommit, docOpts: DocOpts = {}, docSyncInterval: number): Promise<Document> {
+  static async applyCommit(apiUrl: string, docId: DocID | string, commit: CeramicCommit, opts: DocOpts = {}, docSyncInterval: number): Promise<Document> {
     const { state } = await fetchJson(apiUrl + '/commits', {
       method: 'post',
       body: {
         docId: docId.toString(),
         commit: DoctypeUtils.serializeCommit(commit),
-        docOpts,
+        opts,
       }
     })
     return new Document(DoctypeUtils.deserializeState(state), apiUrl, docSyncInterval)


### PR DESCRIPTION
This is technically a breaking change to the HTTP api, but a minor one. It seemed worth doing to avoid having an arg called docOpts when we're moving away from calling all doctypes (streamtypes) documents.