### PR TITLE
feat(core,cli): Add --disable-anchors flag to allow ceramic to start up without a working CAS

### DIFF
--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -23,6 +23,7 @@ program
     .option('--max-healthy-cpu <decimal>', 'Fraction of total CPU usage considered healthy. Defaults to 0.7')
     .option('--max-healthy-memory <decimal>', 'Fraction of total memory usage considered healthy. Defaults to 0.7')
     .option('--cors-allowed-origins <list>', 'Space-separated list of strings and/or regex expressions to set for Access-Control-Allow-Origin . Defaults to all: "*"')
+    .option('--disable-anchors', 'Allows Ceramic Daemon to start up without a configured anchor service. Any anchor requests made will fail.')
     .description('Start the daemon')
     .action(async ({
         ipfsApi,
@@ -41,7 +42,8 @@ program
         logDirectory,
         network,
         pubsubTopic,
-        corsAllowedOrigins
+        corsAllowedOrigins,
+        disableAnchors,
     }) => {
         if (stateStoreDirectory && stateStoreS3Bucket) {
           throw new Error("Cannot specify both --state-store-directory and --state-store-s3-bucket. Only one state store - either on local storage or on S3 - can be used at a time")
@@ -63,8 +65,13 @@ program
             logDirectory,
             network,
             pubsubTopic,
-            corsAllowedOrigins
-        )
+            corsAllowedOrigins,
+            disableAnchors,
+        ).catch((err) => {
+          console.error('Ceramic daemon failed to start up:')
+          console.error(err)
+          process.exit(-1)
+        })
     })
 
 program

