### PR TITLE
feat(core): Invalid commits don't prevent loading a stream

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -392,7 +392,7 @@ export class CeramicDaemon {
     upconvertLegacySyncOption(opts)
     // The HTTP client generally only calls applyCommit as part of an app-requested update to a
     // stream, so we want to throw an error if applying that commit fails for any reason.
-    opts.throwOnApplyCommitError = opts.throwOnApplyCommitError ?? true
+    opts.throwOnInvalidCommit = opts.throwOnInvalidCommit ?? true
 
     const streamId = req.body.streamId || docId
     if (!(streamId && commit)) {

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -390,6 +390,10 @@ export class CeramicDaemon {
     const { docId, commit, docOpts } = req.body
     const opts = req.body.opts || docOpts
     upconvertLegacySyncOption(opts)
+    // The HTTP client generally only calls applyCommit as part of an app-requested update to a
+    // stream, so we want to throw an error if applying that commit fails for any reason.
+    opts.throwOnApplyCommitError = opts.throwOnApplyCommitError ?? true
+
     const streamId = req.body.streamId || docId
     if (!(streamId && commit)) {
       throw new Error('streamId and commit are required in order to apply commit')

--- a/packages/common/src/docopts.ts
+++ b/packages/common/src/docopts.ts
@@ -47,7 +47,7 @@ export interface InternalOpts {
    * This option is used internally but is not designed to be set by user applications.
    * @private
    */
-  throwOnApplyCommitError?: boolean
+  throwOnInvalidCommit?: boolean
 }
 
 /**

--- a/packages/common/src/docopts.ts
+++ b/packages/common/src/docopts.ts
@@ -21,6 +21,9 @@ export enum SyncOptions {
   NEVER_SYNC,
 }
 
+/**
+ * Options shared between LoadOpts and CreateOpts
+ */
 interface BasicLoadOpts {
   /**
    * Controls the behavior related to syncing a stream to the most recent tip.
@@ -31,6 +34,20 @@ interface BasicLoadOpts {
    * How long to wait for a response from pubsub when syncing a stream.
    */
   syncTimeoutSeconds?: number
+}
+
+/**
+ * Options that are used internally but aren't designed to be set by end users.
+ */
+export interface InternalOpts {
+  /**
+   * If true, when loading a stream log will throw an exception if any commit fails to apply.
+   * If false, the error will be logged, but the log application operation will return as much
+   * of the log as it was able to successfully apply.
+   * This option is used internally but is not designed to be set by user applications.
+   * @private
+   */
+  throwOnApplyCommitError?: boolean
 }
 
 /**
@@ -46,7 +63,7 @@ export interface LoadOpts extends BasicLoadOpts {
 /**
  * Extra options passed as part of operations that perform updates to streams
  */
-export interface UpdateOpts {
+interface BasicUpdateOpts {
   /**
    * Whether or not to request an anchor after performing the operation.
    */
@@ -58,6 +75,8 @@ export interface UpdateOpts {
    */
   publish?: boolean
 }
+
+export interface UpdateOpts extends BasicUpdateOpts, InternalOpts {}
 
 /**
  * Extra options passed as part of operations that create streams

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -413,7 +413,7 @@ test('enforces schema in update that assigns schema', async () => {
   await anchorUpdate(ceramic, stream)
   const updateRec = await stream.makeCommit(ceramic, null, { schema: schemaDoc.commitId })
   await expect(ceramic.repository.stateManager.applyCommit(
-      streamState.id, updateRec, { anchor: false, throwOnApplyCommitError: true })
+      streamState.id, updateRec, { anchor: false, throwOnInvalidCommit: true })
   ).rejects.toThrow('Validation Error: data/stuff must be string')
 })
 
@@ -434,7 +434,7 @@ test('enforce previously assigned schema during future update', async () => {
     ceramic.repository.stateManager.applyCommit(streamState.id, updateRec, {
       anchor: false,
       publish: false,
-      throwOnApplyCommitError: true
+      throwOnInvalidCommit: true
     })
   ).rejects.toThrow('Validation Error: data/stuff must be string')
 })

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -412,8 +412,8 @@ test('enforces schema in update that assigns schema', async () => {
   const streamState = await ceramic.repository.load(stream.id, {})
   await anchorUpdate(ceramic, stream)
   const updateRec = await stream.makeCommit(ceramic, null, { schema: schemaDoc.commitId })
-  await expect(
-    ceramic.repository.stateManager.applyCommit(streamState.id, updateRec, { anchor: false })
+  await expect(ceramic.repository.stateManager.applyCommit(
+      streamState.id, updateRec, { anchor: false, throwOnApplyCommitError: true })
   ).rejects.toThrow('Validation Error: data/stuff must be string')
 })
 
@@ -434,6 +434,7 @@ test('enforce previously assigned schema during future update', async () => {
     ceramic.repository.stateManager.applyCommit(streamState.id, updateRec, {
       anchor: false,
       publish: false,
+      throwOnApplyCommitError: true
     })
   ).rejects.toThrow('Validation Error: data/stuff must be string')
 })

--- a/packages/core/src/conflict-resolution.ts
+++ b/packages/core/src/conflict-resolution.ts
@@ -260,10 +260,9 @@ export class ConflictResolution {
       const genesis = await this.dispatcher.retrieveCommit(genesisCid)
       await handler.applyCommit(genesis, { cid: genesisCid, timestamp: timestamp }, this.context)
     }
-    const itr = unappliedCommits.entries()
-    let entry = itr.next()
-    while (!entry.done) {
-      const logEntry = await this.getCommitData(entry.value[1])
+
+    for (const entry of unappliedCommits) {
+      const logEntry = await this.getCommitData(entry)
       const commitMeta = { cid: logEntry.cid, timestamp: logEntry.timestamp }
       // TODO - should catch potential thrown error here
 
@@ -287,7 +286,6 @@ export class ConflictResolution {
       if (breakOnAnchor && AnchorStatus.ANCHORED === state.anchorStatus) {
         return state
       }
-      entry = itr.next()
     }
     return state
   }

--- a/packages/core/src/conflict-resolution.ts
+++ b/packages/core/src/conflict-resolution.ts
@@ -276,7 +276,7 @@ export class ConflictResolution {
   /**
    * Applies the log to the stream and updates the state.
    * If an error is encountered while applying a commit, commit application stops and the state
-   * that was built thus far is returned, unless 'opts.throwOnApplyCommitError' is true.
+   * that was built thus far is returned, unless 'opts.throwOnInvalidCommit' is true.
    */
   private async applyLogToState<T extends Stream>(
     handler: StreamHandler<T>,
@@ -302,7 +302,7 @@ export class ConflictResolution {
         // TODO(1586): include StreamID in log message
         this.context.loggerProvider.getDiagnosticsLogger().warn(
           `Error while applying commit ${entry.cid.toString()}: ${err}`)
-        if (opts.throwOnApplyCommitError) {
+        if (opts.throwOnInvalidCommit) {
           throw err
         } else {
           return state
@@ -392,7 +392,7 @@ export class ConflictResolution {
   async snapshotAtCommit(initialState: StreamState, commitId: CommitID): Promise<StreamState> {
     // Throw if any commit fails to apply as we are trying to load at a specific commit and want
     // to error if we can't.
-    const opts = { throwOnApplyCommitError: true }
+    const opts = { throwOnInvalidCommit: true }
 
     // If 'commit' is ahead of 'initialState', sync state up to 'commit'
     const baseState = (await this.applyTip(initialState, commitId.commit, opts)) || initialState

--- a/packages/core/src/conflict-resolution.ts
+++ b/packages/core/src/conflict-resolution.ts
@@ -7,6 +7,7 @@ import {
   CommitData,
   CommitType,
   Context,
+  InternalOpts,
   LogEntry,
   Stream,
   StreamHandler,
@@ -275,13 +276,14 @@ export class ConflictResolution {
   /**
    * Applies the log to the stream and updates the state.
    * If an error is encountered while applying a commit, commit application stops and the state
-   * that was built thus far is returned.
+   * that was built thus far is returned, unless 'opts.throwOnApplyCommitError' is true.
    */
   private async applyLogToState<T extends Stream>(
     handler: StreamHandler<T>,
     unappliedCommits: CommitData[],
-    state?: StreamState,
-    breakOnAnchor?: boolean
+    state: StreamState | null,
+    breakOnAnchor: boolean,
+    opts: InternalOpts,
   ): Promise<StreamState> {
     // When we have genesis state only, and add some commits on top, we should check a signature at particular timestamp.
     // Most probably there is a timestamp information there. If no timestamp found, we consider it to be _now_.
@@ -300,7 +302,11 @@ export class ConflictResolution {
         // TODO(1586): include StreamID in log message
         this.context.loggerProvider.getDiagnosticsLogger().warn(
           `Error while applying commit ${entry.cid.toString()}: ${err}`)
-        return state
+        if (opts.throwOnApplyCommitError) {
+          throw err
+        } else {
+          return state
+        }
       }
 
       if (breakOnAnchor && AnchorStatus.ANCHORED === state.anchorStatus) {
@@ -316,11 +322,13 @@ export class ConflictResolution {
    * @param initialState - State to apply log to.
    * @param initialStateLog - HistoryLog representation of the `initialState.log` with SignedCommits expanded out and CIDs for their `link` record included in the log.
    * @param unappliedCommits - commits to apply
+   * @param opts - options that control the behavior when applying the commit
    */
   private async applyLog(
     initialState: StreamState,
     initialStateLog: HistoryLog,
-    unappliedCommits: CommitData[]
+    unappliedCommits: CommitData[],
+    opts: InternalOpts,
   ): Promise<StreamState | null> {
     const handler = this.handlers.get(initialState.type)
     const tip = initialStateLog.last
@@ -331,7 +339,7 @@ export class ConflictResolution {
     const commitData = await this.getCommitData(unappliedCommits[0])
     if (commitData.commit.prev.equals(tip)) {
       // the new log starts where the previous one ended
-      return this.applyLogToState(handler, unappliedCommits, cloneDeep(initialState))
+      return this.applyLogToState(handler, unappliedCommits, cloneDeep(initialState), false, opts)
     }
 
     // we have a conflict since prev is in the log of the local state, but isn't the tip
@@ -340,17 +348,17 @@ export class ConflictResolution {
     const canonicalLog = initialStateLog.items
     const localLog = canonicalLog.splice(conflictIdx)
     // Compute state up till conflictIdx
-    const state: StreamState = await this.applyLogToState(handler, canonicalLog)
+    const state: StreamState = await this.applyLogToState(handler, canonicalLog, null, false, opts)
     // Compute next transition in parallel
-    const localState = await this.applyLogToState(handler, localLog, cloneDeep(state), true)
-    const remoteState = await this.applyLogToState(handler, unappliedCommits, cloneDeep(state), true)
+    const localState = await this.applyLogToState(handler, localLog, cloneDeep(state), true, opts)
+    const remoteState = await this.applyLogToState(handler, unappliedCommits, cloneDeep(state), true, opts)
 
     const selectedState = await pickLogToAccept(localState, remoteState)
     if (selectedState === localState) {
       return null
     }
 
-    return this.applyLogToState(handler, unappliedCommits, cloneDeep(state))
+    return this.applyLogToState(handler, unappliedCommits, cloneDeep(state), false, opts)
   }
 
   /**
@@ -358,12 +366,13 @@ export class ConflictResolution {
    *
    * @param initialState - State to start from
    * @param tip - Commit CID
+   * @param opts - options that control the behavior when applying the commit
    */
-  async applyTip(initialState: StreamState, tip: CID): Promise<StreamState | null> {
+  async applyTip(initialState: StreamState, tip: CID, opts: InternalOpts): Promise<StreamState | null> {
     const stateLog = HistoryLog.fromState(this.dispatcher, initialState)
     const log = await fetchLog(this.dispatcher, tip, stateLog)
     if (log.length) {
-      return this.applyLog(initialState, stateLog, log)
+      return this.applyLog(initialState, stateLog, log, opts)
     }
   }
 
@@ -381,8 +390,12 @@ export class ConflictResolution {
    * Return state at `commitId` version.
    */
   async snapshotAtCommit(initialState: StreamState, commitId: CommitID): Promise<StreamState> {
+    // Throw if any commit fails to apply as we are trying to load at a specific commit and want
+    // to error if we can't.
+    const opts = { throwOnApplyCommitError: true }
+
     // If 'commit' is ahead of 'initialState', sync state up to 'commit'
-    const baseState = (await this.applyTip(initialState, commitId.commit)) || initialState
+    const baseState = (await this.applyTip(initialState, commitId.commit, opts)) || initialState
 
     const baseStateLog = HistoryLog.fromState(this.dispatcher, baseState)
 
@@ -399,7 +412,7 @@ export class ConflictResolution {
     // to reset the state to the state at the requested commit.
     const resetLog = baseStateLog.slice(0, commitIndex + 1).items
     const handler = this.handlers.get(initialState.type)
-    return this.applyLogToState(handler, resetLog)
+    return this.applyLogToState(handler, resetLog, null, false, opts)
   }
 
   /**

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -8,6 +8,7 @@ import {
   AnchorStatus,
   CreateOpts,
   LoadOpts,
+  InternalOpts,
   UpdateOpts,
   UnreachableCaseError,
   RunningStateLike,
@@ -154,9 +155,18 @@ export class StateManager {
     }
   }
 
-  private async _handleTip(state$: RunningState, cid: CID): Promise<void> {
+  /**
+   * Applies the given tip CID as a new commit to the given running state.
+   * @param state$ - State to apply tip to
+   * @param cid - tip CID
+   * @param opts - options that control the behavior when applying the commit
+   * @private
+   */
+  private async _handleTip(state$: RunningState, cid: CID, opts: InternalOpts = {}): Promise<void> {
+    // by default swallow and log errors applying commits
+    opts.throwOnApplyCommitError = opts.throwOnApplyCommitError ?? false
     this.logger.verbose(`Learned of new tip ${cid.toString()} for stream ${state$.id.toString()}`)
-    const next = await this.conflictResolution.applyTip(state$.value, cid)
+    const next = await this.conflictResolution.applyTip(state$.value, cid, opts)
     if (next) {
       state$.next(next)
       this.logger.verbose(
@@ -201,13 +211,13 @@ export class StateManager {
   applyCommit(
     streamId: StreamID,
     commit: any,
-    opts: CreateOpts | UpdateOpts
+    opts: CreateOpts | UpdateOpts,
   ): Promise<RunningState> {
     return this.executionQ.forStream(streamId).run(async () => {
       const state$ = await this.load(streamId, opts)
       const cid = await this.dispatcher.storeCommit(commit, streamId)
 
-      await this._handleTip(state$, cid)
+      await this._handleTip(state$, cid, opts)
       await this.applyWriteOpts(state$, opts)
       return state$
     })

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -164,7 +164,7 @@ export class StateManager {
    */
   private async _handleTip(state$: RunningState, cid: CID, opts: InternalOpts = {}): Promise<void> {
     // by default swallow and log errors applying commits
-    opts.throwOnApplyCommitError = opts.throwOnApplyCommitError ?? false
+    opts.throwOnInvalidCommit = opts.throwOnInvalidCommit ?? false
     this.logger.verbose(`Learned of new tip ${cid.toString()} for stream ${state$.id.toString()}`)
     const next = await this.conflictResolution.applyTip(state$.value, cid, opts)
     if (next) {

--- a/packages/stream-caip10-link/src/caip10-link.ts
+++ b/packages/stream-caip10-link/src/caip10-link.ts
@@ -23,7 +23,7 @@ const throwReadOnlyError = (): Promise<void> => {
 }
 
 const DEFAULT_CREATE_OPTS = { anchor: false, publish: true, sync: SyncOptions.PREFER_CACHE }
-const DEFAULT_UPDATE_OPTS = { anchor: true, publish: true, throwOnApplyCommitError: true }
+const DEFAULT_UPDATE_OPTS = { anchor: true, publish: true, throwOnInvalidCommit: true }
 const DEFAULT_LOAD_OPTS = { sync: SyncOptions.PREFER_CACHE }
 
 /**

--- a/packages/stream-caip10-link/src/caip10-link.ts
+++ b/packages/stream-caip10-link/src/caip10-link.ts
@@ -23,7 +23,7 @@ const throwReadOnlyError = (): Promise<void> => {
 }
 
 const DEFAULT_CREATE_OPTS = { anchor: false, publish: true, sync: SyncOptions.PREFER_CACHE }
-const DEFAULT_UPDATE_OPTS = { anchor: true, publish: true }
+const DEFAULT_UPDATE_OPTS = { anchor: true, publish: true, throwOnApplyCommitError: true }
 const DEFAULT_LOAD_OPTS = { sync: SyncOptions.PREFER_CACHE }
 
 /**

--- a/packages/stream-tile/src/tile-document.ts
+++ b/packages/stream-tile/src/tile-document.ts
@@ -58,7 +58,7 @@ export interface TileMetadataArgs {
 
 const DEFAULT_CREATE_OPTS = { anchor: true, publish: true, sync: SyncOptions.PREFER_CACHE }
 const DEFAULT_LOAD_OPTS = { sync: SyncOptions.PREFER_CACHE }
-const DEFAULT_UPDATE_OPTS = { anchor: true, publish: true }
+const DEFAULT_UPDATE_OPTS = { anchor: true, publish: true, throwOnApplyCommitError: true }
 
 /**
  * Converts from metadata format into CommitHeader format to be put into a CeramicCommit

--- a/packages/stream-tile/src/tile-document.ts
+++ b/packages/stream-tile/src/tile-document.ts
@@ -58,7 +58,7 @@ export interface TileMetadataArgs {
 
 const DEFAULT_CREATE_OPTS = { anchor: true, publish: true, sync: SyncOptions.PREFER_CACHE }
 const DEFAULT_LOAD_OPTS = { sync: SyncOptions.PREFER_CACHE }
-const DEFAULT_UPDATE_OPTS = { anchor: true, publish: true, throwOnApplyCommitError: true }
+const DEFAULT_UPDATE_OPTS = { anchor: true, publish: true, throwOnInvalidCommit: true }
 
 /**
  * Converts from metadata format into CommitHeader format to be put into a CeramicCommit


### PR DESCRIPTION
If an error is encountered while applying commits as part of loading a stream, the application process stops and the stream is returned with as much of the state as could be validly constructed