### PR TITLE
feat(core,http-client): Add 'force' option to pin API

### DIFF
--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -480,5 +480,21 @@ describe('Ceramic interop: core <> http-client', () => {
       pinnedDocs = await pinLs(docA.id)
       expect(pinnedDocs).toHaveLength(0)
     })
+
+    it('force pin', async () => {
+      const pinSpy = jest.spyOn(ipfs.pin, 'add')
+      await client.pin.add(docA.id)
+
+      // 2 CIDs pinned for the one genesis commit (signed envelope + payload)
+      expect(pinSpy).toBeCalledTimes(2)
+
+      // Pin a second time, shouldn't cause any more calls to ipfs.pin.add
+      await client.pin.add(docA.id)
+      expect(pinSpy).toBeCalledTimes(2)
+
+      // Now force re-pin and make sure underlying state and ipfs records get re-pinned
+      await client.pin.add(docA.id, true)
+      expect(pinSpy).toBeCalledTimes(4)
+    })
   })
 })

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -490,7 +490,8 @@ export class CeramicDaemon {
    */
   async pinStream(req: Request, res: Response): Promise<void> {
     const streamId = StreamID.fromString(req.params.streamid || req.params.docid)
-    await this.ceramic.pin.add(streamId)
+    const { force } = req.body
+    await this.ceramic.pin.add(streamId, force)
     res.json({
       streamId: streamId.toString(),
       docId: streamId.toString(),

--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -12,8 +12,10 @@ export interface PinApi {
   /**
    * Pin stream
    * @param streamId - Stream ID
+   * @param force - If true, re-pins all stream content even if the node already believes the stream
+   +  to be pinned.
    */
-  add(streamId: StreamID): Promise<void>
+  add(streamId: StreamID, force?: boolean): Promise<void>
 
   /**
    * Unpin stream

--- a/packages/core/src/__tests__/ceramic-pinning.test.ts
+++ b/packages/core/src/__tests__/ceramic-pinning.test.ts
@@ -201,7 +201,7 @@ describe('Ceramic stream pinning', () => {
     await ceramic.close()
   })
 
-  it('Double pin is noop', async () => {
+  it('Double pin', async () => {
     const ceramic = await createCeramic(ipfs1, tmpFolder.path)
     const stream = await TileDocument.create(ceramic, { foo: 'bar' }, null, {
       anchor: false,
@@ -219,6 +219,11 @@ describe('Ceramic stream pinning', () => {
     await ceramic.pin.add(stream.id)
     expect(pinSpy).toBeCalledTimes(2)
     expect(saveStateSpy).toBeCalledTimes(1)
+
+    // Now force re-pin and make sure underlying state and ipfs records get re-pinned
+    await ceramic.pin.add(stream.id, true)
+    expect(pinSpy).toBeCalledTimes(4)
+    expect(saveStateSpy).toBeCalledTimes(2)
 
     await ceramic.close()
   })
@@ -244,31 +249,6 @@ describe('Ceramic stream pinning', () => {
 
     await ceramic.close()
   })
-
-  /**
-   * TODO(1818)
-  it('Force re-pinning', async () => {
-    const ceramic = await createCeramic(ipfs1, tmpFolder.path)
-    const stream = await TileDocument.create(ceramic, { foo: 'bar' }, null, {
-      anchor: false,
-      publish: false,
-    })
-    const pinSpy = jest.spyOn(ipfs1.pin, 'add')
-    const saveStateSpy = jest.spyOn(ceramic.repository._deps.pinStore.stateStore, 'save')
-    await ceramic.pin.add(stream.id)
-
-    // 2 CIDs pinned for the one genesis commit (signed envelope + payload)
-    expect(pinSpy).toBeCalledTimes(2)
-    expect(saveStateSpy).toBeCalledTimes(1)
-
-    // Pin a second time, shouldn't cause any more calls to ipfs.pin.add
-    await ceramic.pin.add(stream.id) // todo force
-    expect(pinSpy).toBeCalledTimes(4)
-    expect(saveStateSpy).toBeCalledTimes(2)
-
-    await ceramic.close()
-  })
-  */
 
   /** TODO(1817)
    * it('re-pin after unpin', async () => {

--- a/packages/core/src/__tests__/local-pin-api.test.ts
+++ b/packages/core/src/__tests__/local-pin-api.test.ts
@@ -33,7 +33,7 @@ async function toArray<A>(iterable: AsyncIterable<A>): Promise<A[]> {
 test('add', async () => {
   await pinApi.add(STREAM_ID)
   expect(repository.load).toBeCalledWith(STREAM_ID, { sync: SyncOptions.PREFER_CACHE })
-  expect(repository.pin).toBeCalledWith(state$)
+  expect(repository.pin).toBeCalledWith(state$, undefined)
 })
 
 test('rm', async () => {

--- a/packages/core/src/local-pin-api.ts
+++ b/packages/core/src/local-pin-api.ts
@@ -12,9 +12,9 @@ export class LocalPinApi implements PinApi {
     private readonly logger: DiagnosticsLogger
   ) {}
 
-  async add(streamId: StreamID): Promise<void> {
+  async add(streamId: StreamID, force?: boolean): Promise<void> {
     const state$ = await this.repository.load(streamId, { sync: SyncOptions.PREFER_CACHE })
-    await this.repository.pin(state$)
+    await this.repository.pin(state$, force)
     this.logger.verbose(`Pinned stream ${streamId.toString()}`)
   }
 

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -288,8 +288,8 @@ export class Repository {
     this.inmemory.set(state$.id.toString(), state$)
   }
 
-  pin(state$: RunningState): Promise<void> {
-    return this.#deps.pinStore.add(state$)
+  pin(state$: RunningState, force?: boolean): Promise<void> {
+    return this.#deps.pinStore.add(state$, force)
   }
 
   async unpin(streamId: StreamID, opts?: PublishOpts): Promise<void> {

--- a/packages/http-client/src/remote-pin-api.ts
+++ b/packages/http-client/src/remote-pin-api.ts
@@ -8,8 +8,15 @@ import { PublishOpts } from '@ceramicnetwork/common'
 export class RemotePinApi implements PinApi {
   constructor(private readonly _apiUrl: string) {}
 
-  async add(streamId: StreamID): Promise<void> {
-    await fetchJson(this._apiUrl + '/pins' + `/${streamId.toString()}`, { method: 'post' })
+  async add(streamId: StreamID, force?: boolean): Promise<void> {
+    const args: any = {}
+    if (force) {
+      args.force = true
+    }
+    await fetchJson(this._apiUrl + '/pins' + `/${streamId.toString()}`, {
+      method: 'post',
+      body: args,
+    })
   }
 
   async rm(streamId: StreamID, opts?: PublishOpts): Promise<void> {


### PR DESCRIPTION
builds on https://github.com/ceramicnetwork/js-ceramic/pull/1819