### PR TITLE
fix(core): check for cas url equality

### DIFF
--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -381,7 +381,8 @@ export class Ceramic implements CeramicApi {
 
       if (
         (networkOptions.name == Networks.MAINNET || networkOptions.name == Networks.ELP) &&
-        !(anchorServiceUrl in [DEFAULT_ANCHOR_SERVICE_URLS[networkOptions.name], "https://cas-internal.3boxlabs.com"])
+        (anchorServiceUrl !== "https://cas-internal.3boxlabs.com") &&
+        (anchorServiceUrl !== DEFAULT_ANCHOR_SERVICE_URLS[networkOptions.name])
       ) {
         throw new Error('Cannot use custom anchor service on Ceramic mainnet')
       }


### PR DESCRIPTION
The 'in' syntax did not work 😥

Tested with the following...

Fails
```
node packages/cli/bin/ceramic.js daemon --anchor-service-api "https://hello.example" --network=elp

...
Ceramic daemon failed to start up:
Error: Cannot use custom anchor service on Ceramic mainnet
```

Succeeds
```
node packages/cli/bin/ceramic.js daemon --anchor-service-api "https://cas.3boxlabs.com" --network=elp
```
```
node packages/cli/bin/ceramic.js daemon --anchor-service-api "https://cas-internal.3boxlabs.com" --network=elp
```