### PR TITLE
chore(blockchain-utils-linking): Move near-api-js to prod dependencies

### DIFF
--- a/packages/blockchain-utils-linking/package.json
+++ b/packages/blockchain-utils-linking/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@stablelib/sha256": "^1.0.0",
     "caip": "~0.9.2",
+    "near-api-js": "^0.42.0",
     "uint8arrays": "^2.0.5"
   },
   "devDependencies": {
@@ -44,8 +45,7 @@
     "@tendermint/sig": "^0.6.0",
     "@zondax/filecoin-signing-tools": "^0.15.0",
     "eth-sig-util": "^3.0.0",
-    "ganache-core": "^2.13.1",
-    "near-api-js": "^0.42.0"
+    "ganache-core": "^2.13.1"
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
Bug report: #1786

CC @PaulLeCam 