### PR TITLE
feat(core): Update running state's pinned commits when adding pins to pin store

### DIFF
--- a/packages/core/src/__tests__/local-pin-api.test.ts
+++ b/packages/core/src/__tests__/local-pin-api.test.ts
@@ -1,7 +1,7 @@
 import { LocalPinApi } from '../local-pin-api'
 import StreamID from '@ceramicnetwork/streamid'
 import * as random from '@stablelib/random'
-import { CommitType, StreamState, LoggerProvider } from '@ceramicnetwork/common'
+import { CommitType, StreamState, LoggerProvider, SyncOptions } from '@ceramicnetwork/common'
 import { Repository } from '../state-management/repository'
 import CID from 'cids'
 import { RunningState, StateSource } from '../state-management/running-state'
@@ -32,7 +32,7 @@ async function toArray<A>(iterable: AsyncIterable<A>): Promise<A[]> {
 
 test('add', async () => {
   await pinApi.add(STREAM_ID)
-  expect(repository.load).toBeCalledWith(STREAM_ID, {})
+  expect(repository.load).toBeCalledWith(STREAM_ID, { sync: SyncOptions.PREFER_CACHE })
   expect(repository.pin).toBeCalledWith(state$)
 })
 

--- a/packages/core/src/__tests__/local-pin-api.test.ts
+++ b/packages/core/src/__tests__/local-pin-api.test.ts
@@ -11,16 +11,18 @@ const STREAM_ID = StreamID.fromString(
 )
 const FAKE_CID = new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
 
-const repository = { pin: jest.fn(), unpin: jest.fn(), list: jest.fn() } as unknown as Repository
-
 const streamState = {
   type: 0,
   log: [{ cid: FAKE_CID, type: CommitType.GENESIS }],
 } as unknown as StreamState
 const state$ = new RunningState(streamState, StateSource.STATESTORE)
-const loadStream = jest.fn(async () => state$)
-
-const pinApi = new LocalPinApi(repository, loadStream, new LoggerProvider().getDiagnosticsLogger())
+const repository = {
+  load: jest.fn(() => Promise.resolve(state$)),
+  pin: jest.fn(),
+  unpin: jest.fn(),
+  list: jest.fn(),
+} as unknown as Repository
+const pinApi = new LocalPinApi(repository, new LoggerProvider().getDiagnosticsLogger())
 
 async function toArray<A>(iterable: AsyncIterable<A>): Promise<A[]> {
   const result: A[] = []
@@ -30,7 +32,7 @@ async function toArray<A>(iterable: AsyncIterable<A>): Promise<A[]> {
 
 test('add', async () => {
   await pinApi.add(STREAM_ID)
-  expect(loadStream).toBeCalledWith(STREAM_ID)
+  expect(repository.load).toBeCalledWith(STREAM_ID, {})
   expect(repository.pin).toBeCalledWith(state$)
 })
 

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -257,11 +257,7 @@ export class Ceramic implements CeramicApi {
   }
 
   private _buildPinApi(): PinApi {
-    const boundStreamLoader = this.loadStream.bind(this)
-    const loaderWithSyncSet = (streamid) => {
-      return boundStreamLoader(streamid, { sync: SyncOptions.PREFER_CACHE })
-    }
-    return new LocalPinApi(this.repository, loaderWithSyncSet, this._logger)
+    return new LocalPinApi(this.repository, this._logger)
   }
 
   private static _generateNetworkOptions(config: CeramicConfig): CeramicNetworkOptions {

--- a/packages/core/src/local-pin-api.ts
+++ b/packages/core/src/local-pin-api.ts
@@ -1,4 +1,4 @@
-import { PinApi, PublishOpts, RunningStateLike } from '@ceramicnetwork/common'
+import { PinApi, PublishOpts, SyncOptions } from '@ceramicnetwork/common'
 import StreamID from '@ceramicnetwork/streamid'
 import { DiagnosticsLogger } from '@ceramicnetwork/common'
 import { Repository } from './state-management/repository'
@@ -13,7 +13,7 @@ export class LocalPinApi implements PinApi {
   ) {}
 
   async add(streamId: StreamID): Promise<void> {
-    const state$ = await this.repository.load(streamId, {})
+    const state$ = await this.repository.load(streamId, { sync: SyncOptions.PREFER_CACHE })
     await this.repository.pin(state$)
     this.logger.verbose(`Pinned stream ${streamId.toString()}`)
   }

--- a/packages/core/src/local-pin-api.ts
+++ b/packages/core/src/local-pin-api.ts
@@ -9,12 +9,11 @@ import { Repository } from './state-management/repository'
 export class LocalPinApi implements PinApi {
   constructor(
     private readonly repository: Repository,
-    private readonly loadStream: (streamId: StreamID) => Promise<RunningStateLike>,
     private readonly logger: DiagnosticsLogger
   ) {}
 
   async add(streamId: StreamID): Promise<void> {
-    const state$ = await this.loadStream(streamId)
+    const state$ = await this.repository.load(streamId, {})
     await this.repository.pin(state$)
     this.logger.verbose(`Pinned stream ${streamId.toString()}`)
   }

--- a/packages/core/src/state-management/__tests__/running-state.test.ts
+++ b/packages/core/src/state-management/__tests__/running-state.test.ts
@@ -58,25 +58,29 @@ test('emit on distinct changes', async () => {
 })
 
 describe('set pinned state', () => {
-  test('set in constructor then set in call to setPinnedState', async () => {
-    const state$ = new RunningState(initial, StateSource.STATESTORE)
+  test('set in constructor then set in call to markAsPinned', async () => {
+    const streamState = Object.assign({}, initial)
+    const state$ = new RunningState(streamState, StateSource.STATESTORE)
     expect(state$.pinnedCommits.size).toBe(1)
     expect(state$.stateSource).toBe(StateSource.STATESTORE)
     expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)
 
-    state$.setPinnedState(second)
+    Object.assign(streamState, second)
+    state$.markAsPinned()
     expect(state$.pinnedCommits.size).toBe(2)
     expect(state$.stateSource).toBe(StateSource.STATESTORE)
     expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)
     expect(state$.pinnedCommits.has(FAKE_CID2.toString())).toBe(true)
   })
 
-  test('not set in constructor but set in call to setPinnedStae', async () => {
-    const state$ = new RunningState(initial, StateSource.NETWORK)
+  test('not set in constructor but set in call to markAsPinned', async () => {
+    const streamState = Object.assign({}, initial)
+    const state$ = new RunningState(streamState, StateSource.NETWORK)
     expect(state$.pinnedCommits).toBe(undefined)
     expect(state$.stateSource).toBe(StateSource.NETWORK)
 
-    state$.setPinnedState(second)
+    Object.assign(streamState, second)
+    state$.markAsPinned()
     expect(state$.pinnedCommits.size).toBe(2)
     expect(state$.stateSource).toBe(StateSource.STATESTORE)
     expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -2,14 +2,12 @@ import StreamID, { CommitID } from '@ceramicnetwork/streamid'
 import {
   AnchorService,
   AnchorStatus,
-  CommitType,
   Context,
   CreateOpts,
   LoadOpts,
   PinningOpts,
   PublishOpts,
   StreamState,
-  StreamStateHolder,
   StreamUtils,
   SyncOptions,
   UpdateOpts,
@@ -286,8 +284,8 @@ export class Repository {
     this.inmemory.set(state$.id.toString(), state$)
   }
 
-  pin(streamStateHolder: StreamStateHolder): Promise<void> {
-    return this.#deps.pinStore.add(new RunningState(streamStateHolder.state, StateSource.NETWORK))
+  pin(state$: RunningState): Promise<void> {
+    return this.#deps.pinStore.add(state$)
   }
 
   async unpin(streamId: StreamID, opts?: PublishOpts): Promise<void> {

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -287,7 +287,7 @@ export class Repository {
   }
 
   pin(streamStateHolder: StreamStateHolder): Promise<void> {
-    return this.#deps.pinStore.add(streamStateHolder)
+    return this.#deps.pinStore.add(new RunningState(streamStateHolder.state, StateSource.NETWORK))
   }
 
   async unpin(streamId: StreamID, opts?: PublishOpts): Promise<void> {

--- a/packages/core/src/state-management/running-state.ts
+++ b/packages/core/src/state-management/running-state.ts
@@ -33,7 +33,7 @@ export class RunningState extends StreamStateSubject implements RunningStateLike
     this.id = new StreamID(initial.type, initial.log[0].cid)
 
     if (stateSource === StateSource.STATESTORE) {
-      this.setPinnedState(initial)
+      this.markAsPinned()
     }
   }
 
@@ -61,11 +61,11 @@ export class RunningState extends StreamStateSubject implements RunningStateLike
   }
 
   /**
-   * Sets the pinned state to the given state by storing the CIDs
+   * Sets the pinned state to the current state by storing the CIDs
    * @param newState state of the stream to be pinned
    */
-  setPinnedState(newState: StreamState) {
+  markAsPinned() {
     this.stateSource = StateSource.STATESTORE
-    this.pinnedCommits = new Set(newState.log.map(({ cid }) => cid.toString()))
+    this.pinnedCommits = new Set(this.state.log.map(({ cid }) => cid.toString()))
   }
 }

--- a/packages/core/src/state-management/running-state.ts
+++ b/packages/core/src/state-management/running-state.ts
@@ -62,7 +62,6 @@ export class RunningState extends StreamStateSubject implements RunningStateLike
 
   /**
    * Sets the pinned state to the current state by storing the CIDs
-   * @param newState state of the stream to be pinned
    */
   markAsPinned() {
     this.stateSource = StateSource.STATESTORE

--- a/packages/core/src/store/__tests__/pin-store.test.ts
+++ b/packages/core/src/store/__tests__/pin-store.test.ts
@@ -73,7 +73,7 @@ describe('#add', () => {
   test('save and pin', async () => {
     const pinStore = new PinStore(stateStore, pinning, jest.fn(), jest.fn())
     const runningState = new RunningState(state, StateSource.NETWORK)
-    const runningStateSpy = jest.spyOn(runningState, 'setPinnedState')
+    const runningStateSpy = jest.spyOn(runningState, 'markAsPinned')
     await pinStore.add(runningState)
     expect(stateStore.save).toBeCalledWith(runningState)
     expect(pinning.pin).toBeCalledTimes(1)
@@ -105,7 +105,7 @@ describe('#add', () => {
     })
     const pinStore = new PinStore(stateStore, pinning, retrieve, resolve)
     const runningState = new RunningState(stateWithProof, StateSource.NETWORK)
-    const runningStateSpy = jest.spyOn(runningState, 'setPinnedState')
+    const runningStateSpy = jest.spyOn(runningState, 'markAsPinned')
     await pinStore.add(runningState)
     expect(stateStore.save).toBeCalledWith(runningState)
     expect(pinning.pin).toBeCalledTimes(4)
@@ -149,7 +149,7 @@ describe('#add', () => {
     })
     const pinStore = new PinStore(stateStore, pinning, retrieve, resolve)
     const runningState = new RunningState(stateWithProof, StateSource.NETWORK)
-    const runningStateSpy = jest.spyOn(runningState, 'setPinnedState')
+    const runningStateSpy = jest.spyOn(runningState, 'markAsPinned')
     await pinStore.add(runningState)
     expect(stateStore.save).toBeCalledWith(runningState)
     expect(pinning.pin).toBeCalledTimes(6)
@@ -169,7 +169,7 @@ describe('#add', () => {
     const pinStore = new PinStore(stateStore, pinning, jest.fn(), jest.fn())
     const toBeUpdatedState = Object.assign({}, state)
     const runningState = new RunningState(toBeUpdatedState, StateSource.STATESTORE)
-    const runningStateSpy = jest.spyOn(runningState, 'setPinnedState')
+    const runningStateSpy = jest.spyOn(runningState, 'markAsPinned')
     Object.assign(toBeUpdatedState, {
       log: [
         { cid: new CID('QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D') },
@@ -192,7 +192,7 @@ describe('#add', () => {
     const pinStore = new PinStore(stateStore, pinning, jest.fn(), jest.fn())
     const toBeUpdatedState = Object.assign({}, state)
     const runningState = new RunningState(toBeUpdatedState, StateSource.STATESTORE)
-    const runningStateSpy = jest.spyOn(runningState, 'setPinnedState')
+    const runningStateSpy = jest.spyOn(runningState, 'markAsPinned')
     Object.assign(toBeUpdatedState, {
       log: [
         { cid: new CID('QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D') },

--- a/packages/core/src/store/__tests__/state-store-integration.test.ts
+++ b/packages/core/src/store/__tests__/state-store-integration.test.ts
@@ -14,6 +14,7 @@ import CID from 'cids'
 import { createIPFS } from '../../__tests__/ipfs-util'
 import { createCeramic } from '../../__tests__/create-ceramic'
 import { anchorUpdate } from '../../state-management/__tests__/anchor-update'
+import { RunningState, StateSource } from '../../state-management/running-state'
 
 const FAKE_CID = new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
 
@@ -64,7 +65,7 @@ describe('Level data store', () => {
     }
     await expect(store.stateStore.load(streamId)).resolves.toBeNull()
     const pinSpy = jest.spyOn(store.pinning, 'pin')
-    await store.add({ id: streamId, state: state })
+    await store.add(new RunningState(state, StateSource.NETWORK))
     expect(pinSpy).toBeCalledWith(FAKE_CID)
     expect(pinSpy).toBeCalledTimes(1)
     await expect(store.stateStore.load(streamId)).resolves.toEqual(state)

--- a/packages/core/src/store/pin-store.ts
+++ b/packages/core/src/store/pin-store.ts
@@ -48,7 +48,7 @@ export class PinStore {
     const points = await this.getComponentCIDsOfCommits(newCommits)
     await Promise.all(points.map((point) => this.pinning.pin(point)))
     await this.stateStore.save(runningState)
-    runningState.setPinnedState(runningState.state)
+    runningState.markAsPinned()
   }
 
   async rm(streamId: StreamID): Promise<void> {


### PR DESCRIPTION
# Update running state's pinned commits when adding pins to pin store 
https://github.com/ceramicnetwork/ceramic/issues/118
https://github.com/ceramicnetwork/ceramic/issues/119
https://github.com/ceramicnetwork/ceramic/issues/127

## Description

* `PinStore.add` finishes by calling a `setPinnedState` on `RunningState`, which sets the `pinnedState` field to the given state, and updates the `StateSource` for the `RunningState` to `StateStore`. This will prevent repinning of commits on subsequent `Pinstore.add` calls
* `PinStore.add` is given a second, optional argument `force` which if set to true causes it to pin everything in the entire stream history.  This is useful in case the state store and ipfs pin store get out of sync and there are CIDs that aren't pinned in IPFS even though they're included in the state object stored in the state store.

## How Has This Been Tested?

Unit Tests

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties
