### PR TITLE
feat: Return last anchored state

### DIFF
--- a/packages/3id-did-resolver/src/__tests__/index.test.ts
+++ b/packages/3id-did-resolver/src/__tests__/index.test.ts
@@ -27,6 +27,7 @@ const DID_LD_JSON = 'application/did+ld+json'
 import vectors from './vectors.json'
 
 const v1 = '3IDv1'
+const v1unanchored = '3IDv1-unanchored'
 const v0 = '3IDv0'
 const v0NoUpdates = '3IDv0-no-updates'
 
@@ -60,6 +61,14 @@ describe('3ID DID Resolver', () => {
         const didVTime = vectors[v1].did + query.params[1]
         expect(await resolver.resolve(didVTime)).toEqual(query.result)
       }
+      expect(await resolver.resolve(did, { accept: DID_LD_JSON })).toEqual(toLdFormat(query.result))
+    })
+
+    test.each(vectors[v1unanchored].queries)('resolves unanchored 3id documents correctly %#', async (query) => {
+      const threeIdResolver = ThreeIdResolver.getResolver(ceramic)
+      const resolver = new Resolver(threeIdResolver)
+      const did = vectors[v1unanchored].did + query.params[0]
+      expect(await resolver.resolve(did)).toEqual(query.result)
       expect(await resolver.resolve(did, { accept: DID_LD_JSON })).toEqual(toLdFormat(query.result))
     })
 

--- a/packages/3id-did-resolver/src/__tests__/vectors.json
+++ b/packages/3id-did-resolver/src/__tests__/vectors.json
@@ -64,6 +64,22 @@
       }
     }]
   },
