### PR TITLE
chore(core): Remove StateSource enum in favor of pinned bool

### DIFF
--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -8,7 +8,7 @@ import { delay } from './delay'
 import tmp from 'tmp-promise'
 import { LevelStateStore } from '../store/level-state-store'
 import { PinStore } from '../store/pin-store'
-import { RunningState, StateSource } from '../state-management/running-state'
+import { RunningState } from '../state-management/running-state'
 import { StateManager } from '../state-management/state-manager'
 import cloneDeep from 'lodash.clonedeep'
 
@@ -92,7 +92,7 @@ describe('Dispatcher', () => {
   })
 
   it('retrieves commit correctly', async () => {
-    ipfs.dag.get.mockReturnValueOnce({value: 'data'})
+    ipfs.dag.get.mockReturnValueOnce({ value: 'data' })
     expect(await dispatcher.retrieveCommit(FAKE_CID)).toEqual('data')
 
     expect(ipfs.dag.get.mock.calls.length).toEqual(1)
@@ -100,8 +100,8 @@ describe('Dispatcher', () => {
   })
 
   it('retries on timeout', async () => {
-    ipfs.dag.get.mockRejectedValueOnce({code: 'ERR_TIMEOUT'})
-    ipfs.dag.get.mockReturnValueOnce({value: 'data'})
+    ipfs.dag.get.mockRejectedValueOnce({ code: 'ERR_TIMEOUT' })
+    ipfs.dag.get.mockReturnValueOnce({ value: 'data' })
     expect(await dispatcher.retrieveCommit(FAKE_CID)).toEqual('data')
 
     expect(ipfs.dag.get.mock.calls.length).toEqual(2)
@@ -111,7 +111,7 @@ describe('Dispatcher', () => {
 
   it('caches and retrieves commit correctly', async () => {
     const ipfsSpy = ipfs.dag.get
-    ipfsSpy.mockReturnValueOnce({value: 'data'})
+    ipfsSpy.mockReturnValueOnce({ value: 'data' })
     expect(await dispatcher.retrieveCommit(FAKE_CID)).toEqual('data')
     // Commit not found in cache so IPFS lookup performed and cache updated
     expect(ipfsSpy).toBeCalledTimes(1)
@@ -126,11 +126,11 @@ describe('Dispatcher', () => {
 
   it('caches and retrieves with path correctly', async () => {
     const ipfsSpy = ipfs.dag.get
-    ipfsSpy.mockImplementation(function(cid, opts) {
+    ipfsSpy.mockImplementation(function (cid, opts) {
       if (opts.path == '/foo') {
-        return {value: 'foo'}
+        return { value: 'foo' }
       } else if (opts.path == '/bar') {
-        return {value: 'bar'}
+        return { value: 'bar' }
       } else {
         return null
       }
@@ -183,7 +183,7 @@ describe('Dispatcher', () => {
     dispatcher.repository.stateManager = {} as unknown as StateManager
 
     async function register(state: StreamState) {
-      const runningState = new RunningState(state, StateSource.STATESTORE)
+      const runningState = new RunningState(state, false)
       repository.add(runningState)
       dispatcher.messageBus.queryNetwork(runningState.id).subscribe()
       return runningState

--- a/packages/core/src/__tests__/local-pin-api.test.ts
+++ b/packages/core/src/__tests__/local-pin-api.test.ts
@@ -4,7 +4,7 @@ import * as random from '@stablelib/random'
 import { CommitType, StreamState, LoggerProvider, SyncOptions } from '@ceramicnetwork/common'
 import { Repository } from '../state-management/repository'
 import CID from 'cids'
-import { RunningState, StateSource } from '../state-management/running-state'
+import { RunningState } from '../state-management/running-state'
 
 const STREAM_ID = StreamID.fromString(
   'k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki'
@@ -15,7 +15,7 @@ const streamState = {
   type: 0,
   log: [{ cid: FAKE_CID, type: CommitType.GENESIS }],
 } as unknown as StreamState
-const state$ = new RunningState(streamState, StateSource.STATESTORE)
+const state$ = new RunningState(streamState, true)
 const repository = {
   load: jest.fn(() => Promise.resolve(state$)),
   get: jest.fn(() => Promise.resolve(state$)),

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -6,7 +6,7 @@ import {
   StreamUtils,
 } from '@ceramicnetwork/common'
 import CID from 'cids'
-import { RunningState, StateSource } from '../state-management/running-state'
+import { RunningState } from '../state-management/running-state'
 import { createIPFS } from './ipfs-util'
 import { createCeramic } from './create-ceramic'
 import Ceramic from '../ceramic'
@@ -379,7 +379,7 @@ test('handles basic conflict', async () => {
   const initialState = await ceramic.repository.stateManager
     .atCommit(streamState1, streamId.atCommit(streamId.cid))
     .then((stream) => stream.state)
-  const state$ = new RunningState(initialState, StateSource.STATESTORE)
+  const state$ = new RunningState(initialState, true)
   ceramic.repository.add(state$)
   await (ceramic.repository.stateManager as any)._handleTip(state$, tipPreUpdate)
   await new Promise((resolve) => setTimeout(resolve, 1000))

--- a/packages/core/src/state-management/__tests__/running-state.test.ts
+++ b/packages/core/src/state-management/__tests__/running-state.test.ts
@@ -1,6 +1,6 @@
 import CID from 'cids'
 import { CommitType, StreamState } from '@ceramicnetwork/common'
-import { RunningState, StateSource } from '../running-state'
+import { RunningState } from '../running-state'
 
 const FAKE_CID1 = new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
 const FAKE_CID2 = new CID('bafybeig6xv5nwphfmvcnektpnojts44jqcuam7bmye2pb54adnrtccjlsu')
@@ -26,7 +26,7 @@ const second = {
 } as unknown as StreamState
 
 test('emit on distinct changes', async () => {
-  const state$ = new RunningState(initial, StateSource.STATESTORE)
+  const state$ = new RunningState(initial, true)
   const updates: StreamState[] = []
   state$.subscribe((state) => {
     updates.push(state)
@@ -60,29 +60,29 @@ test('emit on distinct changes', async () => {
 describe('set pinned state', () => {
   test('set in constructor then set in call to markAsPinned', async () => {
     const streamState = Object.assign({}, initial)
-    const state$ = new RunningState(streamState, StateSource.STATESTORE)
+    const state$ = new RunningState(streamState, true)
     expect(state$.pinnedCommits.size).toBe(1)
-    expect(state$.stateSource).toBe(StateSource.STATESTORE)
+    expect(state$.pinned).toBe(true)
     expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)
 
     Object.assign(streamState, second)
     state$.markAsPinned()
     expect(state$.pinnedCommits.size).toBe(2)
-    expect(state$.stateSource).toBe(StateSource.STATESTORE)
+    expect(state$.pinned).toBe(true)
     expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)
     expect(state$.pinnedCommits.has(FAKE_CID2.toString())).toBe(true)
   })
 
   test('not set in constructor but set in call to markAsPinned', async () => {
     const streamState = Object.assign({}, initial)
-    const state$ = new RunningState(streamState, StateSource.NETWORK)
+    const state$ = new RunningState(streamState, false)
     expect(state$.pinnedCommits).toBe(undefined)
-    expect(state$.stateSource).toBe(StateSource.NETWORK)
+    expect(state$.pinned).toBe(false)
 
     Object.assign(streamState, second)
     state$.markAsPinned()
     expect(state$.pinnedCommits.size).toBe(2)
-    expect(state$.stateSource).toBe(StateSource.STATESTORE)
+    expect(state$.pinned).toBe(true)
     expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)
     expect(state$.pinnedCommits.has(FAKE_CID2.toString())).toBe(true)
   })

--- a/packages/core/src/state-management/__tests__/running-state.test.ts
+++ b/packages/core/src/state-management/__tests__/running-state.test.ts
@@ -62,13 +62,11 @@ describe('set pinned state', () => {
     const streamState = Object.assign({}, initial)
     const state$ = new RunningState(streamState, true)
     expect(state$.pinnedCommits.size).toBe(1)
-    expect(state$.pinned).toBe(true)
     expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)
 
     Object.assign(streamState, second)
     state$.markAsPinned()
     expect(state$.pinnedCommits.size).toBe(2)
-    expect(state$.pinned).toBe(true)
     expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)
     expect(state$.pinnedCommits.has(FAKE_CID2.toString())).toBe(true)
   })
@@ -76,13 +74,11 @@ describe('set pinned state', () => {
   test('not set in constructor but set in call to markAsPinned', async () => {
     const streamState = Object.assign({}, initial)
     const state$ = new RunningState(streamState, false)
-    expect(state$.pinnedCommits).toBe(undefined)
-    expect(state$.pinned).toBe(false)
+    expect(state$.pinnedCommits).toBe(null)
 
     Object.assign(streamState, second)
     state$.markAsPinned()
     expect(state$.pinnedCommits.size).toBe(2)
-    expect(state$.pinned).toBe(true)
     expect(state$.pinnedCommits.has(FAKE_CID1.toString())).toBe(true)
     expect(state$.pinnedCommits.has(FAKE_CID2.toString())).toBe(true)
   })

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -8,14 +8,13 @@ import {
   PinningOpts,
   PublishOpts,
   StreamState,
-  StreamUtils,
   SyncOptions,
   UpdateOpts,
 } from '@ceramicnetwork/common'
 import { PinStore } from '../store/pin-store'
 import { DiagnosticsLogger } from '@ceramicnetwork/common'
 import { ExecutionQueue } from './execution-queue'
-import { RunningState, StateSource } from './running-state'
+import { RunningState } from './running-state'
 import { StateManager } from './state-manager'
 import type { Dispatcher } from '../dispatcher'
 import type { ConflictResolution } from '../conflict-resolution'
@@ -106,7 +105,7 @@ export class Repository {
   private async fromStateStore(streamId: StreamID): Promise<RunningState | undefined> {
     const streamState = await this.#deps.pinStore.stateStore.load(streamId)
     if (streamState) {
-      const runningState = new RunningState(streamState, StateSource.STATESTORE)
+      const runningState = new RunningState(streamState, true)
       this.add(runningState)
       const toRecover =
         runningState.value.anchorStatus === AnchorStatus.PENDING ||
@@ -131,7 +130,7 @@ export class Repository {
     commitData.disableTimecheck = true
     const state = await handler.applyCommit(commitData, this.#deps.context)
     await this.#deps.stateValidation.validate(state, state.content)
-    const state$ = new RunningState(state, StateSource.NETWORK)
+    const state$ = new RunningState(state, false)
     this.add(state$)
     this.logger.verbose(`Genesis commit for stream ${streamId.toString()} successfully loaded`)
     return state$
@@ -325,7 +324,7 @@ export class Repository {
     return new Observable<StreamState>((subscriber) => {
       const id = new StreamID(init.type, init.log[0].cid)
       this.get(id).then((found) => {
-        const state$ = found || new RunningState(init, StateSource.NETWORK)
+        const state$ = found || new RunningState(init, false)
         this.inmemory.endure(id.toString(), state$)
         state$.subscribe(subscriber).add(() => {
           if (state$.observers.length === 0) {

--- a/packages/core/src/state-management/running-state.ts
+++ b/packages/core/src/state-management/running-state.ts
@@ -11,9 +11,9 @@ import CID from 'cids'
 export class RunningState extends StreamStateSubject implements RunningStateLike {
   readonly id: StreamID
   readonly subscriptionSet: SubscriptionSet = new SubscriptionSet()
-  private _pinnedCommits?: Set<string>
+  private _pinnedCommits?: Set<string> | null
 
-  constructor(initial: StreamState, private pinned: boolean) {
+  constructor(initial: StreamState, pinned: boolean) {
     super(initial)
     this.id = new StreamID(initial.type, initial.log[0].cid)
 
@@ -30,7 +30,7 @@ export class RunningState extends StreamStateSubject implements RunningStateLike
     return this.value
   }
 
-  get pinnedCommits(): Set<string> {
+  get pinnedCommits(): Set<string> | null {
     return this._pinnedCommits
   }
 
@@ -53,7 +53,6 @@ export class RunningState extends StreamStateSubject implements RunningStateLike
    * Sets the pinned state to the current state by storing the CIDs
    */
   markAsPinned() {
-    this.pinned = true
     this._pinnedCommits = new Set(this.state.log.map(({ cid }) => cid.toString()))
   }
 
@@ -61,7 +60,6 @@ export class RunningState extends StreamStateSubject implements RunningStateLike
    * Clears the pinned state.
    */
   markAsUnpinned() {
-    this.pinned = false
     this._pinnedCommits = null
   }
 }

--- a/packages/core/src/state-management/running-state.ts
+++ b/packages/core/src/state-management/running-state.ts
@@ -11,7 +11,7 @@ import CID from 'cids'
 export class RunningState extends StreamStateSubject implements RunningStateLike {
   readonly id: StreamID
   readonly subscriptionSet: SubscriptionSet = new SubscriptionSet()
-  private _pinnedCommits?: Set<string> | null
+  private _pinnedCommits?: Set<string> | null = null
 
   constructor(initial: StreamState, pinned: boolean) {
     super(initial)

--- a/packages/core/src/state-management/running-state.ts
+++ b/packages/core/src/state-management/running-state.ts
@@ -8,31 +8,16 @@ import {
 import { StreamID } from '@ceramicnetwork/streamid'
 import CID from 'cids'
 
-/**
- * Describes the source from which this RunningState was initialized with its StreamState
- */
-export enum StateSource {
-  /**
-   * Indicates that the stream was pinned and its state was loaded from the StateStore. This will cause runningState to keep track of the stored commit CIDs.
-   * The stored commit CIDs can be used to prevent commits from being stored again.
-   */
-  STATESTORE,
-  /**
-   * Indicates that the Stream was loaded from the network.
-   * runningState does not keep track of the commit CID's of the state as they may not have been stored.
-   */
-  NETWORK,
-}
 export class RunningState extends StreamStateSubject implements RunningStateLike {
   readonly id: StreamID
   readonly subscriptionSet: SubscriptionSet = new SubscriptionSet()
-  pinnedCommits?: Set<string>
+  private _pinnedCommits?: Set<string>
 
-  constructor(initial: StreamState, public stateSource: StateSource) {
+  constructor(initial: StreamState, private pinned: boolean) {
     super(initial)
     this.id = new StreamID(initial.type, initial.log[0].cid)
 
-    if (stateSource === StateSource.STATESTORE) {
+    if (pinned) {
       this.markAsPinned()
     }
   }
@@ -43,6 +28,10 @@ export class RunningState extends StreamStateSubject implements RunningStateLike
 
   get state(): StreamState {
     return this.value
+  }
+
+  get pinnedCommits(): Set<string> {
+    return this._pinnedCommits
   }
 
   /**
@@ -64,15 +53,15 @@ export class RunningState extends StreamStateSubject implements RunningStateLike
    * Sets the pinned state to the current state by storing the CIDs
    */
   markAsPinned() {
-    this.stateSource = StateSource.STATESTORE
-    this.pinnedCommits = new Set(this.state.log.map(({ cid }) => cid.toString()))
+    this.pinned = true
+    this._pinnedCommits = new Set(this.state.log.map(({ cid }) => cid.toString()))
   }
 
   /**
    * Clears the pinned state.
    */
   markAsUnpinned() {
-    this.stateSource = StateSource.NETWORK // todo rename this to be more accurate
-    this.pinnedCommits = null
+    this.pinned = false
+    this._pinnedCommits = null
   }
 }

--- a/packages/core/src/store/__tests__/pin-store.test.ts
+++ b/packages/core/src/store/__tests__/pin-store.test.ts
@@ -10,7 +10,7 @@ import {
   CommitType,
   TestUtils,
 } from '@ceramicnetwork/common'
-import { RunningState, StateSource } from '../../state-management/running-state'
+import { RunningState } from '../../state-management/running-state'
 
 let stateStore: StateStore
 let pinning: PinningBackend
@@ -72,7 +72,7 @@ test('#close', async () => {
 describe('#add', () => {
   test('save and pin', async () => {
     const pinStore = new PinStore(stateStore, pinning, jest.fn(), jest.fn())
-    const runningState = new RunningState(state, StateSource.NETWORK)
+    const runningState = new RunningState(state, false)
     const runningStateSpy = jest.spyOn(runningState, 'markAsPinned')
     await pinStore.add(runningState)
     expect(stateStore.save).toBeCalledWith(runningState)
@@ -104,7 +104,7 @@ describe('#add', () => {
       }
     })
     const pinStore = new PinStore(stateStore, pinning, retrieve, resolve)
-    const runningState = new RunningState(stateWithProof, StateSource.NETWORK)
+    const runningState = new RunningState(stateWithProof, false)
     const runningStateSpy = jest.spyOn(runningState, 'markAsPinned')
     await pinStore.add(runningState)
     expect(stateStore.save).toBeCalledWith(runningState)
@@ -148,7 +148,7 @@ describe('#add', () => {
       }
     })
     const pinStore = new PinStore(stateStore, pinning, retrieve, resolve)
-    const runningState = new RunningState(stateWithProof, StateSource.NETWORK)
+    const runningState = new RunningState(stateWithProof, false)
     const runningStateSpy = jest.spyOn(runningState, 'markAsPinned')
     await pinStore.add(runningState)
     expect(stateStore.save).toBeCalledWith(runningState)
@@ -168,7 +168,7 @@ describe('#add', () => {
   test('save and pin only new commits', async () => {
     const pinStore = new PinStore(stateStore, pinning, jest.fn(), jest.fn())
     const toBeUpdatedState = Object.assign({}, state)
-    const runningState = new RunningState(toBeUpdatedState, StateSource.STATESTORE)
+    const runningState = new RunningState(toBeUpdatedState, true)
     const runningStateSpy = jest.spyOn(runningState, 'markAsPinned')
     Object.assign(toBeUpdatedState, {
       log: [
@@ -191,7 +191,7 @@ describe('#add', () => {
   test('save and pin all commits using force', async () => {
     const pinStore = new PinStore(stateStore, pinning, jest.fn(), jest.fn())
     const toBeUpdatedState = Object.assign({}, state)
-    const runningState = new RunningState(toBeUpdatedState, StateSource.STATESTORE)
+    const runningState = new RunningState(toBeUpdatedState, true)
     const runningStateSpy = jest.spyOn(runningState, 'markAsPinned')
     Object.assign(toBeUpdatedState, {
       log: [
@@ -216,7 +216,7 @@ describe('#add', () => {
 test('#rm', async () => {
   const pinStore = new PinStore(stateStore, pinning, jest.fn(), jest.fn())
   const stream = new FakeType(TestUtils.runningState(state), {})
-  const runningState = new RunningState(state, StateSource.STATESTORE)
+  const runningState = new RunningState(state, true)
   await pinStore.rm(runningState)
   expect(stateStore.remove).toBeCalledWith(stream.id)
   expect(pinning.unpin).toBeCalledWith(state.log[0].cid)

--- a/packages/core/src/store/__tests__/state-store-integration.test.ts
+++ b/packages/core/src/store/__tests__/state-store-integration.test.ts
@@ -14,7 +14,7 @@ import CID from 'cids'
 import { createIPFS } from '../../__tests__/ipfs-util'
 import { createCeramic } from '../../__tests__/create-ceramic'
 import { anchorUpdate } from '../../state-management/__tests__/anchor-update'
-import { RunningState, StateSource } from '../../state-management/running-state'
+import { RunningState } from '../../state-management/running-state'
 
 const FAKE_CID = new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
 
@@ -65,7 +65,7 @@ describe('Level data store', () => {
     }
     await expect(store.stateStore.load(streamId)).resolves.toBeNull()
     const pinSpy = jest.spyOn(store.pinning, 'pin')
-    await store.add(new RunningState(state, StateSource.NETWORK))
+    await store.add(new RunningState(state, false))
     expect(pinSpy).toBeCalledWith(FAKE_CID)
     expect(pinSpy).toBeCalledTimes(1)
     await expect(store.stateStore.load(streamId)).resolves.toEqual(state)


### PR DESCRIPTION
builds on https://github.com/ceramicnetwork/js-ceramic/pull/1821