### PR TITLE
fix: update docker images for streamid package

### DIFF
--- a/Dockerfile.daemon
+++ b/Dockerfile.daemon
@@ -9,25 +9,10 @@ RUN npm install
 
 COPY lerna.json tsconfig.json ./
 
-COPY packages/3id-did-resolver/package*.json ./packages/3id-did-resolver/
-COPY packages/cli/package*.json ./packages/cli/
-COPY packages/common/package*.json ./packages/common/
-COPY packages/core/package*.json ./packages/core/
-COPY packages/docid/package*.json ./packages/docid/
-COPY packages/doctype-caip10-link/package*.json ./packages/doctype-caip10-link/
-COPY packages/doctype-tile/package*.json ./packages/doctype-tile/
-COPY packages/http-client/package*.json ./packages/http-client/
-COPY packages/ipfs-daemon/package*.json ./packages/ipfs-daemon/
-COPY packages/ipfs-topology/package*.json ./packages/ipfs-topology/
-COPY packages/key-did-resolver/package*.json ./packages/key-did-resolver/
-COPY packages/logger/package*.json ./packages/logger/
-COPY packages/pinning-aggregation/package*.json ./packages/pinning-aggregation/
-COPY packages/pinning-ipfs-backend/package*.json ./packages/pinning-ipfs-backend/
-COPY packages/pinning-powergate-backend/package*.json ./packages/pinning-powergate-backend/
+COPY packages ./packages
 
 RUN npx lerna bootstrap --hoist
 
-COPY packages ./packages
 COPY types ./types
 
 RUN npm run build
@@ -35,4 +20,3 @@ RUN npm run build
 EXPOSE 7007
 
 ENTRYPOINT ["./packages/cli/bin/ceramic.js", "daemon"]
-

--- a/Dockerfile.ipfs-daemon
+++ b/Dockerfile.ipfs-daemon
@@ -9,25 +9,10 @@ RUN npm install
 
 COPY lerna.json tsconfig.json ./
 
-COPY packages/3id-did-resolver/package*.json ./packages/3id-did-resolver/
-COPY packages/cli/package*.json ./packages/cli/
-COPY packages/common/package*.json ./packages/common/
-COPY packages/core/package*.json ./packages/core/
-COPY packages/docid/package*.json ./packages/docid/
-COPY packages/doctype-caip10-link/package*.json ./packages/doctype-caip10-link/
-COPY packages/doctype-tile/package*.json ./packages/doctype-tile/
-COPY packages/http-client/package*.json ./packages/http-client/
-COPY packages/ipfs-daemon/package*.json ./packages/ipfs-daemon/
-COPY packages/ipfs-topology/package*.json ./packages/ipfs-topology/
-COPY packages/key-did-resolver/package*.json ./packages/key-did-resolver/
-COPY packages/logger/package*.json ./packages/logger/
-COPY packages/pinning-aggregation/package*.json ./packages/pinning-aggregation/
-COPY packages/pinning-ipfs-backend/package*.json ./packages/pinning-ipfs-backend/
-COPY packages/pinning-powergate-backend/package*.json ./packages/pinning-powergate-backend/
+COPY packages ./packages
 
 RUN npx lerna bootstrap --hoist
 
-COPY packages ./packages
 COPY types ./types
 
 RUN npm run build
@@ -36,4 +21,3 @@ EXPOSE 5011
 EXPOSE 9011
 
 ENTRYPOINT ["./packages/ipfs-daemon/bin/ipfs-daemon.js"]
-


### PR DESCRIPTION
Image builds were failing because docid package no longer exists. This pr cleans up the docker image code and avoids such issues in the future.