### PR TITLE
Support optional genesis property in multiquery API

### DIFF
--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -136,6 +136,10 @@ export interface CeramicApi extends CeramicSigner {
 
 export interface MultiQuery {
   /**
+   * The genesis content for the queried stream
+   */
+  genesis?: Record<string, any>
+  /**
    * The StreamID of the stream to load
    */
   streamId: CommitID | StreamID | string

--- a/packages/common/src/streamopts.ts
+++ b/packages/common/src/streamopts.ts
@@ -1,3 +1,4 @@
+import { Stream } from './stream'
 /**
  * Options that are related to pinning streams.
  */
@@ -68,6 +69,14 @@ export interface LoadOpts extends SyncOpts, PinningOpts {
    * Load a previous version of the stream based on unix timestamp
    */
   atTime?: number
+  /**
+   * Provide the genesis content so it does not need to fetched from IPFS daemon
+   */
+  genesis?: Record<string, any>
+  /**
+   * The created stream from the genesis content. Only present is genesis is present.
+   */
+  streamFromGenesis?: Stream
 }
 
 /**

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -165,6 +165,12 @@ export class Repository {
         }
       }
 
+      if (!stream && opts.genesis && opts.streamFromGenesis) {
+        stream = new RunningState(opts.streamFromGenesis.state)
+        await this.stateManager.sync(stream, opts.syncTimeoutSeconds * 1000, fromStateStore)
+        return this.stateManager.verifyLoneGenesis(stream)
+      }
+
       if (!stream) {
         stream = await this.fromNetwork(streamId)
       }


### PR DESCRIPTION
This PR is meant to address issue https://github.com/ceramicnetwork/js-ceramic/issues/1647

### What was done
- Introduced an optional `genesis?: Record<string, any>` property in the `MultiQuery` interface 
- The `multiquery` function in Ceramic core calls `_loadLinkedStreams` and passes forward the `genesis` property
- `_loadLinkedStreams` calls `loadStream` iteratively, and passes `query.genesis` as part of the `LoadOpts` interface
- `LoadOpts` now has two additional optional properties - `genesis?: Record<string, any>` and `streamFromGenesis?: Stream`
- `loadStream` checks if the `opts.genesis` property is present, and if so, sets `opts.streamFromGenesis` to the returned result from `createStreamFromGenesis`
- `loadStream` proceeds to call either `repository.loadAtCommit`, `repository.loadAtTime` or `repository.load`, the former 2 of which call `repository.load` internally
- `repository.load` checks that if the stream could not be loaded from memory or the store, and the `genesis` and `streamFromGenesis` options are present. If so, it syncs the stream from pubsub and returns it after calling `verifyLoneGenesis` on it

### Expectations
This PR is expected to help with the loading times when the genesis content of a stream is available client side, but the server does not have it in memory or store as querying from pubsub is faster than the worst case `3 * 30s = 90s` timeout set on loading from IPFS.

### Issues
In `loadStream` at line 608 (https://github.com/ceramicnetwork/js-ceramic/blob/05c9b3cd13c92bbd2cdcd7e2f9298912814a7919/packages/core/src/ceramic.ts#L608) I check that the provided StreamID is equal to the created StreamID of the stream created from provided genesis content. 

I am unsure if the following line is proper:
`if (!opts.streamFromGenesis.id.equals(streamRef.baseID))` because I'm not sure if `streamRef.baseID` is the same thing as the StreamID or more of an initial StreamID that changes with updates.

---

### Notes
- This is my first PR to the `js-ceramic` repo so I would appreciate any and all feedback and thoughts. 
- I've cc'd the Protocol team, but not sure if anyone from Platform or Glaze also needs to review this PR before merge