### PR TITLE
feat(common): Import types, when only types are imported

### DIFF
--- a/packages/common/src/anchor-service.ts
+++ b/packages/common/src/anchor-service.ts
@@ -1,8 +1,8 @@
-import CID from 'cids'
+import type CID from 'cids'
 import type { Observable } from 'rxjs'
-import { AnchorProof, AnchorStatus } from './stream'
-import { CeramicApi } from './ceramic-api'
-import StreamID from '@ceramicnetwork/streamid'
+import type { AnchorProof, AnchorStatus } from './stream'
+import type { CeramicApi } from './ceramic-api'
+import type { StreamID } from '@ceramicnetwork/streamid'
 
 export interface AnchorServicePending {
   readonly status: AnchorStatus.PENDING

--- a/packages/common/src/pinning.ts
+++ b/packages/common/src/pinning.ts
@@ -1,5 +1,5 @@
 import type CID from 'cids'
-import { IpfsApi } from './index'
+import type { IpfsApi } from './index'
 
 export interface PinningBackend {
   id: string

--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -1,11 +1,12 @@
-import CID from 'cids'
+import type CID from 'cids'
 import cloneDeep from 'lodash.clonedeep'
 import type { Context } from './context'
-import { CommitID, StreamID } from '@ceramicnetwork/streamid'
+import { StreamID } from '@ceramicnetwork/streamid'
+import type { CommitID } from '@ceramicnetwork/streamid'
 import type { DagJWS, DagJWSResult } from 'dids'
 import { Observable } from 'rxjs'
-import { RunningStateLike } from './running-state-like'
-import { CeramicApi } from './ceramic-api'
+import type { RunningStateLike } from './running-state-like'
+import type { CeramicApi } from './ceramic-api'
 import { LoadOpts, SyncOptions } from './streamopts'
 
 /**
@@ -282,9 +283,5 @@ export interface StreamHandler<T extends Stream> {
    * @param context - Ceramic context
    * @param state - Stream state
    */
-  applyCommit(
-    commitData: CommitData,
-    context: Context,
-    state?: StreamState
-  ): Promise<StreamState>
+  applyCommit(commitData: CommitData, context: Context, state?: StreamState): Promise<StreamState>
 }

--- a/packages/common/src/utils/test-utils.ts
+++ b/packages/common/src/utils/test-utils.ts
@@ -1,4 +1,4 @@
-import { StreamState, Stream } from '../stream'
+import type { StreamState, Stream } from '../stream'
 import { take, filter } from 'rxjs/operators'
 import { BehaviorSubject } from 'rxjs'
 import { RunningStateLike } from '../running-state-like'


### PR DESCRIPTION
Some imports are only used to provide type information. Here we replace vanilla import with `import type`.