### PR TITLE
Cleanups to anchor handling

### DIFF
--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -100,6 +100,26 @@ describe('anchor', () => {
     });
     expect(stream$.value.anchorStatus).not.toEqual(AnchorStatus.ANCHORED);
   });
+
+  test('anchor polling continues after error', async () => {
+    const stateManager = ceramic.repository.stateManager;
+    const fakeUpdateStateIfPinned = jest.fn();
+    (stateManager as any)._updateStateIfPinned = fakeUpdateStateIfPinned;
+
+    // Even if there are multiple errors while polling the anchor service, we continue trying
+    // until success, or until we hear a definitive "anchor failed" response from the anchor service
+    fakeUpdateStateIfPinned.mockRejectedValueOnce(new Error('loading from ipfs failed!'))
+    fakeUpdateStateIfPinned.mockRejectedValueOnce(new Error('loading from ipfs failed!'))
+    fakeUpdateStateIfPinned.mockRejectedValueOnce(new Error('loading from ipfs failed!'))
+
+    const stream = await TileDocument.create(ceramic, INITIAL_CONTENT, null, { anchor: false });
+    const stream$ = await ceramic.repository.load(stream.id, {});
+
+    await new Promise((resolve) => {
+      ceramic.repository.stateManager.anchor(stream$).add(resolve);
+    });
+    expect(stream$.value.anchorStatus).toEqual(AnchorStatus.ANCHORED);
+  });
 });
 
 test('handleTip', async () => {

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -98,7 +98,7 @@ describe('anchor', () => {
     await new Promise((resolve) => {
       ceramic.repository.stateManager.anchor(stream$).add(resolve);
     });
-    expect(stream$.value.anchorStatus).not.toEqual(AnchorStatus.ANCHORED);
+    expect(stream$.value.anchorStatus).toEqual(AnchorStatus.FAILED);
   });
 
   test('anchor polling continues after error', async () => {

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -177,9 +177,11 @@ export class StateManager {
         })
         return
       } catch (error) {
-        this.logger.err(`Error while anchoring stream ${state$.id.toString()}, ${remainingRetries} retries remain. ${error}`)
+        this.logger.warn(`Error while anchoring stream ${state$.id.toString()}, ${remainingRetries} retries remain. ${error}`)
+
         if (remainingRetries == 0) {
-          throw error
+          this.logger.err(`Anchor failed for commit ${commit.toString()} of stream ${state$.id.toString()}: ${error}`)
+          state$.next({ ...state$.value, anchorStatus: AnchorStatus.FAILED });
         }
       }
     }


### PR DESCRIPTION
This PR bundles 3 different small cleanups to how Ceramic handles the polling for and application of anchor commits. Reviewers may find it helpful to look at the 3 commits that make up this PR independently, as they all have slightly different goals. I also plan to merge those 3 commits separately, without squashing them into a single commit as I usually do for PRs.