### PR TITLE
feat: Allow updating tile immediately after controller change

### DIFF
--- a/packages/core/src/__tests__/tile-controller.test.ts
+++ b/packages/core/src/__tests__/tile-controller.test.ts
@@ -61,3 +61,13 @@ describe('throw if controller is different from signer', () => {
     await expect(tile.update({ foo: 'bar' })).rejects.toThrow(/invalid_jws/)
   })
 })
+
+test('change after controller changed', async () => {
+  ceramic.did = alice
+  const tile = await TileDocument.create(ceramic, { foo: 'blah' })
+  await tile.update(tile.content, { controllers: [bob.id] })
+  ceramic.did = bob
+  await tile.update({ foo: 'bar' }) // works all right
+  ceramic.did = alice
+  await expect(tile.update({ foo: 'baz' })).rejects.toThrow(/invalid_jws/)
+})

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -106,7 +106,8 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
     context: Context
   ): Promise<StreamState> {
     // TODO: Assert that the 'prev' of the commit being applied is the end of the log in 'state'
-    await this._verifySignature(commit, meta, context, state.metadata.controllers[0])
+    const controller = state.next?.metadata?.controllers?.[0] || state.metadata.controllers[0]
+    await this._verifySignature(commit, meta, context, controller)
 
     const payload = (await context.ipfs.dag.get(commit.link, { timeout: IPFS_GET_TIMEOUT })).value
     if (!payload.id.equals(state.log[0].cid)) {


### PR DESCRIPTION
Right now, controller change comes into effect only after a tile is anchored. Here we allow a new controller to edit a tile without waiting for an anchor.

Prompted by HackFS discord message.