### PR TITLE
chore: Use proper module name

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -10,7 +10,7 @@ import {
 
 import type { TileDocument } from '@ceramicnetwork/stream-tile'
 import { Dispatcher } from './dispatcher'
-import StreamID from "streamid";
+import type { StreamID } from "@ceramicnetwork/streamid";
 import type CID from 'cids'
 
 /**


### PR DESCRIPTION
Fix a bug.
1. Use `@ceramicnetwork/streamid` instead of `streamid` for import.
2. Import just `StreamID` type.