### PR TITLE
fix(3id-did-resolver): Use the correct url for json-ld context

### DIFF
--- a/packages/3id-did-resolver/src/__tests__/index.test.ts
+++ b/packages/3id-did-resolver/src/__tests__/index.test.ts
@@ -33,7 +33,7 @@ const v0NoUpdates = '3IDv0-no-updates'
 const toLdFormat = result => {
   const newResult = { ...result }
   newResult.didResolutionMetadata.contentType = DID_LD_JSON
-  newResult.didDocument['@context'] = 'https://w3id.org/did/v1'
+  newResult.didDocument['@context'] = 'https://www.w3.org/ns/did/v1'
   return newResult
 }
 

--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -180,7 +180,7 @@ export default {
         const didResult = await (isLegacyDid(parsed.id) ? legacyResolve(ceramic, parsed.id, verNfo) : resolve(ceramic, parsed.id, verNfo))
 
         if (contentType === DID_LD_JSON) {
-          didResult.didDocument['@context'] = 'https://w3id.org/did/v1'
+          didResult.didDocument['@context'] = 'https://www.w3.org/ns/did/v1'
           didResult.didResolutionMetadata.contentType = DID_LD_JSON
         } else if (contentType !== DID_JSON) {
           didResult.didDocument = null


### PR DESCRIPTION
Apparently we were using an incorrect url for the `@context` property for the json-ld encoded DID document.

Feel free to merge this without my oversight.