### PR TITLE
support solana wallet

### DIFF
--- a/packages/blockchain-utils-linking/package.json
+++ b/packages/blockchain-utils-linking/package.json
@@ -49,7 +49,7 @@
     "@zondax/filecoin-signing-tools": "^0.15.0",
     "eth-sig-util": "^3.0.0",
     "ganache-core": "^2.13.1",
-    "tweetnacl": "^1.0.3"
+    "@stablelib/ed25519": "^1.0.2"
   },
   "jest": {
     "testEnvironment": "node",

--- a/packages/blockchain-utils-linking/package.json
+++ b/packages/blockchain-utils-linking/package.json
@@ -41,12 +41,15 @@
     "@polkadot/util": "^7.1.1",
     "@polkadot/util-crypto": "^7.0.2",
     "@smontero/eosio-local-provider": "^0.0.3",
+    "@solana/wallet-adapter-base": "^0.6.0",
+    "@solana/web3.js": "^1.20.0",
     "@taquito/signer": "^9.2.0",
     "@taquito/taquito": "^9.2.0",
     "@tendermint/sig": "^0.6.0",
     "@zondax/filecoin-signing-tools": "^0.15.0",
     "eth-sig-util": "^3.0.0",
-    "ganache-core": "^2.13.1"
+    "ganache-core": "^2.13.1",
+    "tweetnacl": "^1.0.3"
   },
   "jest": {
     "testEnvironment": "node",

--- a/packages/blockchain-utils-linking/src/__tests__/__snapshots__/solana.test.ts.snap
+++ b/packages/blockchain-utils-linking/src/__tests__/__snapshots__/solana.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Blockchain: Solana authenticate create proof for 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp 1`] = `"0xd042f28e5ff37a2f68f7d7b96adca0d10b5cba3d4d6d056796653479d8a70c0e"`;
+
+exports[`Blockchain: Solana createLink create proof for 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp 1`] = `
+Object {
+  "account": "2q7pyhPwAwZ3QMfZrnAbDhnh9mDUqycszcpf86VgQxhF@solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  "message": "Link this account to your identity
+
+did:3:bafysdfwefwe 
+Timestamp: 666",
+  "signature": "KriuHY8KAU87qNeGjdtvutl0TWgSnOPpUDI8fniN8jHGdwcKubYUooJja/hnFZoizq7q66dx5XRPxKS4EcnGDA",
+  "timestamp": 666,
+  "type": "solana",
+  "version": 2,
+}
+`;

--- a/packages/blockchain-utils-linking/src/__tests__/solana.test.ts
+++ b/packages/blockchain-utils-linking/src/__tests__/solana.test.ts
@@ -1,8 +1,7 @@
 import { MessageSignerWalletAdapterProps } from '@solana/wallet-adapter-base';
 import { SOLANA_MAINNET_CHAIN_REF, SolanaAuthProvider } from '../solana'
 import { Keypair } from '@solana/web3.js';
-import { Buffer } from 'buffer';
-import * as nacl from 'tweetnacl';
+import { sign } from '@stablelib/ed25519'
 import * as uint8arrays from 'uint8arrays'
 
 const did = 'did:3:bafysdfwefwe'
@@ -18,14 +17,14 @@ class MyWalletAdapter implements MessageSignerWalletAdapterProps {
   }
 
   async signMessage(message: Uint8Array): Promise<Uint8Array> {
-    return nacl.sign.detached(message, this._keyPair.secretKey)
+    return sign(this._keyPair.secretKey, message)
   }
 }
 
 let keyPairEd25519: Keypair
 
 beforeAll(() => {
-  keyPairEd25519 = Keypair.fromSecretKey(Buffer.from(privKey, 'base64'))
+  keyPairEd25519 = Keypair.fromSecretKey(uint8arrays.fromString(privKey, 'base64'))
   global.Date.now = jest.fn().mockImplementation(() => 666000)
 })
 

--- a/packages/blockchain-utils-linking/src/__tests__/solana.test.ts
+++ b/packages/blockchain-utils-linking/src/__tests__/solana.test.ts
@@ -1,0 +1,54 @@
+import { MessageSignerWalletAdapterProps } from '@solana/wallet-adapter-base';
+import { SOLANA_MAINNET_CHAIN_REF, SolanaAuthProvider } from '../solana'
+import { Keypair } from '@solana/web3.js';
+import { Buffer } from 'buffer';
+import * as nacl from 'tweetnacl';
+import * as uint8arrays from 'uint8arrays'
+
+const did = 'did:3:bafysdfwefwe'
+const privKey = 'mdqVWeFekT7pqy5T49+tV12jO0m+ESW7ki4zSU9JiCgbL0kJbj5dvQ/PqcDAzZLZqzshVEs01d1KZdmLh4uZIg=='
+const chainRef = SOLANA_MAINNET_CHAIN_REF
+
+
+class MyWalletAdapter implements MessageSignerWalletAdapterProps {
+  readonly _keyPair: Keypair
+
+  constructor(keyPair: Keypair) {
+    this._keyPair = keyPair
+  }
+
+  async signMessage(message: Uint8Array): Promise<Uint8Array> {
+    return nacl.sign.detached(message, this._keyPair.secretKey)
+  }
+}
+
+let keyPairEd25519: Keypair
+
+beforeAll(() => {
+  keyPairEd25519 = Keypair.fromSecretKey(Buffer.from(privKey, 'base64'))
+  global.Date.now = jest.fn().mockImplementation(() => 666000)
+})
+
+afterAll(() => {
+  jest.clearAllMocks()
+})
+
+describe('Blockchain: Solana', () => {
+  describe('createLink', () => {
+    test(`create proof for ${chainRef}`, async () => {
+      const provider = new MyWalletAdapter(keyPairEd25519)
+      const authProvider = new SolanaAuthProvider(provider, keyPairEd25519.publicKey.toString(), chainRef)
+      const proof = await authProvider.createLink(did)
+      expect(proof).toMatchSnapshot()
+    })
+  })
+
+  describe('authenticate', () => {
+    test(`create proof for ${chainRef}`, async () => {
+      const provider = new MyWalletAdapter(keyPairEd25519)
+      const authProvider = new SolanaAuthProvider(provider, keyPairEd25519.publicKey.toString(), chainRef)
+      const result = await authProvider.authenticate("msg")
+      expect(result).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/blockchain-utils-linking/src/index.ts
+++ b/packages/blockchain-utils-linking/src/index.ts
@@ -6,6 +6,7 @@ export * as polkadot from './polkadot'
 export * as eosio from './eosio'
 export * as cosmos from './cosmos'
 export * as tezos from './tezos'
+export * as solana from './solana'
 
 export { EthereumAuthProvider } from './ethereum'
 export { EthereumAuthProvider as AvalancheAuthProvider } from './ethereum'
@@ -15,3 +16,5 @@ export { PolkadotAuthProvider } from './polkadot'
 export { CosmosAuthProvider } from './cosmos'
 export { NearAuthProvider } from './near'
 export { TezosAuthProvider, TezosProvider } from './tezos'
+export { SolanaAuthProvider } from './solana'
+

--- a/packages/blockchain-utils-linking/src/solana.ts
+++ b/packages/blockchain-utils-linking/src/solana.ts
@@ -1,0 +1,59 @@
+import { AccountID } from 'caip'
+import { AuthProvider } from './auth-provider'
+import { getConsentMessage, LinkProof } from './util'
+import * as uint8arrays from 'uint8arrays'
+import * as sha256 from '@stablelib/sha256'
+
+export const SOLANA_TESTNET_CHAIN_REF = '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z' // Solana testnet
+export const SOLANA_DEVNET_CHAIN_REF = 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1' // Solana devnet
+export const SOLANA_MAINNET_CHAIN_REF = '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' // Solana mainnet beta
+
+
+
+export class SolanaAuthProvider implements AuthProvider {
+  readonly isAuthProvider = true
+
+  constructor(
+    private readonly provider: any,
+    private readonly address: string,
+    private readonly chainRef: string
+  ) { }
+
+  async accountId(): Promise<AccountID> {
+    return new AccountID({
+      address: this.address,
+      chainId: `solana:${this.chainRef}`,
+    })
+  }
+
+  async authenticate(message: string): Promise<string> {
+    if (!this.provider.signMessage) {
+      throw new Error(`Unsupported provider; provider must implement signMessage`)
+    }
+    const signatureBytes = await this.provider.signMessage(uint8arrays.fromString(message));
+    const digest = sha256.hash(signatureBytes)
+    return `0x${uint8arrays.toString(digest, 'base16')}`
+  }
+
+  async createLink(did: string): Promise<LinkProof> {
+    if (!this.provider.signMessage) {
+      throw new Error(`Unsupported provider; provider must implement signMessage`)
+    }
+    const { message, timestamp } = getConsentMessage(did, true)
+    const accountID = await this.accountId()
+    const signatureBytes = await this.provider.signMessage(uint8arrays.fromString(message));
+    const signature = uint8arrays.toString(signatureBytes, 'base64')
+    return {
+      version: 2,
+      type: 'solana',
+      message,
+      signature,
+      account: accountID.toString(),
+      timestamp,
+    }
+  }
+
+  withAddress(address: string): AuthProvider {
+    return new SolanaAuthProvider(this.provider, address, this.chainRef)
+  }
+}

--- a/packages/blockchain-utils-validation/package.json
+++ b/packages/blockchain-utils-validation/package.json
@@ -47,6 +47,7 @@
     "@polkadot/util": "^7.1.1",
     "@polkadot/util-crypto": "^7.0.2",
     "@smontero/eosio-local-provider": "^0.0.3",
+    "@solana/wallet-adapter-base": "^0.6.0",
     "@taquito/signer": "^9.2.0",
     "eth-sig-util": "^3.0.0",
     "ganache-core": "^2.13.1",

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/solana.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/solana.test.ts
@@ -2,7 +2,7 @@ import { validateLink } from '../solana'
 import { Keypair } from '@solana/web3.js';
 import { MessageSignerWalletAdapterProps } from '@solana/wallet-adapter-base';
 import { SolanaAuthProvider } from '@ceramicnetwork/blockchain-utils-linking'
-import nacl from 'tweetnacl'
+import { sign } from '@stablelib/ed25519'
 
 const did = 'did:3:bafysdfwefwe'
 const privKey = 'mdqVWeFekT7pqy5T49+tV12jO0m+ESW7ki4zSU9JiCgbL0kJbj5dvQ/PqcDAzZLZqzshVEs01d1KZdmLh4uZIg=='
@@ -17,7 +17,7 @@ class MyWalletAdapter implements MessageSignerWalletAdapterProps {
   }
 
   async signMessage(message: Uint8Array): Promise<Uint8Array> {
-    return nacl.sign.detached(message, this._keyPair.secretKey)
+    return sign(this._keyPair.secretKey, message)
   }
 }
 

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/solana.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/solana.test.ts
@@ -1,0 +1,33 @@
+import { validateLink } from '../solana'
+import { Keypair } from '@solana/web3.js';
+import { MessageSignerWalletAdapterProps } from '@solana/wallet-adapter-base';
+import { SolanaAuthProvider } from '@ceramicnetwork/blockchain-utils-linking'
+import nacl from 'tweetnacl'
+
+const did = 'did:3:bafysdfwefwe'
+const privKey = 'mdqVWeFekT7pqy5T49+tV12jO0m+ESW7ki4zSU9JiCgbL0kJbj5dvQ/PqcDAzZLZqzshVEs01d1KZdmLh4uZIg=='
+const chainRef = '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+const keyPairEd25519 = Keypair.fromSecretKey(Buffer.from(privKey, 'base64'))
+
+class MyWalletAdapter implements MessageSignerWalletAdapterProps {
+  readonly _keyPair: Keypair
+
+  constructor(keyPair: Keypair) {
+    this._keyPair = keyPair
+  }
+
+  async signMessage(message: Uint8Array): Promise<Uint8Array> {
+    return nacl.sign.detached(message, this._keyPair.secretKey)
+  }
+}
+
+describe('Blockchain: Solana', () => {
+  describe('validateLink', () => {
+    test(`validate proof for ${chainRef}`, async () => {
+      const provider = new MyWalletAdapter(keyPairEd25519)
+      const authProvider = new SolanaAuthProvider(provider, keyPairEd25519.publicKey.toString(), chainRef)
+      const proof = await authProvider.createLink(did)
+      await expect(validateLink(proof)).resolves.toEqual(proof)
+    })
+  })
+})

--- a/packages/blockchain-utils-validation/src/blockchains/solana.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/solana.ts
@@ -1,0 +1,36 @@
+import { BlockchainHandler } from '../blockchain-handler'
+import { LinkProof } from '@ceramicnetwork/blockchain-utils-linking'
+import * as uint8arrays from 'uint8arrays'
+import crypto from 'crypto'
+import nacl from 'tweetnacl'
+import { AccountID } from 'caip'
+
+const verifySignature = async (
+  pubKey: Uint8Array,
+  message: string,
+  signature: Uint8Array
+): Promise<Boolean> => {
+  const verified = nacl.sign.detached.verify(
+    uint8arrays.fromString(message),
+    signature,
+    pubKey
+  )
+  return verified
+}
+
+const namespace = 'solana'
+
+export async function validateLink(proof: LinkProof): Promise<LinkProof | null> {
+  const pubKey = uint8arrays.fromString(new AccountID(proof.account).address, "base58btc")
+  const msg = proof.message
+  const sig = uint8arrays.fromString(proof.signature, 'base64')
+  const is_sig_valid = await verifySignature(pubKey, msg, sig)
+  return is_sig_valid ? proof : null
+}
+
+const Handler: BlockchainHandler = {
+  namespace,
+  validateLink,
+}
+
+export default Handler

--- a/packages/blockchain-utils-validation/src/blockchains/solana.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/solana.ts
@@ -1,19 +1,18 @@
 import { BlockchainHandler } from '../blockchain-handler'
 import { LinkProof } from '@ceramicnetwork/blockchain-utils-linking'
-import * as uint8arrays from 'uint8arrays'
-import crypto from 'crypto'
-import nacl from 'tweetnacl'
 import { AccountID } from 'caip'
+import * as uint8arrays from 'uint8arrays'
+import { verify } from '@stablelib/ed25519'
 
 const verifySignature = async (
   pubKey: Uint8Array,
   message: string,
   signature: Uint8Array
 ): Promise<Boolean> => {
-  const verified = nacl.sign.detached.verify(
+  const verified = verify(
+    pubKey,
     uint8arrays.fromString(message),
     signature,
-    pubKey
   )
   return verified
 }


### PR DESCRIPTION
## Description

Support Solana wallet using the most popular Solana wallet adapter (https://github.com/solana-labs/wallet-adapter).
Only support these wallets that provide a signMessage method for signing arbitrary bytes

Phantom
Solflare
Slope
TokenPocket 

(https://github.com/solana-labs/wallet-adapter/blob/master/FAQ.md#how-can-i-sign-and-verify-messages).


## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- Local unit test
run local unit test

- Wallet integration test
1. install these wallets (Phantom/Solflare/Slope/TokenPocket)  in my browser.
2. using Solana wallet adapter as provider to SolanaAuthProvider.
3. invoke authenticate() can properly pop up related wallets to sign the message and produce deterministic result.
4. verify the signature in created link is correct using nacl.

## References:
https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-30.md


@stbrody @dazuck 