### PR TITLE
add `asDID` option to TileDocumentHandler

### DIFF
--- a/packages/canary-integration/package.json
+++ b/packages/canary-integration/package.json
@@ -22,7 +22,9 @@
     "@ceramicnetwork/stream-tile": "^1.5.1-rc.0",
     "@truffle/hdwallet-provider": "^1.5.0",
     "ganache-core": "^2.13.1",
-    "key-did-resolver": "^1.4.0"
+    "key-did-resolver": "^1.4.0",
+    "dids": "^2.4.0",
+    "key-did-provider-ed25519": "^1.1.0"
   },
   "jest": {
     "testEnvironment": "node",

--- a/packages/canary-integration/src/__tests__/tile-update.test.ts
+++ b/packages/canary-integration/src/__tests__/tile-update.test.ts
@@ -1,0 +1,44 @@
+import { IpfsApi } from '@ceramicnetwork/common'
+import { createIPFS } from '../create-ipfs'
+import { CeramicApi } from '@ceramicnetwork/common'
+import { createCeramic } from '../create-ceramic'
+import { TileDocument } from '@ceramicnetwork/stream-tile'
+import { DID } from 'dids'
+import { Ed25519Provider } from 'key-did-provider-ed25519'
+import KeyResolver from 'key-did-resolver'
+import crypto from 'crypto'
+
+let ipfs: IpfsApi
+let ceramic: CeramicApi
+
+beforeAll(async () => {
+  ipfs = await createIPFS()
+  ceramic = await createCeramic(ipfs)
+}, 12000)
+
+afterAll(async () => {
+  await ipfs.stop()
+  await ceramic.close()
+})
+
+test('can update a tile document with valid asDID', async () => {
+  const newTile = await TileDocument.create(ceramic, { foo: 'bar' })
+  await newTile.update({ foo: 'baz' }, null, { asDID: ceramic.did })
+
+  expect(newTile.content).toMatchObject({
+    foo: 'baz',
+  })
+})
+
+test('cannot update a tile document with invalid asDID', async () => {
+  const newTile = await TileDocument.create(ceramic, { foo: 'bar' })
+
+  const provider = new Ed25519Provider(crypto.randomBytes(32))
+  const did = new DID({ provider, resolver: KeyResolver.getResolver() })
+
+  await did.authenticate()
+
+  await expect(newTile.update({ foo: 'baz' }, null, { asDID: did })).rejects.toThrow()
+
+  expect(newTile.content).toMatchObject({ foo: 'bar' })
+})

--- a/packages/canary-integration/src/__tests__/tile-update.test.ts
+++ b/packages/canary-integration/src/__tests__/tile-update.test.ts
@@ -6,7 +6,7 @@ import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { DID } from 'dids'
 import { Ed25519Provider } from 'key-did-provider-ed25519'
 import KeyResolver from 'key-did-resolver'
-import crypto from 'crypto'
+import { randomBytes } from '@stablelib/random'
 
 let ipfs: IpfsApi
 let ceramic: CeramicApi
@@ -33,7 +33,7 @@ test('can update a tile document with valid asDID', async () => {
 test('cannot update a tile document with invalid asDID', async () => {
   const newTile = await TileDocument.create(ceramic, { foo: 'bar' })
 
-  const provider = new Ed25519Provider(crypto.randomBytes(32))
+  const provider = new Ed25519Provider(randomBytes(32))
   const did = new DID({ provider, resolver: KeyResolver.getResolver() })
 
   await did.authenticate()

--- a/packages/common/src/streamopts.ts
+++ b/packages/common/src/streamopts.ts
@@ -1,3 +1,5 @@
+import { DID } from 'dids'
+
 /**
  * Options that are related to pinning streams.
  */
@@ -94,7 +96,9 @@ export interface AnchorOpts {
 /**
  * Extra options passed as part of operations that update streams.
  */
-export interface UpdateOpts extends PublishOpts, AnchorOpts, InternalOpts, PinningOpts {}
+export interface UpdateOpts extends PublishOpts, AnchorOpts, InternalOpts, PinningOpts {
+  asDID?: DID
+}
 
 /**
  * Extra options passed as part of operations that create streams

--- a/packages/common/src/streamopts.ts
+++ b/packages/common/src/streamopts.ts
@@ -1,4 +1,4 @@
-import { DID } from 'dids'
+import type { DID } from 'dids'
 
 /**
  * Options that are related to pinning streams.

--- a/packages/stream-tile/src/tile-document.ts
+++ b/packages/stream-tile/src/tile-document.ts
@@ -279,7 +279,13 @@ export class TileDocument<T = Record<string, any>> extends Stream {
     opts: UpdateOpts = {}
   ): Promise<void> {
     opts = { ...DEFAULT_UPDATE_OPTS, ...opts }
-    const updateCommit = await this.makeCommit(this.api, content, metadata)
+    let signer: CeramicSigner = this.api
+    if (opts.asDID) {
+      signer = {
+        did: opts.asDID,
+      }
+    }
+    const updateCommit = await this.makeCommit(signer, content, metadata)
     const updated = await this.api.applyCommit(this.id, updateCommit, opts)
     this.state$.next(updated.state)
   }

--- a/packages/stream-tile/src/tile-document.ts
+++ b/packages/stream-tile/src/tile-document.ts
@@ -279,12 +279,7 @@ export class TileDocument<T = Record<string, any>> extends Stream {
     opts: UpdateOpts = {}
   ): Promise<void> {
     opts = { ...DEFAULT_UPDATE_OPTS, ...opts }
-    let signer: CeramicSigner = this.api
-    if (opts.asDID) {
-      signer = {
-        did: opts.asDID,
-      }
-    }
+    const signer: CeramicSigner = opts.asDID ? { did: opts.asDID } : this.api
     const updateCommit = await this.makeCommit(signer, content, metadata)
     const updated = await this.api.applyCommit(this.id, updateCommit, opts)
     this.state$.next(updated.state)


### PR DESCRIPTION
## Description - #1836 

Introduces the ability to make an update with a different DID `asDID` than the one invoking the call. Necessary for OCAP work that is in-progress where updates will be made by the permission holder rather than the permission giver.

## How Has This Been Tested?

Since OCAPs are not fully implemented yet, there are two basic tests. 

The first passes the Ceramic Api's authenticated DID as `asDID` - which works as expected (even though we do switch to using `asDid` instead of `ceramic` for the signatures) 

The second passes a random DID `asDID` and it fails when attempting to sign a Dag JWS. 

More tests will be added as the CACAO library progresses and real use cases become available to test. The changes made should not affect any existing code flows.

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [-] I have updated the READMEs of affected packages
- [-] I have made corresponding changes to the documentation

