### PR TITLE
feat: configure nft-did-resolver via config file

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -176,13 +176,13 @@ export class CeramicDaemon {
 
     const ceramic = new Ceramic(modules, params)
     await ceramic._init(true, true)
-
     const did = new DID({
       resolver: {
         ...KeyDidResolver.getResolver(),
         ...ThreeIdResolver.getResolver(ceramic),
         ...NftDidResolver.getResolver({
           ceramic: ceramic,
+          ...opts.resolvers['nft-did-resolver']
         }),
         ...(ceramicConfig.ethereumRpcUrl &&
           EthrDidResolver.getResolver({

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -182,7 +182,7 @@ export class CeramicDaemon {
         ...ThreeIdResolver.getResolver(ceramic),
         ...NftDidResolver.getResolver({
           ceramic: ceramic,
-          ...opts.resolvers?.['nft-did-resolver']
+          ...opts.resolvers?.nftDidResolver
         }),
         ...(ceramicConfig.ethereumRpcUrl &&
           EthrDidResolver.getResolver({

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -182,7 +182,7 @@ export class CeramicDaemon {
         ...ThreeIdResolver.getResolver(ceramic),
         ...NftDidResolver.getResolver({
           ceramic: ceramic,
-          ...opts.resolvers['nft-did-resolver']
+          ...opts.resolvers?.['nft-did-resolver']
         }),
         ...(ceramicConfig.ethereumRpcUrl &&
           EthrDidResolver.getResolver({

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -182,17 +182,11 @@ export class CeramicDaemon {
         ...ThreeIdResolver.getResolver(ceramic),
         ...NftDidResolver.getResolver({
           ceramic: ceramic,
-          ...opts.resolvers?.nftDidResolver
+          ...opts.didResolvers?.nftDidResolver,
         }),
-        ...(ceramicConfig.ethereumRpcUrl &&
-          EthrDidResolver.getResolver({
-            networks: [
-              {
-                name: 'mainnet',
-                rpcUrl: ceramicConfig.ethereumRpcUrl,
-              },
-            ],
-          })),
+        ...(opts.didResolvers?.ethrDidResolver?.networks &&
+          opts.didResolvers?.ethrDidResolver?.networks.length > 0 &&
+          EthrDidResolver.getResolver(opts.didResolvers.ethrDidResolver)),
       },
     })
     await ceramic.setDID(did)

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -263,7 +263,7 @@ export class DaemonConfig {
   stateStore: DaemonStateStoreConfig
 
   @jsonMember(AnyT)
-  resolvers: any;
+  resolvers?: any;
 
   /**
    * Parses the given json string containing the contents of the config file and returns

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -158,8 +158,11 @@ export class DaemonAnchorConfig {
 @jsonObject
 @toJson
 export class DaemonCeramicResolversConfig {
-  @jsonMember(AnyT, {name: 'nft-did-resolver'})
+  @jsonMember(AnyT, { name: 'nft-did-resolver' })
   nftDidResolver?: any
+
+  @jsonMember(AnyT, { name: 'ethr-did-resolver' })
+  ethrDidResolver?: any
 }
 
 /**
@@ -269,8 +272,8 @@ export class DaemonConfig {
   @jsonMember(DaemonStateStoreConfig, { name: 'state-store' })
   stateStore: DaemonStateStoreConfig
 
-  @jsonMember(DaemonCeramicResolversConfig)
-  resolvers?: DaemonCeramicResolversConfig;
+  @jsonMember(DaemonCeramicResolversConfig, { name: 'did-resolvers' })
+  didResolvers?: DaemonCeramicResolversConfig
 
   /**
    * Parses the given json string containing the contents of the config file and returns

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -161,7 +161,7 @@ export class DaemonDidResolversConfig {
   /**
    * Configuration for nft-did-resolver. Its README contains appropriate documentation.
    *
-   * Note: When specifying in a config file, use the name 'nft-did-resolver'.
+   * When specifying in a config file, use the name 'nft-did-resolver'.
    */
   @jsonMember(AnyT, { name: 'nft-did-resolver' })
   nftDidResolver?: any
@@ -169,7 +169,7 @@ export class DaemonDidResolversConfig {
   /**
    * Configuration for ethr-did-resolver. Its README contains appropriate documentation.
    *
-   * Note: When specifying in a config file, use the name 'ethr-did-resolver'.
+   * When specifying in a config file, use the name 'ethr-did-resolver'.
    */
   @jsonMember(AnyT, { name: 'ethr-did-resolver' })
   ethrDidResolver?: any

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata'
-import { jsonObject, jsonMember, jsonArrayMember, TypedJSON, toJson } from 'typedjson'
+import { jsonObject, jsonMember, jsonArrayMember, TypedJSON, toJson, AnyT } from 'typedjson'
 
 /**
  * Whether the daemon should start its own bundled in-process ipfs node, or if it should connect
@@ -261,6 +261,9 @@ export class DaemonConfig {
    */
   @jsonMember(DaemonStateStoreConfig, { name: 'state-store' })
   stateStore: DaemonStateStoreConfig
+
+  @jsonMember(AnyT)
+  resolvers: any;
 
   /**
    * Parses the given json string containing the contents of the config file and returns

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -158,9 +158,15 @@ export class DaemonAnchorConfig {
 @jsonObject
 @toJson
 export class DaemonCeramicResolversConfig {
+  /**
+   * Configuration for nft-did-resolver. Its README contains appropriate documentation.
+   */
   @jsonMember(AnyT, { name: 'nft-did-resolver' })
   nftDidResolver?: any
 
+  /**
+   * Configuration for ethr-did-resolver. Its README contains appropriate documentation.
+   */
   @jsonMember(AnyT, { name: 'ethr-did-resolver' })
   ethrDidResolver?: any
 }
@@ -272,6 +278,9 @@ export class DaemonConfig {
   @jsonMember(DaemonStateStoreConfig, { name: 'state-store' })
   stateStore: DaemonStateStoreConfig
 
+  /**
+   * Options related to DID-resolvers.
+   */
   @jsonMember(DaemonCeramicResolversConfig, { name: 'did-resolvers' })
   didResolvers?: DaemonCeramicResolversConfig
 

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -155,6 +155,13 @@ export class DaemonAnchorConfig {
   ethereumRpcUrl?: string
 }
 
+@jsonObject
+@toJson
+export class DaemonCeramicResolversConfig {
+  @jsonMember(AnyT, {name: 'nft-did-resolver'})
+  nftDidResolver?: any
+}
+
 /**
  * Ceramic Daemon options for configuring miscellaneous behaviors of the underlying Ceramic node.
  */
@@ -262,8 +269,8 @@ export class DaemonConfig {
   @jsonMember(DaemonStateStoreConfig, { name: 'state-store' })
   stateStore: DaemonStateStoreConfig
 
-  @jsonMember(AnyT)
-  resolvers?: any;
+  @jsonMember(DaemonCeramicResolversConfig)
+  resolvers?: DaemonCeramicResolversConfig;
 
   /**
    * Parses the given json string containing the contents of the config file and returns

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -157,15 +157,19 @@ export class DaemonAnchorConfig {
 
 @jsonObject
 @toJson
-export class DaemonCeramicResolversConfig {
+export class DaemonDidResolversConfig {
   /**
    * Configuration for nft-did-resolver. Its README contains appropriate documentation.
+   *
+   * Note: When specifying in a config file, use the name 'nft-did-resolver'.
    */
   @jsonMember(AnyT, { name: 'nft-did-resolver' })
   nftDidResolver?: any
 
   /**
    * Configuration for ethr-did-resolver. Its README contains appropriate documentation.
+   *
+   * Note: When specifying in a config file, use the name 'ethr-did-resolver'.
    */
   @jsonMember(AnyT, { name: 'ethr-did-resolver' })
   ethrDidResolver?: any
@@ -281,8 +285,8 @@ export class DaemonConfig {
   /**
    * Options related to DID-resolvers.
    */
-  @jsonMember(DaemonCeramicResolversConfig, { name: 'did-resolvers' })
-  didResolvers?: DaemonCeramicResolversConfig
+  @jsonMember(DaemonDidResolversConfig, { name: 'did-resolvers' })
+  didResolvers?: DaemonDidResolversConfig
 
   /**
    * Parses the given json string containing the contents of the config file and returns


### PR DESCRIPTION
Pass `resolvers.nft-did-resolver` to nft-did-resolver.

In an ideal universe, one could iterate over keys of `resolvers`, and initialize (and dynamically include!) the appropriate resolvers, but this IMO is for the next time, when dynamic non-http modules are a thing.