### PR TITLE
feat: Test with both go-ipfs and js-ipfs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,41 @@
 version: 2.1
 orbs:
   node: circleci/node@4.7.0
-jobs:
+
+commands:
   build-and-test:
-    machine:
-      image: ubuntu-2004:202107-02
-    environment:
-      NODE_OPTIONS: "--max_old_space_size=4096"
     steps:
       - checkout
       - node/install-npm:
-          version: "6"
+          version: '6'
       - node/install-packages
       - run: npm run lint
       - run: npm run build
       - run:
-          name: Test with go-ipfs
+          name: Test
           command: npm run test
           no_output_timeout: 30m
-          environment:
-            IPFS_FLAVOR: go
-      - run:
-          name: Test with js-ipfs
-          command: npm run test
-          no_output_timeout: 30m
-          environment:
-            IPFS_FLAVOR: js
+jobs:
+  with-go-ipfs:
+    machine:
+      image: ubuntu-2004:202107-02
+    environment:
+      NODE_OPTIONS: '--max_old_space_size=4096'
+      IPFS_FLAVOR: go
+    steps:
+      - build-and-test
       - run: npm run docs
+  with-js-ipfs:
+    machine:
+      image: ubuntu-2004:202107-02
+    environment:
+      NODE_OPTIONS: '--max_old_space_size=4096'
+      IPFS_FLAVOR: js
+    steps:
+      - build-and-test
+
 workflows:
   build-and-test:
     jobs:
-      - build-and-test
+      - with-go-ipfs
+      - with-js-ipfs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
     machine:
       image: ubuntu-2004:202107-02
     environment:
-      NODE_OPTIONS: '--max_old_space_size=4096'
       IPFS_FLAVOR: go
     steps:
       - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,17 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run:
+          name: Test with go-ipfs
           command: npm run test
           no_output_timeout: 30m
+          environment:
+            IPFS_FLAVOR: go
+      - run:
+          name: Test with js-ipfs
+          command: npm run test
+          no_output_timeout: 30m
+          environment:
+            IPFS_FLAVOR: js
       - run: npm run docs
 workflows:
   build-and-test:

--- a/packages/canary-integration/package.json
+++ b/packages/canary-integration/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Canary integration test for Ceramic components",
   "scripts": {
-    "test": "../../node_modules/.bin/jest --silent --coverage",
+    "test": "../../node_modules/.bin/jest --verbose --coverage",
     "build": "../../node_modules/.bin/tsc -p tsconfig.json",
     "lint": "../../node_modules/.bin/eslint ./src --ext .js,.jsx,.ts,.tsx",
     "clean": "rm -rf ./lib"

--- a/packages/canary-integration/package.json
+++ b/packages/canary-integration/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Canary integration test for Ceramic components",
   "scripts": {
-    "test": "../../node_modules/.bin/jest --verbose --coverage",
+    "test": "../../node_modules/.bin/jest --silent --coverage",
     "build": "../../node_modules/.bin/tsc -p tsconfig.json",
     "lint": "../../node_modules/.bin/eslint ./src --ext .js,.jsx,.ts,.tsx",
     "clean": "rm -rf ./lib"

--- a/packages/canary-integration/src/create-ipfs.ts
+++ b/packages/canary-integration/src/create-ipfs.ts
@@ -2,7 +2,7 @@ import * as dagJose from 'dag-jose'
 import { path } from 'go-ipfs'
 import * as Ctl from 'ipfsd-ctl'
 import * as ipfsHttp from 'ipfs-http-client'
-import type { IPFS, Options } from 'ipfs-core'
+import type { Options } from 'ipfs-core'
 import { create } from 'ipfs-core'
 import getPort from 'get-port'
 import mergeOpts from 'merge-options'
@@ -15,20 +15,20 @@ const mergeOptions = mergeOpts.bind({ ignoreUndefined: true })
  * Create an IPFS instance
  * @param overrideConfig - IFPS config for override
  */
-export async function createIPFS(overrideConfig: Partial<Options> = {}): Promise<IPFS> {
+export async function createIPFS(overrideConfig: Partial<Options> = {}): Promise<IpfsApi> {
   const flavor = process.env.IPFS_FLAVOR
   if (flavor && flavor.toLowerCase() == 'js') {
-    return createJSIPFS(overrideConfig)
+    return createJsIPFS(overrideConfig)
   } else {
     return createGoIPFS(overrideConfig)
   }
 }
 
 /**
- * Create an IPFS instance
+ * Create go-ipfs instance
  * @param overrideConfig - IFPS config for override
  */
-export async function createGoIPFS(overrideConfig: Partial<Options> = {}): Promise<IPFS> {
+async function createGoIPFS(overrideConfig: Partial<Options> = {}): Promise<IpfsApi> {
   const swarmPort = await getPort()
   const apiPort = await getPort()
   const gatewayPort = await getPort()
@@ -59,10 +59,10 @@ export async function createGoIPFS(overrideConfig: Partial<Options> = {}): Promi
 }
 
 /**
- * Create an IPFS instance
+ * Create js-ipfs instance
  * @param overrideConfig - IFPS config for override
  */
-export async function createJSIPFS(overrideConfig: Record<string, unknown> = {}): Promise<IpfsApi> {
+async function createJsIPFS(overrideConfig: Record<string, unknown> = {}): Promise<IpfsApi> {
   const tmpFolder = await tmp.dir({ unsafeCleanup: true })
 
   const port = await getPort()

--- a/packages/cli/babel.config.js
+++ b/packages/cli/babel.config.js
@@ -16,7 +16,7 @@ module.exports = {
 			"allowTopLevelThis": true
 		}],
         ["@babel/plugin-proposal-decorators", { "legacy": true }],
-        ["@babel/plugin-proposal-class-properties", { "loose": true }]
+        ["@babel/plugin-proposal-class-properties", { "loose": false }]
 	]
 }
 

--- a/packages/core/src/__tests__/ipfs-util.ts
+++ b/packages/core/src/__tests__/ipfs-util.ts
@@ -6,10 +6,12 @@ import * as ipfsHttp from 'ipfs-http-client'
 import type { Options } from 'ipfs-core'
 import getPort from 'get-port'
 import mergeOpts from 'merge-options'
+import tmp from 'tmp-promise'
+import { create } from 'ipfs-core'
 
 const mergeOptions = mergeOpts.bind({ ignoreUndefined: true })
 
-async function ipfsConfig(override: Partial<Options> = {}): Promise<Options> {
+async function goIpfsConfig(override: Partial<Options> = {}): Promise<Options> {
   const swarmPort = await getPort()
   const apiPort = await getPort()
   const gatewayPort = await getPort()
@@ -35,12 +37,21 @@ async function ipfsConfig(override: Partial<Options> = {}): Promise<Options> {
  * Create an IPFS instance
  * @param overrideConfig - IFPS config for override
  */
+export async function createIPFS(overrideConfig: Partial<Options> = {}): Promise<IpfsApi> {
+  const flavor = process.env.IPFS_FLAVOR
+  if (flavor && flavor.toLowerCase() == 'js') {
+    return createJsIPFS(overrideConfig)
+  } else {
+    return createGoIPFS(overrideConfig)
+  }
+}
+
 /**
- * Create an IPFS instance
+ * Create go-ipfs instance
  * @param overrideConfig - IFPS config for override
  */
-export async function createIPFS(overrideConfig: Partial<Options> = {}): Promise<IpfsApi> {
-  const ipfsOptions = await ipfsConfig(overrideConfig)
+async function createGoIPFS(overrideConfig: Partial<Options> = {}): Promise<IpfsApi> {
+  const ipfsOptions = await goIpfsConfig(overrideConfig)
 
   const ipfsd = await Ctl.createController({
     ipfsHttpModule: ipfsHttp,
@@ -52,6 +63,43 @@ export async function createIPFS(overrideConfig: Partial<Options> = {}): Promise
   })
   return ipfsd.api
 }
+
+/**
+ * Create js-ipfs instance
+ * @param overrideConfig - IFPS config for override
+ */
+async function createJsIPFS(overrideConfig: Record<string, unknown> = {}): Promise<IpfsApi> {
+  const tmpFolder = await tmp.dir({ unsafeCleanup: true })
+
+  const port = await getPort()
+  const defaultConfig = {
+    ipld: { codecs: [dagJose] },
+    repo: `${tmpFolder.path}/ipfs${port}/`,
+    config: {
+      Addresses: { Swarm: [`/ip4/127.0.0.1/tcp/${port}`] },
+      Bootstrap: [],
+    },
+  }
+
+  const config = { ...defaultConfig, ...overrideConfig }
+  const instance = await create(config)
+
+  // IPFS does not notify you when it stops.
+  // Here we intercept a call to `ipfs.stop` to clean up IPFS repository folder.
+  // Poor man's hook.
+  return new Proxy(instance, {
+    get(target: any, p: PropertyKey): any {
+      if (p === 'stop') {
+        return () => {
+          const vanilla = target[p]
+          return vanilla().finally(() => tmpFolder.cleanup())
+        }
+      }
+      return target[p]
+    },
+  })
+}
+
 /**
  * Connect two IPFS instances via `swarm.connect`
  *
@@ -66,11 +114,28 @@ export async function swarmConnect(a: IpfsApi, b: IpfsApi) {
 }
 
 /**
- * Start `n` IPFS instances, and stop them after `task` is done.
+ * Start `n` IPFS (go-ipfs or js-ipfs based on `process.env.IPFS_FLAVOR`) instances, and stop them after `task` is done.
  * @param n - Number of IPFS instances to create.
  * @param task - Function that uses the IPFS instances.
  */
 export async function withFleet(
+  n: number,
+  task: (instances: IpfsApi[]) => Promise<void>
+): Promise<void> {
+  const flavor = process.env.IPFS_FLAVOR
+  if (flavor && flavor.toLowerCase() == 'js') {
+    return withJsFleet(n, task)
+  } else {
+    return withGoFleet(n, task)
+  }
+}
+
+/**
+ * Start `n` go-ipfs instances, and stop them after `task` is done.
+ * @param n - Number of go-ipfs instances to create.
+ * @param task - Function that uses go-ipfs instances.
+ */
+async function withGoFleet(
   n: number,
   task: (instances: IpfsApi[]) => Promise<void>
 ): Promise<void> {
@@ -82,7 +147,7 @@ export async function withFleet(
   })
   const controllers = await Promise.all(
     Array.from({ length: n }).map(async () => {
-      const ipfsOptions = await ipfsConfig()
+      const ipfsOptions = await goIpfsConfig()
 
       return factory.spawn({
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -96,5 +161,31 @@ export async function withFleet(
     await task(instances)
   } finally {
     await factory.clean()
+  }
+}
+
+/**
+ * Instantiate a number of js-ipfs instances
+ * @param n - number of js-ipfs instances
+ * @param overrideConfig - IPFS config for override
+ */
+function fleet(n: number, overrideConfig: Record<string, unknown> = {}): Promise<IpfsApi[]> {
+  return Promise.all(Array.from({ length: n }).map(() => createJsIPFS(overrideConfig)))
+}
+
+/**
+ * Start `n` js-ipfs instances, and stop them after `task` is done.
+ * @param n - Number of js-ipfs instances to create.
+ * @param task - Function that uses the IPFS instances.
+ */
+async function withJsFleet(
+  n: number,
+  task: (instances: IpfsApi[]) => Promise<void>
+): Promise<void> {
+  const instances = await fleet(n)
+  try {
+    await task(instances)
+  } finally {
+    instances.map((instance) => instance.stop())
   }
 }


### PR DESCRIPTION
Make CircleCI test using go-ipfs and js-ipfs based on `IPFS_FLAVOR` env variable. Uses go-ipfs by default, but if `IPFS_FLAVOR` env is set to `js` or `JS`, then `js-ipfs` is used.