--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -70,7 +70,7 @@ program
         ).catch((err) => {
           console.error('Ceramic daemon failed to start up:')
           console.error(err)
-          process.exit(-1)
+          process.exit(1)
         })
     })
 

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -47,7 +47,8 @@ export class CeramicCliUtils {
      * @param stateStoreDirectory - Path to the directory that will be used for storing pinned stream state
      * @param stateStoreS3Bucket - S3 bucket name for storing pinned stream state
      * @param gateway - read only endpoints available. It is disabled by default
-     * @param port - port daemon is availabe. Default is 7007
+     * @param port - port on which daemon is available. Default is 7007
+     * @param hostname - hostname to listen on.
      * @param debug - Enable debug logging level
      * @param verbose - Enable verbose logging
      * @param logToFiles - Enable writing logs to files
@@ -55,6 +56,7 @@ export class CeramicCliUtils {
      * @param network - The Ceramic network to connect to
      * @param pubsubTopic - Pub/sub topic to use for protocol messages.
      * @param corsAllowedOrigins - Origins for Access-Control-Allow-Origin header. Default is all
+     * @param disableAnchors - If true all anchors will fail. Allows the daemon to start up even if CAS is unavailable.
      */
     static async createDaemon(
         ipfsApi: string,
@@ -73,7 +75,8 @@ export class CeramicCliUtils {
         logDirectory: string,
         network = DEFAULT_NETWORK,
         pubsubTopic: string,
-        corsAllowedOrigins: string
+        corsAllowedOrigins: string,
+        disableAnchors: boolean,
     ): Promise<CeramicDaemon> {
         let _corsAllowedOrigins: string | RegExp[] = '*'
         if (corsAllowedOrigins != null && corsAllowedOrigins != '*') {
@@ -101,6 +104,7 @@ export class CeramicCliUtils {
             pubsubTopic,
             corsAllowedOrigins: _corsAllowedOrigins,
             ipfsHost: ipfsApi,
+            disableAnchors,
         }
         return CeramicDaemon.create(config)
     }

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -36,6 +36,7 @@ export interface CreateOpts {
 
   ethereumRpcUrl?: string;
   anchorServiceUrl?: string;
+  disableAnchors?: boolean;
   stateStoreDirectory?: string;
   s3StateStoreBucket?: string;
 
@@ -61,6 +62,7 @@ export function makeCeramicConfig (opts: CreateOpts): CeramicConfig {
     loggerProvider,
     gateway: opts.gateway || false,
     anchorServiceUrl: opts.anchorServiceUrl,
+    disableAnchors: opts.disableAnchors,
     ethereumRpcUrl: opts.ethereumRpcUrl,
     ipfsPinningEndpoints: opts.ipfsPinningEndpoints,
     networkName: opts.network,
@@ -157,7 +159,7 @@ export class CeramicDaemon {
     const ipfs = await buildIpfsConnection(
       opts.network, ceramicConfig.loggerProvider.getDiagnosticsLogger(), opts.ipfsHost)
 
-    const [modules, params] = await Ceramic._processConfig(ipfs, ceramicConfig)
+    const [modules, params] = Ceramic._processConfig(ipfs, ceramicConfig)
 
     if (opts.s3StateStoreBucket) {
       const s3StateStore = new S3StateStore(opts.s3StateStoreBucket)

--- a/packages/core/src/__tests__/ceramic-recover-streams.test.ts
+++ b/packages/core/src/__tests__/ceramic-recover-streams.test.ts
@@ -41,7 +41,7 @@ async function createCeramic(ipfs: IpfsApi, stateStoreDirectory: string, anchorS
         anchorOnRequest: false,
         pubsubTopic: PUBSUB_TOPIC, // necessary so Ceramic instances can talk to each other
     };
-    const [modules, params] = await Ceramic._processConfig(ipfs, config)
+    const [modules, params] = Ceramic._processConfig(ipfs, config)
     if (anchorService) {
         modules.anchorService = anchorService
     }

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -85,7 +85,10 @@ describe('Ceramic integration', () => {
   })
 
   it('cannot create Ceramic instance on network not supported by our anchor service', async () => {
-    await expect(Ceramic._loadSupportedChains("local", new InMemoryAnchorService({}))).rejects.toThrow(
+    const [modules, params] = await Ceramic._processConfig(ipfs1, {networkName: 'local'});
+    modules.anchorService = new InMemoryAnchorService({})
+    const ceramic = new Ceramic(modules, params)
+    await expect(ceramic._init(false, false)).rejects.toThrow(
         "No usable chainId for anchoring was found.  The ceramic network 'local' supports the chains: ['eip155:1337'], but the configured anchor service '<inmemory>' only supports the chains: ['inmemory:12345']")
     await delay(1000)
   })

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -443,10 +443,9 @@ class Ceramic implements CeramicApi {
     }
 
     if (!this._disableAnchors) {
-      const anchorService = this.context.anchorService
-      await anchorService.init()
+      await this.context.anchorService.init()
       await this._loadSupportedChains()
-      this._logger.imp(`Connected to anchor service '${anchorService.url}' with supported anchor chains ['${this._supportedChains.join("','")}']`)
+      this._logger.imp(`Connected to anchor service '${this.context.anchorService.url}' with supported anchor chains ['${this._supportedChains.join("','")}']`)
     }
 
     if (restoreStreams) {

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -98,7 +98,7 @@ export class Repository {
       const toRecover =
         runningState.value.anchorStatus === AnchorStatus.PENDING ||
         runningState.value.anchorStatus === AnchorStatus.PROCESSING;
-      if (toRecover) {
+      if (toRecover && this.stateManager.anchorService) {
         this.stateManager.confirmAnchorResponse(runningState);
       }
       return runningState;

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -228,6 +228,9 @@ export class StateManager {
    * Request anchor for the latest stream state
    */
   anchor(state$: RunningState): Subscription {
+    if (!this.anchorService) {
+      throw new Error(`Anchor requested for stream ${state$.id.toString()} but anchoring is disabled`)
+    }
     if (state$.value.anchorStatus == AnchorStatus.ANCHORED) {
       return Subscription.EMPTY;
     }


### PR DESCRIPTION
If you try to create or update a stream in a way that requests an anchor (either because of the defaults or because of explicitly requesting `anchor: true`), then the operation throws an exception. This means that when creating a stream with `anchor:true` an exception will be thrown so the application code will *not* get back a StreamID even though the stream was actually successfully created.  I decided that was okay in this case, even though I decided it *wasn't* okay in https://github.com/ceramicnetwork/js-ceramic/pull/1487, because in this case trying to anchor when no CAS is set up is a configuration error, which you'll want to notice and fix ASAP, rather than a transient runtime error due to temporary unavailability.