### PR TITLE
Daemon http paths and params

### DIFF
--- a/packages/cli/src/__tests__/ceramic-error.test.ts
+++ b/packages/cli/src/__tests__/ceramic-error.test.ts
@@ -79,7 +79,7 @@ test('write to http-access', async () => {
   const httpAccessLog = safeRead(httpAccessLogPath);
   const lines = httpAccessLog.split('\n');
   const lastLine = lines[lines.length - 2];
-  expect(lastLine).toContain('error_message=-');
+  expect(lastLine).toContain('error_message="-"');
   expect(lastLine).toContain('error_code=-');
   expect(lastLine).toContain('status=200');
 });
@@ -87,7 +87,7 @@ test('write to http-access', async () => {
 test('write error to http access log: no error code', async () => {
   const httpAccessLogPath = path.resolve(tmpFolder.path, 'http-access.log');
   core.createStreamFromGenesis = async () => {
-    throw new Error(`BANG`);
+    throw new Error(`BANG BANG`);
   };
   await expect(
     TileDocument.create(client, { test: 123 }, null, { anchor: false, publish: false, syncTimeoutSeconds:0 }),
@@ -96,7 +96,7 @@ test('write error to http access log: no error code', async () => {
   const httpAccessLog = safeRead(httpAccessLogPath);
   const lines = httpAccessLog.split('\n');
   const lastLine = lines[lines.length - 2];
-  expect(lastLine).toContain('error_message=BANG');
+  expect(lastLine).toContain('error_message="BANG BANG"');
   expect(lastLine).toContain('error_code=-');
   expect(lastLine).toContain('status=500');
 });
@@ -107,7 +107,7 @@ test('write error to http access log: with error code', async () => {
     readonly code = 345;
   }
   core.createStreamFromGenesis = async () => {
-    throw new FauxError(`BANG`);
+    throw new FauxError(`BANG BANG`);
   };
   await expect(
     TileDocument.create(client, { test: 123 }, null, { anchor: false, publish: false, syncTimeoutSeconds:0 }),
@@ -116,7 +116,7 @@ test('write error to http access log: with error code', async () => {
   const httpAccessLog = safeRead(httpAccessLogPath);
   const lines = httpAccessLog.split('\n');
   const lastLine = lines[lines.length - 2];
-  expect(lastLine).toContain('error_message=BANG');
+  expect(lastLine).toContain('error_message="BANG BANG"');
   expect(lastLine).toContain('error_code=345');
   expect(lastLine).toContain('status=500');
 });

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -216,6 +216,14 @@ class CeramicDaemon {
       recordsRouter.postAsync('/',  this._notSupported.bind(this)) // Deprecated
     }
 
+    commitsRouter.use(errorHandler(this.diagnosticsLogger))
+    documentsRouter.use(errorHandler(this.diagnosticsLogger))
+    multiqueriesRouter.use(errorHandler(this.diagnosticsLogger))
+    nodeRouter.use(errorHandler(this.diagnosticsLogger))
+    pinsRouter.use(errorHandler(this.diagnosticsLogger))
+    recordsRouter.use(errorHandler(this.diagnosticsLogger))
+    streamsRouter.use(errorHandler(this.diagnosticsLogger))
+
     baseRouter.use('/commits', commitsRouter)
     baseRouter.use('/documents', documentsRouter)
     baseRouter.use('/multiqueries', multiqueriesRouter)

--- a/packages/cli/src/daemon/log-requests.ts
+++ b/packages/cli/src/daemon/log-requests.ts
@@ -2,7 +2,7 @@ import { LoggerProvider } from '@ceramicnetwork/common';
 import { Request, Response } from 'express';
 import morgan from 'morgan';
 
-const ACCESS_LOG_FMT = 'ip=:remote-addr ts=:date[iso] method=:method original_url=:original-url base_url=:base-url path=:path:params http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=:user-agent elapsed_ms=:total-time[3] error_message=:error-message error_code=:error-code';
+const ACCESS_LOG_FMT = 'ip=:remote-addr ts=:date[iso] method=:method original_url=:original-url base_url=:base-url path=:path:params http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=:user-agent elapsed_ms=:total-time[3] error_message=":error-message" error_code=:error-code';
 
 export function logRequests(loggerProvider: LoggerProvider): any[] {
   morgan.token<Request, Response>('error-message', (req, res: Response) => {

--- a/packages/cli/src/daemon/log-requests.ts
+++ b/packages/cli/src/daemon/log-requests.ts
@@ -21,14 +21,16 @@ export function logRequests(loggerProvider: LoggerProvider): any[] {
     return req.path;
   });
   morgan.token<Request, Response>('params', (req) => {
-    const keys = Object.keys(req.params);
-    if (keys.length < 1) {
-      return ' params=-';
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > 0) {
+        const params = keys.reduce((prev, curr) => {
+          return prev + ` params.${curr}=${req.params[curr]}`;
+        }, '');
+        return params;
+      }
     }
-    const params = keys.reduce((prev, curr) => {
-        return prev + ` params.${curr}=${req.params[curr]}`;
-    }, '');
-    return params;
+    return ' params=-';
   });
 
   const logger = loggerProvider.makeServiceLogger('http-access');

--- a/packages/cli/src/daemon/log-requests.ts
+++ b/packages/cli/src/daemon/log-requests.ts
@@ -2,7 +2,7 @@ import { LoggerProvider } from '@ceramicnetwork/common';
 import { Request, Response } from 'express';
 import morgan from 'morgan';
 
-const ACCESS_LOG_FMT = 'ip=:remote-addr ts=:date[iso] method=:method original_url=:original-url base_url=:base-url path=:path:params http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=:user-agent elapsed_ms=:total-time[3] error_message=":error-message" error_code=:error-code';
+const ACCESS_LOG_FMT = 'ip=:remote-addr ts=:date[iso] method=:method original_url=:original-url base_url=:base-url path=:path:params http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=":user-agent" elapsed_ms=:total-time[3] error_message=":error-message" error_code=:error-code';
 
 export function logRequests(loggerProvider: LoggerProvider): any[] {
   morgan.token<Request, Response>('error-message', (req, res: Response) => {

--- a/packages/cli/src/daemon/log-requests.ts
+++ b/packages/cli/src/daemon/log-requests.ts
@@ -1,8 +1,8 @@
-import { Request, Response } from 'express';
 import { LoggerProvider } from '@ceramicnetwork/common';
+import { Request, Response } from 'express';
 import morgan from 'morgan';
 
-const ACCESS_LOG_FMT = 'ip=:remote-addr ts=:date[iso] method=:method original_url=:original-url base_url=:base-url path=:path http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=:user-agent elapsed_ms=:total-time[3] error_message=:error-message error_code=:error-code';
+const ACCESS_LOG_FMT = 'ip=:remote-addr ts=:date[iso] method=:method original_url=:original-url base_url=:base-url path=:path:params http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=:user-agent elapsed_ms=:total-time[3] error_message=:error-message error_code=:error-code';
 
 export function logRequests(loggerProvider: LoggerProvider): any[] {
   morgan.token<Request, Response>('error-message', (req, res: Response) => {
@@ -19,6 +19,16 @@ export function logRequests(loggerProvider: LoggerProvider): any[] {
   });
   morgan.token<Request, Response>('path', (req) => {
     return req.path;
+  });
+  morgan.token<Request, Response>('params', (req) => {
+    const keys = Object.keys(req.params);
+    if (keys.length < 1) {
+      return ' params=-';
+    }
+    const params = keys.reduce((prev, curr) => {
+        return prev + ` params.${curr}=${req.params[curr]}`;
+    }, '');
+    return params;
   });
 
   const logger = loggerProvider.makeServiceLogger('http-access');


### PR DESCRIPTION
### Motivation

We want to be able to show requests per endpoint in our monitoring dashboards

### Changes

- Use express routers to organize request url, path, and params
- Add params to http-access logs
- Clean up http logs with string wrapping (to follow [logfmt](https://brandur.org/logfmt))

### Notes

1. It's harder to read the endpoints now in the code. Generally these routes would be organized in separate files. I'm down to move towards making this cleaner and more organized if people agree it would be helpful. Quick change.

2. 404s will not have these log properties assigned properly because they don't lead to any real handler. So the logs will look like the old format.

Old format
```js
[Thu, 06 May 2021 19:35:31 GMT]
service=http-access
ip=35.203.252.113
ts=2021-05-06T19:35:31.668Z
method=GET
// notice urls and path
original_url=/api/v0/documents/k2t6wyfsu4pg1bu91pkuskd2ig92gldvd3hz6sy9rbuk8zmp2g3fds5ju7j6l1
base_url=-
path=/api/v0/documents/k2t6wyfsu4pg1bu91pkuskd2ig92gldvd3hz6sy9rbuk8zmp2g3fds5ju7j6l1
http_version=1.1
req_header-
status=200
content_length=370
content_type="application/json; charset=utf-8"
ref=-
user_agent=node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
elapsed_ms=1106.483
error_message=-
error_code=-
```

New format
```js
[Thu, 06 May 2021 19:41:10 GMT]
service=http-access
ip=127.0.0.1
ts=2021-05-06T19:41:10.211Z
method=GET
// notice urls, path, params
original_url=/api/v0/documents/k2t6wyfsu4pg2r88kogtioocim6p6ewxnhakzau0ekd4xmparhncekviu7nvuq/
base_url=/api/v0/documents
path=/k2t6wyfsu4pg2r88kogtioocim6p6ewxnhakzau0ekd4xmparhncekviu7nvuq/
params.docid=k2t6wyfsu4pg2r88kogtioocim6p6ewxnhakzau0ekd4xmparhncekviu7nvuq
http_version=1.1
req_header-
status=200
content_length=354
content_type="application/json; charset=utf-8"
ref=-
user_agent="insomnia/2021.2.2"
elapsed_ms=4.742
error_message="-"
error_code=-
```