### PR TITLE
feat(core): Allow lazy initializtaion of anchor service

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -157,7 +157,7 @@ export class CeramicDaemon {
     const ipfs = await buildIpfsConnection(
       opts.network, ceramicConfig.loggerProvider.getDiagnosticsLogger(), opts.ipfsHost)
 
-    const [modules, params] = await Ceramic._processConfig(ipfs, ceramicConfig)
+    const [modules, params] = Ceramic._processConfig(ipfs, ceramicConfig)
 
     if (opts.s3StateStoreBucket) {
       const s3StateStore = new S3StateStore(opts.s3StateStoreBucket)

--- a/packages/common/src/anchor-service.ts
+++ b/packages/common/src/anchor-service.ts
@@ -69,7 +69,7 @@ export interface AnchorService {
    * @param streamId - Stream ID
    * @param tip - CID tip
    */
-  requestAnchor(streamId: StreamID, tip: CID): Observable<AnchorServiceResponse>;
+  requestAnchor(streamId: StreamID, tip: CID): Promise<Observable<AnchorServiceResponse>>;
 
   /**
    * Start polling the anchor service to learn of the results of an existing anchor request for the

--- a/packages/core/src/__tests__/ceramic-recover-streams.test.ts
+++ b/packages/core/src/__tests__/ceramic-recover-streams.test.ts
@@ -41,7 +41,7 @@ async function createCeramic(ipfs: IpfsApi, stateStoreDirectory: string, anchorS
         anchorOnRequest: false,
         pubsubTopic: PUBSUB_TOPIC, // necessary so Ceramic instances can talk to each other
     };
-    const [modules, params] = await Ceramic._processConfig(ipfs, config)
+    const [modules, params] = Ceramic._processConfig(ipfs, config)
     if (anchorService) {
         modules.anchorService = anchorService
     }

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -60,8 +60,9 @@ describe('anchor', () => {
     const stream = await TileDocument.create(ceramic, INITIAL_CONTENT, null, { anchor: false });
     const stream$ = await ceramic.repository.load(stream.id, {});
 
+    const subscription = await ceramic.repository.stateManager.anchor(stream$)
     await new Promise((resolve) => {
-      ceramic.repository.stateManager.anchor(stream$).add(resolve);
+      subscription.add(resolve);
     });
     expect(stream$.value.anchorStatus).toEqual(AnchorStatus.ANCHORED);
   });
@@ -70,15 +71,17 @@ describe('anchor', () => {
     const stream = await TileDocument.create(ceramic, INITIAL_CONTENT, null, { anchor: false });
     const stream$ = await ceramic.repository.load(stream.id, {});
 
+    const subscription = await ceramic.repository.stateManager.anchor(stream$)
     await new Promise((resolve) => {
-      ceramic.repository.stateManager.anchor(stream$).add(resolve);
+      subscription.add(resolve);
     });
     expect(stream$.value.anchorStatus).toEqual(AnchorStatus.ANCHORED);
     expect(stream$.value.log.length).toEqual(2)
 
     // Now re-request an anchor when the stream is already anchored. Should be a no-op
+    const subscription2 = await ceramic.repository.stateManager.anchor(stream$)
     await new Promise((resolve) => {
-      ceramic.repository.stateManager.anchor(stream$).add(resolve);
+      subscription.add(resolve);
     });
     expect(stream$.value.log.length).toEqual(2)
   });
@@ -94,8 +97,9 @@ describe('anchor', () => {
     fakeHandleTip.mockRejectedValueOnce(new Error("Handle tip failed"))
     fakeHandleTip.mockImplementationOnce(realHandleTip)
 
+    const subscription = await ceramic.repository.stateManager.anchor(stream$)
     await new Promise((resolve) => {
-      ceramic.repository.stateManager.anchor(stream$).add(resolve);
+      subscription.add(resolve);
     });
     expect(stream$.value.anchorStatus).toEqual(AnchorStatus.ANCHORED);
   });
@@ -112,8 +116,9 @@ describe('anchor', () => {
     fakeHandleTip.mockRejectedValueOnce(new Error("Handle tip failed"))
     fakeHandleTip.mockImplementationOnce(realHandleTip)
 
+    const subscription = await ceramic.repository.stateManager.anchor(stream$)
     await new Promise((resolve) => {
-      ceramic.repository.stateManager.anchor(stream$).add(resolve);
+      subscription.add(resolve);
     });
     expect(stream$.value.anchorStatus).toEqual(AnchorStatus.FAILED);
   });
@@ -123,8 +128,9 @@ test('handleTip', async () => {
   const stream1 = await TileDocument.create(ceramic, INITIAL_CONTENT, null, { anchor:false });
   stream1.subscribe();
   const streamState1 = await ceramic.repository.load(stream1.id, {});
+  const subscription = await ceramic.repository.stateManager.anchor(streamState1)
   await new Promise((resolve) => {
-    ceramic.repository.stateManager.anchor(streamState1).add(resolve);
+    subscription.add(resolve);
   });
 
 

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -117,7 +117,7 @@ export default class EthereumAnchorService implements AnchorService {
    * @param streamId - Stream ID
    * @param tip - Tip CID of the stream
    */
-  requestAnchor(streamId: StreamID, tip: CID): Observable<AnchorServiceResponse> {
+  async requestAnchor(streamId: StreamID, tip: CID): Promise<Observable<AnchorServiceResponse>> {
     const cidStreamPair: CidAndStream = { cid: tip, streamId };
     return concat(
       this._announcePending(cidStreamPair),

--- a/packages/core/src/anchor/memory/in-memory-anchor-service.ts
+++ b/packages/core/src/anchor/memory/in-memory-anchor-service.ts
@@ -237,7 +237,7 @@ class InMemoryAnchorService implements AnchorService {
    * @param streamId - Stream ID
    * @param tip - Commit CID
    */
-  requestAnchor(streamId: StreamID, tip: CID): Observable<AnchorServiceResponse> {
+  async requestAnchor(streamId: StreamID, tip: CID): Promise<Observable<AnchorServiceResponse>> {
     const candidate = new Candidate(tip, streamId);
     if (this.#anchorOnRequest) {
       this._process(candidate).catch((error) => {

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -428,12 +428,7 @@ class Ceramic implements CeramicApi {
       await this._ipfsTopology.start()
     }
 
-    try {
-      await this.context.anchorService.init();
-      await this.getSupportedChains() // Will log if it successfully connects
-    } catch (e) {
-      this._logger.warn(`Error while initializing connection to anchor service '${this.context.anchorService.url}'. Will try again on demand.`)
-    }
+    await this.context.anchorService.init();
 
     if (restoreStreams) {
       this.restoreStreams()

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -172,7 +172,7 @@ export class Repository {
    */
   async applyCreateOpts(streamId: StreamID, opts: CreateOpts): Promise<RunningState> {
     const state = await this.load(streamId, opts)
-    this.stateManager.applyWriteOpts(state, opts)
+    await this.stateManager.applyWriteOpts(state, opts)
     return state
   }
 

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -119,11 +119,11 @@ export class StateManager {
    * @param opts - Initialization options (request anchor, publish to pubsub, etc.)
    * @private
    */
-  applyWriteOpts(state$: RunningState, opts: CreateOpts | UpdateOpts) {
+  async applyWriteOpts(state$: RunningState, opts: CreateOpts | UpdateOpts) {
     const anchor = (opts as any).anchor
     const publish = (opts as any).publish
     if (anchor) {
-      this.anchor(state$);
+      await this.anchor(state$);
     }
     if (publish) {
       this.publishTip(state$);
@@ -227,11 +227,11 @@ export class StateManager {
   /**
    * Request anchor for the latest stream state
    */
-  anchor(state$: RunningState): Subscription {
+  async anchor(state$: RunningState): Promise<Subscription> {
     if (state$.value.anchorStatus == AnchorStatus.ANCHORED) {
       return Subscription.EMPTY;
     }
-    const anchorStatus$ = this.anchorService.requestAnchor(state$.id, state$.tip);
+    const anchorStatus$ = await this.anchorService.requestAnchor(state$.id, state$.tip);
     return this._processAnchorResponse(state$, anchorStatus$)
   }
 


### PR DESCRIPTION
This PR allows Ceramic to start up with the CAS unavailable. If any operations are attempted which try to perform an anchor, the anchor will fail and a warning will be logged to the logs.  The operation that attempted the anchor, however, will **not** get an exception thrown.  That means that if you are using the CLI to create or update streams, you will not see any error or any indication that the anchor failed unless you read the logs or check the state of the stream and notice that the AnchorStatus is FAILED. This is consistent with the way we handle all anchor failures currently, although the behavior may be surprising to some users that not just when the anchor fails on the CAS, but even when we fail to even *submit the request* to the CAS, they still see no error in their app.

I started work on a patch to change things so that if we fail while initially requesting the anchor we throw an exception in the operation that requested it, while leaving anchor failures later on in the process as happening in the background and just setting the anchorStatus to FAILED.  The problem with that change is that now if you try to create a stream and requesting the anchor fails, you get an exception thrown, which is good for informing you that something went wrong, but means you don't get back the StreamID. This is a problem since the stream actually was created, but now you have no handle to it or any way to get a handle to it.

So I guess I'll just leave things as-is on this front for now, but it's not very satisfying. It feels like developers will want fast feedback if their anchor requests are failing. The fact that you can configure a ceramic node with no available CAS, then create and update streams against it from the CLI without seeing any indication that anything is wrong is fairly worrisome.