### PR TITLE
feat: Drop "created" metadata property from 3id did resolution result

### DIFF
--- a/packages/3id-did-resolver/src/__tests__/vectors.json
+++ b/packages/3id-did-resolver/src/__tests__/vectors.json
@@ -22,7 +22,6 @@
         "didResolutionMetadata":{"contentType":"application/did+json"},
         "didDocument":{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","verificationMethod":[{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#ALmMYTWJ5UKJ4CM","type":"EcdsaSecp256k1Signature2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"xCqJqZeymJunxxLBtPiUrCZDK82qCcJERchhzjoC5aLd"},{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#ybNYrGwCnFBSJza","type":"X25519KeyAgreementKey2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"FdBHiB7JRU5Azf11Pie3EUqoWGTxmNRDfsZFiKbeiwDp"}],"authentication":[{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#ALmMYTWJ5UKJ4CM","type":"EcdsaSecp256k1Signature2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"xCqJqZeymJunxxLBtPiUrCZDK82qCcJERchhzjoC5aLd"}],"keyAgreement":[{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#ybNYrGwCnFBSJza","type":"X25519KeyAgreementKey2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"FdBHiB7JRU5Azf11Pie3EUqoWGTxmNRDfsZFiKbeiwDp"}]},
         "didDocumentMetadata":{
-          "created": "2021-03-16T15:35:10Z",
           "updated": "2021-03-16T15:38:09Z",
           "versionId": "bafyreihlb5brxifcy3eb7v4vqw27r56clvizkt5x5gricdh77w45kwvq4y"
         }
@@ -34,7 +33,6 @@
         "didResolutionMetadata":{"contentType":"application/did+json"},
         "didDocument":{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","verificationMethod":[{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#C5x4WNbgo5r2PbW","type":"EcdsaSecp256k1Signature2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"rQnWFmm6RwydcU9uhRB5A3MSpEPwfe3R8acoPTQioujn"},{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#nsL9o7pTE6wpZ99","type":"X25519KeyAgreementKey2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"GNkmWA7c23heXcViLVQWUH5smc7SPBhBGpQ8xmTR7BNP"}],"authentication":[{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#C5x4WNbgo5r2PbW","type":"EcdsaSecp256k1Signature2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"rQnWFmm6RwydcU9uhRB5A3MSpEPwfe3R8acoPTQioujn"}],"keyAgreement":[{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#nsL9o7pTE6wpZ99","type":"X25519KeyAgreementKey2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"GNkmWA7c23heXcViLVQWUH5smc7SPBhBGpQ8xmTR7BNP"}]},
         "didDocumentMetadata":{
-          "created": "2021-03-16T15:35:10Z",
           "nextUpdate": "2021-03-16T15:35:10Z",
           "nextVersionId": "bafyreie7ova3gtkvkgla6cslvism7kjn4uzhtngahyir5dng2pfa4vouja",
           "versionId": "0"
@@ -47,7 +45,6 @@
         "didResolutionMetadata":{"contentType":"application/did+json"},
         "didDocument":{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","verificationMethod":[{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#7jEnrHWn5h9s1cR","type":"EcdsaSecp256k1Signature2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"prhGKL2DVgPwRnbncSc3jNpXdpiFLZghrvXiUk22eXkh"},{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#DGxmANwF6Zq8hQP","type":"X25519KeyAgreementKey2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"96xrhQ1z2wy8hceh4xfLRmk7YnFWRc6otBfFkdvJRKdd"}],"authentication":[{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#7jEnrHWn5h9s1cR","type":"EcdsaSecp256k1Signature2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"prhGKL2DVgPwRnbncSc3jNpXdpiFLZghrvXiUk22eXkh"}],"keyAgreement":[{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#DGxmANwF6Zq8hQP","type":"X25519KeyAgreementKey2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"96xrhQ1z2wy8hceh4xfLRmk7YnFWRc6otBfFkdvJRKdd"}]},
         "didDocumentMetadata":{
-          "created": "2021-03-16T15:35:10Z",
           "nextUpdate": "2021-03-16T15:38:09Z",
           "nextVersionId": "bafyreihlb5brxifcy3eb7v4vqw27r56clvizkt5x5gricdh77w45kwvq4y",
           "updated": "2021-03-16T15:35:10Z",
@@ -61,7 +58,6 @@
         "didResolutionMetadata":{"contentType":"application/did+json"},
         "didDocument":{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","verificationMethod":[{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#ALmMYTWJ5UKJ4CM","type":"EcdsaSecp256k1Signature2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"xCqJqZeymJunxxLBtPiUrCZDK82qCcJERchhzjoC5aLd"},{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#ybNYrGwCnFBSJza","type":"X25519KeyAgreementKey2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"FdBHiB7JRU5Azf11Pie3EUqoWGTxmNRDfsZFiKbeiwDp"}],"authentication":[{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#ALmMYTWJ5UKJ4CM","type":"EcdsaSecp256k1Signature2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"xCqJqZeymJunxxLBtPiUrCZDK82qCcJERchhzjoC5aLd"}],"keyAgreement":[{"id":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy#ybNYrGwCnFBSJza","type":"X25519KeyAgreementKey2019","controller":"did:3:bafyreifggosi6ia5qksm2couvprbvq2h3jltjfn4qrcoio63fwitpivvmy","publicKeyBase58":"FdBHiB7JRU5Azf11Pie3EUqoWGTxmNRDfsZFiKbeiwDp"}]},
         "didDocumentMetadata":{
-          "created": "2021-03-16T15:35:10Z",
           "updated": "2021-03-16T15:38:09Z",
           "versionId": "bafyreihlb5brxifcy3eb7v4vqw27r56clvizkt5x5gricdh77w45kwvq4y"
         }
@@ -77,7 +73,6 @@
         "didResolutionMetadata":{"contentType":"application/did+json"},
         "didDocument":{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","verificationMethod":[{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#aH6oxPEu6krriD6","type":"EcdsaSecp256k1Signature2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"eHTnoNWU5ifdTsRoxGi4t13N7xTJx2EZt2dSbm5jeEMN"},{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HWPYEjsV6rz1nB8","type":"X25519KeyAgreementKey2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"5krYs5YM6NX7VPaJ6WdxbJzsLrRAigLEfG2BzeDTJQQN"}],"authentication":[{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#aH6oxPEu6krriD6","type":"EcdsaSecp256k1Signature2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"eHTnoNWU5ifdTsRoxGi4t13N7xTJx2EZt2dSbm5jeEMN"}],"keyAgreement":[{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HWPYEjsV6rz1nB8","type":"X25519KeyAgreementKey2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"5krYs5YM6NX7VPaJ6WdxbJzsLrRAigLEfG2BzeDTJQQN"}]},
         "didDocumentMetadata":{
-          "created": "2021-03-16T10:08:21Z",
           "updated": "2021-03-16T10:11:17Z",
           "versionId": "bafyreigxsxcy6goi2rk6pnjf3ij5quw2re2pmjpnk44bge6bb7a6borzdu"
         }
@@ -89,7 +84,6 @@
         "didResolutionMetadata":{"contentType":"application/did+json"},
         "didDocument":{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","verificationMethod":[{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#8HvzHTqA8yTsXxf","type":"EcdsaSecp256k1Signature2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"mNY41bTaUbzzwqvWcVfKf7qvVcZXxaFQ4Mi2roJLf46w"},{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#LpuhVp4zz6hDB3s","type":"X25519KeyAgreementKey2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"47qi3yn2VAqGeoZr3e6ttrSsVdU7LjekpX6PWXTAVoH7"}],"authentication":[{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#8HvzHTqA8yTsXxf","type":"EcdsaSecp256k1Signature2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"mNY41bTaUbzzwqvWcVfKf7qvVcZXxaFQ4Mi2roJLf46w"}],"keyAgreement":[{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#LpuhVp4zz6hDB3s","type":"X25519KeyAgreementKey2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"47qi3yn2VAqGeoZr3e6ttrSsVdU7LjekpX6PWXTAVoH7"}]},
         "didDocumentMetadata":{
-          "created": "2021-03-16T10:08:21Z",
           "nextUpdate": "2021-03-16T10:08:21Z",
           "nextVersionId": "bafyreidmpfv7aumgqeqacprb2yv3t7sapsoro6dpopopyxtelknfbxifia",
           "versionId": "0"
@@ -102,7 +96,6 @@
         "didResolutionMetadata":{"contentType":"application/did+json"},
         "didDocument":{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","verificationMethod":[{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HU1DGqXqxA2L4n2","type":"EcdsaSecp256k1Signature2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"m1K5r87rP1JFcNGjzG2xqTPabQbPSjRUHM5jYcUu7avJ"},{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#n7SH4mBgNemdDAQ","type":"X25519KeyAgreementKey2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"CiYaJorrKbRpkqfLcMqhgRCXZD3QeAwHQ63WBv1EuqPe"}],"authentication":[{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HU1DGqXqxA2L4n2","type":"EcdsaSecp256k1Signature2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"m1K5r87rP1JFcNGjzG2xqTPabQbPSjRUHM5jYcUu7avJ"}],"keyAgreement":[{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#n7SH4mBgNemdDAQ","type":"X25519KeyAgreementKey2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"CiYaJorrKbRpkqfLcMqhgRCXZD3QeAwHQ63WBv1EuqPe"}]},
         "didDocumentMetadata":{
-          "created": "2021-03-16T10:08:21Z",
           "nextUpdate": "2021-03-16T10:11:17Z",
           "nextVersionId": "bafyreigxsxcy6goi2rk6pnjf3ij5quw2re2pmjpnk44bge6bb7a6borzdu",
           "updated": "2021-03-16T10:08:21Z",
@@ -116,7 +109,6 @@
         "didResolutionMetadata":{"contentType":"application/did+json"},
         "didDocument":{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","verificationMethod":[{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#aH6oxPEu6krriD6","type":"EcdsaSecp256k1Signature2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"eHTnoNWU5ifdTsRoxGi4t13N7xTJx2EZt2dSbm5jeEMN"},{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HWPYEjsV6rz1nB8","type":"X25519KeyAgreementKey2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"5krYs5YM6NX7VPaJ6WdxbJzsLrRAigLEfG2BzeDTJQQN"}],"authentication":[{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#aH6oxPEu6krriD6","type":"EcdsaSecp256k1Signature2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"eHTnoNWU5ifdTsRoxGi4t13N7xTJx2EZt2dSbm5jeEMN"}],"keyAgreement":[{"id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HWPYEjsV6rz1nB8","type":"X25519KeyAgreementKey2019","controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd","publicKeyBase58":"5krYs5YM6NX7VPaJ6WdxbJzsLrRAigLEfG2BzeDTJQQN"}]},
         "didDocumentMetadata":{
-          "created": "2021-03-16T10:08:21Z",
           "updated": "2021-03-16T10:11:17Z",
           "versionId": "bafyreigxsxcy6goi2rk6pnjf3ij5quw2re2pmjpnk44bge6bb7a6borzdu"
         }

--- a/packages/3id-did-resolver/src/error-representation.ts
+++ b/packages/3id-did-resolver/src/error-representation.ts
@@ -1,0 +1,24 @@
+import type { DIDResolutionMetadata, DIDResolutionResult, WrappedResolver } from 'did-resolver'
+
+/**
+ * Represent error as DID resolution result.
+ */
+export const errorRepresentation = (metadata: DIDResolutionMetadata): DIDResolutionResult => {
+  return {
+    didResolutionMetadata: metadata,
+    didDocument: null,
+    didDocumentMetadata: {},
+  }
+}
+
+/**
+ * Report a thrown error as a DID resolution result.
+ */
+export const withResolutionError = (f: WrappedResolver): Promise<DIDResolutionResult> => {
+  return f().catch((e) =>
+    errorRepresentation({
+      error: 'invalidDid',
+      message: e.toString(),
+    })
+  )
+}

--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -97,11 +97,7 @@ function extractMetadata(
     latestVersionState.log.find(
       ({ timestamp }) => timestamp > updated || (!updated && timestamp)
     ) || {}
-  const created = latestVersionState.log.find(({ timestamp }) => Boolean(timestamp))?.timestamp
 
-  if (created) {
-    metadata.created = formatTime(created)
-  }
   if (updated) {
     metadata.updated = formatTime(updated)
   }

--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -14,6 +14,7 @@ import LegacyResolver from './legacyResolver'
 import * as u8a from 'uint8arrays'
 import { StreamID } from '@ceramicnetwork/streamid'
 import CID from 'cids'
+import { errorRepresentation, withResolutionError } from './error-representation'
 //import dagCBOR from 'ipld-dag-cbor'
 
 const DID_LD_JSON = 'application/did+ld+json'
@@ -203,24 +204,6 @@ const resolve = async (
   }
 }
 
-/**
- * Report a thrown error as a DID resolution result.
- */
-const withResolutionError = (
-  f: () => Promise<DIDResolutionResult>
-): Promise<DIDResolutionResult> => {
-  return f().catch((e) => {
-    return {
-      didResolutionMetadata: {
-        error: 'invalidDid',
-        message: e.toString(),
-      },
-      didDocument: null,
-      didDocumentMetadata: {},
-    }
-  })
-}
-
 export default {
   getResolver: (ceramic: CeramicApi): ResolverRegistry => ({
     '3': (
@@ -232,20 +215,29 @@ export default {
       return withResolutionError(async () => {
         const contentType = options.accept || DID_JSON
         const verNfo = getVersionInfo(parsed.query)
-        const didResult = await (isLegacyDid(parsed.id)
-          ? legacyResolve(ceramic, parsed.id, verNfo)
-          : resolve(ceramic, parsed.id, verNfo))
+        const id = parsed.id
 
-        if (contentType === DID_LD_JSON) {
-          didResult.didDocument['@context'] = 'https://www.w3.org/ns/did/v1'
-          didResult.didResolutionMetadata.contentType = DID_LD_JSON
-        } else if (contentType !== DID_JSON) {
-          didResult.didDocument = null
-          didResult.didDocumentMetadata = {}
-          delete didResult.didResolutionMetadata.contentType
-          didResult.didResolutionMetadata.error = 'representationNotSupported'
+        // application/did+json
+        const didResult = () => {
+          if (isLegacyDid(id)) {
+            return legacyResolve(ceramic, id, verNfo)
+          } else {
+            return resolve(ceramic, id, verNfo)
+          }
         }
-        return didResult
+
+        switch (contentType) {
+          case DID_JSON:
+            return didResult()
+          case DID_LD_JSON: {
+            const result = await didResult()
+            result.didDocument['@context'] = 'https://www.w3.org/ns/did/v1'
+            result.didResolutionMetadata.contentType = DID_LD_JSON
+            return result
+          }
+          default:
+            return errorRepresentation({ error: 'representationNotSupported' })
+        }
       })
     },
   }),


### PR DESCRIPTION
"created" timestamp refers to a time of DID Create Operation. By design of 3id, create operation timestamp could be any time in the past, and there is no way to determine it via anchor commits. An anchor commit is only present after 3id update operation, which is effectively key rotation. So, "created" field has to be removed.