### PR TITLE
Pass through all parameters for multiquery through the HTTP Client

### DIFF
--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -389,6 +389,30 @@ describe('Ceramic interop: core <> http-client', () => {
       expect(resCore[docC.id.toString()].content).toEqual(resClient[docC.id.toString()].content)
       expect(resCore[docD.id.toString()].content).toEqual(resClient[docD.id.toString()].content)
     })
+
+    it('returns stream when using multiquery with genesis and no updates', async () => {
+      const metadata = {
+        controllers: ['did:test'],
+        family: 'test',
+      }
+      const genesis = await TileDocument.makeGenesis(
+        {
+          did: core.did,
+        },
+        null,
+        {
+          ...metadata,
+          deterministic: true,
+        }
+      )
+
+      const streamId = await StreamID.fromGenesis('tile', genesis)
+      const resCore = await core.multiQuery([{ genesis, streamId }])
+      const resClient = await client.multiQuery([{ genesis, streamId }])
+
+      expect(resCore[streamId.toString()].metadata).toEqual(metadata)
+      expect(resClient[streamId.toString()].metadata).toEqual(metadata)
+    })
   })
 
   describe('pin api', () => {

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -145,9 +145,8 @@ export class CeramicClient implements CeramicApi {
   async multiQuery(queries: Array<MultiQuery>): Promise<Record<string, Stream>> {
     const queriesJSON = queries.map((q) => {
       return {
+        ...q,
         streamId: typeof q.streamId === 'string' ? q.streamId : q.streamId.toString(),
-        paths: q.paths,
-        atTime: q.atTime,
       }
     })
 


### PR DESCRIPTION
# [Pass all parameters when using multiqueries through HTTP Client] - #[https://github.com/ceramicnetwork/js-ceramic/issues/1797]

## Description

https://github.com/ceramicnetwork/js-ceramic/issues/1797 described the case where loading a deterministic stream with provided genesis did not resolve while using multiqueries. However, it should have been. The issue arose due to the HTTP client not passing forth the `genesis` parameter to the ceramic daemon, which this PR fixes.


- [x] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties
