### PR TITLE
chore(core): Test that conflictResolution.snapshotAtCommit does not mutate state object

### DIFF
--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -176,6 +176,12 @@ export class StreamUtils {
       }
     }
 
+    if (state.anchorStatus != base.anchorStatus) {
+      // Re-creating a state object from the exact same set of commits can still lose information,
+      // such as whether or not an anchor has been requested.
+      return false
+    }
+
     return true
   }
 

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -466,7 +466,7 @@ describe('Ceramic integration', () => {
         queries.push({ streamId: commitId })
       }
 
-      const result = await ceramic2.multiQuery(queries, 10000)
+      const result = await ceramic2.multiQuery(queries, 30000)
       expect(Object.keys(result).length).toEqual(stream.allCommitIds.length + 1) // +1 for base streamid
       expect(result[stream.id.toString()].content).toEqual({ counter: NUM_UPDATES - 1 })
 

--- a/packages/core/src/state-management/running-state.ts
+++ b/packages/core/src/state-management/running-state.ts
@@ -35,7 +35,7 @@ export class RunningState extends StreamStateSubject implements RunningStateLike
   }
 
   get isPinned(): boolean {
-    return this.pinnedCommits != null
+    return this.pinnedCommits && this.pinnedCommits.size > 0
   }
 
   /**


### PR DESCRIPTION
Using deep-freeze unfortunately didn't work as it would throw an error `Cannot freeze array buffer views with elements` when called on a state object.

So instead I made the tests make a deep clone of the state object and compare them before and after loading at a commit to make sure they aren't modified.