### PR TITLE
WIP attempt to use type system to force functions that run within a TaskQueue to mark themselves as such by taking a single 'FromQueue' arg

### DIFF
--- a/packages/core/src/pubsub/task-queue.ts
+++ b/packages/core/src/pubsub/task-queue.ts
@@ -4,7 +4,9 @@ export const noop = () => {
   // Do Nothing
 }
 
-export type Task<TaskResultType> = () => Promise<TaskResultType>
+export class FromQueue {}
+
+export type Task<TaskResultType> = (handle: FromQueue) => Promise<TaskResultType>
 
 /**
  * TaskQueue aspect.
@@ -52,7 +54,7 @@ export class TaskQueue implements TaskQueueLike {
   /**
    * Add task to queue. Fire-and-forget semantics.
    */
-  add(task, onFinally?): void {
+  add(task: Task<void>, onFinally?): void {
     this.run(task)
       .catch((error) => {
         const retry = () => this.add(task, onFinally)
@@ -67,7 +69,7 @@ export class TaskQueue implements TaskQueueLike {
    * Note "fire-and-forget" comment for the `add` method.
    */
   run<T>(task: Task<T>): Promise<T> {
-    return this.#pq.add(task)
+    return this.#pq.add(() => task(new FromQueue()))
   }
 
   /**

--- a/packages/core/src/state-management/named-task-queue.ts
+++ b/packages/core/src/state-management/named-task-queue.ts
@@ -1,4 +1,4 @@
-import { noop, TaskQueue } from '../pubsub/task-queue'
+import { noop, TaskQueue, Task } from '../pubsub/task-queue'
 
 /**
  * Set of named PQueues.
@@ -47,7 +47,7 @@ export class NamedTaskQueue {
    *
    * Returns result of the task execution.
    */
-  run<A>(name: string, task: () => Promise<A>): Promise<A> {
+  run<A>(name: string, task: Task<A>): Promise<A> {
     const queue = this.queue(name)
     return queue.run(task).finally(() => {
       this.remove(name)
@@ -60,10 +60,10 @@ export class NamedTaskQueue {
    * All the tasks added under the same name are executed sequentially.
    * Tasks with different names are executed in parallel.
    */
-  add(name: string, task: () => Promise<void>): void {
+  add(name: string, task: Task<void>): void {
     const queue = this.queue(name)
     queue.add(
-      () => task(),
+      (handle) => task(handle),
       () => this.remove(name)
     )
   }

--- a/packages/core/src/state-management/running-state.ts
+++ b/packages/core/src/state-management/running-state.ts
@@ -34,6 +34,10 @@ export class RunningState extends StreamStateSubject implements RunningStateLike
     return this._pinnedCommits
   }
 
+  get isPinned(): boolean {
+    return this.pinnedCommits != null
+  }
+
   /**
    * Track related subscription.
    */

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -73,10 +73,8 @@ export class StateManager {
    * genesis commit) and kicks off the process to load and apply the most recent Tip to it.
    * @param state$
    * @param timeoutMillis
-   * @param pinned - True if the stream was loaded from the state store, indicating that the stream
-   *   is pinned. Pinned streams get added to the `syncedPinnedStreams` set when they are synced.
    */
-  async sync(state$: RunningState, timeoutMillis: number, pinned: boolean): Promise<void> {
+  async sync(state$: RunningState, timeoutMillis: number): Promise<void> {
     const tip$ = this.dispatcher.messageBus.queryNetwork(state$.id)
     await tip$
       .pipe(
@@ -84,7 +82,7 @@ export class StateManager {
         concatMap((tip) => this._handleTip(state$, tip))
       )
       .toPromise()
-    if (pinned) {
+    if (state$.isPinned) {
       this.syncedPinnedStreams.add(state$.id.toString())
     }
   }

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -21,6 +21,7 @@ import { catchError, concatMap, takeUntil } from 'rxjs/operators'
 import { empty, Observable, Subject, Subscription, timer } from 'rxjs'
 import { SnapshotState } from './snapshot-state'
 import { CommitID, StreamID } from '@ceramicnetwork/streamid'
+import { FromQueue } from '../pubsub/task-queue'
 
 const APPLY_ANCHOR_COMMIT_ATTEMPTS = 3
 


### PR DESCRIPTION
This experiment didn't seem to work.  If it had, then all the functions in state-manager or the repository that schedule tasks into the `executionQ` or `loadingQ` would be failing to compile because the tasks take 0 args instead of the 1 `FromQueue` arg that they should be required to provide.


See https://github.com/ceramicnetwork/js-ceramic/pull/1902 for context