### PR TITLE
feat(cli): use 0 address for default hostname

### DIFF
--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -13,7 +13,7 @@ program
     .option('--state-store-s3-bucket <string>', `The S3 bucket name to use for storing pinned stream state. If not provided pinned stream state will only be saved locally but not to S3.`)
     .option('--gateway', 'Makes read only endpoints available. It is disabled by default')
     .option('--port <int>', 'Port daemon is available on. Default is 7007')
-    .option('--hostname <string>', 'Host daemon is available on. Default is "localhost"')
+    .option('--hostname <string>', 'Host daemon is available on. Default is 0.0.0.0')
     .option('--debug', 'Enable debug logging level. Default is false')
     .option('--verbose', 'Enable verbose logging level. Default is false')
     .option('--log-to-files', 'If debug is true, write logs to files. Default is false')

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -22,7 +22,7 @@ import { addAsync, ExpressWithAsync } from '@awaitjs/express'
 import { logRequests } from './daemon/log-requests';
 import type { Server } from 'http';
 
-const DEFAULT_HOSTNAME = 'localhost'
+const DEFAULT_HOSTNAME = '0.0.0.0'
 const DEFAULT_PORT = 7007
 const toApiPath = (ending: string): string => '/api/v0' + ending
 


### PR DESCRIPTION
Less friction to serve it from any address so that a proxy is not required