+  "3IDv1-unanchored": {
+    "did": "did:3:kjzl6cwe1jw14ah8wjy8grgzl52sl18sbyirgi9bqy9yzu28kbxvjmhip99r14k",
+    "queries": [
+      {
+        "name": "latest",
+        "params": [
+          ""
+        ],
+        "result": {
+          "didResolutionMetadata": { "contentType": "application/did+json" },
+          "didDocument": { "id": "did:3:kjzl6cwe1jw14ah8wjy8grgzl52sl18sbyirgi9bqy9yzu28kbxvjmhip99r14k", "verificationMethod": [{"id": "did:3:kjzl6cwe1jw14ah8wjy8grgzl52sl18sbyirgi9bqy9yzu28kbxvjmhip99r14k#ALmMYTWJ5UKJ4CM", "type": "EcdsaSecp256k1Signature2019", "controller": "did:3:kjzl6cwe1jw14ah8wjy8grgzl52sl18sbyirgi9bqy9yzu28kbxvjmhip99r14k", "publicKeyBase58": "xCqJqZeymJunxxLBtPiUrCZDK82qCcJERchhzjoC5aLd"}, {"id": "did:3:kjzl6cwe1jw14ah8wjy8grgzl52sl18sbyirgi9bqy9yzu28kbxvjmhip99r14k#ybNYrGwCnFBSJza", "type": "X25519KeyAgreementKey2019", "controller": "did:3:kjzl6cwe1jw14ah8wjy8grgzl52sl18sbyirgi9bqy9yzu28kbxvjmhip99r14k", "publicKeyBase58": "FdBHiB7JRU5Azf11Pie3EUqoWGTxmNRDfsZFiKbeiwDp"}], "authentication": [{"id": "did:3:kjzl6cwe1jw14ah8wjy8grgzl52sl18sbyirgi9bqy9yzu28kbxvjmhip99r14k#ALmMYTWJ5UKJ4CM", "type": "EcdsaSecp256k1Signature2019", "controller": "did:3:kjzl6cwe1jw14ah8wjy8grgzl52sl18sbyirgi9bqy9yzu28kbxvjmhip99r14k", "publicKeyBase58": "xCqJqZeymJunxxLBtPiUrCZDK82qCcJERchhzjoC5aLd"}], "keyAgreement": [{ "id": "did:3:kjzl6cwe1jw14ah8wjy8grgzl52sl18sbyirgi9bqy9yzu28kbxvjmhip99r14k#ybNYrGwCnFBSJza", "type": "X25519KeyAgreementKey2019", "controller": "did:3:kjzl6cwe1jw14ah8wjy8grgzl52sl18sbyirgi9bqy9yzu28kbxvjmhip99r14k", "publicKeyBase58": "FdBHiB7JRU5Azf11Pie3EUqoWGTxmNRDfsZFiKbeiwDp" }]},
+          "didDocumentMetadata": { "updated": "2021-03-16T15:35:10Z", "versionId": "bafyreie7ova3gtkvkgla6cslvism7kjn4uzhtngahyir5dng2pfa4vouja" }
+        }
+      }
+    ]
+  },
   "3IDv1": {
     "did": "did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
     "queries": [{
@@ -272,6 +288,11 @@
       "expectedBody": {"queries":[{"streamId":"kjzl6cwe1jw1490n1846tytf2fypoqb8aokqxl6n0lgyp1undfilllca3ztltho"},{"streamId":"k3y52l7qbv1fry84jsppsl3l75diunv3uzyrjiun7o8omq55y7ic9ljrbweqj5pmo"}]},
       "response": {
         "kjzl6cwe1jw1490n1846tytf2fypoqb8aokqxl6n0lgyp1undfilllca3ztltho":{"type":0,"content":{},"metadata":{"family":"3id","controllers":["did:key:zQ3shcMwX6vEZkhBgM38F4erHWNDfsHQhxtHrJdUDqh515pT2"]},"signature":0,"anchorStatus":"NOT_REQUESTED","log":[{"cid":"bafyreibd3imfprrpgsvm7qciu7pszyaevvy5acg74ksckbfpjkxhqnke3i","type":0}]}
+      }
+    }, {
+      "expectedBody": {"queries":  [{"streamId":"kjzl6cwe1jw14ah8wjy8grgzl52sl18sbyirgi9bqy9yzu28kbxvjmhip99r14k"}]},
+      "response": {
+        "kjzl6cwe1jw14ah8wjy8grgzl52sl18sbyirgi9bqy9yzu28kbxvjmhip99r14k":{"type":0,"content":{"publicKeys":{"ALmMYTWJ5UKJ4CM":"zQ3shi9zKgi8T5x8gD41cGUbXfnvextDoVALmMYTWJ5UKJ4CM","ybNYrGwCnFBSJza":"z6LSrJMTEUvAWvnv63NmvN9zZ54HMR15TybNYrGwCnFBSJza"}}, "next": {"publicKeys":{"aH6oxPEu6krriD6":"zQ3shQEcoeWywQMtWhy7ELMb7hbQomieHEaH6oxPEu6krriD6","HWPYEjsV6rz1nB8":"z6LSgS2iPPMDBqEramx4dA9uuuDMBzxHRHWPYEjsV6rz1nB8"}},"metadata":{"family":"3id","controllers":["did:key:z6Mkte2hed9vh5xaKPhxF8EpA5jj71BF4Gk1efkuRvNPmgRN"]},"signature":2,"anchorStatus":"REQUESTED","log":[{"cid":"bagcqcera2dizthol4rfcrthiampqyyukitekjn67emp7ngs3o4azwqalxn2a","type":0},{"cid":"bagcqcera3jzvu6lfkstkgr5ykabaaikf5uu2dqum4n2q33c2mj4v6byanria","type":1},{"cid":"bafyreie7ova3gtkvkgla6cslvism7kjn4uzhtngahyir5dng2pfa4vouja","type":2,"timestamp":1615908910},{"cid":"bagcqcera4nkr2zsd55zozxllhdoacn7qwz47xj23cecjub3mcrx35uf2zz5q","type":1}]}
       }
     }]
   }

