### PR TITLE
fix(store): web browsers don't have access to fs

### DIFF
--- a/packages/core/src/store/level-state-store.ts
+++ b/packages/core/src/store/level-state-store.ts
@@ -27,7 +27,9 @@ export class LevelStateStore implements StateStore {
     open(networkName: string): void {
         // Always store the pinning state in a network-specific directory
         const storePath = path.join(this.storeRoot, networkName)
-        fs.mkdirSync(storePath, { recursive: true }) // create dir if it doesn't exist
+        if (!!fs) {
+            fs.mkdirSync(storePath, { recursive: true }) // create dir if it doesn't exist
+        }
         this.#store = new Level(storePath);
     }
 


### PR DESCRIPTION
When using `js-ceramic` with webpack, nodes can't be used due to the use of `fs` in the Level store. Since `fs` is `undefined` in web browsers, a simple solution is to only use `fs` when it's defined. There seems to only be 1 occurance in `js-ceramic` of this, and I updated it accordingly.