### PR TITLE
feat(cli): ethr-did-resolver support for mainnet

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,6 +49,7 @@
     "dag-jose": "^0.3.0",
     "did-resolver": "^3.1.0",
     "dids": "^2.4.0",
+    "ethr-did-resolver": "4.3.4",
     "express": "^4.17.1",
     "flat": "^5.0.2",
     "ipfs-http-client": "~50.1.1",

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -15,6 +15,7 @@ import {
 import StreamID, { StreamType } from '@ceramicnetwork/streamid'
 import ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
 import KeyDidResolver from 'key-did-resolver'
+import EthrDidResolver from 'ethr-did-resolver'
 import { DID } from 'dids'
 import cors from 'cors'
 import { errorHandler } from './daemon/error-handler'
@@ -181,6 +182,15 @@ export class CeramicDaemon {
       resolver: {
         ...KeyDidResolver.getResolver(),
         ...ThreeIdResolver.getResolver(ceramic),
+        ...(ceramicConfig.ethereumRpcUrl &&
+          EthrDidResolver.getResolver({
+            networks: [
+              {
+                name: 'mainnet',
+                rpcUrl: ceramicConfig.ethereumRpcUrl,
+              },
+            ],
+          })),
       },
     })
     await ceramic.setDID(did)


### PR DESCRIPTION
This PR adds support for `did:ethr` in the CLI daemon.

To create ceramic documents using `did:ethr` one can use [Veramo](https://github.com/uport-project/veramo/pull/627)

Current implementation assumes that ceramic node is being run with `--ethereum-rpc` parameter. E.x.:
```
./bin/ceramic.js daemon --network inmemory --debug --ethereum-rpc https://mainnet.infura.io/v3/5ffc47f65c4042ce847ef66a3fa70d4c
```
