### PR TITLE
feat: named exports

### DIFF
--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -216,7 +216,7 @@ const resolve = async (
   }
 }
 
-export default {
+export const threeId =  {
   getResolver: (ceramic: CeramicApi): ResolverRegistry => ({
     '3': (
       did: string,
@@ -254,3 +254,5 @@ export default {
     },
   }),
 }
+
+export default threeId

--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -216,8 +216,8 @@ const resolve = async (
   }
 }
 
-export const threeId =  {
-  getResolver: (ceramic: CeramicApi): ResolverRegistry => ({
+export function getResolver(ceramic: CeramicApi): ResolverRegistry {
+  return {
     '3': (
       did: string,
       parsed: ParsedDID,
@@ -252,7 +252,7 @@ export const threeId =  {
         }
       })
     },
-  }),
+  }
 }
 
-export default threeId
+export default { getResolver }

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -164,7 +164,7 @@ const tryStreamId = (id: string): StreamID | null => {
  * To install this library:<br/>
  * `$ npm install --save @ceramicnetwork/core`
  */
-class Ceramic implements CeramicApi {
+export class Ceramic implements CeramicApi {
   public readonly context: Context
   public readonly dispatcher: Dispatcher
   public readonly loggerProvider: LoggerProvider

--- a/packages/key-did-resolver/src/index.ts
+++ b/packages/key-did-resolver/src/index.ts
@@ -19,7 +19,7 @@ const prefixToDriverMap: any = {
   0xed: ed25519,
 }
 
-export default {
+export const key = {
   getResolver: (): ResolverRegistry => ({
     key: async (
       did: string,
@@ -55,3 +55,5 @@ export default {
     },
   }),
 }
+
+export default key

--- a/packages/key-did-resolver/src/index.ts
+++ b/packages/key-did-resolver/src/index.ts
@@ -19,8 +19,8 @@ const prefixToDriverMap: any = {
   0xed: ed25519,
 }
 
-export const key = {
-  getResolver: (): ResolverRegistry => ({
+export function getResolver(): ResolverRegistry {
+  return {
     key: async (
       did: string,
       parsed: ParsedDID,
@@ -53,7 +53,7 @@ export const key = {
       }
       return response
     },
-  }),
+  }
 }
 
-export default key
+export default { getResolver }


### PR DESCRIPTION
Following on https://github.com/ceramicnetwork/js-ceramic/pull/1661 this adds named exports for the DID resolvers and the core package.