### PR TITLE
feat: Check signature of a lone genesis

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
     "cors": "^2.8.5",
     "dag-jose": "^0.3.0",
     "did-resolver": "^3.1.0",
-    "dids": "^2.2.1",
+    "dids": "^2.3.0",
     "express": "^4.17.1",
     "flat": "^5.0.2",
     "ipfs-http-client": "~50.1.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -45,7 +45,7 @@
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/logfmt": "^1.2.1",
     "@types/node": "^13.13.15",
-    "dids": "^2.2.1",
+    "dids": "^2.3.0",
     "ipfs-core-types": "~0.5.1",
     "json-schema-to-typescript": "^9.1.1",
     "typescript-json-schema": "^0.42.0"

--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -85,6 +85,10 @@ export type CeramicCommit =
 export type CommitMeta = {
   cid: CID
   timestamp?: number
+  /**
+   * Do not time-check a signature.
+   */
+  disableTimecheck?: boolean
 }
 
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "await-semaphore": "^0.1.3",
     "blockcodec-to-ipld-format": "^1.0.0",
     "cids": "~1.1.6",
-    "dids": "^2.2.1",
+    "dids": "^2.3.0",
     "ipld-dag-cbor": "^1.0.0",
     "level-ts": "^2.0.5",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -1,4 +1,10 @@
-import { AnchorStatus, IpfsApi, SignatureStatus, StreamUtils } from '@ceramicnetwork/common'
+import {
+  AnchorStatus,
+  IpfsApi,
+  CommitType,
+  SignatureStatus,
+  StreamUtils,
+} from '@ceramicnetwork/common'
 import CID from 'cids'
 import { RunningState } from '../state-management/running-state'
 import { createIPFS } from './ipfs-util'
@@ -52,7 +58,7 @@ describe('anchor', () => {
 
   afterEach(() => {
     // Restore the _handleTip function in case any of the tests modified it
-    (ceramic.repository.stateManager as any)._handleTip = realHandleTip
+    ;(ceramic.repository.stateManager as any)._handleTip = realHandleTip
   })
 
   test('anchor call', async () => {
@@ -479,7 +485,12 @@ describe('sync', () => {
     ceramic.dispatcher.messageBus.queryNetwork = () => from(response)
     const fakeHandleTip = jest.fn(() => Promise.resolve())
     ;(stateManager as any)._handleTip = fakeHandleTip
-    const state$ = { id: FAKE_STREAM_ID } as unknown as RunningState
+    const state$ = {
+      id: FAKE_STREAM_ID,
+      value: {
+        log: [{ type: CommitType.GENESIS, cid: FAKE_STREAM_ID }],
+      },
+    } as unknown as RunningState
     await stateManager.sync(state$, 1000, false)
     expect(fakeHandleTip).toHaveBeenCalledWith(state$, response[0])
   })
@@ -490,7 +501,12 @@ describe('sync', () => {
     ceramic.dispatcher.messageBus.queryNetwork = () => from(response)
     const fakeHandleTip = jest.fn(() => Promise.resolve())
     ;(stateManager as any)._handleTip = fakeHandleTip
-    const state$ = { id: FAKE_STREAM_ID } as unknown as RunningState
+    const state$ = {
+      id: FAKE_STREAM_ID,
+      value: {
+        log: [{ type: CommitType.GENESIS, cid: FAKE_STREAM_ID }],
+      },
+    } as unknown as RunningState
     await stateManager.sync(state$, 1000, false)
     response.forEach((r) => {
       expect(fakeHandleTip).toHaveBeenCalledWith(state$, r)
@@ -509,7 +525,13 @@ describe('sync', () => {
       )
     const fakeHandleTip = jest.fn(() => Promise.resolve())
     ;(stateManager as any)._handleTip = fakeHandleTip
-    const state$ = { id: FAKE_STREAM_ID } as unknown as RunningState
+    const state$ = {
+      id: FAKE_STREAM_ID,
+      value: {
+        log: [{ type: CommitType.GENESIS, cid: FAKE_STREAM_ID }],
+      },
+    } as unknown as RunningState
+    stateManager.conflictResolution.verifyLoneGenesis = jest.fn()
     await stateManager.sync(state$, 1000, false)
     expect(fakeHandleTip).toBeCalledTimes(5)
     response.slice(0, 5).forEach((r) => {
@@ -525,7 +547,13 @@ describe('sync', () => {
       timer(0, MAX_RESPONSE_INTERVAL * 0.5).pipe(map((n) => hash(n.toString())))
     const fakeHandleTip = jest.fn(() => Promise.resolve())
     ;(stateManager as any)._handleTip = fakeHandleTip
-    const state$ = { id: FAKE_STREAM_ID } as unknown as RunningState
+    const state$ = {
+      id: FAKE_STREAM_ID,
+      value: {
+        log: [{ type: CommitType.GENESIS, cid: FAKE_STREAM_ID }],
+      },
+    } as unknown as RunningState
+    stateManager.conflictResolution.verifyLoneGenesis = jest.fn()
     await stateManager.sync(state$, MAX_RESPONSE_INTERVAL * 10, false)
     expect(fakeHandleTip).toBeCalledTimes(20)
   })

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -58,7 +58,9 @@ describe('anchor', () => {
 
   afterEach(() => {
     // Restore the _handleTip function in case any of the tests modified it
-    ;(ceramic.repository.stateManager as any)._handleTip = realHandleTip
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    ceramic.repository.stateManager._handleTip = realHandleTip
   })
 
   test('anchor call', async () => {
@@ -524,7 +526,9 @@ describe('sync', () => {
         })
       )
     const fakeHandleTip = jest.fn(() => Promise.resolve())
-    ;(stateManager as any)._handleTip = fakeHandleTip
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    stateManager._handleTip = fakeHandleTip
     const state$ = {
       id: FAKE_STREAM_ID,
       value: {

--- a/packages/core/src/conflict-resolution.ts
+++ b/packages/core/src/conflict-resolution.ts
@@ -2,7 +2,6 @@ import type CID from 'cids'
 import {
   AnchorCommit,
   AnchorProof,
-  AnchorService,
   AnchorStatus,
   CommitType,
   Context,
@@ -363,6 +362,16 @@ export class ConflictResolution {
     if (log.length) {
       return this.applyLog(initialState, stateLog, log)
     }
+  }
+
+  /**
+   * Verify signature of a lone genesis commit, using current time to check for revoked key.
+   */
+  async verifyLoneGenesis(state: StreamState) {
+    const handler = this.handlers.get(state.type)
+    const genesisCid = state.log[0].cid
+    const genesis = await this.dispatcher.retrieveCommit(genesisCid)
+    await handler.applyCommit(genesis, { cid: genesisCid }, this.context)
   }
 
   /**

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -122,7 +122,7 @@ export class Repository {
     // Do not check for possible key revocation here, as we will do so later after loading the tip (or learning that the genesis commit *is* the current tip), when we will have timestamp information for when the genesis commit was anchored. In order to disable this check for key rotation, set a timestamp that will be considered earlier than any other timestamp so it will always appear to have happened earlier than any possible key revocation.
     const state = await handler.applyCommit(
       commit,
-      { cid: streamId.cid, timestamp: 1 },
+      { cid: streamId.cid, disableTimecheck: true },
       this.#deps.context
     )
     await this.#deps.stateValidation.validate(state, state.content)

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -119,7 +119,7 @@ export class Repository {
     if (commit == null) {
       throw new Error(`No genesis commit found with CID ${genesisCid.toString()}`)
     }
-    // Do not check for possible key revocation here, as we will do so later after loading the tip (or learning that the genesis commit *is* the current tip), when we will have timestamp information for when the genesis commit was anchored. In order to disable this check for key rotation, set a timestamp that will be considered earlier than any other timestamp so it will always appear to have happened earlier than any possible key revocation.
+    // Do not check for possible key revocation here, as we will do so later after loading the tip (or learning that the genesis commit *is* the current tip), when we will have timestamp information for when the genesis commit was anchored.
     const state = await handler.applyCommit(
       commit,
       { cid: streamId.cid, disableTimecheck: true },

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -119,10 +119,10 @@ export class Repository {
     if (commit == null) {
       throw new Error(`No genesis commit found with CID ${genesisCid.toString()}`)
     }
-    // Do not check timestamp here
+    // Do not check for possible key revocation here, as we will do so later after loading the tip (or learning that the genesis commit *is* the current tip), when we will have timestamp information for when the genesis commit was anchored. In order to disable this check for key rotation, set a timestamp that will be considered earlier than any other timestamp so it will always appear to have happened earlier than any possible key revocation.
     const state = await handler.applyCommit(
       commit,
-      { cid: streamId.cid, timestamp: null },
+      { cid: streamId.cid, timestamp: 1 },
       this.#deps.context
     )
     await this.#deps.stateValidation.validate(state, state.content)
@@ -166,11 +166,11 @@ export class Repository {
       }
 
       if (opts.sync == SyncOptions.NEVER_SYNC) {
-        return stream
+        return this.stateManager.verifyLoneGenesis(stream)
       }
 
       await this.stateManager.sync(stream, opts.syncTimeoutSeconds * 1000, fromStateStore)
-      return stream
+      return this.stateManager.verifyLoneGenesis(stream)
     })
   }
 

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -83,11 +83,21 @@ export class StateManager {
         concatMap((tip) => this._handleTip(state$, tip))
       )
       .toPromise()
-      .then(() => {
-        if (pinned) {
-          this.syncedPinnedStreams.add(state$.id.toString())
-        }
-      })
+    if (pinned) {
+      this.syncedPinnedStreams.add(state$.id.toString())
+    }
+  }
+
+  /**
+   * If it is a lone genesis, verify the signature.
+   * @param state$
+   */
+  async verifyLoneGenesis(state$: RunningState): Promise<RunningState> {
+    if (state$.value.log.length > 1) {
+      return state$
+    }
+    await this.conflictResolution.verifyLoneGenesis(state$.value)
+    return state$
   }
 
   /**

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@types/node": "^13.13.15",
     "cids": "~1.1.6",
-    "dids": "^2.2.1"
+    "dids": "^2.3.0"
   },
   "jest": {
     "testEnvironment": "node",

--- a/packages/stream-caip10-link/package.json
+++ b/packages/stream-caip10-link/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@ceramicnetwork/blockchain-utils-linking": "^1.0.2",
     "@types/node": "^13.13.15",
-    "dids": "^2.2.1"
+    "dids": "^2.3.0"
   },
   "gitHead": "4f42c6ac204ad25e66efda4e24aed12c339b3c98"
 }

--- a/packages/stream-tile-handler/package.json
+++ b/packages/stream-tile-handler/package.json
@@ -36,7 +36,7 @@
     "@types/lodash.clonedeep": "^4.5.6",
     "cids": "~1.1.6",
     "did-resolver": "^3.1.0",
-    "dids": "^2.2.1",
+    "dids": "^2.3.0",
     "ipld-dag-cbor": "^1.0.0",
     "key-did-resolver": "^1.2.1"
   },

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -195,7 +195,10 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
   ): Promise<DIDResolutionResult> {
     let result
     try {
-      result = await context.did.verifyJWS(commit, { atTime: meta.timestamp })
+      result = await context.did.verifyJWS(commit, {
+        atTime: meta.timestamp,
+        disableTimecheck: meta.disableTimecheck,
+      })
     } catch (e) {
       throw new Error('Invalid signature for signed commit. ' + e)
     }


### PR DESCRIPTION
There can be a case, when a stream has only genesis commit. Its signature has to be verified. On the other hand, a stream can has more commits, which can provide timestamp information important for signature verification. A Ceramic node has to verify only lone-genesis signature, while postponing verification for multi-commit streams until all the commits are available

This has to be the case, until proper full-log state reconstruction is available.
---

v2 approach after the global prettier-ification.

Replaces https://github.com/ceramicnetwork/js-ceramic/pull/1518