### PR TITLE
feat(core): Add stateSource to runningState

### DIFF
--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -8,7 +8,7 @@ import { delay } from './delay'
 import tmp from 'tmp-promise'
 import { LevelStateStore } from '../store/level-state-store'
 import { PinStore } from '../store/pin-store'
-import { RunningState } from '../state-management/running-state'
+import { RunningState, StateSource } from '../state-management/running-state'
 import { StateManager } from '../state-management/state-manager'
 import cloneDeep from 'lodash.clonedeep'
 
@@ -183,7 +183,7 @@ describe('Dispatcher', () => {
     dispatcher.repository.stateManager = {} as unknown as StateManager
 
     async function register(state: StreamState) {
-      const runningState = new RunningState(state)
+      const runningState = new RunningState(state, StateSource.STATESTORE)
       repository.add(runningState)
       dispatcher.messageBus.queryNetwork(runningState.id).subscribe()
       return runningState

--- a/packages/core/src/__tests__/local-pin-api.test.ts
+++ b/packages/core/src/__tests__/local-pin-api.test.ts
@@ -4,7 +4,7 @@ import * as random from '@stablelib/random'
 import { CommitType, StreamState, LoggerProvider } from '@ceramicnetwork/common'
 import { Repository } from '../state-management/repository'
 import CID from 'cids'
-import { RunningState } from '../state-management/running-state'
+import { RunningState, StateSource } from '../state-management/running-state'
 
 const STREAM_ID = StreamID.fromString(
   'k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki'
@@ -17,7 +17,7 @@ const streamState = {
   type: 0,
   log: [{ cid: FAKE_CID, type: CommitType.GENESIS }],
 } as unknown as StreamState
-const state$ = new RunningState(streamState)
+const state$ = new RunningState(streamState, StateSource.STATESTORE)
 const loadStream = jest.fn(async () => state$)
 
 const pinApi = new LocalPinApi(repository, loadStream, new LoggerProvider().getDiagnosticsLogger())

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -6,7 +6,7 @@ import {
   StreamUtils,
 } from '@ceramicnetwork/common'
 import CID from 'cids'
-import { RunningState } from '../state-management/running-state'
+import { RunningState, StateSource } from '../state-management/running-state'
 import { createIPFS } from './ipfs-util'
 import { createCeramic } from './create-ceramic'
 import Ceramic from '../ceramic'
@@ -379,7 +379,7 @@ test('handles basic conflict', async () => {
   const initialState = await ceramic.repository.stateManager
     .atCommit(streamState1, streamId.atCommit(streamId.cid))
     .then((stream) => stream.state)
-  const state$ = new RunningState(initialState)
+  const state$ = new RunningState(initialState, StateSource.STATESTORE)
   ceramic.repository.add(state$)
   await (ceramic.repository.stateManager as any)._handleTip(state$, tipPreUpdate)
   await new Promise((resolve) => setTimeout(resolve, 1000))

--- a/packages/core/src/state-management/__tests__/running-state.test.ts
+++ b/packages/core/src/state-management/__tests__/running-state.test.ts
@@ -57,15 +57,29 @@ test('emit on distinct changes', async () => {
   expect(updates[1]).toBe(second)
 })
 
-test('set pinned state', async () => {
-  const state$ = new RunningState(initial, StateSource.NETWORK)
-  console.log(state$.pinnedCommits)
-  expect(state$.pinnedCommits).toBe(undefined)
-  expect(state$.stateSource).toBe(StateSource.NETWORK)
+describe('set pinned state', () => {
+  test('set in constructor then set in call to setPinnedState', async () => {
+    const state$ = new RunningState(initial, StateSource.STATESTORE)
+    expect(state$.pinnedCommits.size).toBe(1)
+    expect(state$.stateSource).toBe(StateSource.STATESTORE)
+    expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)
 
-  state$.setPinnedState(second)
-  expect(state$.pinnedCommits.size).toBe(2)
-  expect(state$.stateSource).toBe(StateSource.STATESTORE)
-  expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)
-  expect(state$.pinnedCommits.has(FAKE_CID2.toString())).toBe(true)
+    state$.setPinnedState(second)
+    expect(state$.pinnedCommits.size).toBe(2)
+    expect(state$.stateSource).toBe(StateSource.STATESTORE)
+    expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)
+    expect(state$.pinnedCommits.has(FAKE_CID2.toString())).toBe(true)
+  })
+
+  test('not set in constructor but set in call to setPinnedStae', async () => {
+    const state$ = new RunningState(initial, StateSource.NETWORK)
+    expect(state$.pinnedCommits).toBe(undefined)
+    expect(state$.stateSource).toBe(StateSource.NETWORK)
+
+    state$.setPinnedState(second)
+    expect(state$.pinnedCommits.size).toBe(2)
+    expect(state$.stateSource).toBe(StateSource.STATESTORE)
+    expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)
+    expect(state$.pinnedCommits.has(FAKE_CID2.toString())).toBe(true)
+  })
 })

--- a/packages/core/src/state-management/__tests__/running-state.test.ts
+++ b/packages/core/src/state-management/__tests__/running-state.test.ts
@@ -1,32 +1,32 @@
 import CID from 'cids'
 import { CommitType, StreamState } from '@ceramicnetwork/common'
-import { RunningState } from '../running-state'
+import { RunningState, StateSource } from '../running-state'
 
-const FAKE_CID_1 = new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
+const FAKE_CID1 = new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
 const FAKE_CID2 = new CID('bafybeig6xv5nwphfmvcnektpnojts44jqcuam7bmye2pb54adnrtccjlsu')
 
-test('emit on distinct changes', async () => {
-  const initial = {
-    type: 0,
-    log: [
-      {
-        type: CommitType.GENESIS,
-        cid: FAKE_CID_1,
-      },
-    ],
-  } as unknown as StreamState
-  const second = {
-    ...initial,
-    log: [
-      ...initial.log,
-      {
-        type: CommitType.SIGNED,
-        cid: FAKE_CID2,
-      },
-    ],
-  } as unknown as StreamState
+const initial = {
+  type: 0,
+  log: [
+    {
+      type: CommitType.GENESIS,
+      cid: FAKE_CID1,
+    },
+  ],
+} as unknown as StreamState
+const second = {
+  ...initial,
+  log: [
+    ...initial.log,
+    {
+      type: CommitType.SIGNED,
+      cid: FAKE_CID2,
+    },
+  ],
+} as unknown as StreamState
 
-  const state$ = new RunningState(initial)
+test('emit on distinct changes', async () => {
+  const state$ = new RunningState(initial, StateSource.STATESTORE)
   const updates: StreamState[] = []
   state$.subscribe((state) => {
     updates.push(state)
@@ -55,4 +55,17 @@ test('emit on distinct changes', async () => {
   expect(updates.length).toEqual(2)
   expect(updates[0]).toBe(initial)
   expect(updates[1]).toBe(second)
+})
+
+test('set pinned state', async () => {
+  const state$ = new RunningState(initial, StateSource.NETWORK)
+  console.log(state$.pinnedCommits)
+  expect(state$.pinnedCommits).toBe(undefined)
+  expect(state$.stateSource).toBe(StateSource.NETWORK)
+
+  state$.setPinnedState(second)
+  expect(state$.pinnedCommits.size).toBe(2)
+  expect(state$.stateSource).toBe(StateSource.STATESTORE)
+  expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)
+  expect(state$.pinnedCommits.has(FAKE_CID2.toString())).toBe(true)
 })

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -17,7 +17,7 @@ import {
 import { PinStore } from '../store/pin-store'
 import { DiagnosticsLogger } from '@ceramicnetwork/common'
 import { ExecutionQueue } from './execution-queue'
-import { RunningState } from './running-state'
+import { RunningState, StateSource } from './running-state'
 import { StateManager } from './state-manager'
 import type { Dispatcher } from '../dispatcher'
 import type { ConflictResolution } from '../conflict-resolution'
@@ -104,7 +104,7 @@ export class Repository {
   private async fromStateStore(streamId: StreamID): Promise<RunningState | undefined> {
     const streamState = await this.#deps.pinStore.stateStore.load(streamId)
     if (streamState) {
-      const runningState = new RunningState(streamState)
+      const runningState = new RunningState(streamState, StateSource.STATESTORE)
       this.add(runningState)
       const toRecover =
         runningState.value.anchorStatus === AnchorStatus.PENDING ||
@@ -129,7 +129,7 @@ export class Repository {
     commitData.disableTimecheck = true
     const state = await handler.applyCommit(commitData, this.#deps.context)
     await this.#deps.stateValidation.validate(state, state.content)
-    const state$ = new RunningState(state)
+    const state$ = new RunningState(state, StateSource.STATESTORE)
     this.add(state$)
     this.logger.verbose(`Genesis commit for stream ${streamId.toString()} successfully loaded`)
     return state$
@@ -325,7 +325,7 @@ export class Repository {
     return new Observable<StreamState>((subscriber) => {
       const id = new StreamID(init.type, init.log[0].cid)
       this.get(id).then((found) => {
-        const state$ = found || new RunningState(init)
+        const state$ = found || new RunningState(init, StateSource.STATESTORE)
         this.inmemory.endure(id.toString(), state$)
         state$.subscribe(subscriber).add(() => {
           if (state$.observers.length === 0) {

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -129,7 +129,7 @@ export class Repository {
     commitData.disableTimecheck = true
     const state = await handler.applyCommit(commitData, this.#deps.context)
     await this.#deps.stateValidation.validate(state, state.content)
-    const state$ = new RunningState(state, StateSource.STATESTORE)
+    const state$ = new RunningState(state, StateSource.NETWORK)
     this.add(state$)
     this.logger.verbose(`Genesis commit for stream ${streamId.toString()} successfully loaded`)
     return state$
@@ -325,7 +325,7 @@ export class Repository {
     return new Observable<StreamState>((subscriber) => {
       const id = new StreamID(init.type, init.log[0].cid)
       this.get(id).then((found) => {
-        const state$ = found || new RunningState(init, StateSource.STATESTORE)
+        const state$ = found || new RunningState(init, StateSource.NETWORK)
         this.inmemory.endure(id.toString(), state$)
         state$.subscribe(subscriber).add(() => {
           if (state$.observers.length === 0) {

--- a/packages/core/src/state-management/running-state.ts
+++ b/packages/core/src/state-management/running-state.ts
@@ -13,7 +13,7 @@ import CID from 'cids'
  */
 export enum StateSource {
   /**
-   * Source of the state is form a state store. This will cause runningState to keep track of the stored commit CIDs.
+   * Source of the state is from a state store. This will cause runningState to keep track of the stored commit CIDs.
    * The stored commit CIDs can be used to prevent commits from being stored again.
    */
   STATESTORE,

--- a/packages/core/src/state-management/running-state.ts
+++ b/packages/core/src/state-management/running-state.ts
@@ -9,16 +9,16 @@ import { StreamID } from '@ceramicnetwork/streamid'
 import CID from 'cids'
 
 /**
- * Describes the source of the state
+ * Describes the source from which this RunningState was initialized with its StreamState
  */
 export enum StateSource {
   /**
-   * Source of the state is from a state store. This will cause runningState to keep track of the stored commit CIDs.
+   * Indicates that the stream was pinned and its state was loaded from the StateStore. This will cause runningState to keep track of the stored commit CIDs.
    * The stored commit CIDs can be used to prevent commits from being stored again.
    */
   STATESTORE,
   /**
-   * Source of the state is the network.
+   * Indicates that the Stream was loaded from the network.
    * runningState does not keep track of the commit CID's of the state as they may not have been stored.
    */
   NETWORK,

--- a/packages/core/src/state-management/running-state.ts
+++ b/packages/core/src/state-management/running-state.ts
@@ -8,8 +8,19 @@ import {
 import { StreamID } from '@ceramicnetwork/streamid'
 import CID from 'cids'
 
+/**
+ * Describes the source of the state
+ */
 export enum StateSource {
+  /**
+   * Source of the state is form a state store. This will cause runningState to keep track of the stored commit CIDs.
+   * The stored commit CIDs can be used to prevent commits from being stored again.
+   */
   STATESTORE,
+  /**
+   * Source of the state is the network.
+   * runningState does not keep track of the commit CID's of the state as they may not have been stored.
+   */
   NETWORK,
 }
 export class RunningState extends StreamStateSubject implements RunningStateLike {
@@ -22,7 +33,7 @@ export class RunningState extends StreamStateSubject implements RunningStateLike
     this.id = new StreamID(initial.type, initial.log[0].cid)
 
     if (stateSource === StateSource.STATESTORE) {
-      this.pinnedCommits = new Set(initial.log.map(({ cid }) => cid.toString()))
+      this.setPinnedState(initial)
     }
   }
 


### PR DESCRIPTION
# Optimize Pinning (Add state source to running state)
(https://github.com/ceramicnetwork/ceramic/issues/114)
(https://github.com/ceramicnetwork/ceramic/issues/115)

## Description

Update RunningState constructor to always take a StateSource argument so you know whether the state came from the state store or from the network. 
Store the pinned CIDs so we won't pin them again

## How Has This Been Tested?

Added a test to the running state tests 

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties

## References:
None