### PR TITLE
chore(blockchain-utils-linking,blockchain-utils-validation): Upgrade '@polkadot/util' package

### DIFF
--- a/packages/blockchain-utils-linking/package.json
+++ b/packages/blockchain-utils-linking/package.json
@@ -36,7 +36,7 @@
     "@polkadot/api": "^4.6.2",
     "@polkadot/keyring": "^6.2.1",
     "@polkadot/types": "^4.6.2",
-    "@polkadot/util": "^6.2.1",
+    "@polkadot/util": "^7.1.1",
     "@polkadot/util-crypto": "^7.0.2",
     "@smontero/eosio-local-provider": "^0.0.3",
     "@taquito/signer": "^9.2.0",

--- a/packages/blockchain-utils-validation/package.json
+++ b/packages/blockchain-utils-validation/package.json
@@ -44,7 +44,7 @@
     "@polkadot/api": "^4.6.2",
     "@polkadot/keyring": "^6.2.1",
     "@polkadot/types": "^4.6.2",
-    "@polkadot/util": "^6.2.1",
+    "@polkadot/util": "^7.1.1",
     "@polkadot/util-crypto": "^7.0.2",
     "@smontero/eosio-local-provider": "^0.0.3",
     "@taquito/signer": "^9.2.0",


### PR DESCRIPTION
Resolves the warning we've been seeing anytime Ceramic is run:
```
@polkadot/util has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
        7.1.1   /home/spencer/js-ceramic3/node_modules/@polkadot/util-crypto/node_modules/@polkadot/util
        6.11.1  /home/spencer/js-ceramic3/node_modules/@polkadot/util
```