### PR TITLE
feat(core): Split AnchorService from AnchorValidator

### DIFF
--- a/packages/common/src/anchor-service.ts
+++ b/packages/common/src/anchor-service.ts
@@ -80,14 +80,25 @@ export interface AnchorService {
   pollForAnchorResponse(streamId: StreamID, tip: CID): Observable<AnchorServiceResponse>;
 
   /**
-   * Validate anchor proof commit
-   * @param anchorProof - Proof of blockchain inclusion
-   */
-  validateChainInclusion(anchorProof: AnchorProof): Promise<void>;
-
-  /**
    * @returns An array of the CAIP-2 chain IDs of the blockchains that are supported by this
    * anchor service.
    */
   getSupportedChains(): Promise<Array<string>>;
+}
+
+/**
+ * Describes behavior for validation anchor commit inclusion on chain
+ */
+export interface AnchorValidator {
+  /**
+   * Performs whatever initialization work is required to validate commits anchored on the
+   * configured blockchain.
+   */
+  init(chainId: string | null): Promise<void>;
+
+  /**
+   * Validate anchor proof commit
+   * @param anchorProof - Proof of blockchain inclusion
+   */
+  validateChainInclusion(anchorProof: AnchorProof): Promise<void>;
 }

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -1,10 +1,7 @@
 import CID from "cids"
