### PR TITLE
fix(ipfs-topology): return null when no network is given for peerlist

### DIFF
--- a/packages/ipfs-topology/src/ipfs-topology.ts
+++ b/packages/ipfs-topology/src/ipfs-topology.ts
@@ -15,8 +15,9 @@ const PEER_FILE_URLS = (ceramicNetwork: Networks): string | null => {
     case Networks.INMEMORY:
       return null;
     default: {
-      const unhandledCase: never = ceramicNetwork;
-      throw new Error(`Unhandled case: ${unhandledCase}`);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const preventCompilingUnhandledCase: never = ceramicNetwork;
+      return null;
     }
   }
 };
@@ -42,8 +43,9 @@ const BASE_BOOTSTRAP_LIST = (ceramicNetwork: Networks): Array<string> | null => 
     case Networks.INMEMORY:
       return null;
     default: {
-      const unhandledCase: never = ceramicNetwork;
-      throw new Error(`Unhandled case: ${unhandledCase}`);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const preventCompilingUnhandledCase: never = ceramicNetwork;
+      return null;
     }
   }
 };


### PR DESCRIPTION
### Motivation

We don't want to throw if a network is not provided to the ipfs-daemon/topology, instead we want to keep the behavior of logging a warning.

### Changes

- Return `null` instead of throwing
- Renamed the type checking variable to make it more clear why it's there