### PR TITLE
chore(streamid): Don't use exceptions as control flow in StreamRef::from

### DIFF
--- a/packages/streamid/src/reading-bytes.ts
+++ b/packages/streamid/src/reading-bytes.ts
@@ -13,9 +13,17 @@ function isCidVersion(input: number): input is 0 | 1 {
 }
 
 export function readCid(bytes: Uint8Array): [CID, Uint8Array] {
+  const result = readCidNoThrow(bytes)
+  if (result instanceof Error) {
+    throw result
+  }
+  return result
+}
+
+export function readCidNoThrow(bytes: Uint8Array): [CID, Uint8Array] | Error {
   const [cidVersion, cidVersionRemainder] = readVarint(bytes)
   if (!isCidVersion(cidVersion)) {
-    throw new Error(`Unknown CID version ${cidVersion}`)
+    return new Error(`Unknown CID version ${cidVersion}`)
   }
   const [codec, codecRemainder] = readVarint(cidVersionRemainder)
   const [, mhCodecRemainder, mhCodecLength] = readVarint(codecRemainder)


### PR DESCRIPTION
This allows WebStorm's "Any exception" breakpoint to be useful again without hitting tons of false positives from `StreamRef::from`.

An alternative approach would have been to add `StreamID.isValid` and `CommitID.isValid` static methods that never throw but return true or false based on if their input is a valid representation of a StreamID/CommitID.  That approach though would have resulted in `StreamRef::from` parsing the same input twice - once to determine if it was valid, and a second time to actually parse the input into the appropriate data type.