### PR TITLE
feat(core): Loading a CommitID makes the node handle the commit CID as a potential new tip

### DIFF
--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -148,6 +148,26 @@ export class StreamUtils {
     }
 
     /**
+     * Returns true iff 'state' describes a state object containing all the same history as
+     * 'base', possibly with additional commits on top.
+     * @param state - the state that might be a superset of 'base'
+     * @param base - the baseline to be compared against
+     */
+    static isStateSupersetOf(state: StreamState, base: StreamState): boolean {
+        if (state.log.length < base.log.length) {
+            return false
+        }
+
+        for (const i in base.log) {
+            if (!state.log[i].cid.equals(base.log[i].cid)) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    /**
      * Converts commit to SignedCommitContainer. The only difference is with signed commit for now
      * @param commit - Commit value
      * @param ipfs - IPFS instance

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -432,7 +432,7 @@ describe('Ceramic API', () => {
       expect(Object.keys(streams).length).toEqual(4)
       const states = Object.values(streams).map(stream => stream.state)
       // annoying thing, was pending when snapshotted but will
-      // obviously not be when rewinded
+      // obviously not be when loaded at a specific commit
       streamFStates[0].anchorStatus = 0
       expect(states[0]).toEqual(streamFStates[0])
       expect(states[1]).toEqual(streamFStates[1])

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -356,6 +356,39 @@ describe('Ceramic integration', () => {
     await ceramic2.close()
   })
 
+  it("Loading at a CommitID that's ahead of the cache will update the cache", async () => {
+    await swarmConnect(ipfs1, ipfs2)
+    const ceramic1 = await createCeramic(ipfs1, false)
+    const ceramic2 = await createCeramic(ipfs2, false)
+
+    const content0 = { foo: 0 }
+    const content1 = { foo: 1 }
+    const content2 = { foo: 2 }
+
+    const stream1 = await TileDocument.create(ceramic1, content0, null, { anchor: false })
+    await stream1.update(content1, null, { anchor: false })
+
+    // Now load the stream into the cache on second node.
+    const stream2 = await ceramic2.loadStream<TileDocument>(stream1.id)
+    expect(stream2.content).toEqual(content1)
+
+    // Now update the stream on node 1, but don't tell node 2 about it.
+    await stream1.update(content2, null, { anchor: false, publish: false })
+
+    // Now load the CommitID of the newest update on node 2.
+    const streamAtCommit = await ceramic2.loadStream<TileDocument>(stream1.commitId)
+    expect(streamAtCommit.content).toEqual(content2)
+
+    // Now ensure that the stream cache has been updated to the newest commit that was learned
+    // about by loading at the CommitID
+    const streamCurrent = await ceramic2.loadStream<TileDocument>(stream1.id, { sync: SyncOptions.PREFER_CACHE, syncTimeoutSeconds: 0 })
+    expect(streamCurrent.content).toEqual(content2)
+
+
+    await ceramic1.close()
+    await ceramic2.close()
+  })
+
   it('validates schema on stream change', async () => {
     const ceramic = await createCeramic(ipfs1)
 

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -379,11 +379,10 @@ describe('Ceramic integration', () => {
     const streamAtCommit = await ceramic2.loadStream<TileDocument>(stream1.commitId)
     expect(streamAtCommit.content).toEqual(content2)
 
-    // Now ensure that the stream cache has been updated to the newest commit that was learned
-    // about by loading at the CommitID
-    const streamCurrent = await ceramic2.loadStream<TileDocument>(stream1.id, { sync: SyncOptions.PREFER_CACHE, syncTimeoutSeconds: 0 })
+    // Now ensure that the stream cache has been updated to the newest commit.
+    const streamCurrent = await ceramic2.loadStream<TileDocument>(
+      stream1.id, { sync: SyncOptions.NEVER_SYNC, syncTimeoutSeconds: 0 })
     expect(streamCurrent.content).toEqual(content2)
-
 
     await ceramic1.close()
     await ceramic2.close()

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -168,7 +168,7 @@ test('handleTip for commit already in log', async () => {
   await ceramic2.close();
 });
 
-test('commit history and rewind', async () => {
+test('commit history and atCommit', async () => {
   const stream = await TileDocument.create<any>(ceramic, INITIAL_CONTENT);
   stream.subscribe();
   const streamState = await ceramic.repository.load(stream.id, {});
@@ -220,35 +220,35 @@ test('commit history and rewind', async () => {
   expect(stream.state.log.length).toEqual(5);
 
   // Correctly check out a specific commit
-  const streamV0 = await ceramic.repository.stateManager.rewind(streamState, commit0);
+  const streamV0 = await ceramic.repository.stateManager.atCommit(streamState, commit0);
   expect(streamV0.id.equals(commit0.baseID)).toBeTruthy();
   expect(streamV0.value.log.length).toEqual(1);
   expect(streamV0.value.metadata.controllers).toEqual(controllers);
   expect(streamV0.value.content).toEqual(INITIAL_CONTENT);
   expect(streamV0.value.anchorStatus).toEqual(AnchorStatus.NOT_REQUESTED);
 
-  const streamV1 = await ceramic.repository.stateManager.rewind(streamState, commit1);
+  const streamV1 = await ceramic.repository.stateManager.atCommit(streamState, commit1);
   expect(streamV1.id.equals(commit1.baseID)).toBeTruthy();
   expect(streamV1.value.log.length).toEqual(2);
   expect(streamV1.value.metadata.controllers).toEqual(controllers);
   expect(streamV1.value.content).toEqual(INITIAL_CONTENT);
   expect(streamV1.value.anchorStatus).toEqual(AnchorStatus.ANCHORED);
 
-  const streamV2 = await ceramic.repository.stateManager.rewind(streamState, commit2);
+  const streamV2 = await ceramic.repository.stateManager.atCommit(streamState, commit2);
   expect(streamV2.id.equals(commit2.baseID)).toBeTruthy();
   expect(streamV2.value.log.length).toEqual(3);
   expect(streamV2.value.metadata.controllers).toEqual(controllers);
   expect(streamV2.value.next.content).toEqual(newContent);
   expect(streamV2.value.anchorStatus).toEqual(AnchorStatus.NOT_REQUESTED);
 
-  const streamV3 = await ceramic.repository.stateManager.rewind(streamState, commit3);
+  const streamV3 = await ceramic.repository.stateManager.atCommit(streamState, commit3);
   expect(streamV3.id.equals(commit3.baseID)).toBeTruthy();
   expect(streamV3.value.log.length).toEqual(4);
   expect(streamV3.value.metadata.controllers).toEqual(controllers);
   expect(streamV3.value.content).toEqual(newContent);
   expect(streamV3.value.anchorStatus).toEqual(AnchorStatus.ANCHORED);
 
-  const streamV4 = await ceramic.repository.stateManager.rewind(streamState, commit4);
+  const streamV4 = await ceramic.repository.stateManager.atCommit(streamState, commit4);
   expect(streamV4.id.equals(commit4.baseID)).toBeTruthy();
   expect(streamV4.value.log.length).toEqual(5);
   expect(streamV4.value.metadata.controllers).toEqual(controllers);
@@ -256,7 +256,7 @@ test('commit history and rewind', async () => {
   expect(streamV4.value.anchorStatus).toEqual(AnchorStatus.NOT_REQUESTED);
 });
 
-describe('rewind', () => {
+describe('atCommit', () => {
   test('non-existing commit', async () => {
     const stream = await TileDocument.create(ceramic, INITIAL_CONTENT, null, { anchor: false });
     const streamState = await ceramic.repository.load(stream.id, {});
@@ -270,7 +270,7 @@ describe('rewind', () => {
         return originalRetrieve(cid);
       }
     });
-    await expect(ceramic.repository.stateManager.rewind(streamState, nonExistentCommitID)).rejects.toThrow(
+    await expect(ceramic.repository.stateManager.atCommit(streamState, nonExistentCommitID)).rejects.toThrow(
       `No commit found for CID ${nonExistentCommitID.commit?.toString()}`,
     );
   });
@@ -283,7 +283,7 @@ describe('rewind', () => {
     const ceramic2 = await createCeramic(ipfs, { anchorOnRequest: false });
     const stream2 = await TileDocument.load(ceramic, stream1.id);
     const streamState2 = await ceramic2.repository.load(stream2.id, { syncTimeoutSeconds: 0 });
-    const snapshot = await ceramic2.repository.stateManager.rewind(streamState2, stream1.commitId);
+    const snapshot = await ceramic2.repository.stateManager.atCommit(streamState2, stream1.commitId);
 
     expect(StreamUtils.statesEqual(snapshot.state, stream1.state));
     const snapshotStream = streamFromState<TileDocument>(ceramic2.context, ceramic2._streamHandlers, snapshot.value);
@@ -315,7 +315,7 @@ test('handles basic conflict', async () => {
   // create invalid change that happened after main change
 
   const initialState = await ceramic.repository.stateManager
-    .rewind(streamState1, streamId.atCommit(streamId.cid))
+    .atCommit(streamState1, streamId.atCommit(streamId.cid))
     .then((stream) => stream.state);
   const state$ = new RunningState(initialState);
   ceramic.repository.add(state$);
@@ -342,11 +342,11 @@ test('handles basic conflict', async () => {
   expect(stream1.content).toEqual(newContent);
 
   // Loading valid commit works
-  const streamAtValidCommit = await ceramic.repository.stateManager.rewind(streamState1, streamId.atCommit(tipValidUpdate));
+  const streamAtValidCommit = await ceramic.repository.stateManager.atCommit(streamState1, streamId.atCommit(tipValidUpdate));
   expect(streamAtValidCommit.value.content).toEqual(newContent);
 
   // Loading invalid commit fails
-  await expect(ceramic.repository.stateManager.rewind(streamState1, streamId.atCommit(tipInvalidUpdate))).rejects.toThrow(
+  await expect(ceramic.repository.stateManager.atCommit(streamState1, streamId.atCommit(tipInvalidUpdate))).rejects.toThrow(
     `Requested commit CID ${tipInvalidUpdate.toString()} not found in the log for stream ${streamId.toString()}`,
   );
 }, 10000);

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -233,7 +233,7 @@ class Ceramic implements CeramicApi {
   }
 
   private _buildPinApi(): PinApi {
-    const boundStreamLoader = this._loadStream.bind(this)
+    const boundStreamLoader = this.loadStream.bind(this)
     const loaderWithSyncSet = (streamid) => { return boundStreamLoader(streamid, { sync: SyncOptions.PREFER_CACHE })}
     return new LocalPinApi(this.repository, loaderWithSyncSet, this._logger)
   }
@@ -489,7 +489,7 @@ class Ceramic implements CeramicApi {
   async loadStream<T extends Stream>(streamId: StreamID | CommitID | string, opts: LoadOpts = {}): Promise<T> {
     opts = { ...DEFAULT_LOAD_OPTS, ...opts };
     const streamRef = StreamRef.from(streamId)
-    const base$ = await this._loadStream(streamRef.baseID, opts)
+    const base$ = await this.repository.load(streamRef.baseID, opts);
     if (CommitID.isInstance(streamRef)) {
       // Here CommitID is requested, let's return stream at specific commit
       const snapshot$ = await this.repository.stateManager.rewind(base$, streamRef)
@@ -577,15 +577,6 @@ class Ceramic implements CeramicApi {
   }
 
   /**
-   * Load stream instance
-   * @param streamId - Stream ID
-   * @param opts - Initialization options
-   */
-  async _loadStream(streamId: StreamID, opts: LoadOpts): Promise<RunningState> {
-    return this.repository.load(streamId, opts)
-  }
-
-  /**
    * @returns An array of the CAIP-2 chain IDs of the blockchains that are supported for anchoring
    * streams.
    */
@@ -600,7 +591,7 @@ class Ceramic implements CeramicApi {
     this.repository.listPinned().then(async list => {
       let n = 0
       await Promise.all(list.map(async streamId => {
-        await this._loadStream(StreamID.fromString(streamId), { sync: SyncOptions.NEVER_SYNC })
+        await this.loadStream(StreamID.fromString(streamId), { sync: SyncOptions.NEVER_SYNC })
         n++;
       }))
       this._logger.verbose(`Successfully restored ${n} pinned streams`)

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -490,10 +490,10 @@ class Ceramic implements CeramicApi {
     opts = { ...DEFAULT_LOAD_OPTS, ...opts };
     const streamRef = StreamRef.from(streamId)
     if (CommitID.isInstance(streamRef)) {
-      const snapshot$ = await this.repository.loadAtCommit(streamId as CommitID, opts);
+      const snapshot$ = await this.repository.loadAtCommit(streamRef, opts);
       return streamFromState<T>(this.context, this._streamHandlers, snapshot$.value)
     } else if (opts.atTime) {
-      const snapshot$ = await this.repository.loadAtTime(streamId as StreamID, opts);
+      const snapshot$ = await this.repository.loadAtTime(streamRef, opts);
       return streamFromState<T>(this.context, this._streamHandlers, snapshot$.value)
     } else {
       const base$ = await this.repository.load(streamRef.baseID, opts);

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -489,15 +489,14 @@ class Ceramic implements CeramicApi {
   async loadStream<T extends Stream>(streamId: StreamID | CommitID | string, opts: LoadOpts = {}): Promise<T> {
     opts = { ...DEFAULT_LOAD_OPTS, ...opts };
     const streamRef = StreamRef.from(streamId)
-    const base$ = await this.repository.load(streamRef.baseID, opts);
     if (CommitID.isInstance(streamRef)) {
-      // Here CommitID is requested, let's return stream at specific commit
-      const snapshot$ = await this.repository.stateManager.rewind(base$, streamRef)
+      const snapshot$ = await this.repository.loadAtCommit(streamId as CommitID, opts);
       return streamFromState<T>(this.context, this._streamHandlers, snapshot$.value)
     } else if (opts.atTime) {
-      const snapshot$ = await this.repository.stateManager.atTime(base$, opts.atTime)
+      const snapshot$ = await this.repository.loadAtTime(streamId as StreamID, opts);
       return streamFromState<T>(this.context, this._streamHandlers, snapshot$.value)
     } else {
+      const base$ = await this.repository.load(streamRef.baseID, opts);
       return streamFromState<T>(this.context, this._streamHandlers, base$.value, this.repository.updates$)
     }
   }

--- a/packages/core/src/conflict-resolution.ts
+++ b/packages/core/src/conflict-resolution.ts
@@ -348,7 +348,7 @@ export class ConflictResolution {
   /**
    * Return state at `commitId` version.
    */
-  async rewind(initialState: StreamState, commitId: CommitID): Promise<StreamState> {
+  async snapshotAtCommit(initialState: StreamState, commitId: CommitID): Promise<StreamState> {
     // If 'commit' is ahead of 'initialState', sync state up to 'commit'
     const baseState = (await this.applyTip(initialState, commitId.commit)) || initialState;
 

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -1,4 +1,4 @@
-import StreamID from '@ceramicnetwork/streamid';
+import StreamID, {CommitID} from '@ceramicnetwork/streamid';
 import {
   AnchorService,
   AnchorStatus,
@@ -20,6 +20,7 @@ import type { HandlersMap } from '../handlers-map';
 import type { StateValidation } from './state-validation';
 import { Observable } from 'rxjs';
 import { StateCache } from './state-cache';
+import {SnapshotState} from "./snapshot-state";
 
 export type RepositoryDependencies = {
   dispatcher: Dispatcher;
@@ -162,6 +163,31 @@ export class Repository {
       await this.stateManager.sync(stream, opts.syncTimeoutSeconds * 1000, fromStateStore);
       return stream
     });
+  }
+
+  /**
+   * Load the state for a stream at a specific CommitID.
+   * @param commitId
+   * @param opts
+   */
+  async loadAtCommit(commitId: CommitID, opts: LoadOpts): Promise<SnapshotState> {
+    // Start by loading the current state of the stream. This might cause us to load more commits
+    // for the stream than is ultimately necessary, but doing so increases the chances that we
+    // detect that the CommitID specified is rejected by the conflict resolution rules due to
+    // conflict with the stream's canonical branch of history.
+    const base$ = await this.load(commitId.baseID, opts);
+    return this.stateManager.rewind(base$, commitId)
+  }
+
+  /**
+   * Load the state for a stream as it was at a specified wall clock time, based on the anchor
+   * timestamps of AnchorCommits in the log.
+   * @param streamId
+   * @param opts - must contain an 'atTime' parameter
+   */
+  async loadAtTime(streamId: StreamID, opts: LoadOpts): Promise<SnapshotState> {
+    const base$ = await this.load(streamId.baseID, opts);
+    return this.stateManager.atTime(base$, opts.atTime);
   }
 
   /**

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -9,7 +9,6 @@ import {
   SyncOptions,
 } from '@ceramicnetwork/common';
 import { PinStore } from '../store/pin-store';
-import { NamedTaskQueue } from './named-task-queue';
 import { DiagnosticsLogger } from '@ceramicnetwork/common';
 import { ExecutionQueue } from './execution-queue';
 import { RunningState } from './running-state';
@@ -20,7 +19,7 @@ import type { HandlersMap } from '../handlers-map';
 import type { StateValidation } from './state-validation';
 import { Observable } from 'rxjs';
 import { StateCache } from './state-cache';
-import {SnapshotState} from "./snapshot-state";
+import { SnapshotState } from "./snapshot-state";
 
 export type RepositoryDependencies = {
   dispatcher: Dispatcher;

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -175,7 +175,7 @@ export class Repository {
     // detect that the CommitID specified is rejected by the conflict resolution rules due to
     // conflict with the stream's canonical branch of history.
     const base$ = await this.load(commitId.baseID, opts);
-    return this.stateManager.rewind(base$, commitId)
+    return this.stateManager.atCommit(base$, commitId)
   }
 
   /**

--- a/packages/core/src/state-management/snapshot-state.ts
+++ b/packages/core/src/state-management/snapshot-state.ts
@@ -5,7 +5,7 @@ import { StreamID } from '@ceramicnetwork/streamid';
 /**
  * Snapshot of a stream state at some commit. Unlike `RunningState` this can not be updated.
  * Only a subset of operations could be performed with an instance of SnapshotState, like
- * `StateManager#rewind` or `StateManager#atTime`.
+ * `StateManager#atCommit` or `StateManager#atTime`.
  */
 export class SnapshotState extends Observable<StreamState> implements RunningStateLike {
   readonly id: StreamID;

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -90,14 +90,15 @@ export class StateManager {
   /**
    * Take the version of a stream state and a specific commit and returns a snapshot of a state
    * at the requested commit. If the requested commit is for a branch of history that conflicts with the
-   * known commits, throw an error.
+   * known commits, throw an error. If the requested commit is ahead of the currently known state
+   * for this stream, emit the new state.
    *
-   * @param state$ - Stream state to rewind.
+   * @param state$ - Currently known state of the stream.
    * @param commitId - Requested commit.
    */
-  async rewind(state$: RunningStateLike, commitId: CommitID): Promise<SnapshotState> {
+  async atCommit(state$: RunningStateLike, commitId: CommitID): Promise<SnapshotState> {
     return this.executionQ.forStream(commitId.baseID).run(async () => {
-      const snapshot = await this.conflictResolution.rewind(state$.value, commitId);
+      const snapshot = await this.conflictResolution.snapshotAtCommit(state$.value, commitId);
 
       // If the provided CommitID is ahead of what we have in the cache, then we should update
       // the cache to include it.
@@ -119,7 +120,7 @@ export class StateManager {
    */
   atTime(state$: RunningStateLike, timestamp: number): Promise<SnapshotState> {
     const commitId = commitAtTime(state$, timestamp);
-    return this.rewind(state$, commitId);
+    return this.atCommit(state$, commitId);
   }
 
   /**

--- a/packages/core/src/state-management/stream-from-state.ts
+++ b/packages/core/src/state-management/stream-from-state.ts
@@ -9,7 +9,8 @@ import { StateLink } from './state-link';
  * @param context - Ceramic context
  * @param handlersMap - available stream handlers
  * @param state - current state of the stream
- * @param update$ - On-demand feed of updates for the stream
+ * @param update$ - On-demand feed of updates for the stream. If not provided then the returned
+ *   Stream object is marked read-only and cannot be used to update the stream.
  */
 export function streamFromState<T extends Stream>(
   context: Context,


### PR DESCRIPTION
This basically makes loading a stream with a CommitID function as a backdoor way to expose "handleTip" to the public API.