### PR TITLE
chore: Made test suite run again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
   build-and-test:
     docker:
       - image: circleci/node:14
+    resource_class: "medium+"
     environment:
       NODE_OPTIONS: "--max_old_space_size=4096"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,16 @@
 version: 2.1
 orbs:
-  node: circleci/node@4.5.1
+  node: circleci/node@4.7.0
 jobs:
   build-and-test:
-    docker:
-      - image: circleci/node:14
-    resource_class: "medium+"
+    machine:
+      image: ubuntu-2004:202107-02
     environment:
       NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
       - checkout
+      - node/install-npm:
+          version: "6"
       - node/install-packages
       - run: npm run lint
       - run: npm run build

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/eosio.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/eosio.test.ts
@@ -3,7 +3,7 @@ import { validateLink } from '../eosio'
 import { AccountID } from 'caip'
 import * as linking from '@ceramicnetwork/blockchain-utils-linking'
 
-jest.setTimeout(30000)
+jest.setTimeout(120000)
 
 const did = 'did:3:bafysdfwefwe'
 const telosTestnetChainId = '1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f'


### PR DESCRIPTION
- Increase timeout for EOS test in blockchain-utils-validation
- Set max Node memory to 4G
- Change CircleCI executor from `docker` to `machine`: increases available memory from 4G to 7.5G

Note: we are still on "medium" machine, please disregard "medium+" commit.