--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -83,16 +83,15 @@ export function wrapDocument(content: any, did: string): DIDDocument | null {
  * Return last anchor log entry, or genesis if no anchors found
  */
 function lastAnchorOrGenesisEntry(log: LogEntry[]): LogEntry {
-  // Genesis
-  if (log.length === 1) {
-    return log[0]
+  // Look for last anchor
+  for (let index = log.length - 1; index >= 0; index--) {
+    const entry = log[index]
+    if (entry.type === CommitType.ANCHOR) {
+      return entry
+    }
   }
-  const last = log[log.length - 1]
-  if (last.type === CommitType.ANCHOR) {
-    return last
-  } else {
-    return lastAnchorOrGenesisEntry(log.slice(0, log.length - 1))
-  }
+  // Genesis, if no anchor present
+  return log[0]
 }
 
 /**

--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -8,13 +8,14 @@ import type {
   ResolverRegistry,
   VerificationMethod,
 } from 'did-resolver'
-import type { StreamState, MultiQuery, CeramicApi } from '@ceramicnetwork/common'
+import type { StreamState, MultiQuery, CeramicApi, LogEntry } from '@ceramicnetwork/common'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 import LegacyResolver from './legacyResolver'
 import * as u8a from 'uint8arrays'
 import { StreamID } from '@ceramicnetwork/streamid'
 import CID from 'cids'
 import { errorRepresentation, withResolutionError } from './error-representation'
+import { CommitType } from '@ceramicnetwork/common'
 //import dagCBOR from 'ipld-dag-cbor'
 
 const DID_LD_JSON = 'application/did+ld+json'
@@ -79,6 +80,23 @@ export function wrapDocument(content: any, did: string): DIDDocument | null {
 }
 
 /**
+ * Return last anchor log entry, or genesis if no anchors found
+ * @param log
+ */
+function lastAnchorOrGenesisEntry(log: LogEntry[]): LogEntry {
+  // Genesis
+  if (log.length === 1) {
+    return log[0]
+  }
+  const last = log[log.length - 1]
+  if (last.type === CommitType.ANCHOR) {
+    return last
+  } else {
+    return lastAnchorOrGenesisEntry(log.slice(0, log.length - 1))
+  }
+}
+
+/**
  * Extracts the DIDDocumentMetadata for the 3ID that we have resolved.
  * Requires the latest version of the 3ID ceramic document state as
  * well as the state of the version we are resolving
@@ -91,7 +109,7 @@ function extractMetadata(
   latestVersionState: StreamState
 ): DIDDocumentMetadata {
   const metadata: DIDDocumentMetadata = {}
-  const { timestamp: updated, cid: versionId } = requestedVersionState.log.pop() || {}
+  const { timestamp: updated, cid: versionId } = lastAnchorOrGenesisEntry(requestedVersionState.log)
 
   const { timestamp: nextUpdate, cid: nextVersionId } =
     latestVersionState.log.find(
@@ -105,7 +123,7 @@ function extractMetadata(
     metadata.nextUpdate = formatTime(nextUpdate)
   }
   if (versionId) {
-    metadata.versionId = requestedVersionState.log.length === 0 ? '0' : versionId?.toString()
+    metadata.versionId = requestedVersionState.log.length === 1 ? '0' : versionId?.toString()
   }
   if (nextVersionId) {
     metadata.nextVersionId = nextVersionId.toString()
@@ -190,7 +208,7 @@ const resolve = async (
     throw new Error(`No resolution for commit ${commitIdStr}`)
   }
 
-  const content = tile.content
+  const content = tile.state.content
   const document = wrapDocument(content, `did:3:${v03ID || didId}`)
 
   return {

--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -81,7 +81,6 @@ export function wrapDocument(content: any, did: string): DIDDocument | null {
 
 /**
  * Return last anchor log entry, or genesis if no anchors found
- * @param log
  */
 function lastAnchorOrGenesisEntry(log: LogEntry[]): LogEntry {
   // Genesis


### PR DESCRIPTION
3id-did-resolver returns now only the latest anchored state, or genesis state for vanilla DID URL like `did:3:foo`. See #1520 