### PR TITLE
CI Docker

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,12 +10,14 @@ jobs:
     name: Build and push
     runs-on: ubuntu-latest
     env:
-      BRANCH: ${{ GITHUB_REF##*/ }}
       SHA_TAG: ${{ github.sha }}
     steps:
       -
         name: Check out the repo
         uses: actions/checkout@v2
+      -
+        name: Set branch name
+        run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
       -
         name: Set env tag
         if: ${{ env.BRANCH == 'master' }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,14 +31,14 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: "@ceramicnetwork/js-ceramic:$NOW_TAG\n@ceramicnetwork/js-ceramic:$SHA_TAG\n"
+          tags: "@ceramicnetwork/js-ceramic:${{ env.NOW_TAG }}\n@ceramicnetwork/js-ceramic:${{ env.SHA_TAG }}\n"
       -
         name: Build and push ipfs-daemon
         id: ipfs_daemon
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: "@ceramicnetwork/ipfs-daemon:$NOW_TAG\n@ceramicnetwork/ipfs-daemon:$SHA_TAG\n"
+          tags: "@ceramicnetwork/ipfs-daemon:${{ env.NOW_TAG }}\n@ceramicnetwork/ipfs-daemon:${{ env.SHA_TAG }}\n"
       -
         name: Image digest
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -47,14 +47,22 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: "@ceramicnetwork/js-ceramic:${{ env.ENV_TAG }}\n@ceramicnetwork/js-ceramic:${{ env.SHA_TAG }}\n@ceramicnetwork/js-ceramic:${{ env.BRANCH }}\n"
+          file: ./Dockerfile.daemon
+          tags: |
+            @ceramicnetwork/js-ceramic:${{ env.ENV_TAG }}
+            @ceramicnetwork/js-ceramic:${{ env.SHA_TAG }}
+            @ceramicnetwork/js-ceramic:${{ env.BRANCH }}
       -
         name: Build and push ipfs-daemon
         id: ipfs_daemon
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: "@ceramicnetwork/ipfs-daemon:${{ env.ENV_TAG }}\n@ceramicnetwork/ipfs-daemon:${{ env.SHA_TAG }}\n@ceramicnetwork/js-ceramic:${{ env.BRANCH }}\n"
+          file: ./Dockerfile.ipfs-daemon
+          tags: |
+            @ceramicnetwork/ipfs-daemon:${{ env.ENV_TAG }}
+            @ceramicnetwork/ipfs-daemon:${{ env.SHA_TAG }}
+            @ceramicnetwork/ipfs-daemon:${{ env.BRANCH }}
       -
         name: Image digest
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,46 @@
+name: Publish images to Docker Hub
+
+on:
+  push:
+    branches: [ develop, feat/ci-docker ]
+  workflow_dispatch: # manually triggered
+
+jobs:
+  push_js_ceramic:
+    name: Build and push
+    runs-on: ubuntu-latest
+    env:
+      NOW_TAG: $(date +%s)
+      SHA_TAG: ${{ github.sha }}
+    steps:
+      -
+        name: Check out the repo
+        uses: actions/checkout@v2
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push js-ceramic (daemon)
+        id: js_ceramic
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: "@ceramicnetwork/js-ceramic:$NOW_TAG\n@ceramicnetwork/js-ceramic:$SHA_TAG\n"
+      -
+        name: Build and push ipfs-daemon
+        id: ipfs_daemon
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: "@ceramicnetwork/ipfs-daemon:$NOW_TAG\n@ceramicnetwork/ipfs-daemon:$SHA_TAG\n"
+      -
+        name: Image digest
+        run: |
+          echo ${{ steps.js_ceramic.outputs.digest }}
+          echo ${{ steps.ipfs_daemon.outputs.digest }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -59,7 +59,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Push js-ceramic image
-        run: docker push ceramicnetwork/js-ceramic --all-tags docker.io/ceramicnetwork/js-ceramic
+        run: docker image push --all-tags docker.io/ceramicnetwork/js-ceramic
       -
         name: Push ipfs-daemon image
-        run: docker push ceramicnetwork/ipfs-daemon --all-tags docker.io/ceramicnetwork/ipfs-daemon
+        run: docker image push --all-tags docker.io/ceramicnetwork/ipfs-daemon

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -59,7 +59,7 @@ jobs:
           IMAGE_ID: "ceramicnetwork/ipfs-daemon"
         run: |
           docker buildx build . --file Dockerfile.ipfs-daemon \
+            --output "type=image,push=true" \
             --tag ${{ env.IMAGE_ID }}:${{ env.ENV_TAG }} \
             --tag ${{ env.IMAGE_ID }}:${{ env.SHA_TAG }} \
             --tag ${{ env.IMAGE_ID }}:${{ env.BRANCH }}
-          docker image push --all-tags docker.io/ceramicnetwork/ipfs-daemon

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,12 +22,16 @@ jobs:
         run: echo "ENV_TAG=latest" >> $GITHUB_ENV
       -
         name: Set env tag
+        if: ${{ env.BRANCH == 'release-candidate' }}
+        run: echo "ENV_TAG=tnet" >> $GITHUB_ENV
+      -
+        name: Set env tag
         if: ${{ env.BRANCH == 'develop' }}
         run: echo "ENV_TAG=dev" >> $GITHUB_ENV
       -
-        name: Set env tag
-        if: ${{ env.BRANCH == 'release-candidate' }}
-        run: echo "ENV_TAG=tnet" >> $GITHUB_ENV
+        name: Set env tag (default)
+        if: ${{ env.ENV_TAG == '' }}
+        run: echo "ENV_TAG=dev" >> $GITHUB_ENV
       - 
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,8 +9,6 @@ jobs:
   push_js_ceramic:
     name: Build and push
     runs-on: ubuntu-latest
-    env:
-      SHA_TAG: ${{ github.sha }}
     steps:
       -
         name: Check out the repo
@@ -19,15 +17,20 @@ jobs:
         name: Set branch name
         run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
       -
-        name: Set env tag
+        name: Set sha tag
+        run: |
+          SHA_TAG=$(git rev-parse --short=12 "${{ github.sha }}")
+          echo "SHA_TAG=$SHA_TAG" >> $GITHUB_ENV
+      -
+        name: Set master branch tag
         if: ${{ env.BRANCH == 'master' }}
         run: echo "ENV_TAG=latest" >> $GITHUB_ENV
       -
-        name: Set env tag
+        name: Set rc branch tag
         if: ${{ env.BRANCH == 'release-candidate' }}
         run: echo "ENV_TAG=tnet" >> $GITHUB_ENV
       -
-        name: Set env tag
+        name: Set develop branch tag
         if: ${{ env.BRANCH == 'develop' }}
         run: echo "ENV_TAG=dev" >> $GITHUB_ENV
       -

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,7 +41,6 @@ jobs:
         name: Build js-ceramic image
         run: |
           docker buildx build . --file Dockerfile.daemon \
-            --tag ceramicnetwork/js-ceramic \
             --tag ceramicnetwork/js-ceramic:${{ env.ENV_TAG }} \
             --tag ceramicnetwork/js-ceramic:${{ env.SHA_TAG }} \
             --tag ceramicnetwork/js-ceramic:${{ env.BRANCH }}
@@ -49,7 +48,6 @@ jobs:
         name: Build ipfs-daemon image
         run: |
           docker buildx build . --file Dockerfile.ipfs-daemon \
-            --tag ceramicnetwork/ipfs-daemon \
             --tag ceramicnetwork/ipfs-daemon:${{ env.ENV_TAG }} \
             --tag ceramicnetwork/ipfs-daemon:${{ env.SHA_TAG }} \
             --tag ceramicnetwork/ipfs-daemon:${{ env.BRANCH }}
@@ -61,7 +59,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Push js-ceramic image
-        run: docker push ceramicnetwork/js-ceramic
+        run: docker push ceramicnetwork/js-ceramic --all-tags docker.io/ceramicnetwork/js-ceramic
       -
         name: Push ipfs-daemon image
-        run: docker push ceramicnetwork/ipfs-daemon
+        run: docker push ceramicnetwork/ipfs-daemon --all-tags docker.io/ceramicnetwork/ipfs-daemon

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,6 +41,7 @@ jobs:
         name: Build js-ceramic image
         run: |
           docker buildx build . --file Dockerfile.daemon \
+            --tag ceramicnetwork/js-ceramic \
             --tag ceramicnetwork/js-ceramic:${{ env.ENV_TAG }} \
             --tag ceramicnetwork/js-ceramic:${{ env.SHA_TAG }} \
             --tag ceramicnetwork/js-ceramic:${{ env.BRANCH }}
@@ -48,6 +49,7 @@ jobs:
         name: Build ipfs-daemon image
         run: |
           docker buildx build . --file Dockerfile.ipfs-daemon \
+            --tag ceramicnetwork/ipfs-daemon \
             --tag ceramicnetwork/ipfs-daemon:${{ env.ENV_TAG }} \
             --tag ceramicnetwork/ipfs-daemon:${{ env.SHA_TAG }} \
             --tag ceramicnetwork/ipfs-daemon:${{ env.BRANCH }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build and push
     runs-on: ubuntu-latest
     env:
-      BRANCH: ${GITHUB_REF##*/}
+      BRANCH: ${{ GITHUB_REF##*/ }}
       SHA_TAG: ${{ github.sha }}
     steps:
       -

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -51,9 +51,9 @@ jobs:
           push: true
           file: ./Dockerfile.daemon
           tags: |
-            js-ceramic:${{ env.ENV_TAG }}
-            js-ceramic:${{ env.SHA_TAG }}
-            js-ceramic:${{ env.BRANCH }}
+            ceramicnetwork/js-ceramic:${{ env.ENV_TAG }}
+            ceramicnetwork/js-ceramic:${{ env.SHA_TAG }}
+            ceramicnetwork/js-ceramic:${{ env.BRANCH }}
       -
         name: Build and push ipfs-daemon
         id: ipfs_daemon
@@ -62,9 +62,9 @@ jobs:
           push: true
           file: ./Dockerfile.ipfs-daemon
           tags: |
-            ipfs-daemon:${{ env.ENV_TAG }}
-            ipfs-daemon:${{ env.SHA_TAG }}
-            ipfs-daemon:${{ env.BRANCH }}
+            ceramicnetwork/ipfs-daemon:${{ env.ENV_TAG }}
+            ceramicnetwork/ipfs-daemon:${{ env.SHA_TAG }}
+            ceramicnetwork/ipfs-daemon:${{ env.BRANCH }}
       -
         name: Image digest
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -38,35 +38,28 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
+        name: Build js-ceramic image
+        run: |
+          docker buildx build . --file Dockerfile.daemon \
+            --tag ceramicnetwork/js-ceramic:${{ env.ENV_TAG }} \
+            --tag ceramicnetwork/js-ceramic:${{ env.SHA_TAG }} \
+            --tag ceramicnetwork/js-ceramic:${{ env.BRANCH }}
+      -
+        name: Build ipfs-daemon image
+        run: |
+          docker buildx build . --file Dockerfile.ipfs-daemon \
+            --tag ceramicnetwork/ipfs-daemon:${{ env.ENV_TAG }} \
+            --tag ceramicnetwork/ipfs-daemon:${{ env.SHA_TAG }} \
+            --tag ceramicnetwork/ipfs-daemon:${{ env.BRANCH }}
+      -
         name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push js-ceramic (daemon)
-        id: js_ceramic
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          file: ./Dockerfile.daemon
-          tags: |
-            ceramicnetwork/js-ceramic:${{ env.ENV_TAG }}
-            ceramicnetwork/js-ceramic:${{ env.SHA_TAG }}
-            ceramicnetwork/js-ceramic:${{ env.BRANCH }}
+        name: Push js-ceramic image
+        run: docker push ceramicnetwork/js-ceramic
       -
-        name: Build and push ipfs-daemon
-        id: ipfs_daemon
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          file: ./Dockerfile.ipfs-daemon
-          tags: |
-            ceramicnetwork/ipfs-daemon:${{ env.ENV_TAG }}
-            ceramicnetwork/ipfs-daemon:${{ env.SHA_TAG }}
-            ceramicnetwork/ipfs-daemon:${{ env.BRANCH }}
-      -
-        name: Image digest
-        run: |
-          echo ${{ steps.js_ceramic.outputs.digest }}
-          echo ${{ steps.ipfs_daemon.outputs.digest }}
+        name: Push ipfs-daemon image
+        run: docker push ceramicnetwork/ipfs-daemon

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -38,28 +38,28 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
-        name: Build js-ceramic image
-        run: |
-          docker buildx build . --file Dockerfile.daemon \
-            --tag ceramicnetwork/js-ceramic:${{ env.ENV_TAG }} \
-            --tag ceramicnetwork/js-ceramic:${{ env.SHA_TAG }} \
-            --tag ceramicnetwork/js-ceramic:${{ env.BRANCH }}
-      -
-        name: Build ipfs-daemon image
-        run: |
-          docker buildx build . --file Dockerfile.ipfs-daemon \
-            --tag ceramicnetwork/ipfs-daemon:${{ env.ENV_TAG }} \
-            --tag ceramicnetwork/ipfs-daemon:${{ env.SHA_TAG }} \
-            --tag ceramicnetwork/ipfs-daemon:${{ env.BRANCH }}
-      -
         name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Push js-ceramic image
-        run: docker image push --all-tags docker.io/ceramicnetwork/js-ceramic
+        name: Build js-ceramic image
+        env:
+          IMAGE_ID: "ceramicnetwork/js-ceramic"
+        run: |
+          docker buildx build . --file Dockerfile.daemon \
+            --output "type=image,push=true" \
+            --tag ${{ env.IMAGE_ID }}:${{ env.ENV_TAG }} \
+            --tag ${{ env.IMAGE_ID }}:${{ env.SHA_TAG }} \
+            --tag ${{ env.IMAGE_ID }}:${{ env.BRANCH }}
       -
-        name: Push ipfs-daemon image
-        run: docker image push --all-tags docker.io/ceramicnetwork/ipfs-daemon
+        name: Build ipfs-daemon image
+        env:
+          IMAGE_ID: "ceramicnetwork/ipfs-daemon"
+        run: |
+          docker buildx build . --file Dockerfile.ipfs-daemon \
+            --tag ${{ env.IMAGE_ID }}:${{ env.ENV_TAG }} \
+            --tag ${{ env.IMAGE_ID }}:${{ env.SHA_TAG }} \
+            --tag ${{ env.IMAGE_ID }}:${{ env.BRANCH }}
+          docker image push --all-tags docker.io/ceramicnetwork/ipfs-daemon

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -51,9 +51,9 @@ jobs:
           push: true
           file: ./Dockerfile.daemon
           tags: |
-            @ceramicnetwork/js-ceramic:${{ env.ENV_TAG }}
-            @ceramicnetwork/js-ceramic:${{ env.SHA_TAG }}
-            @ceramicnetwork/js-ceramic:${{ env.BRANCH }}
+            js-ceramic:${{ env.ENV_TAG }}
+            js-ceramic:${{ env.SHA_TAG }}
+            js-ceramic:${{ env.BRANCH }}
       -
         name: Build and push ipfs-daemon
         id: ipfs_daemon
@@ -62,9 +62,9 @@ jobs:
           push: true
           file: ./Dockerfile.ipfs-daemon
           tags: |
-            @ceramicnetwork/ipfs-daemon:${{ env.ENV_TAG }}
-            @ceramicnetwork/ipfs-daemon:${{ env.SHA_TAG }}
-            @ceramicnetwork/ipfs-daemon:${{ env.BRANCH }}
+            ipfs-daemon:${{ env.ENV_TAG }}
+            ipfs-daemon:${{ env.SHA_TAG }}
+            ipfs-daemon:${{ env.BRANCH }}
       -
         name: Image digest
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,7 @@ name: Publish images to Docker Hub
 
 on:
   push:
-    branches: [ develop, feat/ci-docker ]
+    branches: [ develop, release-candidate, master ]
   workflow_dispatch: # manually triggered
 
 jobs:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,12 +10,24 @@ jobs:
     name: Build and push
     runs-on: ubuntu-latest
     env:
-      NOW_TAG: $(date +%s)
+      BRANCH: ${GITHUB_REF##*/}
       SHA_TAG: ${{ github.sha }}
     steps:
       -
         name: Check out the repo
         uses: actions/checkout@v2
+      -
+        name: Set env tag
+        if: ${{ env.BRANCH == 'master' }}
+        run: echo "ENV_TAG=latest" >> $GITHUB_ENV
+      -
+        name: Set env tag
+        if: ${{ env.BRANCH == 'develop' }}
+        run: echo "ENV_TAG=dev" >> $GITHUB_ENV
+      -
+        name: Set env tag
+        if: ${{ env.BRANCH == 'release-candidate' }}
+        run: echo "ENV_TAG=tnet" >> $GITHUB_ENV
       - 
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -31,14 +43,14 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: "@ceramicnetwork/js-ceramic:${{ env.NOW_TAG }}\n@ceramicnetwork/js-ceramic:${{ env.SHA_TAG }}\n"
+          tags: "@ceramicnetwork/js-ceramic:${{ env.ENV_TAG }}\n@ceramicnetwork/js-ceramic:${{ env.SHA_TAG }}\n@ceramicnetwork/js-ceramic:${{ env.BRANCH }}\n"
       -
         name: Build and push ipfs-daemon
         id: ipfs_daemon
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: "@ceramicnetwork/ipfs-daemon:${{ env.NOW_TAG }}\n@ceramicnetwork/ipfs-daemon:${{ env.SHA_TAG }}\n"
+          tags: "@ceramicnetwork/ipfs-daemon:${{ env.ENV_TAG }}\n@ceramicnetwork/ipfs-daemon:${{ env.SHA_TAG }}\n@ceramicnetwork/js-ceramic:${{ env.BRANCH }}\n"
       -
         name: Image digest
         run: |


### PR DESCRIPTION
**Note: Anyone can review and merge.**

Tested on a feature branch and works properly. See images built here: https://hub.docker.com/repository/registry-1.docker.io/ceramicnetwork/js-ceramic/tags?page=1&ordering=last_updated

This builds our docker images and pushes them to dockerhub. I turned off the automated builds on docker hub website--way too slow and unreliable.

This creates and pushes the image on each push to our branches `master`, `release-candidate`, and `develop`. However we can change this in the future to only build and push when we actually make a release. Just need to get this in for right now.