### PR TITLE
feat(cli): add global sync option and disable restore stream to options

### DIFF
--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -24,6 +24,8 @@ program
     .option('--max-healthy-memory <decimal>', 'Fraction of total memory usage considered healthy. Defaults to 0.7')
     .option('--cors-allowed-origins <list>', 'Space-separated list of strings and/or regex expressions to set for Access-Control-Allow-Origin . Defaults to all: "*"')
     .option('--disable-anchors', 'Allows Ceramic Daemon to start up without a configured anchor service. Any anchor requests made will fail.')
+    .option('--no-restore-streams', 'Disable loading pinned stream state into memory at startup')
+    .option('--sync <string>', 'Global modes for syncing streams. One of: "prefer-cache", "sync-always", or "never-sync". Defaults to "prefer-cache"')
     .description('Start the daemon')
     .action(async ({
         ipfsApi,
@@ -44,6 +46,8 @@ program
         pubsubTopic,
         corsAllowedOrigins,
         disableAnchors,
+        restoreStreams,
+        sync
     }) => {
         if (stateStoreDirectory && stateStoreS3Bucket) {
           throw new Error("Cannot specify both --state-store-directory and --state-store-s3-bucket. Only one state store - either on local storage or on S3 - can be used at a time")
@@ -67,6 +71,8 @@ program
             pubsubTopic,
             corsAllowedOrigins,
             disableAnchors,
+            restoreStreams,
+            sync
         ).catch((err) => {
           console.error('Ceramic daemon failed to start up:')
           console.error(err)

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -7,7 +7,7 @@ import { promises as fs } from 'fs'
 
 import { Ed25519Provider } from 'key-did-provider-ed25519'
 import CeramicClient from '@ceramicnetwork/http-client'
-import { CeramicApi, StreamUtils, LoggerConfig, LogLevel, Networks } from '@ceramicnetwork/common'
+import { CeramicApi, StreamUtils, LoggerConfig, LogLevel, Networks, SyncOptions } from '@ceramicnetwork/common'
 import StreamID, {CommitID} from '@ceramicnetwork/streamid'
 
 import { CreateOpts, CeramicDaemon } from './ceramic-daemon'
@@ -21,6 +21,12 @@ import { DID } from 'dids'
 const DEFAULT_CLI_CONFIG_FILE = 'config.json'
 const DEFAULT_CLI_CONFIG_PATH = path.join(os.homedir(), '.ceramic')
 const DEFAULT_NETWORK = Networks.TESTNET_CLAY
+
+const SYNC_OPTIONS_MAP = {
+    'prefer-cache': SyncOptions.PREFER_CACHE, 
+    'sync-always': SyncOptions.SYNC_ALWAYS,
+    'never-sync': SyncOptions.NEVER_SYNC
+}
 
 /**
  * CLI configuration
@@ -77,6 +83,8 @@ export class CeramicCliUtils {
         pubsubTopic: string,
         corsAllowedOrigins: string,
         disableAnchors: boolean,
+        restoreStreams: boolean,
+        sync: string
     ): Promise<CeramicDaemon> {
         let _corsAllowedOrigins: string | RegExp[] = '*'
         if (corsAllowedOrigins != null && corsAllowedOrigins != '*') {
@@ -88,6 +96,8 @@ export class CeramicCliUtils {
           logDirectory,
           logLevel,
         }
+
+        const _sync = SYNC_OPTIONS_MAP[sync]
 
         const config: CreateOpts = {
             ethereumRpcUrl: ethereumRpc,
@@ -105,6 +115,8 @@ export class CeramicCliUtils {
             corsAllowedOrigins: _corsAllowedOrigins,
             ipfsHost: ipfsApi,
             disableAnchors,
+            restoreStreams,
+            sync: _sync
         }
         return CeramicDaemon.create(config)
     }

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -46,6 +46,8 @@ export interface CreateOpts {
   loggerConfig?: LoggerConfig,
   network?: string;
   pubsubTopic?: string;
+  restoreStreams?: boolean;
+  sync: SyncOptions
 }
 
 interface MultiQueryWithDocId extends MultiQuery {
@@ -69,6 +71,7 @@ export function makeCeramicConfig (opts: CreateOpts): CeramicConfig {
     pubsubTopic: opts.pubsubTopic,
     stateStoreDirectory: opts.stateStoreDirectory,
     validateStreams: opts.validateStreams,
+    sync: opts.sync
   }
 
   return ceramicConfig
@@ -167,7 +170,7 @@ export class CeramicDaemon {
     }
 
     const ceramic = new Ceramic(modules, params)
-    await ceramic._init(true, true)
+    await ceramic._init(true, opts.restoreStreams ?? true)
 
     const did = new DID({ resolver: {
       ...KeyDidResolver.getResolver(),

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -37,6 +37,7 @@ import { FauxStateValidation, RealStateValidation, StateValidation } from './sta
 import { streamFromState } from './state-management/stream-from-state';
 import { ConflictResolution } from './conflict-resolution';
 import { RunningState } from './state-management/running-state';
+import { ExecFileSyncOptions } from 'child_process';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageJson = require('../package.json')
@@ -92,6 +93,7 @@ export interface CeramicConfig {
 
   useCentralizedPeerDiscovery?: boolean;
   restoreStreams?: boolean;
+  sync?: SyncOptions
 
   [index: string]: any; // allow arbitrary properties
 }
@@ -120,8 +122,15 @@ export interface CeramicParameters {
   disableAnchors: boolean,
   networkOptions: CeramicNetworkOptions,
   validateStreams: boolean,
+  syncOptions: SyncConfig
 }
 
+/**
+ * Global Sync Config Options
+ */
+export interface SyncConfig {
+  sync?: SyncOptions 
+}
 
 /**
  * Protocol options that are derived from the specified Ceramic network name (e.g. "mainnet", "testnet-clay", etc)
@@ -172,6 +181,7 @@ class Ceramic implements CeramicApi {
   private _supportedChains: Array<string>
   private readonly _validateStreams: boolean
   private readonly stateValidation: StateValidation
+  private readonly _syncOptions: SyncConfig
 
   constructor (modules: CeramicModules, params: CeramicParameters) {
     this._ipfsTopology = modules.ipfsTopology
@@ -184,6 +194,7 @@ class Ceramic implements CeramicApi {
     this._disableAnchors = params.disableAnchors
     this._networkOptions = params.networkOptions
     this._validateStreams = params.validateStreams
+    this._syncOptions = params.syncOptions
 
     this.context = {
       api: this,
@@ -356,13 +367,14 @@ class Ceramic implements CeramicApi {
       anchorService = networkOptions.name != Networks.INMEMORY ? new EthereumAnchorService(anchorServiceUrl, ethereumRpcUrl, logger) : new InMemoryAnchorService(config as any)
     }
 
-
     const pinStoreOptions = {
       networkName: networkOptions.name,
       stateStoreDirectory: config.stateStoreDirectory,
       pinningEndpoints: config.ipfsPinningEndpoints,
       pinningBackends: config.pinningBackends,
     }
+
+    const syncOptions = config.sync ? { sync: config.sync } : {}
 
     const streamCacheLimit = config.streamCacheLimit ?? DEFAULT_CACHE_LIMIT
     const concurrentRequestsLimit = config.concurrentRequestsLimit ?? streamCacheLimit
@@ -376,6 +388,7 @@ class Ceramic implements CeramicApi {
       disableAnchors: config.disableAnchors,
       networkOptions,
       validateStreams: config.validateStreams ?? true,
+      syncOptions
     }
 
     const modules = {
@@ -475,7 +488,7 @@ class Ceramic implements CeramicApi {
    * @param opts - Initialization options
    */
   async applyCommit<T extends Stream>(streamId: string | StreamID, commit: CeramicCommit, opts: CreateOpts | UpdateOpts = {}): Promise<T> {
-    opts = { ...DEFAULT_APPLY_COMMIT_OPTS, ...opts };
+    opts = { ...DEFAULT_APPLY_COMMIT_OPTS, ...opts, ...this._syncOptions};
     const state$ = await this.repository.stateManager.applyCommit(normalizeStreamID(streamId), commit, opts as CreateOpts)
     return streamFromState<T>(this.context, this._streamHandlers, state$.value, this.repository.updates$)
   }
@@ -487,7 +500,7 @@ class Ceramic implements CeramicApi {
    * @param opts - Initialization options
    */
   async createStreamFromGenesis<T extends Stream>(type: number, genesis: any, opts: CreateOpts = {}): Promise<T> {
-    opts = { ...DEFAULT_CREATE_FROM_GENESIS_OPTS, ...opts };
+    opts = { ...DEFAULT_CREATE_FROM_GENESIS_OPTS, ...opts, ...this._syncOptions};
     const genesisCid = await this.dispatcher.storeCommit(genesis);
     const streamId = new StreamID(type, genesisCid);
     const state$ = await this.repository.applyCreateOpts(streamId, opts);
@@ -500,7 +513,7 @@ class Ceramic implements CeramicApi {
    * @param opts - Initialization options
    */
   async loadStream<T extends Stream>(streamId: StreamID | CommitID | string, opts: LoadOpts = {}): Promise<T> {
-    opts = { ...DEFAULT_LOAD_OPTS, ...opts };
+    opts = { ...DEFAULT_LOAD_OPTS, ...opts, ...this._syncOptions};
     const streamRef = StreamRef.from(streamId)
     if (CommitID.isInstance(streamRef)) {
       const snapshot$ = await this.repository.loadAtCommit(streamRef, opts);


### PR DESCRIPTION
Adds to cli following options: 
--no-restore-streams
--sync    "prefer-cache", "sync-always", or "never-sync"

Adds syncOptions to core, which will force sync option on all requests 

Both these options are required for gateway, but also could have been passed with env vars.

TODO:

Probably make sense to split sync options into something like Default Sync Options and Global Sync Options (or other names). Where default is fallback, given individual call does not include option, while global is a force/override. This would also allow this option to be added to http client with consistency (not added now). Where default is more useful for http client (likely no use case for global), and core/daemon will often use either one. 

Another note, all these boolean options dont behave as expected, or as we use them in terraform. Ie --log-to-files --debug etc. Any of these options when given any value return true. `ceramic daemon --log-to-files false` will set log to files true. 

Reason why --no-restore-streams (vs restore-streams) is used here for consistency, but can also change all these booleans to strings, to accept true/false values, rather than just flag. Might be breaking though if any one just using flag without value, but didnt check behavior, should be able to implement anyways. 
