### PR TITLE
fix(core): Add information for validating transactions on rinkeby

### DIFF
--- a/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
@@ -26,8 +26,9 @@ interface EthNetwork {
  * Maps some of Ethereum chain IDs to network configuration
  */
 const ETH_CHAIN_ID_MAPPINGS: Record<string, EthNetwork> = {
-    "eip155:1": { network: "mainnet", chain: "ETH", chainId: 1, networkId: 1, type: "Production" },
-    "eip155:3": { network: "ropsten", chain: "ETH", chainId: 3, networkId: 3, type: "Test" },
+  "eip155:1": { network: "mainnet", chain: "ETH", chainId: 1, networkId: 1, type: "Production" },
+  "eip155:3": { network: "ropsten", chain: "ETH", chainId: 3, networkId: 3, type: "Test" },
+  "eip155:4": { network: "rinkeby", chain: "ETH", chainId: 4, networkId: 4, type: "Test" },
 }
 
 const BASE_CHAIN_ID = "eip155"


### PR DESCRIPTION
Without this change I get an error when trying to load a stream on dev-unstable that has been anchored against rinkeby.
```
Error loading transaction info for transaction 0xd05dd4d973596d766e9d1f2ae62aa7ca740480c96cd763d48d77cc19b8680518 from Ethereum: Error: No ethereum provider available for chainId eip155:4
Error: No ethereum provider available for chainId eip155:4
```

The fact that we're *not* seeing these errors in the integration tests has me pretty confused as to why not...