### PR TITLE
fix(common): CeramicApi compatibility

### DIFF
--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -46,7 +46,7 @@ interface CeramicCommon {
  * available users can provide any object containing an authenticated DID instance.
  */
 export interface CeramicSigner extends CeramicCommon {
-    did: DID | null
+    did: DID | undefined
 
     [index: string]: any // allow arbitrary properties
 }


### PR DESCRIPTION
CeramicApi is currently incompatible with CeramicClient and Ceramic core.