### PR TITLE
docs(ipfs-daemon): change dockerhub url to public

### DIFF
--- a/packages/ipfs-daemon/README.md
+++ b/packages/ipfs-daemon/README.md
@@ -36,7 +36,7 @@ await ipfsDaemon.stop()
 ```
 
 ### Using Docker
-Public builds of the image [Dockerfile.ipfs-daemon](../../Dockerfile.ipfs-daemon) are hosted here: [ceramicnetwork/ipfs-daemon on Docker Hub](https://hub.docker.com/repository/docker/ceramicnetwork/ipfs-daemon)
+Public builds of the image [Dockerfile.ipfs-daemon](../../Dockerfile.ipfs-daemon) are hosted here: [ceramicnetwork/ipfs-daemon on Docker Hub](https://hub.docker.com/r/ceramicnetwork/ipfs-daemon)
 ```
 docker pull ceramicnetwork/ipfs-daemon
 docker run -p 5011:5011 -e CERAMIC_NETWORK=testnet-clay ceramicnetwork/ipfs-daemon


### PR DESCRIPTION
The original URL points to the private dashboard so I swapped it for the public url that anyone can view.