### PR TITLE
fix(blockchain-utils-linking): pass through opts authProvider for eoa…

### DIFF
--- a/packages/blockchain-utils-linking/src/ethereum.ts
+++ b/packages/blockchain-utils-linking/src/ethereum.ts
@@ -14,6 +14,10 @@ const ADDRESS_TYPES = {
   erc1271: "erc1271",
 };
 
+type EthProviderOpts = {
+  eoaSignAccount?: string
+}
+
 const CHAIN_NAMESPACE = "eip155";
 
 /**
@@ -24,7 +28,8 @@ export class EthereumAuthProvider implements AuthProvider {
 
   constructor(
       private readonly provider: any,
-      private readonly address: string
+      private readonly address: string,
+      private readonly opts: EthProviderOpts = {}
   ) {}
 
   async accountId() {
@@ -44,7 +49,7 @@ export class EthereumAuthProvider implements AuthProvider {
 
   async createLink(did: string): Promise<LinkProof> {
     const accountId = await this.accountId();
-    return createLink(did, accountId, this.provider, { type: "ethereum-eoa" });
+    return createLink(did, accountId, this.provider, this.opts);
   }
 
   withAddress(address: string): AuthProvider {


### PR DESCRIPTION
…SignAccount

Ref: https://github.com/ceramicnetwork/js-3id-blockchain-utils/pull/36