### PR TITLE
feat: update Tezos message encoding based on community input

### DIFF
--- a/packages/blockchain-utils-linking/src/__tests__/__snapshots__/tezos.test.ts.snap
+++ b/packages/blockchain-utils-linking/src/__tests__/__snapshots__/tezos.test.ts.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Blockchain: Tezos authenticate create proof for NetXdQprcVkpaWU 1`] = `"0x15e26348cde1c94a5e0ec29fbea24d06a4c4bc1e2944d34c6ccf6b78cdcfc56d"`;
+exports[`Blockchain: Tezos authenticate create proof for NetXdQprcVkpaWU 1`] = `"0xa7be667195657a51d34efc8ce0fde68560d9110b243e737e695dc1325a9e8dbf"`;
 
-exports[`Blockchain: Tezos authenticate entropy replication for NetXdQprcVkpaWU 1`] = `"0x26adbdccdc12f976fc4fb8d7315f6e12c6a74720a3a6827e1fb42181aeb095a1"`;
+exports[`Blockchain: Tezos authenticate entropy replication for NetXdQprcVkpaWU 1`] = `"0x56db1b9d98064056438a5a9245c9be1e5116d63493959bb8387198d7dc5111a0"`;
 
-exports[`Blockchain: Tezos authenticate entropy replication for NetXdQprcVkpaWU 2`] = `"0x26adbdccdc12f976fc4fb8d7315f6e12c6a74720a3a6827e1fb42181aeb095a1"`;
+exports[`Blockchain: Tezos authenticate entropy replication for NetXdQprcVkpaWU 2`] = `"0x56db1b9d98064056438a5a9245c9be1e5116d63493959bb8387198d7dc5111a0"`;
 
 exports[`Blockchain: Tezos createLink create proof for NetXdQprcVkpaWU 1`] = `
 Object {
@@ -13,7 +13,7 @@ Object {
 
 did:3:bafysdfwefwe 
 Timestamp: 666",
-  "signature": "p2sigeBMBpSKhYJwMM2ZbZKLKHn4rTrNWyJQgLzWLNsAWj3Ktk5zrscHVaLsJYCvHFDeyX3LUouxvrMDABqRkcNKvrLJFFyzwW",
+  "signature": "p2sigNYcqkNERyCnBb7PKwmuZqeXBZx4m2c8YKcR282iWN9iafSdcTrJ4VxQdANg1oo7nGteZ7uGEDiy1ZpAqCCb71xdy9MptM",
   "timestamp": 666,
   "version": 2,
 }

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/__snapshots__/tezos.test.ts.snap
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/__snapshots__/tezos.test.ts.snap
@@ -24,7 +24,7 @@ Object {
 
 did:3:bafysdfwefwe 
 Timestamp: 666",
-  "signature": "p2sigeBMBpSKhYJwMM2ZbZKLKHn4rTrNWyJQgLzWLNsAWj3Ktk5zrscHVaLsJYCvHFDeyX3LUouxvrMDABqRkcNKvrLJFFyzwW",
+  "signature": "p2sigNYcqkNERyCnBb7PKwmuZqeXBZx4m2c8YKcR282iWN9iafSdcTrJ4VxQdANg1oo7nGteZ7uGEDiy1ZpAqCCb71xdy9MptM",
   "timestamp": 666,
   "version": 2,
 }


### PR DESCRIPTION
# Update Tezos message encoding in `@ceramicnetwork/blockchain-utils-*`

## Description

Taking into consideration Tezos community input, a signing message string should be transferred to a signer as its Micheline representation for security reasons.

## How Has This Been Tested?

Unit tests have been updated.

## References:
 - https://github.com/Cryptonomic/ConseilJS/blob/fb718632d6ce47718dad5aa77c67fc514afaa0b9/src/chain/tezos/lexer/Micheline.ts#L62L71
 - https://tezos.gitlab.io/shell/micheline.html
