### PR TITLE
fix(core): allow cas internal url

### DIFF
--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -381,7 +381,7 @@ export class Ceramic implements CeramicApi {
 
       if (
         (networkOptions.name == Networks.MAINNET || networkOptions.name == Networks.ELP) &&
-        anchorServiceUrl != DEFAULT_ANCHOR_SERVICE_URLS[networkOptions.name]
+        !(anchorServiceUrl in [DEFAULT_ANCHOR_SERVICE_URLS[networkOptions.name], "https://cas-internal.3boxlabs.com"])
       ) {
         throw new Error('Cannot use custom anchor service on Ceramic mainnet')
       }


### PR DESCRIPTION
### Motivation
Latest mainnet release from last week was not deployed to 3Box infra successfully due to prohibiting passing an anchor service url when on mainnet.

One way to fix this is to use the default mainnet cas url `http://cas.3boxlabs.com` and add static IPs for our nodes to the firewall. This is unfortunately non-trivial as we are using load balancers pointing to ECS targets so we don't have static IPs and setting up a configuration to generate static IPs is likely a week of work to do it right.

The other way to fix it is this PR.

### Changes
- Do not throw an error if the url passed is `https://cas-internal.3boxlabs.com`

### Notes

All of our mainnet nodes are still on https://github.com/ceramicnetwork/js-ceramic/commit/3aad2e20d08815c00695f528c18b6b37372552dc with the exception of the gateway (https://github.com/ceramicnetwork/js-ceramic/commit/987fccc9afce634de44922c32068004a3b354d48), which is not affected by this code.

It's a good thing that when new deployments fail, the old ones continue to run, however we lack visibility into this failure mode. Opened a story here to address this: https://app.zenhub.com/workspaces/platform-611996cb76d3b50013bfb993/issues/3box/ceramic-infra/436