### PR TITLE
feat: remove mainnet unsupported error

### DIFF
--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -323,10 +323,6 @@ export class Ceramic implements CeramicApi {
       }
     }
 
-    if (networkName == Networks.MAINNET) {
-      throw new Error('Ceramic mainnet is not yet supported')
-    }
-
     return { name: networkName, pubsubTopic }
   }
 


### PR DESCRIPTION
Instead of throwing an error when someone uses the mainnet flag we should now allow people to run Ceramic on mainnet.

@oed Is this correct?