### PR TITLE
feat: Rely on default nft-did-resolver subgraphs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,7 @@
     "key-did-resolver": "^1.3.0-rc.0",
     "levelup": "^4.4.0",
     "morgan": "^1.10.0",
-    "nft-did-resolver": "^0.2.0-alpha.1",
+    "nft-did-resolver": "^0.2.0-alpha.2",
     "s3leveldown": "^2.2.1",
     "stream-to-array": "^2.3.0",
     "uint8arrays": "^2.0.5"

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -185,12 +185,6 @@ export class CeramicDaemon {
         ...ThreeIdResolver.getResolver(ceramic),
         ...NftDidResolver.getResolver({
           ceramic: ceramic,
-          subGraphUrls: {
-            'eip155:1': {
-              erc1155: 'https://api.thegraph.com/subgraphs/name/sunguru98/mainnet-erc1155-subgraph',
-              erc721: 'https://api.thegraph.com/subgraphs/name/sunguru98/mainnet-erc721-subgraph',
-            },
-          },
         }),
         ...(ceramicConfig.ethereumRpcUrl &&
           EthrDidResolver.getResolver({


### PR DESCRIPTION
and use latest nft-did-resolver