### PR TITLE
chore(common): Remove 'ceramic' handle from AnchorService

### DIFF
--- a/packages/common/src/anchor-service.ts
+++ b/packages/common/src/anchor-service.ts
@@ -53,13 +53,6 @@ export interface AnchorService {
   init(): Promise<void>;
 
   /**
-   * Set Ceramic API instance
-   *
-   * @param ceramic - Ceramic API used for various purposes
-   */
-  ceramic: CeramicApi;
-
-  /**
    * URL of the connected anchor service
    */
   url: string;

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -86,7 +86,7 @@ describe('Ceramic integration', () => {
 
   it('cannot create Ceramic instance on network not supported by our anchor service', async () => {
     const [modules, params] = await Ceramic._processConfig(ipfs1, {networkName: 'local'});
-    modules.anchorService = new InMemoryAnchorService({})
+    modules.anchorService = new InMemoryAnchorService({}, modules.dispatcher, modules.loggerProvider.getDiagnosticsLogger())
     const ceramic = new Ceramic(modules, params)
     await expect(ceramic._init(false, false)).rejects.toThrow(
         "No usable chainId for anchoring was found.  The ceramic network 'local' supports the chains: ['eip155:1337'], but the configured anchor service '<inmemory>' only supports the chains: ['inmemory:12345']")

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -72,15 +72,6 @@ export default class EthereumAnchorService implements AnchorService {
     this._logger = logger
   }
 
-  /**
-   * Set Ceramic API instance
-   *
-   * @param ceramic - Ceramic API used for various purposes
-   */
-  set ceramic(ceramic: CeramicApi) {
-    // Do Nothing
-  }
-
   get url() {
     return this.anchorServiceUrl
   }

--- a/packages/core/src/anchor/memory/in-memory-anchor-service.ts
+++ b/packages/core/src/anchor/memory/in-memory-anchor-service.ts
@@ -58,10 +58,12 @@ class InMemoryAnchorService implements AnchorService {
 
   #queue: Candidate[] = [];
 
-  constructor(_config: InMemoryAnchorConfig) {
+  constructor(_config: InMemoryAnchorConfig, dispathcer: Dispatcher, logger: DiagnosticsLogger) {
     this.#anchorDelay = _config?.anchorDelay ?? 0;
     this.#anchorOnRequest = _config?.anchorOnRequest ?? true;
     this.#verifySignatures = _config?.verifySignatures ?? true;
+    this.#dispatcher = dispathcer
+    this.#logger = logger
 
     // Remember the most recent AnchorServiceResponse for each anchor request
     this.#feed.subscribe(asr => this.#anchors.set(asr.cid.toString(), asr))
@@ -215,17 +217,6 @@ class InMemoryAnchorService implements AnchorService {
       history.push(prevCommitId);
       currentCommitId = prevCommitId;
     }
-  }
-
-  /**
-   * Set Ceramic API instance
-   *
-   * @param ceramic - Ceramic API used for various purposes
-   */
-  set ceramic(ceramic: Ceramic) {
-    this.#ceramic = ceramic;
-    this.#dispatcher = this.#ceramic.dispatcher;
-    this.#logger = this.#ceramic?.context?.loggerProvider.getDiagnosticsLogger();
   }
 
   get url() {


### PR DESCRIPTION
This eliminates a circular dependency between 'AnchorService' and 'Ceramic'