### PR TITLE
fix(core): Disable ajv strictTypes and strictTuples log warnings

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -11,7 +11,7 @@ export default class Utils {
 
     @Memoize()
     static get validator() {
-      const ajv = new Ajv({ allErrors: true });
+      const ajv = new Ajv({ allErrors: true, strictTypes: false, strictTuples: false });
       addFormats(ajv);
       return ajv;
     }


### PR DESCRIPTION
Instead of completely turning off strict mode, I changed the `strictTypes` and `strictTuples` sub-settings of strict mode.  I changed those 2 because those 2 default to `"log"` mode where they don't fail the validation but log the warning - I turned them to 'off' so they no longer log.  I left the other strict mode properties `strictSchema` and `strictNumbers` as those default to `true` where they will actually fail the validation entirely.  Since those are enabled now already and none of our schemas are failing those checks, it seemed safe to leave those checks in place.  We can always become more permissive in the future if we want, but it's harder to become more strict.

[Ajv Strict Mode docs](https://ajv.js.org/options.html#strict-mode-options)