### PR TITLE
chore: Bump ethers to the latest version

### DIFF
--- a/packages/blockchain-utils-linking/package.json
+++ b/packages/blockchain-utils-linking/package.json
@@ -30,7 +30,7 @@
     "uint8arrays": "^2.0.5"
   },
   "devDependencies": {
-    "@ethersproject/providers": "5.0.23",
+    "@ethersproject/providers": "^5.4.5",
     "@glif/filecoin-address": "1.1.0",
     "@glif/local-managed-provider": "1.1.0",
     "@polkadot/api": "^4.6.2",

--- a/packages/blockchain-utils-linking/src/__tests__/ethereum.test.ts
+++ b/packages/blockchain-utils-linking/src/__tests__/ethereum.test.ts
@@ -2,7 +2,6 @@ import { AccountID } from 'caip'
 import ganache from 'ganache-core'
 import * as sigUtils from 'eth-sig-util'
 import { ContractFactory, Contract } from '@ethersproject/contracts'
-import * as providers from '@ethersproject/providers'
 import { encodeRpcMessage } from '../util'
 import * as ethereum from '../ethereum'
 
@@ -78,14 +77,6 @@ beforeAll(async () => {
   })
   await send(provider, encodeRpcMessage('eth_sendTransaction', [unsignedTx]))
   contractAddress = Contract.getContractAddress(unsignedTx)
-  // mock ethers providers
-  ;(providers as any).getNetwork = (): any => {
-    return {
-      _defaultProvider: (): any => {
-        return new providers.Web3Provider(provider)
-      },
-    }
-  }
   global.Date.now = jest.fn().mockImplementation(() => 666)
 })
 

--- a/packages/blockchain-utils-validation/package.json
+++ b/packages/blockchain-utils-validation/package.json
@@ -25,9 +25,9 @@
   },
   "dependencies": {
     "@ceramicnetwork/blockchain-utils-linking": "^1.1.2",
-    "@ethersproject/contracts": "^5.0.9",
-    "@ethersproject/providers": "5.0.23",
-    "@ethersproject/wallet": "^5.0.10",
+    "@ethersproject/contracts": "^5.4.1",
+    "@ethersproject/providers": "^5.4.5",
+    "@ethersproject/wallet": "^5.4.0",
     "@polkadot/util-crypto": "^7.0.2",
     "@smontero/eosio-signing-tools": "^0.0.6",
     "@stablelib/ed25519": "^1.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "@ceramicnetwork/stream-tile": "^1.2.0",
     "@ceramicnetwork/stream-tile-handler": "^1.2.0",
     "@ceramicnetwork/streamid": "^1.1.2",
-    "@ethersproject/providers": "5.0.23",
+    "@ethersproject/providers": "^5.4.5",
     "@stablelib/random": "^1.0.0",
     "@stablelib/sha256": "^1.0.0",
     "ajv": "^8.1.0",


### PR DESCRIPTION
Required for 1559 support.

Ceramic uses old ethers packages. CAS uses some Ceramic packages. Due to hoisting, CAS can not really use new ethers packages in presence of the old ethers required by Ceramic packages. So, here we are, updating ethers in Ceramic.