### PR TITLE
DocState contains type as number

### DIFF
--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -91,6 +91,7 @@ describe('Ceramic interop: core <> http-client', () => {
         delete state2.log
         delete state1.metadata.unique
         delete state2.metadata.unique
+        delete state2.doctype
 
         expect(state1).toEqual(state2)
     })

--- a/packages/common/src/__tests__/doc-state-subject.test.ts
+++ b/packages/common/src/__tests__/doc-state-subject.test.ts
@@ -7,7 +7,7 @@ const FAKE_CID2 = new CID('bafybeig6xv5nwphfmvcnektpnojts44jqcuam7bmye2pb54adnrt
 
 test('emit on distinct changes', async () => {
   const initial = ({
-    doctype: 'tile',
+    type: 0,
     log: [
       {
         type: CommitType.GENESIS,

--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -127,6 +127,7 @@ export interface DocStateHolder {
  * Describes common doctype attributes
  */
 export abstract class Stream extends Observable<DocState> implements DocStateHolder {
+    abstract readonly doctype: string
     constructor(protected readonly state$: RunningStateLike, private _context: Context) {
         super(subscriber => {
           state$.subscribe(subscriber)
@@ -135,10 +136,6 @@ export abstract class Stream extends Observable<DocState> implements DocStateHol
 
     get id(): StreamID {
         return new StreamID(this.state$.value.type, this.state$.value.log[0].cid)
-    }
-
-    get doctype(): number {
-        return this.state$.value.type
     }
 
     get api(): CeramicApi {

--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -101,7 +101,7 @@ export interface LogEntry {
  * Document state
  */
 export interface DocState {
-    doctype: string
+    type: number
     content: any
     next?: DocNext
     metadata: DocMetadata
@@ -134,11 +134,11 @@ export abstract class Stream extends Observable<DocState> implements DocStateHol
     }
 
     get id(): StreamID {
-        return new StreamID(this.state$.value.doctype, this.state$.value.log[0].cid)
+        return new StreamID(this.state$.value.type, this.state$.value.log[0].cid)
     }
 
-    get doctype(): string {
-        return this.state$.value.doctype
+    get doctype(): number {
+        return this.state$.value.type
     }
 
     get api(): CeramicApi {
@@ -225,6 +225,7 @@ export interface StreamConstructor<T extends Stream> {
  * Describes document type handler functionality
  */
 export interface StreamHandler<T extends Stream> {
+    type: number
     /**
      * The string name of the doctype
      */

--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -127,7 +127,6 @@ export interface DocStateHolder {
  * Describes common doctype attributes
  */
 export abstract class Stream extends Observable<DocState> implements DocStateHolder {
-    abstract readonly doctype: string
     constructor(protected readonly state$: RunningStateLike, private _context: Context) {
         super(subscriber => {
           state$.subscribe(subscriber)

--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -101,7 +101,7 @@ export class StreamUtils {
             cloned.lastAnchored = cloned.lastAnchored.toString()
         }
 
-        cloned.doctype = StreamType.nameByIndex(cloned.type)
+        cloned.doctype = StreamType.nameByCode(cloned.type)
 
         return cloned
     }
@@ -114,7 +114,7 @@ export class StreamUtils {
         const cloned = cloneDeep(state)
 
         if (cloned.doctype) {
-          cloned.type = StreamType.indexByName(cloned.doctype)
+          cloned.type = StreamType.codeByName(cloned.doctype)
           delete cloned.doctype
         }
 

--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -10,6 +10,7 @@ import {
 } from "../index"
 import { AnchorStatus, DocState, LogEntry } from "../stream"
 import { DagJWS } from "dids"
+import { StreamType } from '@ceramicnetwork/streamid';
 
 /**
  * Stream related utils
@@ -82,8 +83,8 @@ export class StreamUtils {
      * Serializes stream state for over the network transfer
      * @param state - Stream state
      */
-    static serializeState(state: any): any {
-        const cloned = cloneDeep(state)
+    static serializeState(state: DocState): any {
+        const cloned = cloneDeep(state) as any
 
         cloned.log = cloned.log.map((entry: LogEntry) => ({ ...entry, cid: entry.cid.toString() }))
         if (cloned.anchorStatus != null) {
@@ -99,6 +100,9 @@ export class StreamUtils {
         if (cloned.lastAnchored != null) {
             cloned.lastAnchored = cloned.lastAnchored.toString()
         }
+
+        cloned.doctype = StreamType.nameByIndex(cloned.type)
+
         return cloned
     }
 
@@ -108,6 +112,11 @@ export class StreamUtils {
      */
     static deserializeState(state: any): DocState {
         const cloned = cloneDeep(state)
+
+        if (cloned.doctype) {
+          cloned.type = StreamType.indexByName(cloned.doctype)
+          delete cloned.doctype
+        }
 
         cloned.log = cloned.log.map((entry: any): LogEntry => ({ ...entry, cid: new CID(entry.cid) }))
         if (cloned.anchorProof) {

--- a/packages/common/src/utils/test-utils.ts
+++ b/packages/common/src/utils/test-utils.ts
@@ -11,7 +11,7 @@ class FakeRunningState extends BehaviorSubject<DocState> implements RunningState
   constructor(value: DocState) {
     super(value);
     this.state = this.value;
-    this.id = new StreamID(this.state.doctype, this.state.log[0].cid);
+    this.id = new StreamID(this.state.type, this.state.log[0].cid);
   }
 }
 

--- a/packages/core/src/__tests__/__snapshots__/caip10-link.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/caip10-link.test.ts.snap
@@ -95,7 +95,6 @@ Object {
   },
   "anchorStatus": 3,
   "content": "did:key:z6MkjKeH8SgVAYCvTBoyxx7uRJFGM2a9HUeFwfJfd6ctuA3X",
-  "doctype": "caip10-link",
   "log": Array [
     Object {
       "cid": Object {
@@ -277,6 +276,7 @@ Object {
     "family": "caip10-eip155:1",
   },
   "signature": 2,
+  "type": 1,
 }
 `;
 
@@ -284,7 +284,6 @@ exports[`Ceramic API Caip10Link test Create and link DID 1`] = `
 Object {
   "anchorStatus": 0,
   "content": null,
-  "doctype": "caip10-link",
   "log": Array [
     Object {
       "cid": Object {
@@ -390,6 +389,7 @@ Object {
     },
   },
   "signature": 2,
+  "type": 1,
 }
 `;
 
@@ -397,7 +397,6 @@ exports[`Ceramic API Caip10Link test Create from valid account id 1`] = `
 Object {
   "anchorStatus": 0,
   "content": null,
-  "doctype": "caip10-link",
   "log": Array [
     Object {
       "cid": Object {
@@ -453,5 +452,6 @@ Object {
     "content": null,
   },
   "signature": 0,
+  "type": 1,
 }
 `;

--- a/packages/core/src/__tests__/__validation__/doctype.test.ts
+++ b/packages/core/src/__tests__/__validation__/doctype.test.ts
@@ -30,7 +30,7 @@ describe('Stream', () => {
     beforeAll(() => {
         const docSchemaState = {
           content: schema,
-          doctype: 'tile',
+          type: 0,
           metadata: {
             controllers: [],
             schema: 'ceramic://1234567'
@@ -53,7 +53,7 @@ describe('Stream', () => {
 
     it('should pass schema validation', async () => {
         const state = {
-          doctype: 'tile',
+          type: 0,
           metadata: {
             controllers: [],
             schema: 'ceramic://1234567'
@@ -75,7 +75,7 @@ describe('Stream', () => {
 
     it('should fail schema validation', async () => {
         const state = {
-          doctype: 'tile',
+          type: 0,
           metadata: {
             controllers: [],
             schema: 'ceramic://1234567'

--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -136,7 +136,7 @@ describe('Dispatcher', () => {
     }
 
     const initialState = ({
-      doctype: 'tile',
+      type: 0,
       log: [
         {
           cid: FAKE_DOC_ID.cid,

--- a/packages/core/src/__tests__/handlers-map.test.ts
+++ b/packages/core/src/__tests__/handlers-map.test.ts
@@ -14,17 +14,18 @@ describe('constructor', () => {
   });
   test('custom handlers', () => {
     const customHandler = (jest.fn() as unknown) as StreamHandler<Stream>;
-    const handlers = new HandlersMap(logger, new Map().set('custom', customHandler));
-    expect(handlers.get('custom')).toBe(customHandler);
+    const handlers = new HandlersMap(logger, new Map().set(13, customHandler));
+    expect(handlers.get(13)).toBe(customHandler);
   });
 });
 
 test('set and get', () => {
-  const customHandler = ({ name: 'custom' } as unknown) as StreamHandler<Stream>;
+  const customHandler = ({ name: 'custom', type: 13 } as unknown) as StreamHandler<Stream>;
   const handlers = new HandlersMap(logger);
   expect(() => handlers.get('custom')).toThrow();
   handlers.add(customHandler);
-  expect(handlers.get('custom')).toBe(customHandler);
+  expect(() => handlers.get('custom')).toThrow();
+  expect(handlers.get(13)).toBe(customHandler);
 });
 
 test('get non-existing', () => {

--- a/packages/core/src/__tests__/local-pin-api.test.ts
+++ b/packages/core/src/__tests__/local-pin-api.test.ts
@@ -12,7 +12,7 @@ const FAKE_CID = new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtc
 const repository = ({ pin: jest.fn(), unpin: jest.fn(), list: jest.fn() } as unknown) as Repository;
 
 const docState = ({
-  doctype: 'tile',
+  type: 0,
   log: [{ cid: FAKE_CID, type: CommitType.GENESIS }],
 } as unknown) as DocState;
 const state$ = new RunningState(docState)

--- a/packages/core/src/conflict-resolution.ts
+++ b/packages/core/src/conflict-resolution.ts
@@ -288,7 +288,7 @@ export class ConflictResolution {
     initialStateLog: HistoryLog,
     log: Array<CID>,
   ): Promise<DocState | null> {
-    const handler = this.handlers.get(initialState.doctype);
+    const handler = this.handlers.get(initialState.type);
     const tip = initialStateLog.last;
     if (log[log.length - 1].equals(tip)) {
       // log already applied
@@ -359,7 +359,7 @@ export class ConflictResolution {
     // If the requested commit is included in the log, but isn't the most recent commit, we need
     // to reset the state to the state at the requested commit.
     const resetLog = baseStateLog.slice(0, commitIndex + 1).items;
-    const handler = this.handlers.get(initialState.doctype);
+    const handler = this.handlers.get(initialState.type);
     return this.applyLogToState(handler, resetLog);
   }
 }

--- a/packages/core/src/handlers-map.ts
+++ b/packages/core/src/handlers-map.ts
@@ -4,26 +4,25 @@ import { Stream, StreamHandler } from '@ceramicnetwork/common';
 import { DiagnosticsLogger } from '@ceramicnetwork/common';
 import { StreamType } from '@ceramicnetwork/streamid';
 
-type Registry = Map<number, DoctypeHandler<Doctype>>
+type Registry = Map<number, StreamHandler<Stream>>
+
+function defaultHandlers(): Registry {
+  const tile = new TileDocumentHandler()
+  const caip10Link = new Caip10LinkHandler()
+  const handlers = new Map<number, StreamHandler<Stream>>()
+  handlers.set(tile.type, tile)
+  handlers.set(caip10Link.type, caip10Link)
+  return handlers
+}
 
 /**
  * Container for doctype handlers. Maps doctype name to the handler instance.
- * TODO: This should map from doctype id rather than doctype name.
  */
 export class HandlersMap {
   private readonly handlers: Registry;
 
   constructor(private readonly logger: DiagnosticsLogger, handlers?: Registry) {
-    this.handlers = handlers || this.defaultHandlers()
-  }
-
-  private defaultHandlers(): Registry {
-    const tile = new TileDoctypeHandler()
-    const caip10Link = new Caip10LinkDoctypeHandler()
-    const handlers = new Map<number, DoctypeHandler<Doctype>>()
-    handlers.set(tile.type, tile)
-    handlers.set(caip10Link.type, caip10Link)
-    return handlers
+    this.handlers = handlers || defaultHandlers()
   }
 
   /**
@@ -32,7 +31,7 @@ export class HandlersMap {
    * @param type - name or id of the handler.
    */
   get<T extends Stream>(type: string | number): StreamHandler<T> {
-    const id = typeof type == 'string' ? StreamType.indexByName(type) : type
+    const id = typeof type == 'string' ? StreamType.codeByName(type) : type
     const handler = this.handlers.get(id);
     if (handler) {
       return handler as StreamHandler<T>;

--- a/packages/core/src/handlers-map.ts
+++ b/packages/core/src/handlers-map.ts
@@ -2,30 +2,42 @@ import { TileDocumentHandler } from '@ceramicnetwork/doctype-tile-handler';
 import { Caip10LinkHandler } from '@ceramicnetwork/doctype-caip10-link-handler';
 import { Stream, StreamHandler } from '@ceramicnetwork/common';
 import { DiagnosticsLogger } from '@ceramicnetwork/common';
+import { StreamType } from '@ceramicnetwork/streamid';
+
+type Registry = Map<number, DoctypeHandler<Doctype>>
 
 /**
  * Container for doctype handlers. Maps doctype name to the handler instance.
  * TODO: This should map from doctype id rather than doctype name.
  */
 export class HandlersMap {
-  private readonly handlers: Map<string, StreamHandler<Stream>>;
+  private readonly handlers: Registry;
 
-  constructor(private readonly logger: DiagnosticsLogger, handlers?: Map<string, StreamHandler<Stream>>) {
-    this.handlers =
-      handlers || new Map().set('tile', new TileDocumentHandler()).set('caip10-link', new Caip10LinkHandler());
+  constructor(private readonly logger: DiagnosticsLogger, handlers?: Registry) {
+    this.handlers = handlers || this.defaultHandlers()
+  }
+
+  private defaultHandlers(): Registry {
+    const tile = new TileDoctypeHandler()
+    const caip10Link = new Caip10LinkDoctypeHandler()
+    const handlers = new Map<number, DoctypeHandler<Doctype>>()
+    handlers.set(tile.type, tile)
+    handlers.set(caip10Link.type, caip10Link)
+    return handlers
   }
 
   /**
    * Return doctype handler based on its name. Throw error if not found.
    *
-   * @param doctypeName - name of the handler.
+   * @param type - name or id of the handler.
    */
-  get<T extends Stream>(doctypeName: string): StreamHandler<T> {
-    const handler = this.handlers.get(doctypeName);
+  get<T extends Stream>(type: string | number): StreamHandler<T> {
+    const id = typeof type == 'string' ? StreamType.indexByName(type) : type
+    const handler = this.handlers.get(id);
     if (handler) {
       return handler as StreamHandler<T>;
     } else {
-      throw new Error(doctypeName + ' is not a valid doctype');
+      throw new Error(type + ' is not a valid doctype');
     }
   }
 
@@ -33,8 +45,8 @@ export class HandlersMap {
    * Add doctype handler to the collection.
    */
   add<T extends Stream>(doctypeHandler: StreamHandler<T>): HandlersMap {
-    this.logger.debug(`Registered handler for ${doctypeHandler.name} doctype`);
-    this.handlers.set(doctypeHandler.name, doctypeHandler);
+    this.logger.debug(`Registered handler for ${doctypeHandler.type} doctype`);
+    this.handlers.set(doctypeHandler.type, doctypeHandler);
     return this;
   }
 }

--- a/packages/core/src/state-management/__tests__/running-state.test.ts
+++ b/packages/core/src/state-management/__tests__/running-state.test.ts
@@ -7,7 +7,7 @@ const FAKE_CID2 = new CID('bafybeig6xv5nwphfmvcnektpnojts44jqcuam7bmye2pb54adnrt
 
 test('emit on distinct changes', async () => {
   const initial = ({
-    doctype: 'tile',
+    type: 0,
     log: [
       {
         type: CommitType.GENESIS,

--- a/packages/core/src/state-management/__tests__/state-link.test.ts
+++ b/packages/core/src/state-management/__tests__/state-link.test.ts
@@ -8,7 +8,7 @@ const FAKE_CID2 = new CID('bafybeig6xv5nwphfmvcnektpnojts44jqcuam7bmye2pb54adnrt
 
 test('emit on distinct changes', async () => {
   const initial = ({
-    doctype: 'tile',
+    type: 0,
     log: [
       {
         type: CommitType.GENESIS,

--- a/packages/core/src/state-management/doctype-from-state.ts
+++ b/packages/core/src/state-management/doctype-from-state.ts
@@ -17,7 +17,7 @@ export function doctypeFromState<T extends Stream>(
   state: DocState,
   update$?: (init: DocState) => Observable<DocState>,
 ): T {
-  const handler = handlersMap.get<T>(state.doctype);
+  const handler = handlersMap.get<T>(state.type);
   const state$ = new StateLink(state, update$);
   const doctype = new handler.doctype(state$, context);
   if (!update$) {

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -200,7 +200,7 @@ export class Repository {
    */
   updates$(init: DocState): Observable<DocState> {
     return new Observable<DocState>((subscriber) => {
-      const id = new StreamID(init.doctype, init.log[0].cid);
+      const id = new StreamID(init.type, init.log[0].cid);
       this.get(id).then((found) => {
         const state$ = found || new RunningState(init);
         this.inmemory.endure(id.toString(), state$);

--- a/packages/core/src/state-management/running-state.ts
+++ b/packages/core/src/state-management/running-state.ts
@@ -10,7 +10,7 @@ export class RunningState extends DocStateSubject implements RunningStateLike {
 
   constructor(initial: DocState) {
     super(initial);
-    this.id = new StreamID(initial.doctype, initial.log[0].cid);
+    this.id = new StreamID(initial.type, initial.log[0].cid);
   }
 
   get tip(): CID {

--- a/packages/core/src/state-management/snapshot-state.ts
+++ b/packages/core/src/state-management/snapshot-state.ts
@@ -16,7 +16,7 @@ export class SnapshotState extends Observable<DocState> implements RunningStateL
       of(value).subscribe(subscriber);
     });
     this.state = value;
-    this.id = new StreamID(this.state.doctype, this.state.log[0].cid);
+    this.id = new StreamID(this.state.type, this.state.log[0].cid);
   }
 
   next(value: DocState): void {

--- a/packages/core/src/state-management/state-link.ts
+++ b/packages/core/src/state-management/state-link.ts
@@ -36,6 +36,6 @@ export class StateLink extends Observable<DocState> implements RunningStateLike 
   }
 
   get id(): StreamID {
-    return new StreamID(this.state.doctype, this.state.log[this.state.log.length - 1].cid);
+    return new StreamID(this.state.type, this.state.log[this.state.log.length - 1].cid);
   }
 }

--- a/packages/core/src/store/__tests__/level-state-store.test.ts
+++ b/packages/core/src/store/__tests__/level-state-store.test.ts
@@ -43,7 +43,7 @@ beforeEach(async () => {
 })
 
 const state = {
-    doctype: 'tile',
+    type: 0,
     content: {num: 0},
     metadata: {
         controllers: ['']

--- a/packages/core/src/store/__tests__/pin-store.test.ts
+++ b/packages/core/src/store/__tests__/pin-store.test.ts
@@ -10,6 +10,7 @@ import {
   CommitType,
   TestUtils,
 } from '@ceramicnetwork/common';
+import { TileDoctype } from '@ceramicnetwork/doctype-tile';
 
 let stateStore: StateStore
 let pinning: PinningBackend
@@ -36,7 +37,7 @@ beforeEach(() => {
 })
 
 const state: DocState = {
-    doctype: 'tile',
+    type: 0,
     content: {num: 0},
     metadata: {
         controllers: ['']

--- a/packages/core/src/store/__tests__/state-store-integration.test.ts
+++ b/packages/core/src/store/__tests__/state-store-integration.test.ts
@@ -31,7 +31,7 @@ describe('Level data store', () => {
 
   const streamId = new StreamID('tile', FAKE_CID);
   const docState: DocState = {
-    doctype: 'tile',
+    type: 0,
     content: {},
     metadata: { controllers: ['foo'] },
     signature: SignatureStatus.GENESIS,

--- a/packages/doctype-caip10-link-handler/package.json
+++ b/packages/doctype-caip10-link-handler/package.json
@@ -19,7 +19,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "../../node_modules/.bin/jest --coverage --env=node",
+    "test": "../../node_modules/.bin/jest --coverage",
     "build": "../../node_modules/.bin/tsc -p tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",
@@ -41,6 +41,7 @@
     "uint8arrays": "^2.0.5"
   },
   "jest": {
+    "testEnvironment": "node",
     "transformIgnorePatterns": [
       "/node_modules(?!/did-jwt)/"
     ]

--- a/packages/doctype-caip10-link-handler/src/__tests__/__snapshots__/caip10-link-doctype-handler.test.ts.snap
+++ b/packages/doctype-caip10-link-handler/src/__tests__/__snapshots__/caip10-link-doctype-handler.test.ts.snap
@@ -8,7 +8,6 @@ Object {
   },
   "anchorStatus": 3,
   "content": "did:3:testdid1",
-  "doctype": "caip10-link",
   "log": Array [
     Object {
       "cid": Object {
@@ -147,6 +146,7 @@ Object {
     "family": "caip10-eip155:1",
   },
   "signature": 2,
+  "type": 1,
 }
 `;
 
@@ -154,7 +154,6 @@ exports[`Caip10LinkHandler applies genesis commit correctly 1`] = `
 Object {
   "anchorStatus": 0,
   "content": null,
-  "doctype": "caip10-link",
   "log": Array [
     Object {
       "cid": Object {
@@ -210,6 +209,7 @@ Object {
     "content": null,
   },
   "signature": 0,
+  "type": 1,
 }
 `;
 
@@ -217,7 +217,6 @@ exports[`Caip10LinkHandler applies signed commit correctly 1`] = `
 Object {
   "anchorStatus": 0,
   "content": null,
-  "doctype": "caip10-link",
   "log": Array [
     Object {
       "cid": Object {
@@ -323,5 +322,6 @@ Object {
     },
   },
   "signature": 2,
+  "type": 1,
 }
 `;

--- a/packages/doctype-caip10-link-handler/src/caip10-link-handler.ts
+++ b/packages/doctype-caip10-link-handler/src/caip10-link-handler.ts
@@ -17,6 +17,9 @@ import {
 const IPFS_GET_TIMEOUT = 60000 // 1 minute
 
 export class Caip10LinkHandler implements StreamHandler<Caip10Link> {
+    get type(): number {
+      return Caip10Link.DOCTYPE_ID
+    }
     /**
      * Gets doctype name
      */
@@ -63,7 +66,7 @@ export class Caip10LinkHandler implements StreamHandler<Caip10Link> {
 
         // TODO - verify genesis commit
         const state = {
-            doctype: Caip10Link.DOCTYPE_NAME,
+            type: Caip10Link.DOCTYPE_ID,
             content: null,
             next: {
                 content: null

--- a/packages/doctype-caip10-link/src/caip10-link.ts
+++ b/packages/doctype-caip10-link/src/caip10-link.ts
@@ -31,6 +31,10 @@ export class Caip10Link extends Stream {
     static DOCTYPE_NAME = 'caip10-link'
     static DOCTYPE_ID = 1
 
+    get doctype(): string {
+      return Caip10LinkDoctype.DOCTYPE_NAME;
+    }
+
     /**
      * Returns the DID linked to the CAIP10 address this object represents.
      */

--- a/packages/doctype-caip10-link/src/caip10-link.ts
+++ b/packages/doctype-caip10-link/src/caip10-link.ts
@@ -31,10 +31,6 @@ export class Caip10Link extends Stream {
     static DOCTYPE_NAME = 'caip10-link'
     static DOCTYPE_ID = 1
 
-    get doctype(): string {
-      return Caip10LinkDoctype.DOCTYPE_NAME;
-    }
-
     /**
      * Returns the DID linked to the CAIP10 address this object represents.
      */

--- a/packages/doctype-tile-handler/src/__tests__/__snapshots__/three-id.test.ts.snap
+++ b/packages/doctype-tile-handler/src/__tests__/__snapshots__/three-id.test.ts.snap
@@ -14,7 +14,6 @@ Object {
       "test": "0xabc",
     },
   },
-  "doctype": "tile",
   "log": Array [
     Object {
       "cid": Object {
@@ -156,6 +155,7 @@ Object {
     ],
   },
   "signature": 2,
+  "type": 0,
 }
 `;
 
@@ -167,7 +167,6 @@ Object {
       "test": "0xabc",
     },
   },
-  "doctype": "tile",
   "log": Array [
     Object {
       "cid": Object {
@@ -222,6 +221,7 @@ Object {
     ],
   },
   "signature": 2,
+  "type": 0,
 }
 `;
 
@@ -233,7 +233,6 @@ Object {
       "test": "0xabc",
     },
   },
-  "doctype": "tile",
   "log": Array [
     Object {
       "cid": Object {
@@ -347,5 +346,6 @@ Object {
     },
   },
   "signature": 2,
+  "type": 0,
 }
 `;

--- a/packages/doctype-tile-handler/src/__tests__/__snapshots__/tile-doctype.test.ts.snap
+++ b/packages/doctype-tile-handler/src/__tests__/__snapshots__/tile-doctype.test.ts.snap
@@ -12,7 +12,6 @@ Object {
     "much": "data",
     "very": "content",
   },
-  "doctype": "tile",
   "log": Array [
     Object {
       "cid": Object {
@@ -151,6 +150,7 @@ Object {
     ],
   },
   "signature": 2,
+  "type": 0,
 }
 `;
 
@@ -160,7 +160,6 @@ Object {
   "content": Object {
     "much": "data",
   },
-  "doctype": "tile",
   "log": Array [
     Object {
       "cid": Object {
@@ -212,6 +211,7 @@ Object {
     ],
   },
   "signature": 2,
+  "type": 0,
 }
 `;
 
@@ -221,7 +221,6 @@ Object {
   "content": Object {
     "much": "data",
   },
-  "doctype": "tile",
   "log": Array [
     Object {
       "cid": Object {
@@ -327,6 +326,7 @@ Object {
     },
   },
   "signature": 2,
+  "type": 0,
 }
 `;
 
@@ -336,7 +336,6 @@ Object {
   "content": Object {
     "test": "data",
   },
-  "doctype": "tile",
   "log": Array [
     Object {
       "cid": Object {
@@ -486,5 +485,6 @@ Object {
     },
   },
   "signature": 2,
+  "type": 0,
 }
 `;

--- a/packages/doctype-tile-handler/src/tile-document-handler.ts
+++ b/packages/doctype-tile-handler/src/tile-document-handler.ts
@@ -25,6 +25,9 @@ const IPFS_GET_TIMEOUT = 60000 // 1 minute
  * Tile doctype handler implementation
  */
 export class TileDocumentHandler implements StreamHandler<TileDocument> {
+    get type(): number {
+      return TileDocument.DOCTYPE_ID
+    }
     /**
      * Gets doctype name
      */
@@ -81,7 +84,7 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
         }
 
         return {
-            doctype: TileDocument.DOCTYPE_NAME,
+            type: TileDocument.DOCTYPE_ID,
             content: payload.data || {},
             metadata: payload.header,
             signature: isSigned? SignatureStatus.SIGNED : SignatureStatus.GENESIS,

--- a/packages/doctype-tile/src/tile-document.ts
+++ b/packages/doctype-tile/src/tile-document.ts
@@ -106,7 +106,7 @@ export class TileDocument<T = Record<string, any>> extends Stream {
     }
 
     get doctype(): string {
-      return TileDoctype.DOCTYPE_NAME;
+      return TileDocument.DOCTYPE_NAME;
     }
 
     /**

--- a/packages/doctype-tile/src/tile-document.ts
+++ b/packages/doctype-tile/src/tile-document.ts
@@ -105,6 +105,10 @@ export class TileDocument<T = Record<string, any>> extends Stream {
         return this._getContent()
     }
 
+    get doctype(): string {
+      return TileDoctype.DOCTYPE_NAME;
+    }
+
     /**
      * Creates a Tile document.
      * @param ceramic - Instance of CeramicAPI used to communicate with the Ceramic network

--- a/packages/http-client/src/__tests__/document.test.ts
+++ b/packages/http-client/src/__tests__/document.test.ts
@@ -7,7 +7,7 @@ const FAKE_CID2 = new CID('bafybeig6xv5nwphfmvcnektpnojts44jqcuam7bmye2pb54adnrt
 
 test('emit on distinct changes', async () => {
   const initial = ({
-    doctype: 'tile',
+    type: 0,
     log: [
       {
         type: CommitType.GENESIS,

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -63,7 +63,7 @@ export default class CeramicClient implements CeramicApi {
   public readonly context: Context
 
   private readonly _config: CeramicClientConfig
-  public readonly _doctypeConstructors: Record<string, StreamConstructor<Stream>>
+  public readonly _doctypeConstructors: Record<number, StreamConstructor<Stream>>
 
   constructor (apiHost: string = CERAMIC_HOST, config: Partial<CeramicClientConfig> = {}) {
     this._config = { ...DEFAULT_CLIENT_CONFIG, ...config }
@@ -77,8 +77,8 @@ export default class CeramicClient implements CeramicApi {
     this.pin = this._initPinApi()
 
     this._doctypeConstructors = {
-      'tile': TileDocument,
-      'caip10-link': Caip10Link
+      [TileDocument.DOCTYPE_ID]: TileDocument,
+      [Caip10Link.DOCTYPE_ID]: Caip10Link
     }
   }
 
@@ -186,8 +186,8 @@ export default class CeramicClient implements CeramicApi {
     this._doctypeConstructors[doctypeHandler.name] = doctypeHandler.doctype
   }
 
-  findStreamConstructor<T extends Stream>(doctype: string) {
-    const constructor = this._doctypeConstructors[doctype]
+  findStreamConstructor<T extends Stream>(type: number) {
+    const constructor = this._doctypeConstructors[type]
     if (constructor) {
       return constructor as StreamConstructor<T>
     } else {
@@ -196,7 +196,7 @@ export default class CeramicClient implements CeramicApi {
   }
 
   private buildStream<T extends Stream = Stream>(document: Document) {
-    const doctypeConstructor = this.findStreamConstructor<T>(document.state.doctype)
+    const doctypeConstructor = this.findStreamConstructor<T>(document.state.type)
     return new doctypeConstructor(document, this.context)
   }
 

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -191,7 +191,7 @@ export default class CeramicClient implements CeramicApi {
     if (constructor) {
       return constructor as StreamConstructor<T>
     } else {
-      throw new Error(`Failed to find doctype constructor for doctype ${doctype}`)
+      throw new Error(`Failed to find constructor for stream ${type}`)
     }
   }
 

--- a/packages/http-client/src/document.ts
+++ b/packages/http-client/src/document.ts
@@ -50,7 +50,7 @@ export class Document extends Observable<DocState> implements RunningStateLike {
   }
 
   get id(): StreamID {
-    return new StreamID(this.state$.value.doctype, this.state$.value.log[0].cid)
+    return new StreamID(this.state$.value.type, this.state$.value.log[0].cid)
   }
 
   static async createFromGenesis (apiUrl: string, streamtype: string, genesis: any, opts: CreateOpts, syncInterval: number): Promise<Document> {

--- a/packages/streamid/src/commit-id.ts
+++ b/packages/streamid/src/commit-id.ts
@@ -1,6 +1,6 @@
 import CID from 'cids';
 import multibase from 'multibase';
-import * as streamtypes from './streamtypes';
+import { StreamType } from './stream-type';
 import varint from 'varint';
 import uint8ArrayConcat from 'uint8arrays/concat';
 import uint8ArrayToString from 'uint8arrays/to-string';
@@ -127,7 +127,7 @@ export class CommitID implements StreamRef {
   constructor(type: string | number, cid: CID | string, commit: CID | string | number = null) {
     if (!type && type !== 0) throw new Error('constructor: type required');
     if (!cid) throw new Error('constructor: cid required');
-    this.#type = typeof type === 'string' ? streamtypes.indexByName(type) : type;
+    this.#type = typeof type === 'string' ? StreamType.indexByName(type) : type;
     this.#cid = typeof cid === 'string' ? new CID(cid) : cid;
     this.#commit = parseCommit(this.#cid, commit);
   }
@@ -152,7 +152,7 @@ export class CommitID implements StreamRef {
    */
   @Memoize()
   get typeName(): string {
-    return streamtypes.nameByIndex(this.#type);
+    return StreamType.nameByIndex(this.#type);
   }
 
   /**

--- a/packages/streamid/src/commit-id.ts
+++ b/packages/streamid/src/commit-id.ts
@@ -116,7 +116,7 @@ export class CommitID implements StreamRef {
   /**
    * Create a new StreamID.
    *
-   * @param {string|number}      stream type
+   * @param type
    * @param {CID|string}         cid
    * @param {CID|string}         commit CID. Pass '0', 0, or omit the value as shorthand for the genesis commit.
    *
@@ -127,7 +127,7 @@ export class CommitID implements StreamRef {
   constructor(type: string | number, cid: CID | string, commit: CID | string | number = null) {
     if (!type && type !== 0) throw new Error('constructor: type required');
     if (!cid) throw new Error('constructor: cid required');
-    this.#type = typeof type === 'string' ? StreamType.indexByName(type) : type;
+    this.#type = typeof type === 'string' ? StreamType.codeByName(type) : type;
     this.#cid = typeof cid === 'string' ? new CID(cid) : cid;
     this.#commit = parseCommit(this.#cid, commit);
   }
@@ -152,7 +152,7 @@ export class CommitID implements StreamRef {
    */
   @Memoize()
   get typeName(): string {
-    return StreamType.nameByIndex(this.#type);
+    return StreamType.nameByCode(this.#type);
   }
 
   /**

--- a/packages/streamid/src/index.ts
+++ b/packages/streamid/src/index.ts
@@ -2,5 +2,6 @@ import { StreamID } from './stream-id'
 export { CommitID } from './commit-id'
 export { StreamID } from './stream-id'
 export { StreamRef } from './stream-ref'
+export * from './stream-type'
 
 export default StreamID

--- a/packages/streamid/src/stream-id.ts
+++ b/packages/streamid/src/stream-id.ts
@@ -1,6 +1,5 @@
 import CID from 'cids';
 import multibase from 'multibase';
-import * as streamtypes from './streamtypes';
 import varint from 'varint';
 import uint8ArrayConcat from 'uint8arrays/concat';
 import uint8ArrayToString from 'uint8arrays/to-string';
@@ -9,6 +8,7 @@ import { readCid, readVarint } from './reading-bytes';
 import { Memoize } from 'typescript-memoize';
 import { CommitID } from './commit-id';
 import { StreamRef } from './stream-ref';
+import { StreamType } from './stream-type';
 
 /**
  * Parse StreamID from bytes representation.
@@ -76,7 +76,7 @@ export class StreamID implements StreamRef {
   constructor(type: string | number, cid: CID | string) {
     if (!(type || type === 0)) throw new Error('constructor: type required');
     if (!cid) throw new Error('constructor: cid required');
-    this.#type = typeof type === 'string' ? streamtypes.indexByName(type) : type;
+    this.#type = typeof type === 'string' ? StreamType.indexByName(type) : type;
     this.#cid = typeof cid === 'string' ? new CID(cid) : cid;
   }
 
@@ -92,7 +92,7 @@ export class StreamID implements StreamRef {
    */
   @Memoize()
   get typeName(): string {
-    return streamtypes.nameByIndex(this.#type);
+    return StreamType.nameByIndex(this.#type);
   }
 
   /**

--- a/packages/streamid/src/stream-id.ts
+++ b/packages/streamid/src/stream-id.ts
@@ -76,7 +76,7 @@ export class StreamID implements StreamRef {
   constructor(type: string | number, cid: CID | string) {
     if (!(type || type === 0)) throw new Error('constructor: type required');
     if (!cid) throw new Error('constructor: cid required');
-    this.#type = typeof type === 'string' ? StreamType.indexByName(type) : type;
+    this.#type = typeof type === 'string' ? StreamType.codeByName(type) : type;
     this.#cid = typeof cid === 'string' ? new CID(cid) : cid;
   }
 
@@ -92,7 +92,7 @@ export class StreamID implements StreamRef {
    */
   @Memoize()
   get typeName(): string {
-    return StreamType.nameByIndex(this.#type);
+    return StreamType.nameByCode(this.#type);
   }
 
   /**

--- a/packages/streamid/src/stream-type.ts
+++ b/packages/streamid/src/stream-type.ts
@@ -3,7 +3,7 @@ const registry: Record<string, number | undefined> = {
   'caip10-link': 1,
 };
 
-export function indexByName(name: string): number {
+function indexByName(name: string): number {
   const index = registry[name];
   if (typeof index !== 'undefined') {
     return index;
@@ -12,11 +12,16 @@ export function indexByName(name: string): number {
   }
 }
 
-export function nameByIndex(index: number): string {
+function nameByIndex(index: number): string {
   const pair = Object.entries(registry).find(([, v]) => v === index);
   if (pair) {
     return pair[0];
   } else {
     throw new Error(`No stream type registered for index ${index}`);
   }
+}
+
+export class StreamType {
+  static nameByIndex = nameByIndex;
+  static indexByName = indexByName;
 }

--- a/packages/streamid/src/stream-type.ts
+++ b/packages/streamid/src/stream-type.ts
@@ -3,7 +3,7 @@ const registry: Record<string, number | undefined> = {
   'caip10-link': 1,
 };
 
-function indexByName(name: string): number {
+function codeByName(name: string): number {
   const index = registry[name];
   if (typeof index !== 'undefined') {
     return index;
@@ -12,7 +12,7 @@ function indexByName(name: string): number {
   }
 }
 
-function nameByIndex(index: number): string {
+function nameByCode(index: number): string {
   const pair = Object.entries(registry).find(([, v]) => v === index);
   if (pair) {
     return pair[0];
@@ -22,6 +22,6 @@ function nameByIndex(index: number): string {
 }
 
 export class StreamType {
-  static nameByIndex = nameByIndex;
-  static indexByName = indexByName;
+  static nameByCode = nameByCode;
+  static codeByName = codeByName;
 }


### PR DESCRIPTION
- DocState#doctype is gone in favour of DocState#type (which is number)
- Concern with HTTP and StateStore is handled by DoctypeUtils: serialises with both type and doctype, deserialises with just `type` (assuming mapping name->id is in stream types registry). So, no breaking changes expected.