### PR TITLE
chore: Bump typescript to 4.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "typedoc": "^0.19.2",
         "typedoc-plugin-lerna-packages": "^0.3.1",
         "typedoc-plugin-pages": "^1.0.1",
-        "typescript": "^4.0.5"
+        "typescript": "^4.2.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -17423,9 +17423,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -33020,9 +33020,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typedoc": "^0.19.2",
     "typedoc-plugin-lerna-packages": "^0.3.1",
     "typedoc-plugin-pages": "^1.0.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.4"
   },
   "prettier": {
     "printWidth": 120,


### PR DESCRIPTION
Apparently, it is a prerequisite for rxjs bump