### PR TITLE
chore(stream-tile): Require metadata when creating a deterministic tile document

### DIFF
--- a/packages/stream-tile/src/tile-document.ts
+++ b/packages/stream-tile/src/tile-document.ts
@@ -224,13 +224,13 @@ export class TileDocument<T = Record<string, any>> extends Stream {
    * @param metadata - Genesis metadata
    * @param opts - Additional options
    */
-   static async deterministic<T>(
+  static async deterministic<T>(
     ceramic: CeramicApi,
-    metadata?: TileMetadataArgs,
+    metadata: TileMetadataArgs,
     opts: CreateOpts = {}
   ): Promise<TileDocument<T>> {
     opts = { ...DEFAULT_CREATE_OPTS, ...opts }
-    metadata = {...metadata, deterministic: true}
+    metadata = { ...metadata, deterministic: true }
 
     if (metadata.family == null && metadata.tags == null) {
       throw new Error('Family and/or tags are required when creating a deterministic tile document')


### PR DESCRIPTION
# Require metadata when creating a deterministic tile document - (no issue)

## Description

Deterministic tile documents are based on the initial metadata so it should be required 

## How Has This Been Tested?

Tests still work

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties

