### PR TITLE
chore(cli): Deprecate advanced CLI flags

### DIFF
--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -8,27 +8,27 @@ program
   .option('--ipfs-api <url>', 'The ipfs http api to use')
   .option(
     '--ethereum-rpc <url>',
-    'The Ethereum RPC URL used for communicating with Ethereum blockchain'
+    'The Ethereum RPC URL used for communicating with Ethereum blockchain. Deprecated.'
   )
-  .option('--anchor-service-api <url>', 'The anchor service URL to use')
-  .option('--ipfs-pinning-endpoint <url...>', 'Ipfs pinning endpoints')
+  .option('--anchor-service-api <url>', 'The anchor service URL to use. Deprecated.')
+  .option('--ipfs-pinning-endpoint <url...>', 'Ipfs pinning endpoints. Deprecated')
   .option(
     '--state-store-directory <string>',
-    `The directory path used for storing pinned stream state. Defaults to HOME_DIR/.ceramic/statestore`
+    `The directory path used for storing pinned stream state. Defaults to HOME_DIR/.ceramic/statestore. Deprecated.`
   )
   .option(
     '--state-store-s3-bucket <string>',
-    `The S3 bucket name to use for storing pinned stream state. If not provided pinned stream state will only be saved locally but not to S3.`
+    `The S3 bucket name to use for storing pinned stream state. If not provided pinned stream state will only be saved locally but not to S3. Deprecated.`
   )
   .option('--gateway', 'Makes read only endpoints available. It is disabled by default')
   .option('--port <int>', 'Port daemon is available on. Default is 7007')
   .option('--hostname <string>', 'Host daemon is available on. Default is 0.0.0.0')
   .option('--debug', 'Enable debug logging level. Default is false')
   .option('--verbose', 'Enable verbose logging level. Default is false')
-  .option('--log-to-files', 'If debug is true, write logs to files. Default is false')
+  .option('--log-to-files', 'If debug is true, write logs to files. Default is false. Deprecated')
   .option(
     '--log-directory <dir>',
-    'Store logs in this directory. Defaults to HOME_DIR/.ceramic/logs'
+    'Store logs in this directory. Defaults to HOME_DIR/.ceramic/logs. Deprecated'
   )
   .option(
     '--network <name>',
@@ -37,11 +37,11 @@ program
   .option('--pubsubTopic <string>', 'Pub/sub topic to use for protocol messages')
   .option(
     '--cors-allowed-origins <list>',
-    'Space-separated list of strings and/or regex expressions to set for Access-Control-Allow-Origin . Defaults to all: ".*"'
+    'Space-separated list of strings and/or regex expressions to set for Access-Control-Allow-Origin . Defaults to all: ".*". Deprecated.'
   )
   .option(
     '--sync-override <string>',
-    'Global forced mode for syncing all streams. One of: "prefer-cache", "sync-always", or "never-sync". Defaults to "prefer-cache"'
+    'Global forced mode for syncing all streams. One of: "prefer-cache", "sync-always", or "never-sync". Defaults to "prefer-cache". Deprecated.'
   )
   .description('Start the daemon')
   .action(

--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -11,10 +11,6 @@ program
     'The Ethereum RPC URL used for communicating with Ethereum blockchain'
   )
   .option('--anchor-service-api <url>', 'The anchor service URL to use')
-  .option(
-    '--validate-streams',
-    'Validate streams according to their schemas. It is enabled by default'
-  )
   .option('--ipfs-pinning-endpoint <url...>', 'Ipfs pinning endpoints')
   .option(
     '--state-store-directory <string>',
@@ -40,14 +36,6 @@ program
   )
   .option('--pubsubTopic <string>', 'Pub/sub topic to use for protocol messages')
   .option(
-    '--max-healthy-cpu <decimal>',
-    'Fraction of total CPU usage considered healthy. Defaults to 0.7'
-  )
-  .option(
-    '--max-healthy-memory <decimal>',
-    'Fraction of total memory usage considered healthy. Defaults to 0.7'
-  )
-  .option(
     '--cors-allowed-origins <list>',
     'Space-separated list of strings and/or regex expressions to set for Access-Control-Allow-Origin . Defaults to all: ".*"'
   )
@@ -62,7 +50,6 @@ program
       ipfsApi,
       ethereumRpc,
       anchorServiceApi,
-      validateStreams,
       ipfsPinningEndpoint,
       stateStoreDirectory,
       stateStoreS3Bucket,
@@ -83,7 +70,6 @@ program
         ipfsApi,
         ethereumRpc,
         anchorServiceApi,
-        validateStreams,
         ipfsPinningEndpoint,
         stateStoreDirectory,
         stateStoreS3Bucket,

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -58,7 +58,6 @@ export class CeramicCliUtils {
    * @param ipfsApi - IPFS api
    * @param ethereumRpc - Ethereum RPC URL
    * @param anchorServiceApi - Anchor service API URL
-   * @param validateStreams - Validate streams according to schemas or not
    * @param ipfsPinningEndpoints - Ipfs pinning endpoints
    * @param stateStoreDirectory - Path to the directory that will be used for storing pinned stream state
    * @param stateStoreS3Bucket - S3 bucket name for storing pinned stream state
@@ -79,7 +78,6 @@ export class CeramicCliUtils {
     ipfsApi: string,
     ethereumRpc: string,
     anchorServiceApi: string,
-    validateStreams: boolean,
     ipfsPinningEndpoints: string[],
     stateStoreDirectory: string,
     stateStoreS3Bucket: string,

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -56,22 +56,22 @@ export class CeramicCliUtils {
    * Create CeramicDaemon instance
    * @param configFilePath - Path to daemon config file
    * @param ipfsApi - IPFS api
-   * @param ethereumRpc - Ethereum RPC URL
-   * @param anchorServiceApi - Anchor service API URL
-   * @param ipfsPinningEndpoints - Ipfs pinning endpoints
-   * @param stateStoreDirectory - Path to the directory that will be used for storing pinned stream state
-   * @param stateStoreS3Bucket - S3 bucket name for storing pinned stream state
+   * @param ethereumRpc - Ethereum RPC URL. Deprecated, use config file if you want to configure this.
+   * @param anchorServiceApi - Anchor service API URL. Deprecated, use config file if you want to configure this.
+   * @param ipfsPinningEndpoints - Ipfs pinning endpoints. Deprecated, use config file if you want to configure this.
+   * @param stateStoreDirectory - Path to the directory that will be used for storing pinned stream state. Deprecated, use config file if you want to configure this.
+   * @param stateStoreS3Bucket - S3 bucket name for storing pinned stream state. Deprecated, use config file if you want to configure this.
    * @param gateway - read only endpoints available. It is disabled by default
    * @param port - port on which daemon is available. Default is 7007
    * @param hostname - hostname to listen on.
    * @param debug - Enable debug logging level
    * @param verbose - Enable verbose logging
-   * @param logToFiles - Enable writing logs to files
-   * @param logDirectory - Store log files in this directory
+   * @param logToFiles - Enable writing logs to files. Deprecated, use config file if you want to configure this.
+   * @param logDirectory - Store log files in this directory. Deprecated, use config file if you want to configure this.
    * @param network - The Ceramic network to connect to
    * @param pubsubTopic - Pub/sub topic to use for protocol messages.
-   * @param corsAllowedOrigins - Origins for Access-Control-Allow-Origin header. Default is all
-   * @param syncOverride - Global forced mode for syncing all streams. Defaults to "prefer-cache"
+   * @param corsAllowedOrigins - Origins for Access-Control-Allow-Origin header. Default is all. Deprecated, use config file if you want to configure this.
+   * @param syncOverride - Global forced mode for syncing all streams. Defaults to "prefer-cache". Deprecated, use config file if you want to configure this.
    */
   static async createDaemon(
     configFilePath: string,


### PR DESCRIPTION
Also fully removes the `--validate-streams`, `--max-healthy-cpu`, and `--max-healthy-memory` flags, which already don't do anything.