### PR TITLE
feat: Disable double unpinning by moving handlePinOpts out of Repository::load

### DIFF
--- a/packages/canary-integration/babel.config.json
+++ b/packages/canary-integration/babel.config.json
@@ -1,0 +1,9 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-typescript"],
+  "plugins": [
+    "@babel/plugin-transform-runtime",
+    "@babel/plugin-proposal-object-rest-spread",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-transform-modules-commonjs"
+  ]
+}

--- a/packages/canary-integration/jest.config.json
+++ b/packages/canary-integration/jest.config.json
@@ -1,0 +1,13 @@
+{
+  "testEnvironment": "node",
+  "resolver": "jest-resolver-enhanced",
+  "preset": "ts-jest",
+  "moduleNameMapper": {
+    "^(\\.{1,2}/.*)\\.js$": "$1"
+  },
+  "testRegex": "(/__tests__/.*(\\.|/)(test|spec))\\.tsx?$",
+  "transformIgnorePatterns": ["node_modules/(?!(dids)/)"],
+  "transform": {
+    "^.+\\.(js|jsx|ts|tsx|mjs)$": "babel-jest"
+  }
+}

--- a/packages/canary-integration/package.json
+++ b/packages/canary-integration/package.json
@@ -24,13 +24,5 @@
     "ganache-core": "^2.13.1",
     "key-did-resolver": "^1.4.0"
   },
-  "jest": {
-    "testEnvironment": "node",
-    "resolver": "jest-resolver-enhanced",
-    "testRegex": ".(spec|test).ts$",
-    "transform": {
-      "^.+\\.ts$": "ts-jest"
-    }
-  },
   "gitHead": "34eeee25597b0a60def72906c26d3afd6230aaf1"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,7 +73,10 @@
     "testMatch": [
       "**/?(*.)+(spec|test).[jt]s?(x)"
     ],
-    "resolver": "jest-resolver-enhanced"
+    "resolver": "jest-resolver-enhanced",
+    "transformIgnorePatterns": [
+      "/node_modules/(?!dids)"
+    ]
   },
   "gitHead": "34eeee25597b0a60def72906c26d3afd6230aaf1"
 }

--- a/packages/core/src/__tests__/ceramic-pinning.test.ts
+++ b/packages/core/src/__tests__/ceramic-pinning.test.ts
@@ -141,11 +141,11 @@ describe('Ceramic stream pinning', () => {
       anchor: false,
       publish: false,
     })
-    expect(isPinned(ceramic, stream.id)).resolves.toBeFalsy()
+    await expect(isPinned(ceramic, stream.id)).resolves.toBeFalsy()
     await stream.update({ foo: 'baz' }, null, { anchor: false, publish: false, pin: true })
-    expect(isPinned(ceramic, stream.id)).resolves.toBeTruthy()
+    await expect(isPinned(ceramic, stream.id)).resolves.toBeTruthy()
     await stream.update({ foo: 'foobarbaz' }, null, { anchor: false, publish: false, pin: false })
-    expect(isPinned(ceramic, stream.id)).resolves.toBeFalsy()
+    await expect(isPinned(ceramic, stream.id)).resolves.toBeFalsy()
     await ceramic.close()
   })
 

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -599,6 +599,7 @@ export class Ceramic implements CeramicApi {
       return streamFromState<T>(this.context, this._streamHandlers, snapshot$.value)
     } else {
       const base$ = await this.repository.load(streamRef.baseID, opts)
+      await this.repository.handlePinOpts(base$, opts)
       return streamFromState<T>(
         this.context,
         this._streamHandlers,

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -176,7 +176,6 @@ export class Repository {
       await this.stateManager.sync(stream, opts.syncTimeoutSeconds * 1000, fromStateStore)
       return this.stateManager.verifyLoneGenesis(stream)
     })
-    await this.handlePinOpts(state$, opts)
 
     return state$
   }

--- a/packages/stream-tile-handler/package.json
+++ b/packages/stream-tile-handler/package.json
@@ -42,7 +42,8 @@
   },
   "jest": {
     "testEnvironment": "node",
-    "resolver": "jest-resolver-enhanced"
+    "resolver": "jest-resolver-enhanced",
+    "transformIgnorePatterns": ["node_modules/(?!(dids)/)"]
   },
   "gitHead": "4f42c6ac204ad25e66efda4e24aed12c339b3c98"
 }


### PR DESCRIPTION
Replaces https://github.com/ceramicnetwork/js-ceramic/pull/1872

Please, disregard changes to ancillary stuff like Jest configs: this is to make the test suite run. Jest and such have to be upgraded.