### PR TITLE
chore(core): log multiquery errors

### DIFF
--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -564,7 +564,9 @@ describe('Ceramic integration', () => {
             genesis: genesisCommit,
           },
         ])
-      ).rejects.toThrowError('Given StreamID CID does not match given genesis content')
+      ).rejects.toThrowError(
+        `Given StreamID CID ${stream1.id.cid.toString()} does not match given genesis content`
+      )
 
       await ceramic1.close()
       await ceramic2.close()

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -647,7 +647,11 @@ export class Ceramic implements CeramicApi {
     const walkNext = async (node: TrieNode, streamId: StreamID | CommitID) => {
       let stream
       try {
-        stream = await promiseTimeout(timeout, this.loadStream(streamId, { atTime: query.atTime }))
+        stream = await promiseTimeout(
+          this.loadStream(streamId, { atTime: query.atTime }),
+          timeout,
+          `Timeout after ${timeout}ms`
+        )
       } catch (e) {
         this._logger.warn(
           `Error loading stream ${streamId.toString()} at time ${

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -2,15 +2,11 @@ import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
 import { Memoize } from 'typescript-memoize'
 
-import {
-  CommitData,
-  CommitType,
-  StreamUtils,
-} from '@ceramicnetwork/common'
+import { CommitData, CommitType, StreamUtils } from '@ceramicnetwork/common'
 
 import type { TileDocument } from '@ceramicnetwork/stream-tile'
 import { Dispatcher } from './dispatcher'
-import type { StreamID } from "@ceramicnetwork/streamid";
+import type { StreamID } from '@ceramicnetwork/streamid'
 import type CID from 'cids'
 
 /**
@@ -80,7 +76,12 @@ export default class Utils {
   /**
    * Return `CommitData` (with commit, JWS envelope, and/or anchor proof/timestamp, as applicable) for the specified CID
    */
-  static async getCommitData(dispatcher: Dispatcher, cid: CID, timestamp?: number, streamId?: StreamID): Promise<CommitData> {
+  static async getCommitData(
+    dispatcher: Dispatcher,
+    cid: CID,
+    timestamp?: number,
+    streamId?: StreamID
+  ): Promise<CommitData> {
     const commit = await dispatcher.retrieveCommit(cid, streamId)
     if (!commit) throw new Error(`No commit found for CID ${cid.toString()}`)
     // The default applies to all cases that do not use DagJWS for signing (e.g. CAIP-10 links)
@@ -127,9 +128,13 @@ export class PathTrie {
   }
 }
 
-export const promiseTimeout = (ms: number, promise: Promise<any>): Promise<any> => {
+export const promiseTimeout = (
+  promise: Promise<any>,
+  ms: number,
+  timeoutErrorMsg: string
+): Promise<any> => {
   const timeout = new Promise((resolve, reject) => {
-    setTimeout(() => reject(), ms)
+    setTimeout(() => reject(new Error(timeoutErrorMsg)), ms)
   })
   return Promise.race([timeout, promise])
 }


### PR DESCRIPTION
also includes a small code cleanup regarding how we ensure the genesis commit already exists when querying with genesis content (FYI @haardikk21)