### PR TITLE
chore: Drop dependency on "events" package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -79,7 +79,6 @@
     "@babel/preset-typescript": "^7.9.0",
     "@babel/register": "^7.10.5",
     "@ceramicnetwork/doctype-tile-handler": "^0.15.0-rc.1",
-    "@types/events": "^3.0.0",
     "@types/express": "^4.17.2",
     "@types/levelup": "^4.3.0",
     "@types/logfmt": "^1.2.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -31,7 +31,6 @@
     "@overnightjs/logger": "^1.2.0",
     "@types/logfmt": "^1.2.1",
     "cids": "~1.1.6",
-    "events": "^3.2.0",
     "flat": "^5.0.2",
     "lodash.clonedeep": "^4.5.0",
     "logfmt": "^1.3.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,6 @@
     "did-jwt": "^5.0.0",
     "did-resolver": "^3.0.1",
     "dids": "^2.0.0",
-    "events": "^3.2.0",
     "ipld-dag-cbor": "^0.17.0",
     "key-did-resolver": "^1.1.1",
     "level-ts": "^2.0.5",


### PR DESCRIPTION
Nothing uses it anyway