### PR TITLE
feat(cli,http-client): Update HTTP API to use streams terminology

### DIFF
--- a/packages/3id-did-resolver/src/__tests__/vectors.json
+++ b/packages/3id-did-resolver/src/__tests__/vectors.json
@@ -124,25 +124,25 @@
     }]
   },
   "http-mock": {
-    "http://localhost:7007/api/v0/documents/kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd": {
+    "http://localhost:7007/api/v0/streams/kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd": {
       "response": {
         "streamId":"kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
         "state":{"doctype":"tile","content":{"publicKeys":{"aH6oxPEu6krriD6":"zQ3shQEcoeWywQMtWhy7ELMb7hbQomieHEaH6oxPEu6krriD6","HWPYEjsV6rz1nB8":"z6LSgS2iPPMDBqEramx4dA9uuuDMBzxHRHWPYEjsV6rz1nB8"}},"metadata":{"family":"3id","controllers":["did:key:zQ3shVxRcEQZ7AvWBDDEhMF2jGvF9MtF5eLZbJyvSYDmUDzeE"]},"signature":2,"anchorStatus":"ANCHORED","log":[{"cid":"bagcqcerabw6s2dqgxfrpmizqacuprdr5qnoiupgmlsv2662to5w6kdwdfs4q","type":0},{"cid":"bagcqcera24xtfgnl3izrdwpe663arliev42dvyxiud4crclcdlckhwlg4pbq","type":1},{"cid":"bafyreidmpfv7aumgqeqacprb2yv3t7sapsoro6dpopopyxtelknfbxifia","type":2,"timestamp":1615889301},{"cid":"bagcqcerarn5y5u546lnvgnn4w6d6q7d7ihg45kf3yozflt6h2ddnwgdwj63a","type":1},{"cid":"bafyreigxsxcy6goi2rk6pnjf3ij5quw2re2pmjpnk44bge6bb7a6borzdu","type":2,"timestamp":1615889477}],"anchorProof":{"root":"bafyreiagxwetpt44kyfr3ngrbdrlx2lwx2tpxwesfaxph7xviguekz7hrq","txHash":"bagjqcgzanmie4uajazd2tsbbcazhic74k4z3lirlskaiyg3nixsg6fgf5lnq","chainId":"eip155:3","blockNumber":9848458,"blockTimestamp":1615889477}}
       }
     },
-    "http://localhost:7007/api/v0/documents/k3y52l7qbv1frxjxxpq1sc3seebw7bt5l802pik95vqbkwjmigqkyy8vmyd1e1csg": {
+    "http://localhost:7007/api/v0/streams/k3y52l7qbv1frxjxxpq1sc3seebw7bt5l802pik95vqbkwjmigqkyy8vmyd1e1csg": {
       "response": {
         "streamId":"kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
         "state":{"doctype":"tile","content":{"publicKeys":{"8HvzHTqA8yTsXxf":"zQ3shXKh4rjw3oFDtBwbvzaYNUiDN9NkWF8HvzHTqA8yTsXxf","LpuhVp4zz6hDB3s":"z6LSeo1saHatadZ1kBwcaHcrDSfMLn1E3LpuhVp4zz6hDB3s"}},"metadata":{"family":"3id","controllers":["did:key:zQ3shWGPatnKuJmUYYfYcFe8sayACuqyNWxu3Noom4p1iariH"]},"signature":2,"anchorStatus":"NOT_REQUESTED","log":[{"cid":"bagcqcerabw6s2dqgxfrpmizqacuprdr5qnoiupgmlsv2662to5w6kdwdfs4q","type":0}]}
       }
     },
-    "http://localhost:7007/api/v0/documents/k6zn3rc3v8qin09w7whr6b19hpkbxwqhi3fbtlg9pjzloe9tizfvta0yhfakd2nnu55vigiyfd4h874uvopwgta10yn6zbz7b4imm89y5t811jkmv5zekao": {
+    "http://localhost:7007/api/v0/streams/k6zn3rc3v8qin09w7whr6b19hpkbxwqhi3fbtlg9pjzloe9tizfvta0yhfakd2nnu55vigiyfd4h874uvopwgta10yn6zbz7b4imm89y5t811jkmv5zekao": {
       "response": {
         "streamId":"kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
         "state":{"doctype":"tile","content":{"publicKeys":{"HU1DGqXqxA2L4n2":"zQ3shWxU6hGbKheX8rTxANLv1f3m2FAnMjHU1DGqXqxA2L4n2","n7SH4mBgNemdDAQ":"z6LSoPijq7fiR49ZrE3791Mf11R1QMaXLn7SH4mBgNemdDAQ"}},"metadata":{"family":"3id","controllers":["did:key:zQ3shoFiAzypE4gzVKFmdESGRVreHTxryKUee6VBJSgfVDLJD"]},"signature":2,"anchorStatus":"ANCHORED","log":[{"cid":"bagcqcerabw6s2dqgxfrpmizqacuprdr5qnoiupgmlsv2662to5w6kdwdfs4q","type":0},{"cid":"bagcqcera24xtfgnl3izrdwpe663arliev42dvyxiud4crclcdlckhwlg4pbq","type":1},{"cid":"bafyreidmpfv7aumgqeqacprb2yv3t7sapsoro6dpopopyxtelknfbxifia","type":2,"timestamp":1615889301}],"anchorProof":{"root":"bafyreibqjxoxncglfxba25gzn4hc5li2rqiv2s26zynfqswi4r3zj256qq","txHash":"bagjqcgzawbvv27qyyjkere23eqh4q2psxzqhavbrhuij2effmvzeqbqyscrq","chainId":"eip155:3","blockNumber":9848447,"blockTimestamp":1615889301}}
       }
     },
-    "http://localhost:7007/api/v0/documents/k6zn3rc3v8qin09w7whr6b19hpkbxwqhi3fbtlg9pjzloe9tizfvta0yhfakd2nnu55vij72959zaqapdttwq2ioep79xtzrb0yub3buzy1uvp8wjtwljbx": {
+    "http://localhost:7007/api/v0/streams/k6zn3rc3v8qin09w7whr6b19hpkbxwqhi3fbtlg9pjzloe9tizfvta0yhfakd2nnu55vij72959zaqapdttwq2ioep79xtzrb0yub3buzy1uvp8wjtwljbx": {
       "response": {
         "streamId":"kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
         "state":{"doctype":"tile","content":{"publicKeys":{"aH6oxPEu6krriD6":"zQ3shQEcoeWywQMtWhy7ELMb7hbQomieHEaH6oxPEu6krriD6","HWPYEjsV6rz1nB8":"z6LSgS2iPPMDBqEramx4dA9uuuDMBzxHRHWPYEjsV6rz1nB8"}},"metadata":{"family":"3id","controllers":["did:key:zQ3shVxRcEQZ7AvWBDDEhMF2jGvF9MtF5eLZbJyvSYDmUDzeE"]},"signature":2,"anchorStatus":"ANCHORED","log":[{"cid":"bagcqcerabw6s2dqgxfrpmizqacuprdr5qnoiupgmlsv2662to5w6kdwdfs4q","type":0},{"cid":"bagcqcera24xtfgnl3izrdwpe663arliev42dvyxiud4crclcdlckhwlg4pbq","type":1},{"cid":"bafyreidmpfv7aumgqeqacprb2yv3t7sapsoro6dpopopyxtelknfbxifia","type":2,"timestamp":1615889301},{"cid":"bagcqcerarn5y5u546lnvgnn4w6d6q7d7ihg45kf3yozflt6h2ddnwgdwj63a","type":1},{"cid":"bafyreigxsxcy6goi2rk6pnjf3ij5quw2re2pmjpnk44bge6bb7a6borzdu","type":2,"timestamp":1615889477}],"anchorProof":{"root":"bafyreiagxwetpt44kyfr3ngrbdrlx2lwx2tpxwesfaxph7xviguekz7hrq","txHash":"bagjqcgzanmie4uajazd2tsbbcazhic74k4z3lirlskaiyg3nixsg6fgf5lnq","chainId":"eip155:3","blockNumber":9848458,"blockTimestamp":1615889477}}
@@ -158,32 +158,32 @@
         "value": {"id":"did:3:GENESIS","@context":"https://w3id.org/did/v1","publicKey":[{"id":"did:3:GENESIS#signingKey","type":"Secp256k1VerificationKey2018","publicKeyHex":"04de2478508c43997345976345976293873124139cae3634be7ffc221e9d0092a1b33e38fcdeb6354ad3b1cd1c6ffc4d69d409a21e7aa4e8b8bd990000000000e0"},{"id":"did:3:GENESIS#encryptionKey","type":"Curve25519EncryptionPublicKey","publicKeyBase64":"5HH9HIKBrQ7iERd4AfH+il3v+GbGbGbehJV6SdzHNnA="},{"id":"did:3:GENESIS#managementKey","type":"Secp256k1VerificationKey2018","ethereumAddress":"0x3f0bb6247d647a30f310025662b29e6fa382b61d"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:3:GENESIS#signingKey"}]}
       }
     },
-    "http://localhost:7007/api/v0/documents": [{
-      "expectedBody": {"doctype":"tile","genesis":{"header":{"controllers":["did:key:zQ3shcMwX6vEZkbCWrZqL5W47yditTzauxC5x4WNbgo5r2PbW"],"family":"3id"}},"docOpts":{"anchor":false,"publish":false,"sync":true}},
+    "http://localhost:7007/api/v0/streams": [{
+      "expectedBody": {"streamtype":"tile","genesis":{"header":{"controllers":["did:key:zQ3shcMwX6vEZkbCWrZqL5W47yditTzauxC5x4WNbgo5r2PbW"],"family":"3id"}},"opts":{"anchor":false,"publish":false,"sync":true}},
       "response": {
         "streamId":"k2t6wyfsu4pfzxkvkqs4sxhgk2vy60icvko3jngl56qzmdewud4lscf5p93wna",
         "state":{"doctype":"tile","content":{"publicKeys":{"ALmMYTWJ5UKJ4CM":"zQ3shi9zKgi8T5x8gD41cGUbXfnvextDoVALmMYTWJ5UKJ4CM","ybNYrGwCnFBSJza":"z6LSrJMTEUvAWvnv63NmvN9zZ54HMR15TybNYrGwCnFBSJza"}},"metadata":{"family":"3id","controllers":["did:key:z6Mkte2hed9vh5xaKPhxF8EpA5jj71BF4Gk1efkuRvNPmgRN"]},"signature":2,"anchorStatus":"ANCHORED","log":[{"cid":"bafyreiecg6f5fcfkyhtrcwn6v2k3gtoyrshxbm5lqua4s337huq2meefay","type":0},{"cid":"bagcqcera3jzvu6lfkstkgr5ykabaaikf5uu2dqum4n2q33c2mj4v6byanria","type":1},{"cid":"bafyreie7ova3gtkvkgla6cslvism7kjn4uzhtngahyir5dng2pfa4vouja","type":2,"timestamp":1615908910},{"cid":"bagcqcera4nkr2zsd55zozxllhdoacn7qwz47xj23cecjub3mcrx35uf2zz5q","type":1},{"cid":"bafyreihlb5brxifcy3eb7v4vqw27r56clvizkt5x5gricdh77w45kwvq4y","type":2,"timestamp":1615909089}],"anchorProof":{"root":"bagcqcera4nkr2zsd55zozxllhdoacn7qwz47xj23cecjub3mcrx35uf2zz5q","txHash":"bagjqcgzazuikj3gdyfbghkknahtuavveqnft6rnjr4u7bbijohbczzsmr6ha","chainId":"eip155:3","blockNumber":9849831,"blockTimestamp":1615909089}}
       }
     }, {
-      "expectedBody": {"doctype":"tile","genesis":{"header":{"controllers":["did:key:zQ3shcMwX6vEZkhBgM38F4erHWNDfsHQhxtHrJdUDqh515pT2"],"family":"3id"}},"docOpts":{"anchor":false,"publish":false,"sync":true}},
+      "expectedBody": {"streamtype":"tile","genesis":{"header":{"controllers":["did:key:zQ3shcMwX6vEZkhBgM38F4erHWNDfsHQhxtHrJdUDqh515pT2"],"family":"3id"}},"opts":{"anchor":false,"publish":false,"sync":true}},
       "response": {
         "streamId":"k2t6wyfsu4pfxkwr4xlff0joqfejg1b42ujhzo4xcf0ujw2upuko0mf5b7834q",
         "state":{"doctype":"tile","content":{},"metadata":{"family":"3id","controllers":["did:key:zQ3shcMwX6vEZkhBgM38F4erHWNDfsHQhxtHrJdUDqh515pT2"]},"signature":0,"anchorStatus":"NOT_REQUESTED","log":[{"cid":"bafyreibd3imfprrpgsvm7qciu7pszyaevvy5acg74ksckbfpjkxhqnke3i","type":0}]}
       }
     }],
-    "http://localhost:7007/api/v0/documents/k2t6wyfsu4pfzxkvkqs4sxhgk2vy60icvko3jngl56qzmdewud4lscf5p93wna": {
+    "http://localhost:7007/api/v0/streams/k2t6wyfsu4pfzxkvkqs4sxhgk2vy60icvko3jngl56qzmdewud4lscf5p93wna": {
       "response": {
         "streamId":"k2t6wyfsu4pfzxkvkqs4sxhgk2vy60icvko3jngl56qzmdewud4lscf5p93wna",
         "state":{"doctype":"tile","content":{"publicKeys":{"ALmMYTWJ5UKJ4CM":"zQ3shi9zKgi8T5x8gD41cGUbXfnvextDoVALmMYTWJ5UKJ4CM","ybNYrGwCnFBSJza":"z6LSrJMTEUvAWvnv63NmvN9zZ54HMR15TybNYrGwCnFBSJza"}},"metadata":{"family":"3id","controllers":["did:key:z6Mkte2hed9vh5xaKPhxF8EpA5jj71BF4Gk1efkuRvNPmgRN"]},"signature":2,"anchorStatus":"ANCHORED","log":[{"cid":"bafyreiecg6f5fcfkyhtrcwn6v2k3gtoyrshxbm5lqua4s337huq2meefay","type":0},{"cid":"bagcqcera3jzvu6lfkstkgr5ykabaaikf5uu2dqum4n2q33c2mj4v6byanria","type":1},{"cid":"bafyreie7ova3gtkvkgla6cslvism7kjn4uzhtngahyir5dng2pfa4vouja","type":2,"timestamp":1615908910},{"cid":"bagcqcera4nkr2zsd55zozxllhdoacn7qwz47xj23cecjub3mcrx35uf2zz5q","type":1},{"cid":"bafyreihlb5brxifcy3eb7v4vqw27r56clvizkt5x5gricdh77w45kwvq4y","type":2,"timestamp":1615909089}],"anchorProof":{"root":"bagcqcera4nkr2zsd55zozxllhdoacn7qwz47xj23cecjub3mcrx35uf2zz5q","txHash":"bagjqcgzazuikj3gdyfbghkknahtuavveqnft6rnjr4u7bbijohbczzsmr6ha","chainId":"eip155:3","blockNumber":9849831,"blockTimestamp":1615909089}}
       }
     },
-    "http://localhost:7007/api/v0/documents/kzdxps4zufv9j5fzvhklukv8370nejivdy3wuii6d0jihjp5jhvih0q0cvx3j6jxczu91kpedse4yq5ureo9wuj6c8h5bculafqgyvm4reyie5bjzxavc": {
+    "http://localhost:7007/api/v0/streams/kzdxps4zufv9j5fzvhklukv8370nejivdy3wuii6d0jihjp5jhvih0q0cvx3j6jxczu91kpedse4yq5ureo9wuj6c8h5bculafqgyvm4reyie5bjzxavc": {
       "response": {
         "streamId":"k2t6wyfsu4pfzxkvkqs4sxhgk2vy60icvko3jngl56qzmdewud4lscf5p93wna",
         "state":{"doctype":"tile","content":{"publicKeys":{"7jEnrHWn5h9s1cR":"zQ3shaorHAUVgpKcpftHCzXV6YyByHauDd7jEnrHWn5h9s1cR","DGxmANwF6Zq8hQP":"z6LSjn92Dhpr8Qgso12TbcBHkMxbPvnd8DGxmANwF6Zq8hQP"}},"metadata":{"family":"3id","controllers":["did:key:z6MkvEwWycRo2mAYTjRPdPoLd2TBELEY5qGRt38arKYH2ijP"]},"signature":2,"anchorStatus":"ANCHORED","log":[{"cid":"bafyreiecg6f5fcfkyhtrcwn6v2k3gtoyrshxbm5lqua4s337huq2meefay","type":0},{"cid":"bagcqcera3jzvu6lfkstkgr5ykabaaikf5uu2dqum4n2q33c2mj4v6byanria","type":1},{"cid":"bafyreie7ova3gtkvkgla6cslvism7kjn4uzhtngahyir5dng2pfa4vouja","type":2,"timestamp":1615908910}],"anchorProof":{"root":"bagcqcera3jzvu6lfkstkgr5ykabaaikf5uu2dqum4n2q33c2mj4v6byanria","txHash":"bagjqcgzamotsqoyh7rqbexhokob3v6mnwsmnaaxx23gsrk36fubrzcix2d4a","chainId":"eip155:3","blockNumber":9849818,"blockTimestamp":1615908910}}
       }
     },
-    "http://localhost:7007/api/v0/documents/kzdxps4zufv9j5fzvhklukv8370nejivdy3wuii6d0jihjp5jhvih0q0cvx3j6jxczuaxeqqni01wl6c58widm5e5v4hnosk1oodcplunzawd1zdxbh7q": {
+    "http://localhost:7007/api/v0/streams/kzdxps4zufv9j5fzvhklukv8370nejivdy3wuii6d0jihjp5jhvih0q0cvx3j6jxczuaxeqqni01wl6c58widm5e5v4hnosk1oodcplunzawd1zdxbh7q": {
       "response": {
         "streamId":"k2t6wyfsu4pfzxkvkqs4sxhgk2vy60icvko3jngl56qzmdewud4lscf5p93wna",
         "state":{"doctype":"tile","content":{"publicKeys":{"ALmMYTWJ5UKJ4CM":"zQ3shi9zKgi8T5x8gD41cGUbXfnvextDoVALmMYTWJ5UKJ4CM","ybNYrGwCnFBSJza":"z6LSrJMTEUvAWvnv63NmvN9zZ54HMR15TybNYrGwCnFBSJza"}},"metadata":{"family":"3id","controllers":["did:key:z6Mkte2hed9vh5xaKPhxF8EpA5jj71BF4Gk1efkuRvNPmgRN"]},"signature":2,"anchorStatus":"ANCHORED","log":[{"cid":"bafyreiecg6f5fcfkyhtrcwn6v2k3gtoyrshxbm5lqua4s337huq2meefay","type":0},{"cid":"bagcqcera3jzvu6lfkstkgr5ykabaaikf5uu2dqum4n2q33c2mj4v6byanria","type":1},{"cid":"bafyreie7ova3gtkvkgla6cslvism7kjn4uzhtngahyir5dng2pfa4vouja","type":2,"timestamp":1615908910},{"cid":"bagcqcera4nkr2zsd55zozxllhdoacn7qwz47xj23cecjub3mcrx35uf2zz5q","type":1},{"cid":"bafyreihlb5brxifcy3eb7v4vqw27r56clvizkt5x5gricdh77w45kwvq4y","type":2,"timestamp":1615909089}],"anchorProof":{"root":"bagcqcera4nkr2zsd55zozxllhdoacn7qwz47xj23cecjub3mcrx35uf2zz5q","txHash":"bagjqcgzazuikj3gdyfbghkknahtuavveqnft6rnjr4u7bbijohbczzsmr6ha","chainId":"eip155:3","blockNumber":9849831,"blockTimestamp":1615909089}}

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -187,8 +187,8 @@ class CeramicDaemon {
     if (!gateway) {
       app.postAsync(toApiPath('/streams'), this.createStreamFromGenesis.bind(this))
       app.postAsync(toApiPath('/commits'), this.applyCommit.bind(this))
-      app.postAsync(toApiPath('/pins/:streamid'), this.pinDocument.bind(this))
-      app.deleteAsync(toApiPath('/pins/:streamid'), this.unpinDocument.bind(this))
+      app.postAsync(toApiPath('/pins/:streamid'), this.pinStream.bind(this))
+      app.deleteAsync(toApiPath('/pins/:streamid'), this.unpinStream.bind(this))
 
       app.postAsync(toApiPath('/documents'), this.createDocFromGenesis.bind(this)) // Deprecated
       app.postAsync(toApiPath('/records'), this.applyCommit.bind(this)) // Deprecated
@@ -350,10 +350,9 @@ class CeramicDaemon {
   }
 
   /**
-   * Pin document
-   * // todo rename
+   * Pin stream
    */
-  async pinDocument (req: Request, res: Response): Promise<void> {
+  async pinStream (req: Request, res: Response): Promise<void> {
     const streamId = StreamID.fromString(req.params.streamid || req.params.docid)
     await this.ceramic.pin.add(streamId)
     res.json({
@@ -364,9 +363,9 @@ class CeramicDaemon {
   }
 
   /**
-   * Unpin document
+   * Unpin stream
    */
-  async unpinDocument (req: Request, res: Response): Promise<void> {
+  async unpinStream (req: Request, res: Response): Promise<void> {
     const streamId = StreamID.fromString(req.params.streamid || req.params.docid)
     await this.ceramic.pin.rm(streamId)
     res.json({
@@ -377,7 +376,7 @@ class CeramicDaemon {
   }
 
   /**
-   * List pinned documents
+   * List pinned streams
    */
   async listPinned (req: Request, res: Response): Promise<void> {
     let streamId: StreamID;

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -182,7 +182,7 @@ class CeramicDaemon {
     app.getAsync(toApiPath('/node/healthcheck'), this.healthcheck.bind(this))
 
     app.getAsync(toApiPath('/documents/:docid'), this.stateOld.bind(this)) // Deprecated
-    app.getAsync(toApiPath('/records/:docid'), this.commits.bind(this)) // Deprecated
+    app.getAsync(toApiPath('/records/:streamid'), this.commits.bind(this)) // Deprecated
 
     if (!gateway) {
       app.postAsync(toApiPath('/streams'), this.createStreamFromGenesis.bind(this))

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -174,26 +174,32 @@ class CeramicDaemon {
 
   registerAPIPaths (app: ExpressWithAsync, gateway: boolean): void {
     app.getAsync(toApiPath('/commits/:streamid'), this.commits.bind(this))
-    app.getAsync(toApiPath('/records/:streamid'), this.commits.bind(this))
     app.postAsync(toApiPath('/multiqueries'), this.multiQuery.bind(this))
-    app.getAsync(toApiPath('/documents/:streamid'), this.state.bind(this))
+    app.getAsync(toApiPath('/streams/:streamid'), this.state.bind(this))
     app.getAsync(toApiPath('/pins/:streamid'), this.listPinned.bind(this))
     app.getAsync(toApiPath('/pins'), this.listPinned.bind(this))
     app.getAsync(toApiPath('/node/chains'), this.getSupportedChains.bind(this))
     app.getAsync(toApiPath('/node/healthcheck'), this.healthcheck.bind(this))
 
+    app.getAsync(toApiPath('/documents/:docid'), this.stateOld.bind(this)) // Deprecated
+    app.getAsync(toApiPath('/records/:docid'), this.commits.bind(this)) // Deprecated
+
     if (!gateway) {
-      app.postAsync(toApiPath('/documents'), this.createDocFromGenesis.bind(this))
+      app.postAsync(toApiPath('/streams'), this.createStreamFromGenesis.bind(this))
       app.postAsync(toApiPath('/commits'), this.applyCommit.bind(this))
-      app.postAsync(toApiPath('/records'), this.applyCommit.bind(this))
       app.postAsync(toApiPath('/pins/:streamid'), this.pinDocument.bind(this))
       app.deleteAsync(toApiPath('/pins/:streamid'), this.unpinDocument.bind(this))
+
+      app.postAsync(toApiPath('/documents'), this.createDocFromGenesis.bind(this)) // Deprecated
+      app.postAsync(toApiPath('/records'), this.applyCommit.bind(this)) // Deprecated
     } else {
-      app.postAsync(toApiPath('/documents'), this.createReadOnlyDocFromGenesis.bind(this))
+      app.postAsync(toApiPath('/streams'), this.createReadOnlyStreamFromGenesis.bind(this))
       app.postAsync(toApiPath('/commits'),  this._notSupported.bind(this))
-      app.postAsync(toApiPath('/records'),  this._notSupported.bind(this))
       app.postAsync(toApiPath('/pins/:streamid'),  this._notSupported.bind(this))
       app.deleteAsync(toApiPath('/pins/:streamid'),  this._notSupported.bind(this))
+
+      app.postAsync(toApiPath('/documents'), this.createReadOnlyDocFromGenesis.bind(this)) // Deprecated
+      app.postAsync(toApiPath('/records'),  this._notSupported.bind(this)) // Deprecated
     }
   }
 
@@ -204,6 +210,7 @@ class CeramicDaemon {
   /**
    * Create document from genesis commit
    * @dev Useful when the streamId is unknown, but you have the genesis contents
+   * @deprecated
    */
   async createDocFromGenesis (req: Request, res: Response): Promise<void> {
     const { doctype, genesis, docOpts } = req.body
@@ -216,12 +223,24 @@ class CeramicDaemon {
   }
 
   /**
+   * Create document from genesis commit
+   * @dev Useful when the streamId is unknown, but you have the genesis contents
+   */
+  async createStreamFromGenesis (req: Request, res: Response): Promise<void> {
+    const { streamtype, genesis, opts } = req.body
+    const stream = await this.ceramic.createDocumentFromGenesis(streamtype, DoctypeUtils.deserializeCommit(genesis), opts)
+    res.json({ streamId: stream.id.toString(), state: DoctypeUtils.serializeState(stream.state) })
+  }
+
+  /**
    * Create read-only document from genesis commit
    * @dev Useful when the streamId is unknown, but you have the genesis contents
    * @TODO Should return null if document does not already exist instead of
    * current behavior, publishing to IPFS. With that change it will make sense
-   * to rename this, e.g. `loadDocFromGenesis`
+   * to rename this, e.g. `loadStreamFromGenesis`
+   * @deprecated
    */
+
   async createReadOnlyDocFromGenesis (req: Request, res: Response): Promise<void> {
     const { doctype, genesis, docOpts } = req.body
     const readOnlyDocOpts = { ...docOpts, anchor: false, publish: false }
@@ -234,17 +253,37 @@ class CeramicDaemon {
   }
 
   /**
-   * Get document state
+   * Create read-only document from genesis commit
+   * @dev Useful when the docId is unknown, but you have the genesis contents
+   * @TODO Should return null if document does not already exist instead of
+   * current behavior, publishing to IPFS. With that change it will make sense
+   * to rename this, e.g. `loadStreamFromGenesis`
+   */
+  async createReadOnlyStreamFromGenesis (req: Request, res: Response): Promise<void> {
+    const { streamtype, genesis, opts } = req.body
+    const readOnlyOpts = { ...opts, anchor: false, publish: false }
+    const stream = await this.ceramic.createDocumentFromGenesis(streamtype, DoctypeUtils.deserializeCommit(genesis), readOnlyOpts)
+    res.json({ streamId: stream.id.toString(), state: DoctypeUtils.serializeState(stream.state) })
+  }
+
+  /**
+   * Get stream state
    */
   async state (req: Request, res: Response): Promise<void> {
     const opts = parseQueryObject(req.query)
-    const streamid = req.params.streamid || req.params.docid
-    const doc = await this.ceramic.loadDocument(streamid, opts)
-    res.json({
-      streamId: doc.id.toString(),
-      docId: doc.id.toString(),
-      state: DoctypeUtils.serializeState(doc.state)
-    })
+    const stream = await this.ceramic.loadDocument(req.params.streamid, opts)
+    res.json({ streamId: stream.id.toString(), state: DoctypeUtils.serializeState(stream.state) })
+  }
+
+  /**
+   * Get document state
+   * @deprecated
+   * // todo remove when 'documents' endpoint is removed
+   */
+  async stateOld (req: Request, res: Response): Promise<void> {
+    const opts = parseQueryObject(req.query)
+    const doc = await this.ceramic.loadDocument(req.params.docid, opts)
+    res.json({ docId: doc.id.toString(), state: DoctypeUtils.serializeState(doc.state) })
   }
 
   /**
@@ -260,6 +299,7 @@ class CeramicDaemon {
       }
     })
 
+    // TODO remove docId from output when we are no longer supporting clients older than v1.0.0
     res.json({
       streamId: streamId.toString(),
       docId: streamId.toString(),
@@ -277,11 +317,11 @@ class CeramicDaemon {
       throw new Error('streamId and commit are required in order to apply commit')
     }
 
-    const doctype = await this.ceramic.applyCommit(streamId, DoctypeUtils.deserializeCommit(commit), docOpts)
+    const stream = await this.ceramic.applyCommit(streamId, DoctypeUtils.deserializeCommit(commit), docOpts)
     res.json({
-      streamId: doctype.id.toString(),
-      docId: doctype.id.toString(),
-      state: DoctypeUtils.serializeState(doctype.state)
+      streamId: stream.id.toString(),
+      docId: stream.id.toString(),
+      state: DoctypeUtils.serializeState(stream.state)
     })
   }
 
@@ -290,6 +330,8 @@ class CeramicDaemon {
    */
   async multiQuery (req: Request, res: Response): Promise<void> {
     let { queries } = <MultiQueries>req.body
+    // Handle queries from old clients by replacing the `docId` arguments with `streamId`.
+    // TODO: Remove this once we no longer need to support http clients older than version 1.0.0
     queries = queries.map((q: MultiQueryWithDocId): MultiQuery => {
       if (q.docId) {
         q.streamId = q.docId
@@ -297,6 +339,7 @@ class CeramicDaemon {
       }
       return q
     })
+
     const results = await this.ceramic.multiQuery(queries)
     const response = Object.entries(results).reduce((acc, e) => {
       const [k, v] = e
@@ -308,6 +351,7 @@ class CeramicDaemon {
 
   /**
    * Pin document
+   * // todo rename
    */
   async pinDocument (req: Request, res: Response): Promise<void> {
     const streamId = StreamID.fromString(req.params.streamid || req.params.docid)
@@ -345,10 +389,11 @@ class CeramicDaemon {
     for await (const id of iterator) {
       pinnedStreamIds.push(id)
     }
-    res.json({
-      pinnedStreamIds: pinnedStreamIds,
-      pinnedDocIds: pinnedStreamIds
-    })
+
+    // Return the same data in two formats: 'pinnedStreamids' and 'pinnedDocIds', to support old clients
+    // TODO: Remove 'pinnedDocIds' once we are okay with no longer supporting applications using a
+    // version of '@ceramicnetwork/http-client' older than v1.0.0
+    res.json({ pinnedStreamIds, pinnedDocIds: pinnedStreamIds })
   }
 
   async _notSupported (req: Request, res: Response): Promise<void> {

--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -124,10 +124,12 @@ export interface MultiQuery {
      * The StreamID of the document to load
      */
     streamId: StreamID | string
+
     /**
      * An array of paths used to look for linked documents
      */
     paths?: Array<string>
+
     /**
      * Load a previous version of the document based on unix timestamp
      */

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -41,7 +41,7 @@ export interface CeramicClientConfig {
   /**
    * Period of synchronisation, in milliseconds. Active when subscribing document.
    */
-  docSyncInterval: number
+  docSyncInterval: number // todo rename to syncInterval
 }
 
 /**

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -41,7 +41,7 @@ export interface CeramicClientConfig {
   /**
    * Period of synchronisation, in milliseconds. Active when subscribing document.
    */
-  docSyncInterval: number // todo rename to syncInterval
+  docSyncInterval: number
 }
 
 /**

--- a/packages/http-client/src/document.ts
+++ b/packages/http-client/src/document.ts
@@ -17,9 +17,9 @@ import QueryString from 'query-string'
 export class Document extends Observable<DocState> implements RunningStateLike {
   private readonly state$: DocStateSubject;
 
-  constructor (initial: DocState, private _apiUrl: string, docSyncInterval: number) {
+  constructor (initial: DocState, private _apiUrl: string, syncInterval: number) {
     super(subscriber => {
-      const periodicUpdates = timer(0, docSyncInterval).pipe(throttle(() => this._syncState())).subscribe();
+      const periodicUpdates = timer(0, syncInterval).pipe(throttle(() => this._syncState())).subscribe();
       this.state$.subscribe(subscriber).add(() => {
         periodicUpdates.unsubscribe();
       })
@@ -40,12 +40,12 @@ export class Document extends Observable<DocState> implements RunningStateLike {
   }
 
   /**
-   * Sync document state
+   * Sync stream state
    * @private
    */
   async _syncState(id?: StreamID | CommitID): Promise<void> {
     const effectiveId = id || this.id
-    const { state } = await fetchJson(this._apiUrl + '/documents/' + effectiveId.toString())
+    const { state } = await fetchJson(this._apiUrl + '/streams/' + effectiveId.toString())
     this.state$.next(DoctypeUtils.deserializeState(state))
   }
 
@@ -53,34 +53,34 @@ export class Document extends Observable<DocState> implements RunningStateLike {
     return new StreamID(this.state$.value.doctype, this.state$.value.log[0].cid)
   }
 
-  static async createFromGenesis (apiUrl: string, doctype: string, genesis: any, docOpts: CreateOpts, docSyncInterval: number): Promise<Document> {
-    const { state } = await fetchJson(apiUrl + '/documents', {
+  static async createFromGenesis (apiUrl: string, streamtype: string, genesis: any, opts: CreateOpts, syncInterval: number): Promise<Document> {
+    const { state } = await fetchJson(apiUrl + '/streams', {
       method: 'post',
       body: {
-        doctype,
+        streamtype,
         genesis: DoctypeUtils.serializeCommit(genesis),
-        docOpts,
+        opts,
       }
     })
-    return new Document(DoctypeUtils.deserializeState(state), apiUrl, docSyncInterval)
+    return new Document(DoctypeUtils.deserializeState(state), apiUrl, syncInterval)
   }
 
-  static async applyCommit(apiUrl: string, streamId: StreamID | string, commit: CeramicCommit, docOpts: UpdateOpts, docSyncInterval: number): Promise<Document> {
+  static async applyCommit(apiUrl: string, streamId: StreamID | string, commit: CeramicCommit, opts: UpdateOpts, streamSyncInterval: number): Promise<Document> {
     const { state } = await fetchJson(apiUrl + '/commits', {
       method: 'post',
       body: {
         streamId: streamId.toString(),
         commit: DoctypeUtils.serializeCommit(commit),
-        docOpts,
+        opts,
       }
     })
-    return new Document(DoctypeUtils.deserializeState(state), apiUrl, docSyncInterval)
+    return new Document(DoctypeUtils.deserializeState(state), apiUrl, streamSyncInterval)
   }
 
-  static async load (streamId: StreamID | CommitID, apiUrl: string, docSyncInterval: number, opts: LoadOpts): Promise<Document> {
-    const url = apiUrl + '/documents/' + streamId.toString() + '?' + QueryString.stringify(opts)
+  static async load (streamId: StreamID | CommitID, apiUrl: string, streamSyncInterval: number, opts: LoadOpts): Promise<Document> {
+    const url = apiUrl + '/streams/' + streamId.toString() + '?' + QueryString.stringify(opts)
     const { state } = await fetchJson(url)
-    return new Document(DoctypeUtils.deserializeState(state), apiUrl, docSyncInterval)
+    return new Document(DoctypeUtils.deserializeState(state), apiUrl, streamSyncInterval)
   }
 
   static async loadDocumentCommits (streamId: StreamID, apiUrl: string): Promise<Array<Record<string, CeramicCommit>>> {

--- a/packages/http-client/src/document.ts
+++ b/packages/http-client/src/document.ts
@@ -17,9 +17,9 @@ import QueryString from 'query-string'
 export class Document extends Observable<DocState> implements RunningStateLike {
   private readonly state$: DocStateSubject;
 
-  constructor (initial: DocState, private _apiUrl: string, syncInterval: number) {
+  constructor (initial: DocState, private _apiUrl: string, docSyncInterval: number) {
     super(subscriber => {
-      const periodicUpdates = timer(0, syncInterval).pipe(throttle(() => this._syncState())).subscribe();
+      const periodicUpdates = timer(0, docSyncInterval).pipe(throttle(() => this._syncState())).subscribe();
       this.state$.subscribe(subscriber).add(() => {
         periodicUpdates.unsubscribe();
       })
@@ -53,7 +53,7 @@ export class Document extends Observable<DocState> implements RunningStateLike {
     return new StreamID(this.state$.value.doctype, this.state$.value.log[0].cid)
   }
 
-  static async createFromGenesis (apiUrl: string, streamtype: string, genesis: any, opts: CreateOpts, syncInterval: number): Promise<Document> {
+  static async createFromGenesis (apiUrl: string, streamtype: string, genesis: any, opts: CreateOpts, docSyncInterval: number): Promise<Document> {
     const { state } = await fetchJson(apiUrl + '/streams', {
       method: 'post',
       body: {
@@ -62,10 +62,10 @@ export class Document extends Observable<DocState> implements RunningStateLike {
         opts,
       }
     })
-    return new Document(DoctypeUtils.deserializeState(state), apiUrl, syncInterval)
+    return new Document(DoctypeUtils.deserializeState(state), apiUrl, docSyncInterval)
   }
 
-  static async applyCommit(apiUrl: string, streamId: StreamID | string, commit: CeramicCommit, opts: UpdateOpts, streamSyncInterval: number): Promise<Document> {
+  static async applyCommit(apiUrl: string, streamId: StreamID | string, commit: CeramicCommit, opts: UpdateOpts, docSyncInterval: number): Promise<Document> {
     const { state } = await fetchJson(apiUrl + '/commits', {
       method: 'post',
       body: {
@@ -74,13 +74,13 @@ export class Document extends Observable<DocState> implements RunningStateLike {
         opts,
       }
     })
-    return new Document(DoctypeUtils.deserializeState(state), apiUrl, streamSyncInterval)
+    return new Document(DoctypeUtils.deserializeState(state), apiUrl, docSyncInterval)
   }
 
-  static async load (streamId: StreamID | CommitID, apiUrl: string, streamSyncInterval: number, opts: LoadOpts): Promise<Document> {
+  static async load (streamId: StreamID | CommitID, apiUrl: string, docSyncInterval: number, opts: LoadOpts): Promise<Document> {
     const url = apiUrl + '/streams/' + streamId.toString() + '?' + QueryString.stringify(opts)
     const { state } = await fetchJson(url)
-    return new Document(DoctypeUtils.deserializeState(state), apiUrl, streamSyncInterval)
+    return new Document(DoctypeUtils.deserializeState(state), apiUrl, docSyncInterval)
   }
 
   static async loadDocumentCommits (streamId: StreamID, apiUrl: string): Promise<Array<Record<string, CeramicCommit>>> {


### PR DESCRIPTION
Also updates the MultiQueries API since that also affects the http API.

Did some simple manual testing of a new daemon with an old http-client. I used an old CLI to create and update a tile document, and to pin, unpin, and list pins.  Anything beyond what's covered by that doesn't have test coverage of backwards compatibility.