### PR TITLE
fix(core): convert pubsub seqno to string

### DIFF
--- a/packages/core/src/pubsub/pubsub.ts
+++ b/packages/core/src/pubsub/pubsub.ts
@@ -5,6 +5,7 @@ import { map, catchError, mergeMap, withLatestFrom } from 'rxjs/operators'
 import { IncomingChannel, filterExternal, IPFSPubsubMessage } from './incoming-channel'
 import { DiagnosticsLogger, ServiceLogger } from '@ceramicnetwork/common'
 import { TextDecoder } from 'util'
+import uint8ArrayToString from 'uint8arrays/to-string'
 
 const textDecoder = new TextDecoder('utf-8')
 
@@ -29,6 +30,8 @@ function ipfsToPubsub(
           const message = deserialize(incoming)
           const serializedMessage = serialize(message)
           const logMessage = { ...incoming, ...JSON.parse(textDecoder.decode(serializedMessage)) }
+          logMessage.seqno = uint8ArrayToString(logMessage.seqno, 'base16')
+          delete logMessage.data // Already included in serialized message
           delete logMessage.key
           delete logMessage.signature
           pubsubLogger.log({ peer: peerId, event: 'received', topic: topic, message: logMessage })


### PR DESCRIPTION
### Motivation
To ensure no line breaks in the pubsub service logs (see for what the logs look like before this change https://github.com/ceramicnetwork/js-ceramic/issues/1538)

### Changes
- convert seqno buffer to base16 string
- remove message data because it is redundant and makes the logs messy

The logs now
```
[Thu, 15 Jul 2021 13:24:33 GMT] service=pubsub peer=QmW4V8TbfaeSWYsbBdtqpydyid2bXkM8RFiEcCw8rHb7k2 event=received topic=/ceramic/testnet-clay message.topicIDs.0=/ceramic/testnet-clay message.from=QmQotCKxiMWt935TyCBFTN23jaivxwrZ3uD58wNxeg5npi message.seqno=2f188761af038ec4 message.receivedFrom=QmQotCKxiMWt935TyCBFTN23jaivxwrZ3uD58wNxeg5npi message.typ=1 message.id=EiBED73bwoCtayzj-RP9XauIbtBV7l-R2zwXRmeS-r5Tyw message.stream=k2t6wyfsu4pfzdupeqsehss3t6zu6in8a5kt64uvs0wfl7dbx5mn5yscxld19q message.doc=k2t6wyfsu4pfzdupeqsehss3t6zu6in8a5kt64uvs0wfl7dbx5mn5yscxld19q
[Thu, 15 Jul 2021 13:24:47 GMT] service=pubsub peer=QmW4V8TbfaeSWYsbBdtqpydyid2bXkM8RFiEcCw8rHb7k2 event=received topic=/ceramic/testnet-clay message.topicIDs.0=/ceramic/testnet-clay message.from=QmWiY3CbNawZjWnHXx3p3DXsg21pZYTj4CRY1iwMkhP8r3 message.seqno=a19685b1c3e7dda1 message.receivedFrom=QmWiY3CbNawZjWnHXx3p3DXsg21pZYTj4CRY1iwMkhP8r3 message.typ=1 message.id=EiDY0OUAb3U7EFxSLewwknhdVeaLulo_OktrM0iTEE9_Yw message.stream=k2t6wyfsu4pfy7f9vfhqop8t151y56tldn7ziwshv9tcqe00z5b688uwafrefr message.doc=k2t6wyfsu4pfy7f9vfhqop8t151y56tldn7ziwshv9tcqe00z5b688uwafrefr
[Thu, 15 Jul 2021 13:24:47 GMT] service=pubsub peer=QmW4V8TbfaeSWYsbBdtqpydyid2bXkM8RFiEcCw8rHb7k2 event=received topic=/ceramic/testnet-clay message.topicIDs.0=/ceramic/testnet-clay message.from=QmWiY3CbNawZjWnHXx3p3DXsg21pZYTj4CRY1iwMkhP8r3 message.seqno=903ec4bbe52a59d0 message.receivedFrom=QmWiY3CbNawZjWnHXx3p3DXsg21pZYTj4CRY1iwMkhP8r3 message.typ=0 message.doc=k2t6wyfsu4pfy7f9vfhqop8t151y56tldn7ziwshv9tcqe00z5b688uwafrefr message.stream=k2t6wyfsu4pfy7f9vfhqop8t151y56tldn7ziwshv9tcqe00z5b688uwafrefr message.tip=bafyreib46have74cvfexkptetqlvwhvyo4xs72bs7oq7hbjoqitqvu6y24
```