-import * as uint8arrays from 'uint8arrays'
-import { decode } from "multihashes"
 import * as providers from "@ethersproject/providers"
 import { LRUMap } from 'lru_map';
 import {
-  AnchorProof,
   CeramicApi,
   AnchorServiceResponse,
   AnchorService,
@@ -15,7 +12,6 @@ import {
 import StreamID from "@ceramicnetwork/streamid";
 import { Observable, interval, from, concat, of } from "rxjs";
 import { concatMap, catchError, map } from "rxjs/operators";
-import {Block, TransactionResponse } from "@ethersproject/providers"
 
 /**
  * CID-streamId pair
@@ -29,28 +25,6 @@ const POLL_INTERVAL = 60000 // 60 seconds
 const MAX_POLL_TIME = 86400000 // 24 hours
 
 /**
- * Ethereum network configuration
- */
-interface EthNetwork {
-    network: string
-    chain: string
-    chainId: number
-    networkId: number
-    type: string
-}
-
-/**
- * Maps some of Ethereum chain IDs to network configuration
- */
-const ETH_CHAIN_ID_MAPPINGS: Record<string, EthNetwork> = {
-    "eip155:1": { network: "mainnet", chain: "ETH", chainId: 1, networkId: 1, type: "Production" },
-    "eip155:3": { network: "ropsten", chain: "ETH", chainId: 3, networkId: 3, type: "Test" },
-}
-
-const BASE_CHAIN_ID = "eip155"
-const MAX_PROVIDERS_COUNT = 100
-
-/**
  * Ethereum anchor service that stores root CIDs on Ethereum blockchain
  */
 export default class EthereumAnchorService implements AnchorService {
@@ -62,13 +36,11 @@ export default class EthereumAnchorService implements AnchorService {
 
   /**
    * @param anchorServiceUrl
-   * @param ethereumRpcEndpoint
    */
-  constructor(readonly anchorServiceUrl: string, readonly ethereumRpcEndpoint: string, logger: DiagnosticsLogger) {
+  constructor(readonly anchorServiceUrl: string, logger: DiagnosticsLogger) {
     this.requestsApiEndpoint = this.anchorServiceUrl + "/api/v0/requests";
     this.chainIdApiEndpoint =
       this.anchorServiceUrl + "/api/v0/service-info/supported_chains";
-    this.providersCache = new LRUMap(MAX_PROVIDERS_COUNT)
     this._logger = logger
   }
 
@@ -92,14 +64,6 @@ export default class EthereumAnchorService implements AnchorService {
         throw new Error("Anchor service returned multiple supported chains, which isn't supported by js-ceramic yet")
     }
     this._chainId = response.supportedChains[0]
-
-    // Confirm that we have an eth provider that works for the same chain that the anchor service supports
-    const provider = this._getEthProvider(this._chainId)
-    const provider_chain_idnum = (await provider.getNetwork()).chainId
-    const provider_chain = BASE_CHAIN_ID + ':' + provider_chain_idnum
-    if (this._chainId != provider_chain) {
-        throw new Error(`Configured eth provider is for chainId ${provider_chain}, but our anchor service uses chain ${this._chainId}`)
-    }
   }
 
   /**
@@ -190,112 +154,6 @@ export default class EthereumAnchorService implements AnchorService {
         }
       })
     );
-  }
-
-  /**
-   * Given a chainId and a transaction hash, loads information from ethereum about the transaction
-   * and block the transaction was included in.
-   * Testing has shown that when no ethereumRpcEndpoint has been provided and we are therefore using
-   * the ethersproject's defaultProvider, we sometimes get back null for the transaction or block,
-   * so this function also includes some extra error handling and throws exceptions with a warning
-   * to use an actual ethereum rpc endpoint if the above behavior is seen.
-   * @param chainId
-   * @param txHash
-   * @private
-   */
-  private async _getTransactionAndBlockInfo(chainId: string, txHash: string): Promise<[TransactionResponse, Block]> {
-    try {
-      // determine network based on a chain ID
-      const provider: providers.BaseProvider = this._getEthProvider(chainId);
-      const transaction = await provider.getTransaction(txHash);
-
-      if (!transaction) {
-        if (!this.ethereumRpcEndpoint) {
-          throw new Error(`Failed to load transaction data for transaction ${txHash}. Try providing an ethereum rpc endpoint`)
-        } else {
-          throw new Error(`Failed to load transaction data for transaction ${txHash}`)
-        }
-      }
-      const block = await provider.getBlock(transaction.blockHash);
-      if (!block) {
-        if (!this.ethereumRpcEndpoint) {
-          throw new Error(`Failed to load transaction data for block with block number ${transaction.blockNumber} and block hash ${transaction.blockHash}. Try providing an ethereum rpc endpoint`)
-        } else {
-          throw new Error(`Failed to load transaction data for block with block number ${transaction.blockNumber} and block hash ${transaction.blockHash}`)
-        }
-      }
-      return [transaction, block]
-    } catch (e) {
-      this._logger.err(`Error loading transaction info for transaction ${txHash} from Ethereum: ${e}`)
-      throw e
-    }
-  }
-
-  /**
-   * Validate anchor proof on the chain
-   * @param anchorProof - Anchor proof instance
-   */
-  async validateChainInclusion(anchorProof: AnchorProof): Promise<void> {
-    const decoded = decode(anchorProof.txHash.multihash);
-    const txHash = "0x" + uint8arrays.toString(decoded.digest, "base16");
-
-    const [transaction, block] = await this._getTransactionAndBlockInfo(anchorProof.chainId, txHash)
-    const txValueHexNumber = parseInt(transaction.data, 16);
-    const rootValueHexNumber = parseInt(
-      "0x" + anchorProof.root.toBaseEncodedString("base16"),
-      16
-    );
-
-    if (txValueHexNumber !== rootValueHexNumber) {
-      throw new Error(
-        `The root CID ${anchorProof.root.toString()} is not in the transaction`
-      );
-    }
-
-    if (anchorProof.blockNumber !== transaction.blockNumber) {
-      throw new Error(`Block numbers are not the same. AnchorProof blockNumber: ${anchorProof.blockNumber}, eth txn blockNumber: ${transaction.blockNumber}`);
-    }
-
-    if (anchorProof.blockTimestamp !== block.timestamp) {
-      throw new Error(`Block timestamps are not the same. AnchorProof blockTimestamp: ${anchorProof.blockTimestamp}, eth txn blockTimestamp: ${block.timestamp}`);
-    }
-  }
-
-  /**
-   * Gets Ethereum provider based on chain ID
-   * @param chain - CAIP-2 Chain ID
-   * @private
-   */
-  private _getEthProvider(chain: string): providers.BaseProvider {
-    const fromCache = this.providersCache.get(chain);
-    if (fromCache) return fromCache;
-
-    if (!chain.startsWith("eip155")) {
-      throw new Error(
-        `Unsupported chainId '${chain}' - must be eip155 namespace`
-      );
-    }
-
-    if (this._chainId != chain) {
-      throw new Error(
-        `Unsupported chainId '${chain}'. Configured anchor service only supports '${this._chainId}'`
-      );
-    }
-
-    if (this.ethereumRpcEndpoint) {
-      const provider = new providers.JsonRpcProvider(this.ethereumRpcEndpoint);
-      this.providersCache.set(chain, provider);
-      return provider;
-    }
-
-    const ethNetwork: EthNetwork = ETH_CHAIN_ID_MAPPINGS[chain];
-    if (ethNetwork == null) {
-      throw new Error(`No ethereum provider available for chainId ${chain}`);
-    }
-
-    const provider = providers.getDefaultProvider(ethNetwork.network);
-    this.providersCache.set(chain, provider);
-    return provider;
   }
 
   /**

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
@@ -1,0 +1,176 @@
+import * as uint8arrays from 'uint8arrays'
+import { decode } from "multihashes"
+import * as providers from "@ethersproject/providers"
+import { LRUMap } from 'lru_map';
+import {
+  AnchorProof,
+  AnchorValidator,
+  DiagnosticsLogger,
+  fetchJson,
+} from "@ceramicnetwork/common";
+import {Block, TransactionResponse } from "@ethersproject/providers"
+
+
+/**
+ * Ethereum network configuration
+ */
+interface EthNetwork {
+    network: string
+    chain: string
+    chainId: number
+    networkId: number
+    type: string
+}
+
+/**
+ * Maps some of Ethereum chain IDs to network configuration
+ */
+const ETH_CHAIN_ID_MAPPINGS: Record<string, EthNetwork> = {
+    "eip155:1": { network: "mainnet", chain: "ETH", chainId: 1, networkId: 1, type: "Production" },
+    "eip155:3": { network: "ropsten", chain: "ETH", chainId: 3, networkId: 3, type: "Test" },
+}
+
+const BASE_CHAIN_ID = "eip155"
+const MAX_PROVIDERS_COUNT = 100
+
+/**
+ * Ethereum anchor service that stores root CIDs on Ethereum blockchain
+ */
+export default class EthereumAnchorValidator implements AnchorValidator {
+  private _chainId: string | null;
+  private readonly providersCache: LRUMap<string, providers.BaseProvider>
+  private readonly _logger: DiagnosticsLogger
+
+  /**
+   * @param ethereumRpcEndpoint
+   * @param logger
+   */
+  constructor(readonly ethereumRpcEndpoint: string, logger: DiagnosticsLogger) {
+    this.providersCache = new LRUMap(MAX_PROVIDERS_COUNT)
+    this._logger = logger
+  }
+
+
+  /**
+   * @param chainId - Chain ID for ethereum chain that we need to validate, or null. If null, then
+   *   the `ethereumRpcEndpoint` needs to be chain-id specific so there's no ambiguity as to
+   *   which chain we are operating with.
+   */
+  async init(chainId: string | null): Promise<void> {
+    // Confirm that we have an eth provider that works for the same chain that the anchor service supports (if given)
+    const provider = this._getEthProvider(this._chainId)
+    const provider_chain_idnum = (await provider.getNetwork()).chainId
+    const provider_chain = BASE_CHAIN_ID + ':' + provider_chain_idnum
+    if (this._chainId && this._chainId != provider_chain) {
+        throw new Error(`Configured eth provider is for chainId ${provider_chain}, but our anchor service uses chain ${this._chainId}`)
+    }
+  }
+
+  /**
+   * Given a chainId and a transaction hash, loads information from ethereum about the transaction
+   * and block the transaction was included in.
+   * Testing has shown that when no ethereumRpcEndpoint has been provided and we are therefore using
+   * the ethersproject's defaultProvider, we sometimes get back null for the transaction or block,
+   * so this function also includes some extra error handling and throws exceptions with a warning
+   * to use an actual ethereum rpc endpoint if the above behavior is seen.
+   * @param chainId
+   * @param txHash
+   * @private
+   */
+  private async _getTransactionAndBlockInfo(chainId: string, txHash: string): Promise<[TransactionResponse, Block]> {
+    try {
+      // determine network based on a chain ID
+      const provider: providers.BaseProvider = this._getEthProvider(chainId);
+      const transaction = await provider.getTransaction(txHash);
+
+      if (!transaction) {
+        if (!this.ethereumRpcEndpoint) {
+          throw new Error(`Failed to load transaction data for transaction ${txHash}. Try providing an ethereum rpc endpoint`)
+        } else {
+          throw new Error(`Failed to load transaction data for transaction ${txHash}`)
+        }
+      }
+      const block = await provider.getBlock(transaction.blockHash);
+      if (!block) {
+        if (!this.ethereumRpcEndpoint) {
+          throw new Error(`Failed to load transaction data for block with block number ${transaction.blockNumber} and block hash ${transaction.blockHash}. Try providing an ethereum rpc endpoint`)
+        } else {
+          throw new Error(`Failed to load transaction data for block with block number ${transaction.blockNumber} and block hash ${transaction.blockHash}`)
+        }
+      }
+      return [transaction, block]
+    } catch (e) {
+      this._logger.err(`Error loading transaction info for transaction ${txHash} from Ethereum: ${e}`)
+      throw e
+    }
+  }
+
+  /**
+   * Validate anchor proof on the chain
+   * @param anchorProof - Anchor proof instance
+   */
+  async validateChainInclusion(anchorProof: AnchorProof): Promise<void> {
+    const decoded = decode(anchorProof.txHash.multihash);
+    const txHash = "0x" + uint8arrays.toString(decoded.digest, "base16");
+
+    const [transaction, block] = await this._getTransactionAndBlockInfo(anchorProof.chainId, txHash)
+    const txValueHexNumber = parseInt(transaction.data, 16);
+    const rootValueHexNumber = parseInt(
+      "0x" + anchorProof.root.toBaseEncodedString("base16"),
+      16
+    );
+
+    if (txValueHexNumber !== rootValueHexNumber) {
+      throw new Error(
+        `The root CID ${anchorProof.root.toString()} is not in the transaction`
+      );
+    }
+
+    if (anchorProof.blockNumber !== transaction.blockNumber) {
+      throw new Error(`Block numbers are not the same. AnchorProof blockNumber: ${anchorProof.blockNumber}, eth txn blockNumber: ${transaction.blockNumber}`);
+    }
+
+    if (anchorProof.blockTimestamp !== block.timestamp) {
+      throw new Error(`Block timestamps are not the same. AnchorProof blockTimestamp: ${anchorProof.blockTimestamp}, eth txn blockTimestamp: ${block.timestamp}`);
+    }
+  }
+
+  /**
+   * Gets Ethereum provider based on chain ID
+   * @param chain - CAIP-2 Chain ID
+   * @private
+   */
+  private _getEthProvider(chain: string): providers.BaseProvider {
+    const fromCache = this.providersCache.get(chain);
+    if (fromCache) return fromCache;
+
+    if (chain) {
+      if (!chain.startsWith("eip155")) {
+        throw new Error(
+          `Unsupported chainId '${chain}' - must be eip155 namespace`
+        );
+      }
+
+      if (this._chainId && this._chainId != chain) {
+        throw new Error(
+          `Unsupported chainId '${chain}'. Configured anchor service only supports '${this._chainId}'`
+        );
+      }
+    }
+
+    if (this.ethereumRpcEndpoint) {
+      const provider = new providers.JsonRpcProvider(this.ethereumRpcEndpoint);
+      this.providersCache.set(chain, provider);
+      return provider;
+    }
+
+    const ethNetwork: EthNetwork = ETH_CHAIN_ID_MAPPINGS[chain];
+    if (ethNetwork == null) {
+      throw new Error(`No ethereum provider available for chainId ${chain}`);
+    }
+
+    const provider = providers.getDefaultProvider(ethNetwork.network);
+    this.providersCache.set(chain, provider);
+    return provider;
+  }
+}

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
@@ -57,11 +57,15 @@ export default class EthereumAnchorValidator implements AnchorValidator {
    *   which chain we are operating with.
    */
   async init(chainId: string | null): Promise<void> {
+    if (!chainId) {
+      return
+    }
+
     // Confirm that we have an eth provider that works for the same chain that the anchor service supports (if given)
     const provider = this._getEthProvider(this._chainId)
     const provider_chain_idnum = (await provider.getNetwork()).chainId
     const provider_chain = BASE_CHAIN_ID + ':' + provider_chain_idnum
-    if (this._chainId && this._chainId != provider_chain) {
+    if (this._chainId != provider_chain) {
         throw new Error(`Configured eth provider is for chainId ${provider_chain}, but our anchor service uses chain ${this._chainId}`)
     }
   }
@@ -144,18 +148,16 @@ export default class EthereumAnchorValidator implements AnchorValidator {
     const fromCache = this.providersCache.get(chain);
     if (fromCache) return fromCache;
 
-    if (chain) {
-      if (!chain.startsWith("eip155")) {
-        throw new Error(
-          `Unsupported chainId '${chain}' - must be eip155 namespace`
-        );
-      }
+    if (!chain.startsWith("eip155")) {
+      throw new Error(
+        `Unsupported chainId '${chain}' - must be eip155 namespace`
+      );
+    }
 
-      if (this._chainId && this._chainId != chain) {
-        throw new Error(
-          `Unsupported chainId '${chain}'. Configured anchor service only supports '${this._chainId}'`
-        );
-      }
+    if (this._chainId && this._chainId != chain) {
+      throw new Error(
+        `Unsupported chainId '${chain}'. Configured anchor service only supports '${this._chainId}'`
+      );
     }
 
     if (this.ethereumRpcEndpoint) {

--- a/packages/core/src/anchor/memory/in-memory-anchor-service.ts
+++ b/packages/core/src/anchor/memory/in-memory-anchor-service.ts
@@ -7,6 +7,7 @@ import {
   AnchorStatus,
   StreamUtils,
   AnchorServiceResponse,
+  AnchorValidator,
 } from "@ceramicnetwork/common";
 
 import type { Dispatcher } from "../../dispatcher";
@@ -43,7 +44,7 @@ const SAMPLE_ETH_TX_HASH =
 /**
  * In-memory anchor service - used locally, not meant to be used in production code
  */
-class InMemoryAnchorService implements AnchorService {
+class InMemoryAnchorService implements AnchorService, AnchorValidator {
   #ceramic: Ceramic;
   #dispatcher: Dispatcher;
   #logger: DiagnosticsLogger;

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -19,7 +19,7 @@ import {
   LoggerProvider,
   Networks,
   UpdateOpts,
-  SyncOptions,
+  SyncOptions, AnchorValidator,
 } from "@ceramicnetwork/common"
 
 import { DID } from 'dids'
@@ -37,6 +37,7 @@ import { FauxStateValidation, RealStateValidation, StateValidation } from './sta
 import { streamFromState } from './state-management/stream-from-state';
 import { ConflictResolution } from './conflict-resolution';
 import { RunningState } from './state-management/running-state';
+import EthereumAnchorValidator from "./anchor/ethereum/ethereum-anchor-validator";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageJson = require('../package.json')
@@ -102,7 +103,8 @@ export interface CeramicConfig {
  * `CeramicConfig` via `Ceramic.create()`.
  */
 export interface CeramicModules {
-  anchorService: AnchorService,
+  anchorService: AnchorService | null,
+  anchorValidator: AnchorValidator,
   dispatcher: Dispatcher,
   ipfs: IpfsApi,
   ipfsTopology: IpfsTopology,
@@ -165,6 +167,7 @@ class Ceramic implements CeramicApi {
   readonly repository: Repository;
 
   readonly _streamHandlers: HandlersMap
+  private readonly _anchorValidator: AnchorValidator
   private readonly _disableAnchors: boolean
   private readonly _ipfsTopology: IpfsTopology
   private readonly _logger: DiagnosticsLogger
@@ -180,6 +183,7 @@ class Ceramic implements CeramicApi {
     this.repository = modules.repository
     this.dispatcher = modules.dispatcher
     this.pin = this._buildPinApi()
+    this._anchorValidator = modules.anchorValidator
 
     this._disableAnchors = params.disableAnchors
     this._networkOptions = params.networkOptions
@@ -200,7 +204,7 @@ class Ceramic implements CeramicApi {
     // This initialization block below has to be redone.
     // Things below should be passed here as `modules` variable.
     this.stateValidation = this._validateStreams ? new RealStateValidation(this.loadStream.bind(this)) : new FauxStateValidation()
-    const conflictResolution = new ConflictResolution(modules.anchorService, this.stateValidation, this.dispatcher, this.context, this._streamHandlers)
+    const conflictResolution = new ConflictResolution(modules.anchorValidator, this.stateValidation, this.dispatcher, this.context, this._streamHandlers)
     const pinStore = modules.pinStoreFactory.createPinStore()
     this.repository.setDeps({
       dispatcher: this.dispatcher,
@@ -348,12 +352,20 @@ class Ceramic implements CeramicApi {
       logger.warn(`Starting without a configured anchor service. All anchor requests will fail.`)
     } else {
       const anchorServiceUrl = config.anchorServiceUrl || DEFAULT_ANCHOR_SERVICE_URLS[networkOptions.name]
-      let ethereumRpcUrl = config.ethereumRpcUrl
-      if (!ethereumRpcUrl && networkOptions.name == Networks.LOCAL) {
-        ethereumRpcUrl = DEFAULT_LOCAL_ETHEREUM_RPC
-      }
 
-      anchorService = networkOptions.name != Networks.INMEMORY ? new EthereumAnchorService(anchorServiceUrl, ethereumRpcUrl, logger) : new InMemoryAnchorService(config as any)
+      anchorService = networkOptions.name != Networks.INMEMORY ? new EthereumAnchorService(anchorServiceUrl, logger) : new InMemoryAnchorService(config as any)
+    }
+
+    let ethereumRpcUrl = config.ethereumRpcUrl
+    if (!ethereumRpcUrl && networkOptions.name == Networks.LOCAL) {
+      ethereumRpcUrl = DEFAULT_LOCAL_ETHEREUM_RPC
+    }
+    let anchorValidator
+    if (networkOptions.name == Networks.INMEMORY) {
+      // Just use the InMemoryAnchorService as the AnchorValidator
+      anchorValidator = anchorService
+    } else {
+      anchorValidator = new EthereumAnchorValidator(ethereumRpcUrl, logger)
     }
 
 
@@ -380,6 +392,7 @@ class Ceramic implements CeramicApi {
 
     const modules = {
       anchorService,
+      anchorValidator,
       dispatcher,
       ipfs,
       ipfsTopology,
@@ -447,6 +460,8 @@ class Ceramic implements CeramicApi {
       await this._loadSupportedChains()
       this._logger.imp(`Connected to anchor service '${this.context.anchorService.url}' with supported anchor chains ['${this._supportedChains.join("','")}']`)
     }
+
+    await this._anchorValidator.init(this._supportedChains[0])
 
     if (restoreStreams) {
       this.restoreStreams()

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -461,7 +461,7 @@ class Ceramic implements CeramicApi {
       this._logger.imp(`Connected to anchor service '${this.context.anchorService.url}' with supported anchor chains ['${this._supportedChains.join("','")}']`)
     }
 
-    await this._anchorValidator.init(this._supportedChains[0])
+    await this._anchorValidator.init(this._supportedChains ? this._supportedChains[0] : null)
 
     if (restoreStreams) {
       this.restoreStreams()

--- a/packages/core/src/conflict-resolution.ts
+++ b/packages/core/src/conflict-resolution.ts
@@ -10,7 +10,7 @@ import {
   StreamStateHolder,
   Stream,
   StreamHandler,
-  StreamUtils,
+  StreamUtils, AnchorValidator,
 } from '@ceramicnetwork/common';
 import { Dispatcher } from './dispatcher';
 import cloneDeep from 'lodash.clonedeep';
@@ -22,12 +22,12 @@ import { HandlersMap } from './handlers-map';
  * Verifies anchor commit structure
  *
  * @param dispatcher - To get raw blob from IPFS
- * @param anchorService - AnchorService to verify chain inclusion
+ * @param anchorValidator - AnchorValidator to verify chain inclusion
  * @param commit - Anchor commit
  */
 async function verifyAnchorCommit(
   dispatcher: Dispatcher,
-  anchorService: AnchorService,
+  anchorValidator: AnchorValidator,
   commit: AnchorCommit,
 ): Promise<AnchorProof> {
   const proofCID = commit.proof;
@@ -55,7 +55,7 @@ async function verifyAnchorCommit(
     );
   }
 
-  await anchorService.validateChainInclusion(proof);
+  await anchorValidator.validateChainInclusion(proof);
   return proof;
 }
 
@@ -221,7 +221,7 @@ export function commitAtTime(stateHolder: StreamStateHolder, timestamp: number):
 
 export class ConflictResolution {
   constructor(
-    public anchorService: AnchorService,
+    public anchorValidator: AnchorValidator,
     private readonly stateValidation: StateValidation,
     private readonly dispatcher: Dispatcher,
     private readonly context: Context,
@@ -252,7 +252,7 @@ export class ConflictResolution {
       if (payload.proof) {
         // it's an anchor commit
         // TODO: Anchor validation should be done by the StreamHandler as part of applying the anchor commit
-        await verifyAnchorCommit(this.dispatcher, this.anchorService, commit);
+        await verifyAnchorCommit(this.dispatcher, this.anchorValidator, commit);
         state = await handler.applyCommit(commit, cid, this.context, state);
       } else {
         // it's a signed commit

--- a/packages/stream-caip10-link-handler/src/caip10-link-handler.ts
+++ b/packages/stream-caip10-link-handler/src/caip10-link-handler.ts
@@ -144,13 +144,6 @@ export class Caip10LinkHandler implements StreamHandler<Caip10Link> {
         // TODO: Assert that the 'prev' of the commit being applied is the end of the log in 'state'
         const proof = (await context.ipfs.dag.get(commit.proof, { timeout: IPFS_GET_TIMEOUT })).value;
 
-        const supportedChains = await context.api.getSupportedChains()
-        if (!supportedChains.includes(proof.chainId)) {
-            throw new Error("Anchor proof chainId '" + proof.chainId
-                + "' is not supported. Supported chains are: '"
-                + supportedChains.join("', '") + "'")
-        }
-
         state.log.push({ cid, type: CommitType.ANCHOR })
         let content = state.content
         if (state.next?.content) {

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -137,13 +137,6 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
         // TODO: Assert that the 'prev' of the commit being applied is the end of the log in 'state'
         const proof = (await context.ipfs.dag.get(commit.proof, { timeout: IPFS_GET_TIMEOUT })).value;
 
-        const supportedChains = await context.api.getSupportedChains()
-        if (!supportedChains.includes(proof.chainId)) {
-            throw new Error("Anchor proof chainId '" + proof.chainId
-                + "' is not supported. Supported chains are: '"
-                + supportedChains.join("', '") + "'")
-        }
-
         state.log.push({ cid, type: CommitType.ANCHOR, timestamp: proof.blockTimestamp })
         let content = state.content
         let metadata = state.metadata


### PR DESCRIPTION
This is important so that Ceramic nodes running with --disableAnchors can still validate AnchorCommits