### PR TITLE
fix(core): Don't refetch CID from IPFS when re-applying commits already in the log

### DIFF
--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -145,6 +145,31 @@ test('handleTip', async () => {
   await ceramic2.close();
 });
 
+test('handleTip for commit already in log', async () => {
+  const newContent = {foo: 'bar'}
+  const stream1 = await TileDocument.create<any>(ceramic, INITIAL_CONTENT, null, { anchor:false });
+  await stream1.update(newContent, null, { anchor: false })
+
+  const ceramic2 = await createCeramic(ipfs);
+  const retrieveCommitSpy = jest.spyOn(ceramic2.dispatcher, 'retrieveCommit');
+
+  const stream2 = await ceramic2.loadStream<TileDocument>(stream1.id, { syncTimeoutSeconds:0 });
+  const streamState2 = await ceramic2.repository.load(stream2.id, {});
+
+
+  retrieveCommitSpy.mockClear()
+  await (ceramic2.repository.stateManager as any)._handleTip(streamState2, stream1.state.log[1].cid);
+
+  expect(streamState2.state).toEqual(stream1.state);
+  expect(retrieveCommitSpy).toBeCalledTimes(7) // TODO(1421): This should be 2!
+
+  // Now re-apply the same commit and don't expect any additional calls to IPFS
+  await (ceramic2.repository.stateManager as any)._handleTip(streamState2, stream1.state.log[1].cid);
+  expect(retrieveCommitSpy).toBeCalledTimes(7)
+
+  await ceramic2.close();
+});
+
 test('commit history and rewind', async () => {
   const stream = await TileDocument.create<any>(ceramic, INITIAL_CONTENT);
   stream.subscribe();

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -165,6 +165,7 @@ test('handleTip for commit already in log', async () => {
 
   // Now re-apply the same commit and don't expect any additional calls to IPFS
   await (ceramic2.repository.stateManager as any)._handleTip(streamState2, stream1.state.log[1].cid);
+  await (ceramic2.repository.stateManager as any)._handleTip(streamState2, stream1.state.log[0].cid);
   expect(retrieveCommitSpy).toBeCalledTimes(7)
 
   await ceramic2.close();

--- a/packages/core/src/conflict-resolution.ts
+++ b/packages/core/src/conflict-resolution.ts
@@ -145,7 +145,7 @@ export class HistoryLog {
    * @param cid - CID value
    */
   async findIndex(cid: CID): Promise<number> {
-    for (let index = 0; index < this.items.length; index++) {
+    for (let index = this.items.length - 1; index >= 0; index--) {
       const current = this.items[index];
       if (current.equals(cid)) {
         return index;


### PR DESCRIPTION
https://github.com/ceramicnetwork/js-ceramic/issues/730 is the better/more complete fix, but this simpler code change optimizes for the most common cases of trying to re-apply tips already in the log