### PR TITLE
fix(http-client): Allow just one stream of sync http calls

### DIFF
--- a/packages/http-client/src/__tests__/document.test.ts
+++ b/packages/http-client/src/__tests__/document.test.ts
@@ -2,8 +2,7 @@ import CID from 'cids';
 import { CommitType, StreamState } from '@ceramicnetwork/common';
 import { Document } from '../document';
 import { BehaviorSubject } from 'rxjs';
-import { filter } from 'rxjs/operators';
-import { first } from 'rxjs/operators';
+import { filter, first } from 'rxjs/operators';
 
 const FAKE_CID_1 = new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu');
 const FAKE_CID2 = new CID('bafybeig6xv5nwphfmvcnektpnojts44jqcuam7bmye2pb54adnrtccjlsu');

--- a/packages/http-client/src/__tests__/document.test.ts
+++ b/packages/http-client/src/__tests__/document.test.ts
@@ -1,6 +1,9 @@
 import CID from 'cids';
 import { CommitType, StreamState } from '@ceramicnetwork/common';
 import { Document } from '../document';
+import { BehaviorSubject } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { first } from 'rxjs/operators';
 
 const FAKE_CID_1 = new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu');
 const FAKE_CID2 = new CID('bafybeig6xv5nwphfmvcnektpnojts44jqcuam7bmye2pb54adnrtccjlsu');
@@ -29,7 +32,9 @@ test('emit on distinct changes', async () => {
   const state$ = new Document(initial, '', 1000);
   // Disable background polling to avoid getting an error from node-fetch since there's no
   // daemon listening to receive the requests.
-  state$._syncState = async function() { /* do nothing*/ }
+  state$._syncState = async function () {
+    /* do nothing*/
+  };
   const updates: StreamState[] = [];
   state$.subscribe((state) => {
     updates.push(state);
@@ -59,5 +64,92 @@ test('emit on distinct changes', async () => {
   expect(updates[0]).toBe(initial);
   expect(updates[1]).toBe(second);
 
-  state$.complete()
+  state$.complete();
+});
+
+describe('periodic subscription', () => {
+  function pairs(input: number[]): number[] {
+    return input.reduce(function (result, value, index, array) {
+      if (index % 2 === 0) result.push(array.slice(index, index + 2));
+      return result;
+    }, []);
+  }
+
+  const SYNC_INTERVAL = 100;
+  const SAMPLES_AMOUNT = 10;
+
+  test('call _syncState periodically when subscribed', async () => {
+    const initial = ({
+      type: 0,
+      log: [
+        {
+          type: CommitType.GENESIS,
+          cid: FAKE_CID_1,
+        },
+      ],
+    } as unknown) as StreamState;
+    const document = new Document(initial, '', SYNC_INTERVAL);
+    // Every Document#_syncState we record when it was called.
+    // Also we track how many invocations happened to stop after enough samples are acquired.
+    const invocations = [];
+    const calledTimes = new BehaviorSubject<number>(0);
+    document._syncState = async () => {
+      calledTimes.next(calledTimes.value + 1);
+      invocations.push(new Date().valueOf());
+    };
+    const subscription = document.subscribe();
+    // Wait for few samples
+    await calledTimes
+      .pipe(
+        filter((n) => n >= SAMPLES_AMOUNT),
+        first(),
+      )
+      .toPromise();
+    subscription.unsubscribe();
+
+    // Invocations should happen every SYNC_INTERVAL (with some error bounded to 10% of SYNC_INTERVAL)
+    const deltas = pairs(invocations).map((pair) => pair[1] - pair[0]);
+    deltas.forEach((delta) => {
+      expect(Math.abs(delta - SYNC_INTERVAL)).toBeLessThan(SYNC_INTERVAL * 0.1);
+    });
+  });
+  test('call _syncState periodically when subscribed multiple times', async () => {
+    // AKA Make sure there is only one stream of periodic _syncState calls
+    const initial = ({
+      type: 0,
+      log: [
+        {
+          type: CommitType.GENESIS,
+          cid: FAKE_CID_1,
+        },
+      ],
+    } as unknown) as StreamState;
+    const document = new Document(initial, '', SYNC_INTERVAL);
+    // Every Document#_syncState we record when it was called.
+    // Also we track how many invocations happened to stop after enough samples are acquired.
+    const invocations = [];
+    const calledTimes = new BehaviorSubject<number>(0);
+    document._syncState = async () => {
+      calledTimes.next(calledTimes.value + 1);
+      invocations.push(new Date().valueOf());
+    };
+    const subscription1 = document.subscribe();
+    const subscription2 = document.subscribe();
+    // Wait for few samples
+    await calledTimes
+      .pipe(
+        filter((n) => n >= SAMPLES_AMOUNT),
+        first(),
+      )
+      .toPromise();
+    subscription1.unsubscribe();
+    subscription2.unsubscribe();
+
+    // Invocations should happen every SYNC_INTERVAL (with some error bounded to 10% of SYNC_INTERVAL)
+    // If more than one stream of _syncState calls exists, some consecutive calls would happen within 1-2ms
+    const deltas = pairs(invocations).map((pair) => pair[1] - pair[0]);
+    deltas.forEach((delta) => {
+      expect(Math.abs(delta - SYNC_INTERVAL)).toBeLessThan(SYNC_INTERVAL * 0.1);
+    });
+  });
 });


### PR DESCRIPTION
Previously, two subscriptions on a stream state resulted in two streams of HTTP update calls. Say, one HTTP call is marked `U`, and sync interval is four dashes (~seconds). With two independent `.subscribe` calls for one `TileDocument` object we would have: `UU----UU----UU----`.

This PR makes it back to `U----U----U----` regardless of how many subscriptions are active. The stream of HTTP calls starts when the first observer arrives, and stops when the last observer unsubscribes.