### PR TITLE
feat(key-did-resolver): secp256r1 support

### DIFF
--- a/packages/key-did-resolver/package.json
+++ b/packages/key-did-resolver/package.json
@@ -30,7 +30,8 @@
     "@stablelib/ed25519": "^1.0.1",
     "multibase": "~4.0.2",
     "uint8arrays": "^2.0.5",
-    "varint": "^6.0.0"
+    "varint": "^6.0.0",
+    "bigint-mod-arith": "^3.0.0"
   },
   "devDependencies": {
     "@types/multibase": "~3.1.0",

--- a/packages/key-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/key-did-resolver/src/__tests__/__snapshots__/index.test.ts.snap
@@ -145,3 +145,228 @@ Object {
   },
 }
 `;
+
+exports[`Index mapper successfully resolves the document from did 5`] = `
+Object {
+  "didDocument": Object {
+    "@context": "https://w3id.org/did/v1",
+    "assertionMethod": Array [
+      "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+    ],
+    "authentication": Array [
+      "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+    ],
+    "capabilityDelegation": Array [
+      "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+    ],
+    "capabilityInvocation": Array [
+      "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+    ],
+    "id": "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+    "verificationMethod": Array [
+      Object {
+        "controller": "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+        "id": "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+        "publicKeyJwk": Object {
+          "crv": "P-256",
+          "kty": "EC",
+          "x": "u-cNviWRiM3i9wGjUvOB-0XyPpIb5rAwmE8o8jDBte7Y",
+          "y": "uHNNnF7isXk_qitI9yNB4PCMY7krXqA224AJq0LByok8",
+        },
+        "type": "JsonWebKey2020",
+      },
+    ],
+  },
+  "didDocumentMetadata": Object {},
+  "didResolutionMetadata": Object {
+    "contentType": "application/did+ld+json",
+  },
+}
+`;
+
+exports[`Index mapper successfully resolves the document from did 6`] = `
+Object {
+  "didDocument": Object {
+    "assertionMethod": Array [
+      "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+    ],
+    "authentication": Array [
+      "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+    ],
+    "capabilityDelegation": Array [
+      "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+    ],
+    "capabilityInvocation": Array [
+      "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+    ],
+    "id": "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+    "verificationMethod": Array [
+      Object {
+        "controller": "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+        "id": "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+        "publicKeyJwk": Object {
+          "crv": "P-256",
+          "kty": "EC",
+          "x": "u-cNviWRiM3i9wGjUvOB-0XyPpIb5rAwmE8o8jDBte7Y",
+          "y": "uHNNnF7isXk_qitI9yNB4PCMY7krXqA224AJq0LByok8",
+        },
+        "type": "JsonWebKey2020",
+      },
+    ],
+  },
+  "didDocumentMetadata": Object {},
+  "didResolutionMetadata": Object {
+    "contentType": "application/did+json",
+  },
+}
+`;
+
+exports[`Index mapper successfully resolves the document from did 7`] = `
+Object {
+  "didDocument": Object {
+    "@context": "https://w3id.org/did/v1",
+    "assertionMethod": Array [
+      "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+    ],
+    "authentication": Array [
+      "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+    ],
+    "capabilityDelegation": Array [
+      "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+    ],
+    "capabilityInvocation": Array [
+      "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+    ],
+    "id": "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+    "verificationMethod": Array [
+      Object {
+        "controller": "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+        "id": "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+        "publicKeyJwk": Object {
+          "crv": "P-256",
+          "kty": "EC",
+          "x": "uOcPddBMXKURtwbPaZ9SfwEb8vwcvzFufpRwFuXQwf5Y",
+          "y": "unEA7FjXwRJ8CvUInUeMxIaRDTxUvKysqP2dSGcXZJfY",
+        },
+        "type": "JsonWebKey2020",
+      },
+    ],
+  },
+  "didDocumentMetadata": Object {},
+  "didResolutionMetadata": Object {
+    "contentType": "application/did+ld+json",
+  },
+}
+`;
+
+exports[`Index mapper successfully resolves the document from did 8`] = `
+Object {
+  "didDocument": Object {
+    "assertionMethod": Array [
+      "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+    ],
+    "authentication": Array [
+      "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+    ],
+    "capabilityDelegation": Array [
+      "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+    ],
+    "capabilityInvocation": Array [
+      "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+    ],
+    "id": "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+    "verificationMethod": Array [
+      Object {
+        "controller": "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+        "id": "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+        "publicKeyJwk": Object {
+          "crv": "P-256",
+          "kty": "EC",
+          "x": "uOcPddBMXKURtwbPaZ9SfwEb8vwcvzFufpRwFuXQwf5Y",
+          "y": "unEA7FjXwRJ8CvUInUeMxIaRDTxUvKysqP2dSGcXZJfY",
+        },
+        "type": "JsonWebKey2020",
+      },
+    ],
+  },
+  "didDocumentMetadata": Object {},
+  "didResolutionMetadata": Object {
+    "contentType": "application/did+json",
+  },
+}
+`;
+
+exports[`Index mapper successfully resolves the document from did 9`] = `
+Object {
+  "didDocument": Object {
+    "@context": "https://w3id.org/did/v1",
+    "assertionMethod": Array [
+      "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+    ],
+    "authentication": Array [
+      "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+    ],
+    "capabilityDelegation": Array [
+      "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+    ],
+    "capabilityInvocation": Array [
+      "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+    ],
+    "id": "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+    "verificationMethod": Array [
+      Object {
+        "controller": "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+        "id": "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+        "publicKeyJwk": Object {
+          "crv": "P-256",
+          "kty": "EC",
+          "x": "u-cNviWRiM3i9wGjUvOB-0XyPpIb5rAwmE8o8jDBte7Y",
+          "y": "uHNNnF7isXk_qitI9yNB4PCMY7krXqA224AJq0LByok8",
+        },
+        "type": "JsonWebKey2020",
+      },
+    ],
+  },
+  "didDocumentMetadata": Object {},
+  "didResolutionMetadata": Object {
+    "contentType": "application/did+ld+json",
+  },
+}
+`;
+
+exports[`Index mapper successfully resolves the document from did 10`] = `
+Object {
+  "didDocument": Object {
+    "assertionMethod": Array [
+      "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+    ],
+    "authentication": Array [
+      "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+    ],
+    "capabilityDelegation": Array [
+      "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+    ],
+    "capabilityInvocation": Array [
+      "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+    ],
+    "id": "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+    "verificationMethod": Array [
+      Object {
+        "controller": "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+        "id": "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+        "publicKeyJwk": Object {
+          "crv": "P-256",
+          "kty": "EC",
+          "x": "u-cNviWRiM3i9wGjUvOB-0XyPpIb5rAwmE8o8jDBte7Y",
+          "y": "uHNNnF7isXk_qitI9yNB4PCMY7krXqA224AJq0LByok8",
+        },
+        "type": "JsonWebKey2020",
+      },
+    ],
+  },
+  "didDocumentMetadata": Object {},
+  "didResolutionMetadata": Object {
+    "contentType": "application/did+json",
+  },
+}
+`;

--- a/packages/key-did-resolver/src/__tests__/__snapshots__/secp256r1.test.ts.snap
+++ b/packages/key-did-resolver/src/__tests__/__snapshots__/secp256r1.test.ts.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Secp256r1 mapper successfully resolves the document from did 1`] = `
+Object {
+  "assertionMethod": Array [
+    "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+  ],
+  "authentication": Array [
+    "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+  ],
+  "capabilityDelegation": Array [
+    "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+  ],
+  "capabilityInvocation": Array [
+    "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+  ],
+  "id": "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+  "verificationMethod": Array [
+    Object {
+      "controller": "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+      "id": "did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ#zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+      "publicKeyJwk": Object {
+        "crv": "P-256",
+        "kty": "EC",
+        "x": "u-cNviWRiM3i9wGjUvOB-0XyPpIb5rAwmE8o8jDBte7Y",
+        "y": "uHNNnF7isXk_qitI9yNB4PCMY7krXqA224AJq0LByok8",
+      },
+      "type": "JsonWebKey2020",
+    },
+  ],
+}
+`;
+
+exports[`Secp256r1 mapper successfully resolves the document from did 2`] = `
+Object {
+  "assertionMethod": Array [
+    "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+  ],
+  "authentication": Array [
+    "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+  ],
+  "capabilityDelegation": Array [
+    "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+  ],
+  "capabilityInvocation": Array [
+    "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+  ],
+  "id": "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+  "verificationMethod": Array [
+    Object {
+      "controller": "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+      "id": "did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu#zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+      "publicKeyJwk": Object {
+        "crv": "P-256",
+        "kty": "EC",
+        "x": "uOcPddBMXKURtwbPaZ9SfwEb8vwcvzFufpRwFuXQwf5Y",
+        "y": "unEA7FjXwRJ8CvUInUeMxIaRDTxUvKysqP2dSGcXZJfY",
+      },
+      "type": "JsonWebKey2020",
+    },
+  ],
+}
+`;
+
+exports[`Secp256r1 mapper successfully resolves the document from did 3`] = `
+Object {
+  "assertionMethod": Array [
+    "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+  ],
+  "authentication": Array [
+    "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+  ],
+  "capabilityDelegation": Array [
+    "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+  ],
+  "capabilityInvocation": Array [
+    "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+  ],
+  "id": "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+  "verificationMethod": Array [
+    Object {
+      "controller": "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+      "id": "did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY#z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+      "publicKeyJwk": Object {
+        "crv": "P-256",
+        "kty": "EC",
+        "x": "u-cNviWRiM3i9wGjUvOB-0XyPpIb5rAwmE8o8jDBte7Y",
+        "y": "uHNNnF7isXk_qitI9yNB4PCMY7krXqA224AJq0LByok8",
+      },
+      "type": "JsonWebKey2020",
+    },
+  ],
+}
+`;

--- a/packages/key-did-resolver/src/__tests__/index.test.ts
+++ b/packages/key-did-resolver/src/__tests__/index.test.ts
@@ -36,7 +36,51 @@ describe('Index mapper', () => {
 
     doc = await resolve('did:key:z6MktvqCyLxTsXUH1tUZncNdVeEZ7hNh7npPRbUU27GTrYb8', parsedDid, {}, { accept: 'application/did+json' })
     expect(doc).toMatchSnapshot()
+
+    parsedDid = {
+      id: "zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ",
+      did: 'did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ',
+      method: "key",
+      didUrl: 'did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ/some/path',
+      path: '/some/path'
+    }
+  
+    doc = await resolve('did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ', parsedDid, {}, { accept: 'application/did+ld+json' })
+    expect(doc).toMatchSnapshot()
+  
+    doc = await resolve('did:key:zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ', parsedDid, {}, { accept: 'application/did+json' })
+    expect(doc).toMatchSnapshot()
+
+    parsedDid = {
+      id: "zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu",
+      did: 'did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu',
+      method: "key",
+      didUrl: 'did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu/some/path',
+      path: '/some/path'
+    }
+  
+    doc = await resolve('did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu', parsedDid, {}, { accept: 'application/did+ld+json' })
+    expect(doc).toMatchSnapshot()
+  
+    doc = await resolve('did:key:zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu', parsedDid, {}, { accept: 'application/did+json' })
+    expect(doc).toMatchSnapshot()
+
+    parsedDid = {
+      id: "z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY",
+      did: 'did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY',
+      method: "key",
+      didUrl: 'did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY/some/path',
+      path: '/some/path'
+    }
+  
+    doc = await resolve('did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY', parsedDid, {}, { accept: 'application/did+ld+json' })
+    expect(doc).toMatchSnapshot()
+  
+    doc = await resolve('did:key:z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY', parsedDid, {}, { accept: 'application/did+json' })
+    expect(doc).toMatchSnapshot()
+
   })
+
 
 })
 

--- a/packages/key-did-resolver/src/__tests__/secp256r1.test.ts
+++ b/packages/key-did-resolver/src/__tests__/secp256r1.test.ts
@@ -1,0 +1,658 @@
+// Brent Shambaugh <brent.shambaugh@gmail.com>. 2021.
+
+import varint from "varint"
+import multibase from "multibase"
+import * as mapper from "../secp256r1"
+import * as u8a from 'uint8arrays'
+
+describe('Secp256r1 mapper', () => {
+
+    // testing the key from the did:key from the raw public key
+    it('successfully resolves the document from did', async () => {
+        const id = "zruuPojWkzGPb8sVc42f2YxcTXKUTpAUbdrzVovaTBmGGNyK6cGFaA4Kp7SSLKecrxYz8Sc9d77Rss7rayYt1oFCaNJ"
+
+        const multicodecPubKey = multibase.decode(id)
+        varint.decode(multicodecPubKey) // decode is changing param multicodecPubKey as well
+        const pubKeyBytes = multicodecPubKey.slice(varint.decode.bytes)
+        const doc = await mapper.keyToDidDoc(pubKeyBytes, id)
+        expect(doc).toMatchSnapshot()
+    })
+
+    // testing the key from the did:key from the compressed public key
+    it('successfully resolves the document from did', async () => {
+        const id = "zDnaeUKTWUXc1HDpGfKbEK31nKLN19yX5aunFd7VK1CUMeyJu"
+
+        const multicodecPubKey = multibase.decode(id)
+        varint.decode(multicodecPubKey) // decode is changing param multicodecPubKey as well
+        const pubKeyBytes = multicodecPubKey.slice(varint.decode.bytes)
+        const doc = await mapper.keyToDidDoc(pubKeyBytes, id)
+        expect(doc).toMatchSnapshot()
+    })
+
+    // testing the key from the did:key from the uncompressed public key
+    it('successfully resolves the document from did', async () => {
+        const id = "z4oJ8emo5e6mGPCUS5wncFZXAyuVzGRyJZvoduwq7FrdZYPd1LZQbDKsp1YAMX8x14zBwy3yHMSpfecJCMDeRFUgFqYsY"
+
+        const multicodecPubKey = multibase.decode(id)
+        varint.decode(multicodecPubKey) // decode is changing param multicodecPubKey as well
+        const pubKeyBytes = multicodecPubKey.slice(varint.decode.bytes)
+        const doc = await mapper.keyToDidDoc(pubKeyBytes, id)
+        expect(doc).toMatchSnapshot()
+    })
+
+})
+
+test('test a hex string with unexpected input', () => {
+   const inputPublicKeyHex = '';
+   const publicKey_u8a = mapper.testHexString(inputPublicKeyHex);
+   expect(publicKey_u8a).toEqual(false);
+});
+
+test('test a hex string with unexpected input : try 2', () => {
+   const inputPublicKeyHex = 99;
+   const publicKey_u8a = mapper.testHexString(inputPublicKeyHex);
+   expect(publicKey_u8a).toEqual(false);
+});
+
+test('test a hex string shorter than 33 bytes', () => {
+   const inputPublicKeyHex = 'abc09';
+   const publicKey_u8a = mapper.testHexString(inputPublicKeyHex);
+   expect(publicKey_u8a).toEqual(true);
+});
+
+test('test testUint8Array with correct input', () => {
+   const inputCompressedPoint = Uint8Array.from([3,127,35,88,48,221,61,239,167,34,239,26,162,73,214,160,221,187,164,249,144,176,129,117,56,147,63,87,54,64,101,53,66]);
+   const publicKey_u8a = mapper.testUint8Array(inputCompressedPoint);
+   expect(publicKey_u8a).toEqual(true);
+});
+
+test('test testUint8Array with number', () => {
+   const inputCompressedPoint = 5;
+   const publicKey_u8a = mapper.testUint8Array(inputCompressedPoint);
+   expect(publicKey_u8a).toEqual(false);
+});
+
+test('test testUint8Array with number', () => {
+   const inputCompressedPoint = 'donkey';
+   const publicKey_u8a = mapper.testUint8Array(inputCompressedPoint);
+   expect(publicKey_u8a).toEqual(false);
+});
+
+test('expect pubKeyBytesToHex to throw an error for null', () => {
+      expect(() => {
+      mapper.pubKeyBytesToHex(null);
+      }).toThrowError('input must be a Uint8Array');
+});
+
+test('expect pubKeyBytesToHex to throw an error for undefined', () => {
+      expect(() => {
+      mapper.pubKeyBytesToHex();
+      }).toThrowError('input must be a Uint8Array');
+});
+
+test('expect pubKeyBytesToHex to throw an error for an unexpected integer', () => {
+      expect(() => {
+      mapper.pubKeyBytesToHex(5);
+      }).toThrowError('input must be a Uint8Array');
+});
+
+test('expect pubKeyBytesToHex to throw an error for an unexpected object', () => {
+      expect(() => {
+      mapper.pubKeyBytesToHex({x: 6n, y: 5n});
+      }).toThrowError('input must be a Uint8Array');
+});
+
+
+test('expect ECPointDecompress to throw an error for undefined', () => {
+      expect(() => {
+      mapper.ECPointDecompress();
+      }).toThrowError('input must be a Uint8Array');
+});
+
+test('expect ECPointDecompress to throw an error for null', () => {
+      expect(() => {
+      mapper.ECPointDecompress(null);
+      }).toThrowError('input must be a Uint8Array');
+});
+
+test('expect ECPointDecompress to throw an error for unexpected input', () => {
+      expect(() => {
+      mapper.ECPointDecompress(5);
+      }).toThrowError('input must be a Uint8Array');
+});
+
+test('expect publicKeyIntToXY to throw an error for incorrect type', () => {
+      expect(() => {
+      mapper.publicKeyIntToXY(5);
+      }).toThrowError('Input must be an object with properties x and y');
+});
+
+test('expect publicKeyIntToXY to throw an error for {x: null, y: null}', () => {
+      expect(() => {
+      mapper.publicKeyIntToXY({x: null, y: null});
+      }).toThrowError('Input coordinates must be BigInt');
+});
+
+test('expect publicKeyIntToXY to throw an error for {x: undefined, y: undefined}', () => {
+      expect(() => {
+      mapper.publicKeyIntToXY();
+      }).toThrow();
+});
+
+
+test('expect publicKeyHextToUint8ArrayPointPair to throw an error for {x: undefined, y: undefined}', () => {
+      expect(() => {
+      mapper.publicKeyHexToUint8ArrayPointPair();
+      }).toThrowError('input must be string with characters 0-9,A-F,a-f');
+});
+
+
+test('expect publicKeyHexToUint8ArrayPointPair to throw an error for incorrect type', () => {
+      expect(() => {
+      mapper.publicKeyHexToUint8ArrayPointPair(5);
+      }).toThrowError('input must be string with characters 0-9,A-F,a-f');
+});
+
+
+test('expect publicKeyHexToUint8ArrayPointPair to throw an error for {x: null, y: null}', () => {
+      expect(() => {
+      mapper.publicKeyHexToUint8ArrayPointPair({x: null, y: null});
+      }).toThrowError('input must be string with characters 0-9,A-F,a-f');
+});
+
+test('expect publicKeyHexToUint8ArrayPointPair to throw an error for {x: undefined, y: undefined}', () => {
+      expect(() => {
+      mapper.publicKeyHexToUint8ArrayPointPair({x: undefined, y: undefined});
+      }).toThrowError('input must be string with characters 0-9,A-F,a-f');
+});
+
+test('expect publicKeyHexToUint8ArrayPointPair to throw an error for null', () => {
+      expect(() => {
+      mapper.publicKeyHexToUint8ArrayPointPair(null);
+      }).toThrowError('input must be string with characters 0-9,A-F,a-f');
+});
+
+test('expect publicKeyToXY to throw an error for null', () => {
+      expect(() => {
+      mapper.publicKeyToXY(null);
+      }).toThrowError('input must be string with characters 0-9,A-F,a-f');
+});
+
+test('expect publicKeyToXY to throw an error for undefined', () => {
+      expect(() => {
+      mapper.publicKeyToXY();
+      }).toThrowError('input must be string with characters 0-9,A-F,a-f');
+});
+
+test('expect publicKeyToXY to throw an error for a non string', () => {
+      expect(() => {
+      mapper.publicKeyToXY(5);
+      }).toThrowError('input must be string with characters 0-9,A-F,a-f');
+});
+
+test('expect publicKeyToXY to throw an error for an invalid hex string', () => {
+      expect(() => {
+      mapper.publicKeyToXY('095ty');
+      }).toThrowError('input must be string with characters 0-9,A-F,a-f');
+});
+
+test('expect publicKeyBytesToXY to throw an error for undefined', () => {
+      expect(() => {
+      mapper.pubKeyBytesToXY();
+      }).toThrowError('input must be a Uint8Array');
+});
+
+test('expect publicKeyBytesToXY to throw an error for null', () => {
+      expect(() => {
+      mapper.pubKeyBytesToXY(null);
+      }).toThrowError('input must be a Uint8Array');
+});
+
+test('expect publicKeyBytesToXY to throw an error for and integer input', () => {
+      expect(() => {
+      mapper.pubKeyBytesToXY(5);
+      }).toThrowError('input must be a Uint8Array');
+});
+
+test('empty key string to should not evaluate to null, or should it??', () => {
+   const inputPublicKeyHex = '';
+   expect(() => {
+      mapper.publicKeyHexToUint8ArrayPointPair(inputPublicKeyHex);
+   }).toThrowError('input must be string with characters 0-9,A-F,a-f');
+ });
+
+test('test a hex string shorter than 33 bytes', () => {
+   const inputPublicKeyHex = '36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb6'
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);
+   expect(publicKey_u8a).not.toEqual(null);
+});
+
+test('test a compressed public key in hex with an odd number of characters', () => {
+   const inputPublicKeyHex = '2f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb6';
+   const output = Uint8Array.from([2,249,195,111,137,100,98,51,120,189,192,104,212,188,224,126,209,124,143,164,134,249,172,12,38,19,202,60,140,48, 109, 123, 182]);
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);
+   expect(publicKey_u8a).toEqual(output);
+});
+
+test('test a uncompressed public key in hex to an x,y point with x, and y url encoded with an unsupported prefix', () => {
+   const inputPublicKeyHex = '03f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb61cd36717b8ac5e4fea8ad23dc8d0783c2318ee4ad7a80db6e0026ad0b072a24f'
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);
+   expect(() => {
+      mapper.pubKeyBytesToXY(publicKey_u8a);
+   }).toThrowError('Unexpected pubKeyBytes');
+});
+
+test('test a compressed public key in hex to an x,y point with x, and y url encoded with an unsupported prefixi: try2', () => {
+   const inputPublicKeyHex = '05f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb6'
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);
+   expect(() => {
+      mapper.pubKeyBytesToXY(publicKey_u8a);
+    }).toThrowError('Unexpected pubKeyBytes');  
+});
+
+test('test a compressed public key in hex to an x,y point with x, and y url encoded with an unsupported prefixi: try3', () => {
+   const inputPublicKeyHex = '04f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb6';
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);
+   expect(() => {
+      mapper.pubKeyBytesToXY(publicKey_u8a);
+    }).toThrowError('Unexpected pubKeyBytes');
+});
+
+test('test a compressed public key in hex to an x,y point with x, and y url encoded with an unsupported prefix', () => {
+   const inputPublicKeyHex = '04f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb6'
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);
+   expect(() => {
+      mapper.pubKeyBytesToXY(publicKey_u8a);
+   }).toThrowError('Unexpected pubKeyBytes');
+});
+
+test('test a compressed public key in hex to an x,y point with x, and y url encoded with an unexpected length', () => {
+   const inputPublicKeyHex = '0239c3dd74131729446dc1b3da67d49fc046fcbf072fcc5b9fa51c05b974307f9642';
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);
+   expect(() => {
+      mapper.pubKeyBytesToXY(publicKey_u8a);
+   }).toThrowError('Unexpected pubKeyBytes');
+});
+
+test('test a hex string longer than 65 bytes', () => {
+   const inputPublicKeyHex = '0704f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb61cd36717b8ac5e4fea8ad23dc8d0783c2318ee4ad7a80db6e0026ad0b072a24f'
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);
+   expect(() => {
+      mapper.pubKeyBytesToXY(publicKey_u8a);
+   }).toThrowError('Unexpected pubKeyBytes');
+});
+
+test('test a hex string longer than 65 bytes: try2', () => {
+   const inputPublicKeyHex = '04f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb61cd36717b8ac5e4fea8ad23dc8d0783c2318ee4ad7a80db6e0026ad0b072a24f07';
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);
+   expect(() => {
+      mapper.pubKeyBytesToXY(publicKey_u8a);
+   }).toThrowError('Unexpected pubKeyBytes');
+})
+
+test('test a compressed public key in hex to an x,y point with x, and y url encoded', () => {
+   const inputPublicKeyHex = '03f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb6'
+   const output = {
+      xm: 'u-cNviWRiM3i9wGjUvOB-0XyPpIb5rAwmE8o8jDBte7Y',
+      ym: 'uHNNnF7isXk_qitI9yNB4PCMY7krXqA224AJq0LByok8'  
+      };
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);  
+   const pubKeyBytesToXY = mapper.pubKeyBytesToXY(publicKey_u8a);
+   expect(pubKeyBytesToXY).toEqual(output);
+});
+
+test('test a uncompressed public key in hex to an x,y point with x, and y url encoded', () => {
+   const inputPublicKeyHex = '04f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb61cd36717b8ac5e4fea8ad23dc8d0783c2318ee4ad7a80db6e0026ad0b072a24f'
+   const output = {
+      xm: 'u-cNviWRiM3i9wGjUvOB-0XyPpIb5rAwmE8o8jDBte7Y',
+      ym: 'uHNNnF7isXk_qitI9yNB4PCMY7krXqA224AJq0LByok8'
+   }; 
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);
+   const pubKeyBytesToXY = mapper.pubKeyBytesToXY(publicKey_u8a);
+   expect(pubKeyBytesToXY).toEqual(output);
+});
+
+test('test a raw public key in hex to an x,y point with x, and y url encoded', () => {
+   const inputPublicKeyHex = 'f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb61cd36717b8ac5e4fea8ad23dc8d0783c2318ee4ad7a80db6e0026ad0b072a24f'
+   const output = {
+      xm: 'u-cNviWRiM3i9wGjUvOB-0XyPpIb5rAwmE8o8jDBte7Y',
+      ym: 'uHNNnF7isXk_qitI9yNB4PCMY7krXqA224AJq0LByok8'
+   }; 
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);
+   const pubKeyBytesToXY = mapper.pubKeyBytesToXY(publicKey_u8a);
+   expect(pubKeyBytesToXY).toEqual(output);   
+});
+
+test('convert a public key x,y where x and y are integers to an x,y point with x and y base64url encoded', () => {
+  const ecpoint = {
+          x: 112971204272793929541699765384018665134067875121047561926148644683187420494774n,
+          y: 13038276010400560657327464707708345466200402936352359974176190171319880557135n
+   };
+  const output = {
+    xm: 'u-cNviWRiM3i9wGjUvOB-0XyPpIb5rAwmE8o8jDBte7Y',
+    ym: 'uHNNnF7isXk_qitI9yNB4PCMY7krXqA224AJq0LByok8'
+  };
+
+  const base64urlPoint = mapper.publicKeyIntToXY(ecpoint);
+  expect(base64urlPoint).toEqual(output);
+
+});
+
+
+test('convert raw public key as a hex string into an x,y point with x and y base64url encoded', () => {
+  const inputPublicKeyHex = 'f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb61cd36717b8ac5e4fea8ad23dc8d0783c2318ee4ad7a80db6e0026ad0b072a24f'
+  const output = {
+    xm: 'u-cNviWRiM3i9wGjUvOB-0XyPpIb5rAwmE8o8jDBte7Y',
+    ym: 'uHNNnF7isXk_qitI9yNB4PCMY7krXqA224AJq0LByok8'
+  };
+  const base64urlPoint = mapper.publicKeyToXY(inputPublicKeyHex);
+  expect(base64urlPoint).toEqual(output);
+});  
+
+test('expect publicKeyIntToXY to throw an error for incorrect type', () => {
+      expect(() => {
+      mapper.publicKeyIntToXY(5);
+      }).toThrowError('Input must be an object with properties x and y');
+});
+
+test('expect publicKeyIntToXY to throw an error for {x: null, y: null}', () => {
+      expect(() => {
+      mapper.publicKeyIntToXY({x: null, y: null});
+      }).toThrowError('Input coordinates must be BigInt');
+});
+
+test('expect publicKeyIntToXY to have properties x and y', () => {
+      expect(() => {
+      mapper.publicKeyIntToXY({x: 5n, z: 8n});
+      }).toThrowError('Input must have properties x and y');
+});
+
+test('expect publicKeyIntToXY to throw an error for {x: undefined, y: undefined}', () => {
+      expect(() => {
+      mapper.publicKeyIntToXY();
+      }).toThrowError('input cannot be null or undefined.');
+});
+
+test('expect publicKeyIntToUint8ArrayPointPair to throw an error for {x: undefined, y: undefined}', () => {
+      expect(() => {
+      mapper.publicKeyHexToUint8ArrayPointPair();
+      }).toThrowError('input must be string with characters 0-9,A-F,a-f');
+});
+
+test('expect publicKeyIntToUint8ArrayPointPair to throw an error for {x: 5, y: 9}', () => {
+      expect(() => {
+      mapper.publicKeyIntToUint8ArrayPointPair({x: 5,y: 9});
+      }).toThrowError('Input coordinates must be BigInt');
+});
+
+test('expect publicKeyIntToUint8ArrayPointPair to throw an error for null', () => {
+      expect(() => {
+      mapper.publicKeyIntToUint8ArrayPointPair(null);
+      }).toThrowError('input cannot be null or undefined.');
+});
+
+test('expect publicKeyIntToUint8ArrayPointPair to throw an error for mislabled coordinate properties', () => {
+      expect(() => {
+      mapper.publicKeyIntToUint8ArrayPointPair({x: 5n, z: 7n});
+      }).toThrowError('Input must have properties x and y');
+});
+
+test('expect publicKeyIntToUint8ArrayPointPair to throw an error for a non object', () => {
+      expect(() => {
+      mapper.publicKeyIntToUint8ArrayPointPair(6);
+      }).toThrowError('Input must be an object with properties x and y');
+});
+
+test('convert a public key x,y where x and y are integers to a pair of Uint8Arrays', () => {
+   const ecpoint = {
+          x: 112971204272793929541699765384018665134067875121047561926148644683187420494774n,
+          y: 13038276010400560657327464707708345466200402936352359974176190171319880557135n
+   };
+   const output = { xOctet : Uint8Array.from([
+                              249, 195, 111, 137, 100,  98,  51,
+                              120, 189, 192, 104, 212, 188, 224,
+                              126, 209, 124, 143, 164, 134, 249,
+                              172,  12,  38,  19, 202,  60, 140,
+                              48, 109, 123, 182
+                               ] ) ,
+                    yOctet : Uint8Array.from([
+                               28, 211, 103,  23, 184, 172,  94,  79,
+                               234, 138, 210, 61, 200, 208, 120,  60,
+                               35,  24, 238,  74, 215, 168,  13, 182,
+                               224,  2, 106, 208, 176, 114, 162,  79
+                               ] )
+                  };
+
+   const u8aPoint = mapper.publicKeyIntToUint8ArrayPointPair(ecpoint);
+   expect(u8aPoint).toEqual(output);   
+});
+
+
+test('test a compressed public key in hex to an x,y point as BigInt (with the wrong parity)', () => {
+   const inputPublicKeyHex = '02f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb6';
+   const output = {
+         x: 112971204272793929541699765384018665134067875121047561926148644683187420494774n,
+         y: 102753813199955688105369982241699228063885740478937954221357441137547217296816n
+   };
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);
+   const point = mapper.ECPointDecompress(publicKey_u8a);
+   expect(point).toEqual(output);
+});
+
+
+test('key decompression (y-coordinate even)', () => {
+  const inputCompressedPoint = Uint8Array.from([2,57,195,221,116,19,23,41,68,109,193,179,218,103,212,159,192,70,252,191,7,47,204,91,159,165,28,5,185,116,48,127,150]);
+  const output = {
+         x: 26127895962184884692520600754586230836934108530588605558459884945533706469270n,
+        y: 70674290392969052505695590170208788569527910698023358885182794820324123289078n
+  };
+
+  const point = mapper.ECPointDecompress( inputCompressedPoint );
+
+  expect(point).toEqual(output);
+});
+
+test('key compression (y-coordinate even)', () => {
+  // inputPublicKeyHex derived from: https://stackoverflow.com/questions/67135136/unable-to-verify-a-raw-uint8array-ecdsa-secp256r1-message-signature-pubkey-usi
+
+  const inputPublicKeyHex = '39c3dd74131729446dc1b3da67d49fc046fcbf072fcc5b9fa51c05b974307f969c403b1635f0449f02bd422751e33121a4434f152f2b2b2a3f675219c5d925f6'
+  const output = Uint8Array.from([2,57,195,221,116,19,23,41,68,109,193,179,218,103,212,159,192,70,252,191,7,47,204,91,159,165,28,5,185,116,48,127,150]);
+
+  const u8aPoint = mapper.publicKeyHexToUint8ArrayPointPair(inputPublicKeyHex);
+  const compressedPoint = ECPointCompress(u8aPoint.xOctet, u8aPoint.yOctet);
+
+  expect(compressedPoint).toEqual(output);
+
+});
+
+test('key decompression (y-coordinate odd) key#2', () => {
+
+   const inputCompressedPoint = Uint8Array.from([3,127,35,88,48,221,61,239,167,34,239,26,162,73,214,160,221,187,164,249,144,176,129,117,56,147,63,87,54,64,101,53,66]);
+   const output = {
+        x: 57506180088397527878367021711159096752486239922681589595989108987041675556162n,
+        y: 60351358491784072971514173700673656664870632871947100762396585099496243621173n
+   };
+
+   const point = mapper.ECPointDecompress( inputCompressedPoint )
+
+   expect(point).toEqual(output);
+});
+
+test('key compression (y-coordinate odd) key#2', () => {
+   const inputPublicKeyHex = '7f235830dd3defa722ef1aa249d6a0ddbba4f990b0817538933f573640653542856da88d335f1fb25b8bcfbe089528dce09b1f7cb99fdd60f88300f4c2cc6d35'
+   const output = Uint8Array.from([3,127,35,88,48,221,61,239,167,34,239,26,162,73,214,160,221,187,164,249,144,176,129,117,56,147,63,87,54,64,101,53,66]);
+   
+   const u8aPoint = mapper.publicKeyHexToUint8ArrayPointPair(inputPublicKeyHex);
+   const compressedPoint = ECPointCompress(u8aPoint.xOctet, u8aPoint.yOctet);
+   
+   expect(compressedPoint).toEqual(output);
+});
+
+test('key decompression (y-coordinate odd)', () => {
+
+   const inputCompressedPoint = Uint8Array.from([3,249,195,111,137,100,98,51,120,189,192,104,212,188,224,126,209,124,143,164,134,249,172,12,38,19,202,60,140,48,109,123,182]);
+   const output = {
+          x: 112971204272793929541699765384018665134067875121047561926148644683187420494774n,
+          y: 13038276010400560657327464707708345466200402936352359974176190171319880557135n
+   };
+
+   const point = mapper.ECPointDecompress( inputCompressedPoint )
+
+   expect(point).toEqual(output);
+});
+
+test('key compression (y-coordinate odd)', () => {
+   const inputPublicKeyHex = 'f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb61cd36717b8ac5e4fea8ad23dc8d0783c2318ee4ad7a80db6e0026ad0b072a24f'
+   const output = Uint8Array.from([3,249,195,111,137,100,98,51,120,189,192,104,212,188,224,126,209,124,143,164,134,249,172,12,38,19,202,60,140,48,109,123,182]);
+ 
+   const u8aPoint = mapper.publicKeyHexToUint8ArrayPointPair(inputPublicKeyHex);
+   const compressedPoint = ECPointCompress(u8aPoint.xOctet, u8aPoint.yOctet);
+
+   expect(compressedPoint).toEqual(output);
+});
+
+test('raw public key as hex string to x,y point with x and y as uint8Arrays', () => {
+   const inputPublicKeyHex = 'f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb61cd36717b8ac5e4fea8ad23dc8d0783c2318ee4ad7a80db6e0026ad0b072a24f'
+   const output = { xOctet : Uint8Array.from([
+                              249, 195, 111, 137, 100,  98,  51,
+                              120, 189, 192, 104, 212, 188, 224,
+                              126, 209, 124, 143, 164, 134, 249,
+                              172,  12,  38,  19, 202,  60, 140,
+                              48, 109, 123, 182
+                               ] ) , 
+                    yOctet : Uint8Array.from([
+                               28, 211, 103,  23, 184, 172,  94,  79,
+                               234, 138, 210, 61, 200, 208, 120,  60,
+                               35,  24, 238,  74, 215, 168,  13, 182,
+                               224,  2, 106, 208, 176, 114, 162,  79
+                               ] ) 
+                  };
+
+     const u8aPoint = mapper.publicKeyHexToUint8ArrayPointPair(inputPublicKeyHex);
+     expect(u8aPoint).toEqual(output);
+});
+
+test('show how to compress a raw public key in hex and return a compressed key in hex', () => {
+   const inputPublicKeyHex = 'f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb61cd36717b8ac5e4fea8ad23dc8d0783c2318ee4ad7a80db6e0026ad0b072a24f';
+   const output = '03f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb6';
+   const compresedKey = compresedKeyInHex(inputPublicKeyHex);
+   expect(compresedKey).toEqual(output);   
+});
+
+test('show how to convert a raw public key in hex and return an uncompressed key in hex', () => {
+  const inputPublicKeyHex = 'f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb61cd36717b8ac5e4fea8ad23dc8d0783c2318ee4ad7a80db6e0026ad0b072a24f';
+  const output = '04f9c36f8964623378bdc068d4bce07ed17c8fa486f9ac0c2613ca3c8c306d7bb61cd36717b8ac5e4fea8ad23dc8d0783c2318ee4ad7a80db6e0026ad0b072a24f';
+  const uncompressedKey = '04'+ inputPublicKeyHex;
+  expect(uncompressedKey).toEqual(output);
+});
+
+/*
+ * tests for functions declared within the test file
+ *
+ */
+
+
+test('test a null coordinates in ECPointCompress', () => {
+   const x = null;
+   const y = null;
+   expect(() => {
+      ECPointCompress(x,y);
+   }).toThrowError('input cannot be null or undefined.');
+});
+
+test('test a undefined coordinates in ECPointCompress', () => {
+   const x = undefined;
+   const y = undefined;
+   expect(() => {
+      ECPointCompress(x,y);
+   }).toThrowError('input cannot be null or undefined.');
+});
+
+test('test null in pubKeyHexToUint8Array', () => {
+   const inputPublicKeyHex = null;
+   expect(() => {
+      pubKeyHexToUint8Array(inputPublicKeyHex);
+   }).toThrowError('input cannot be null or undefined.');   
+});
+
+test('test undefined in pubKeyHexToUint8Array', () => {
+   const inputPublicKeyHex = undefined;
+   expect(() => {
+      pubKeyHexToUint8Array(inputPublicKeyHex);
+   }).toThrowError('input cannot be null or undefined.');
+});
+
+test('test an empty string in pubKeyHexToUint8Array', () => {
+   const inputPublicKeyHex = ''
+   const publicKey_u8a = pubKeyHexToUint8Array(inputPublicKeyHex);
+   expect(publicKey_u8a).toBeDefined();
+   expect(publicKey_u8a).not.toBeNull();
+   // removed because jest gives::: Received: serializes to the same string
+   // expect(publicKey_u8a).toEqual([])
+});
+
+test('test compresedKeyInHex with an empty string', () => {
+   const inputPublicKeyHex = '';
+   const compressedKey = compresedKeyInHex(inputPublicKeyHex);   
+   expect(compressedKey).toBeDefined();
+   expect(compressedKey).not.toBeNull();   
+});
+
+test('test compresedKeyInHex with null', () => {
+   const inputPublicKeyHex = null;
+   expect(() => {
+      compresedKeyInHex(inputPublicKeyHex);
+   }).toThrowError('input cannot be null or undefined.');
+});
+
+test('test compresedKeyInHex with undefined', () => {
+   const inputPublicKeyHex = undefined;
+   expect(() => {
+      compresedKeyInHex(inputPublicKeyHex);
+   }).toThrowError('input cannot be null or undefined.');
+});
+
+//**** end of tests for functions withing the test file
+
+// write a separate test for this function...
+// source: https://stackoverflow.com/questions/17171542/algorithm-for-elliptic-curve-point-compression
+function ECPointCompress( x: Uint8Array, y: Uint8Array )
+{
+ 
+   if(x == null || y == null) {
+     throw new TypeError('input cannot be null or undefined.');
+    }
+  
+   const out = new Uint8Array( x.length + 1 );
+
+    out[0] = 2 + ( y[ y.length-1 ] & 1 );
+    out.set( x, 1 );
+
+    return out;
+}
+
+function pubKeyHexToUint8Array(publicKeyHex: string) {
+  if(publicKeyHex == null) {
+   throw new TypeError('input cannot be null or undefined.');
+  }
+    if(publicKeyHex.length % 2 == 0) {
+          return u8a.fromString(publicKeyHex,'base16');          	 
+      } else {
+          return u8a.fromString(('0'+publicKeyHex),'base16');
+    }
+}
+
+function compresedKeyInHex(publicKeyHex: string) {
+  if(publicKeyHex == null) {
+    throw new TypeError('input cannot be null or undefined.');
+  }
+  const xHex = publicKeyHex.slice(0,publicKeyHex.length/2);
+  const yHex = publicKeyHex.slice(publicKeyHex.length/2,publicKeyHex.length);
+
+  const xOctet = u8a.fromString(xHex,'base16')
+  const yOctet = u8a.fromString(yHex,'base16');
+
+  const compressedPoint = ECPointCompress( xOctet , yOctet );
+  const compressedPointHex = u8a.toString(compressedPoint,'base16');
+  return compressedPointHex;
+}

--- a/packages/key-did-resolver/src/index.ts
+++ b/packages/key-did-resolver/src/index.ts
@@ -10,6 +10,7 @@ import type {
 
 import * as secp256k1 from './secp256k1'
 import * as ed25519 from './ed25519'
+import * as secp256r1 from './secp256r1'
 
 const DID_LD_JSON = 'application/did+ld+json'
 const DID_JSON = 'application/did+json'
@@ -17,6 +18,7 @@ const DID_JSON = 'application/did+json'
 const prefixToDriverMap: any = {
   0xE7: secp256k1,
   0xED: ed25519,
+  0x1200: secp256r1,  
 }
 
 export default {

--- a/packages/key-did-resolver/src/secp256r1.ts
+++ b/packages/key-did-resolver/src/secp256r1.ts
@@ -1,0 +1,272 @@
+// Brent Shambaugh <brent.shambaugh@gmail.com>. 2021.
+
+import * as u8a from 'uint8arrays'
+import  multibase from'multibase'
+import * as bigintModArith from 'bigint-mod-arith'
+
+/**
+  * x,y point as a BigInt (requires at least ES2020)
+  * For BigInt see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
+  */
+interface BigIntPoint {
+   x: BigInt,
+   y : BigInt
+}
+
+/**
+  * xm,ym point with components expresse with base64url utilizing multiformats
+  *
+  * base64url is expressed in the Multibase Table: https://github.com/multiformats/multibase/blob/master/multibase.csv
+  */
+interface base64urlPoint {
+   xm: string,
+   ym: string
+}
+
+/**
+  * Elliptic curve point with coordinates expressed as byte arrays (Uint8Array)
+  */
+interface octetPoint {
+  xOctet: Uint8Array,
+  yOctet: Uint8Array
+}
+
+/**
+ * Constructs the document based on the method key
+ */
+export function keyToDidDoc (pubKeyBytes: Uint8Array, fingerprint: string): any {
+  const did = `did:key:${fingerprint}`
+  const keyId = `${did}#${fingerprint}`
+  const key = pubKeyBytesToXY(pubKeyBytes);
+  return {
+    id: did,
+    verificationMethod: [{
+      id: keyId,
+      type: 'JsonWebKey2020',
+      controller: did,
+       publicKeyJwk: {
+         kty: "EC",
+               crv: "P-256",
+               x: key.xm,
+               y: key.ym,
+       }, 
+    }],
+    authentication: [keyId],
+    assertionMethod: [keyId],
+    capabilityDelegation: [keyId],
+    capabilityInvocation: [keyId],
+  }
+  }
+
+/**
+  * Converts a byte array into a Hex String.
+  *
+  * @param pubKeyBytes - public key
+  * @returns hex string
+  * @throws TypeError: input cannot be null or undefined.
+  */
+export function pubKeyBytesToHex(pubKeyBytes: Uint8Array) : string {
+  if(!testUint8Array(pubKeyBytes)) {
+    throw new TypeError('input must be a Uint8Array');
+  }
+ const bbf = u8a.toString(pubKeyBytes,'base16')
+ return bbf;
+}
+
+/**
+ * Decompress a compressed public key in SEC format.
+ * See section 2.3.3 in SEC 1 v2 : https://www.secg.org/sec1-v2.pdf. 
+ *
+ * Code based on: https://stackoverflow.com/questions/17171542/algorithm-for-elliptic-curve-point-compression/30431547#30431547
+ *
+ * @param - 33 byte compressed public key. 1st byte: 0x02 for even or 0x03 for odd. Following 32 bytes: x coordinate expressed as big-endian.
+ * @throws TypeError: input cannot be null or undefined.
+ */
+ export function ECPointDecompress( comp : Uint8Array ) : BigIntPoint {
+  if(!testUint8Array(comp)) {
+    throw new TypeError('input must be a Uint8Array');
+   }
+  // two, prime, b, and pIdent are constants for the P-256 curve
+  const two = BigInt(2);
+  const prime = (two ** 256n) - (two ** 224n) + (two ** 192n) + (two ** 96n) - 1n;
+  const b = 41058363725152142129326129780047268409114441015993725554835256314039467401291n;
+  const pIdent = (prime + 1n) / 4n;
+
+  const signY = BigInt(comp[0] - 2);
+  const x = comp.subarray(1);
+  const xBig = BigInt(u8a.toString(x,'base10'));
+
+  const a = xBig**3n - xBig*3n + b;
+  let yBig = bigintModArith.modPow(a,pIdent,prime);
+
+  // "// If the parity doesn't match it's the *other* root"
+  if( yBig % 2n !== signY)
+    {
+         // y = prime - y
+         yBig = prime - yBig;
+    }
+
+    return {
+      x: xBig,
+      y: yBig
+    };
+
+}
+
+/**
+ * 
+ * @param publicKeyHex - public key as hex string.
+ * @returns
+ * @throws TypeError: input cannot be null or undefined.
+ */
+export function publicKeyToXY(publicKeyHex: string) : base64urlPoint  {
+  if(!testHexString(publicKeyHex)) {
+    throw new TypeError('input must be string with characters 0-9,A-F,a-f'); 
+   }
+ const u8aOctetPoint = publicKeyHexToUint8ArrayPointPair(publicKeyHex);
+ const xm = u8a.toString(multibase.encode('base64url',u8aOctetPoint.xOctet));
+ const ym = u8a.toString(multibase.encode('base64url',u8aOctetPoint.yOctet));
+ return { xm, ym };
+}
+
+/**
+ * 
+ * @param publicKeyHex - public key as hex string. 
+ * @returns - point with Uint8Array bytes using base16
+ * @throws TypeError: input cannot be null or undefined.
+ */
+export function publicKeyHexToUint8ArrayPointPair(publicKeyHex: string) : octetPoint {
+   if(!testHexString(publicKeyHex)) {
+      throw new TypeError('input must be string with characters 0-9,A-F,a-f');
+    }
+    const xHex = publicKeyHex.slice(0,publicKeyHex.length/2);
+    const yHex = publicKeyHex.slice(publicKeyHex.length/2,publicKeyHex.length);
+    const xOctet = u8a.fromString(xHex,'base16');
+    const yOctet = u8a.fromString(yHex,'base16');
+    return { xOctet, yOctet };
+}
+
+/**
+ * Tests to see if the argument is a Hex String.
+ * @param str
+ * @returns
+ */
+export function testHexString(str : string) : boolean {
+ const regex = new RegExp(/^[A-Fa-f0-9]+/i);
+ if(regex.test(str)) {
+     if(str.length == regex.exec(str)[0].length) {
+         return true;
+     }
+  }
+  return false;
+}
+
+/**
+ * Test to see if the argument is the Uint8Array
+ * @param param
+ * @returns
+ */
+export function testUint8Array(param: Uint8Array) : boolean {
+  if(param == null) {
+     return false;
+  }
+  if(param.constructor === Uint8Array) {
+     return true;
+  } else {
+     return false;
+  }
+}
+
+
+/**
+ * 
+ * @param ecpoint - Public key.
+ * @returns Uint8Array with bytes as base16
+ * @throws TypeError: input cannot be null or undefined.
+ * @throws Error: Input coordinates must be BigInt
+ * @throws Error: Input must have properties x and y
+ * @throws TypeError: Input must be an object with properties x and y
+*/
+export function publicKeyIntToXY(ecpoint: BigIntPoint): base64urlPoint  {
+  if(ecpoint == null) { throw new TypeError('input cannot be null or undefined.'); }
+
+  if(typeof ecpoint !== "object") { throw new TypeError("Input must be an object with properties x and y"); }
+
+  if(!Object.prototype.hasOwnProperty.call(ecpoint, "x") ||  !Object.prototype.hasOwnProperty.call(ecpoint, "y")) { throw new Error("Input must have properties x and y"); }
+
+  if(typeof ecpoint.x !== "bigint" &&  typeof ecpoint.y !== "bigint") { throw new Error("Input coordinates must be BigInt");  }
+
+    const u8aOctetPoint = publicKeyIntToUint8ArrayPointPair(ecpoint);
+    const xm = u8a.toString(multibase.encode('base64url',u8aOctetPoint.xOctet));
+    const ym = u8a.toString(multibase.encode('base64url',u8aOctetPoint.yOctet));
+    return { xm, ym };
+}
+
+/**
+ * 
+ * @param ecpoint -  Public key.
+ * @returns Uint8Array with bytes as base10
+ * @throws TypeError: input cannot be null or undefined.
+ * @throws Error: Input coordinates must be BigInt
+ * @throws Error: Input must have properties x and y
+ * @throws TypeError: Input must be an object with properties x and y
+ */
+export function publicKeyIntToUint8ArrayPointPair(ecpoint: BigIntPoint) : octetPoint {
+     if(ecpoint == null) { throw new TypeError('input cannot be null or undefined.'); }
+
+     if(typeof ecpoint !== "object") { throw new TypeError("Input must be an object with properties x and y"); }
+
+     if(!Object.prototype.hasOwnProperty.call(ecpoint, "x") ||  !Object.prototype.hasOwnProperty.call(ecpoint, "y")) { throw new Error("Input must have properties x and y"); }
+
+     if(typeof ecpoint.x !== "bigint" &&  typeof ecpoint.y !== "bigint") { throw new Error("Input coordinates must be BigInt");  }
+
+       const xHex = (ecpoint.x).toString();
+       const yHex = (ecpoint.y).toString();
+       const xOctet = u8a.fromString(xHex,'base10');
+       const yOctet = u8a.fromString(yHex,'base10');
+       return { xOctet, yOctet };
+}
+
+/**
+ * 
+ * @param pubKeyBytes - public key as uncompressed byte array with no prefix (raw key), 
+ *  uncompressed with 0x04 prefix, or compressed with 0x02 prefix if even and 0x03 prefix if odd.
+ * @returns point x,y with coordinates as multibase encoded base64urls
+ * 
+ * See the the did:key specification: https://w3c-ccg.github.io/did-method-key/#p-256. 
+ * At present only raw p-256 keys are covered in the specification.
+ * @throws TypeError: input cannot be null or undefined.
+ * @throws Error: Unexpected pubKeyBytes
+ * @internal
+ */
+export function pubKeyBytesToXY(pubKeyBytes: Uint8Array) : base64urlPoint  {
+  if(!testUint8Array(pubKeyBytes)) {
+    throw new TypeError('input must be a Uint8Array');
+  }
+  const publicKeyHex = pubKeyBytesToHex(pubKeyBytes);
+  const bytesCount = publicKeyHex.length / 2;
+
+  // raw p-256 key
+  if(bytesCount == 64) {
+     return publicKeyToXY(publicKeyHex); 
+   }
+
+  // uncompressed p-256 key, SEC format
+  if(bytesCount == 65) {
+   if(publicKeyHex.slice(0,2) == '04') {
+     const publicKey = publicKeyHex.slice(2);
+     return publicKeyToXY(publicKey);
+   }
+  }
+
+  // compressed p-256 key, SEC format
+  if(bytesCount == 33) {
+   if(publicKeyHex.slice(0,2) == '03' || publicKeyHex.slice(0,2) == '02') {
+     const publicKey = u8a.fromString(publicKeyHex,'base16')
+     const point = ECPointDecompress(publicKey);
+      return publicKeyIntToXY(point);
+    }
+  }
+
+     throw new Error('Unexpected pubKeyBytes');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
  "compilerOptions": {
    "module": "commonjs",
    "lib": ["es6", "dom", "esnext"],
-   "target": "ES2018",
+   "target": "ES2020",
    "declaration": true,
    "declarationMap": true,
    "skipLibCheck": true,


### PR DESCRIPTION
To be merged when we want to upgrade to ES2020.
<details>

  * commit a temporary file called backup
  
  * rebase to april 9th, and bring in desireable changes to may19th
  
  * remove tests for null and related functions because they are not needed
  
  * Add "bigint-mod-arith": "^3.0.0" to key-did-resolver package.json
  
  * add a try and finally blocks for pubKeyBytesToXY add tests to show errors for functions that are dependencies
  
  * removed try and finally blocks from secp256r1.ts
  
  * refactored code to get linter to pass
  
  * simplify TypeError conditional in pubKeyBytesToXY since null loosely equals undefined
  
  * add additional tests for malformed did:keys , add comments to secp256r1.ts code
  
  * move test for functions in the test file to the end. Clean up and add additional tests to null. Assume this covers undefined.
  
  * add tests for undefined case for functions declared for use in test file. Fix functions to allow undefined cases to pass.
  
  * modify js-ceramic tsconfig.json to include target of ES2020 to allow for support of BigInt in package key-did-resolver
  
  * remove old target for ES2018 js-ceramic in main tsconfig.json, and replace with ES2020 (removing duplicates)
  
  * remove target: ES2020 from key-did-resolver package, since it is redundant with parent js-ceramic tsconfig.json
  
  * first run at adding comments to src/secp256r1.ts . Incomplete.
  
  * added documentation annotations for src/secp256r1.ts. May rewrite after forcing functions to throw custom errors for null and undefined
  
  * updated code and tests
  
  * updated the tests and code for more specific error responses. This is a work in progress.
  
  * update tests and code for publicKeyIntToUint8ArrayPointPair function
  
  * updated tests to pass
  
  * updated publicKeyIntToUint8ArrayPointPair and publicKeyIntToXY parameter description since redundant with error message
  
  * add function with tests to test to see if input is a Uint8Array : testUint8Array
  
  * update testUint8Array with typing info to pass linter test
  
  * added function to test for hex string
  
  * update publicKeyHexToUint8ArrayPointPair with better error checking
  
  * updated publicKeyToXY to handle only hex strings and throw and error otherwise
  
  * update pubKeyBytesToHex to only allow for Uint8Arrays and throw and error if otherwise
  
  * Add error checking for ECPointDecompress so it only allows Uint8Arrays
  
  * Add error checking for publicKeyBytesToXY so it only allows Uint8Arrays
  
  * Refactor publicKeyIntToXY and publicKeyIntToUint8ArrayPointPair in sec/secp256r1.ts
  
  * refactored logic in secp256r1.ts NOT(A AND B) = NOT(A) OR NOT(B)
</details>