### PR TITLE
chore(core): Prevent using custom CAS on mainnet

### DIFF
--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -379,6 +379,12 @@ export class Ceramic implements CeramicApi {
       const anchorServiceUrl =
         config.anchorServiceUrl || DEFAULT_ANCHOR_SERVICE_URLS[networkOptions.name]
 
+      if (
+        (networkOptions.name == Networks.MAINNET || networkOptions.name == Networks.ELP) &&
+        anchorServiceUrl != DEFAULT_ANCHOR_SERVICE_URLS[networkOptions.name]
+      ) {
+        throw new Error('Cannot use custom anchor service on Ceramic mainnet')
+      }
       anchorService =
         networkOptions.name != Networks.INMEMORY
           ? new EthereumAnchorService(anchorServiceUrl, logger)


### PR DESCRIPTION
Until we have the trusted set of anchor services project complete, we don't want anyone using any anchor service other than our official one