### PR TITLE
chore(stream-tile): Add doc comments for TileMetadataArgs

### DIFF
--- a/packages/common/src/docopts.ts
+++ b/packages/common/src/docopts.ts
@@ -1,14 +1,17 @@
 /**
  * Enum describing different modes for syncing a stream.
- * - SYNC_ALWAYS - Means that regardless of whether or not the stream is found in the node's cache
- *   we will always query pubsub for the current tip for the stream and wait up to 'syncTimeoutSeconds'
- *   for the response.
- * - PREFER_CACHE - Means that if the stream is found in the node's in-memory cache or pin store,
- *   then the cached version is returned without performing any query to the pubsub network for the
- *   current tip.
  */
 export enum SyncOptions {
+    /**
+     *  If the stream is found in the node's in-memory cache or pin store, then return the cached version
+     *  without performing any query to the pubsub network for the current tip.
+     */
     PREFER_CACHE,
+
+    /**
+     *  Always query pubsub for the current tip for the stream and wait up to 'syncTimeoutSeconds'
+     *   for the response, regardless of whether or not the stream is found in the node's cache
+     */
     SYNC_ALWAYS,
 }
 

--- a/packages/stream-tile/src/tile-document.ts
+++ b/packages/stream-tile/src/tile-document.ts
@@ -27,11 +27,33 @@ import { CommitID, StreamID, StreamRef } from "@ceramicnetwork/streamid";
  * Arguments used to generate the metadata for Tile documents
  */
 export interface TileMetadataArgs {
-  controllers?: Array<string>
-  family?: string
-  schema?: CommitID | string
-  tags?: Array<string>
-  deterministic?: boolean
+    /**
+     * The DID(s) that are allowed to author updates to this TileDocument
+     */
+    controllers?: Array<string>
+
+    /**
+     * Allows grouping similar documents into "families". Primarily used by indexing services.
+     */
+    family?: string
+
+    /**
+     * Allows tagging documents with additional information. Primarily used by indexing services.
+     */
+    tags?: Array<string>
+
+    /**
+     * If specified, must refer to another TileDocument whose contents are a JSON-schema specification.
+     * The content of this document will then be enforced to conform to the linked schema.
+     */
+    schema?: CommitID | string
+
+    /**
+     * If true, then two calls to TileDocument.create() with the same content and the same metadata
+     * will only create a single document with the same StreamID. If false, then otherwise
+     * identical documents will generate unique StreamIDs and be able to be updated independently.
+     */
+    deterministic?: boolean
 }
 
 const DEFAULT_CREATE_OPTS = { anchor: true, publish: true, sync: SyncOptions.PREFER_CACHE }


### PR DESCRIPTION
Also cleans up the doc comments for the `SyncOptions` enum