### PR TITLE
feat(core): Add env var to configure pubsub qps limit

### DIFF
--- a/packages/core/src/__tests__/dispatcher.test.ts
+++ b/packages/core/src/__tests__/dispatcher.test.ts
@@ -1,7 +1,7 @@
 import { Dispatcher } from '../dispatcher'
 import CID from 'cids'
 import StreamID from '@ceramicnetwork/streamid'
-import { CommitType, StreamState, LoggerProvider } from '@ceramicnetwork/common'
+import { CommitType, StreamState, LoggerProvider, IpfsApi } from '@ceramicnetwork/common'
 import { serialize, MsgType } from '../pubsub/pubsub-message'
 import { Repository, RepositoryDependencies } from '../state-management/repository'
 import { delay } from './delay'
@@ -57,11 +57,12 @@ describe('Dispatcher', () => {
     } as unknown as PinStore
     repository.setDeps({ pinStore } as unknown as RepositoryDependencies)
     dispatcher = new Dispatcher(
-      ipfs,
+      ipfs as any as IpfsApi,
       TOPIC,
       repository,
       loggerProvider.getDiagnosticsLogger(),
-      loggerProvider.makeServiceLogger('pubsub')
+      loggerProvider.makeServiceLogger('pubsub'),
+      10
     )
   })
 

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -45,7 +45,7 @@ import { ConflictResolution } from './conflict-resolution'
 import EthereumAnchorValidator from './anchor/ethereum/ethereum-anchor-validator'
 
 const DEFAULT_CACHE_LIMIT = 500 // number of streams stored in the cache
-const IPFS_GET_TIMEOUT = 60000 // 1 minute
+const DEFAULT_QPS_LIMIT = 10 // Max number of pubsub query messages that can be published per second without rate limiting
 const TESTING = process.env.NODE_ENV == 'test'
 
 const TRAILING_SLASH = /\/$/ // slash at the end of the string
@@ -413,6 +413,9 @@ export class Ceramic implements CeramicApi {
 
     const streamCacheLimit = config.streamCacheLimit ?? DEFAULT_CACHE_LIMIT
     const concurrentRequestsLimit = config.concurrentRequestsLimit ?? streamCacheLimit
+    const maxQueriesPerSecond = process.env.CERAMIC_PUBSUB_QPS_LIMIT
+      ? parseInt(process.env.CERAMIC_PUBSUB_QPS_LIMIT)
+      : DEFAULT_QPS_LIMIT
 
     const ipfsTopology = new IpfsTopology(ipfs, networkOptions.name, logger)
     const pinStoreFactory = new PinStoreFactory(ipfs, pinStoreOptions)
@@ -422,7 +425,8 @@ export class Ceramic implements CeramicApi {
       networkOptions.pubsubTopic,
       repository,
       logger,
-      pubsubLogger
+      pubsubLogger,
+      maxQueriesPerSecond
     )
 
     const params: CeramicParameters = {

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -28,8 +28,6 @@ const IPFS_GET_TIMEOUT = 30000 // 30 seconds per retry, 3 retries = 90 seconds t
 const IPFS_MAX_COMMIT_SIZE = 256000 // 256 KB
 const IPFS_RESUBSCRIBE_INTERVAL_DELAY = 1000 * 15 // 15 sec
 const MAX_PUBSUB_PUBLISH_INTERVAL = 60 * 1000 // one minute
-const MAX_QUERIES_PER_SECOND = 10
-const MAX_QUEUED_QUERIES = 100
 const IPFS_CACHE_SIZE = 1024 // maximum cache size of 256MB
 
 function messageTypeToString(type: MsgType): string {
@@ -60,15 +58,15 @@ export class Dispatcher {
     private readonly topic: string,
     readonly repository: Repository,
     private readonly _logger: DiagnosticsLogger,
-    private readonly _pubsubLogger: ServiceLogger
+    private readonly _pubsubLogger: ServiceLogger,
+    maxQueriesPerSecond: number
   ) {
     const pubsub = new Pubsub(_ipfs, topic, IPFS_RESUBSCRIBE_INTERVAL_DELAY, _pubsubLogger, _logger)
     this.messageBus = new MessageBus(
       new PubsubRateLimit(
         new PubsubKeepalive(pubsub, MAX_PUBSUB_PUBLISH_INTERVAL),
         _logger,
-        MAX_QUERIES_PER_SECOND,
-        MAX_QUEUED_QUERIES
+        maxQueriesPerSecond
       )
     )
     this.messageBus.subscribe(this.handleMessage.bind(this))

--- a/packages/core/src/pubsub/__tests__/pubsub-ratelimit.test.ts
+++ b/packages/core/src/pubsub/__tests__/pubsub-ratelimit.test.ts
@@ -14,9 +14,11 @@ const FAKE_STREAM_ID = StreamID.fromString(
 )
 const PEER_ID = 'PEER_ID'
 const QUERIES_PER_SECOND = 5
-const MAX_QUEUED_QUERIES = 10
+const MAX_QUEUED_QUERIES = QUERIES_PER_SECOND * 10
 
 describe('pubsub with queries rate limited', () => {
+  jest.setTimeout(1000 * 30)
+
   let ipfs
   let pubsub
 
@@ -34,8 +36,7 @@ describe('pubsub with queries rate limited', () => {
     pubsub = new PubsubRateLimit(
       raw_pubsub,
       new LoggerProvider().getDiagnosticsLogger(),
-      QUERIES_PER_SECOND,
-      MAX_QUEUED_QUERIES
+      QUERIES_PER_SECOND
     )
   })
 

--- a/packages/core/src/pubsub/pubsub-ratelimit.ts
+++ b/packages/core/src/pubsub/pubsub-ratelimit.ts
@@ -61,6 +61,10 @@ export class PubsubRateLimit
     this._queryQueue = new TaskQueue((err) => {
       this.logger.err(`Error while publishing pubsub QUERY message: ${err}`)
     })
+
+    this.logger.debug(
+      `Configuring pubsub to rate limit query messages to ${queriesPerSecond} per second`
+    )
   }
 
   /**

--- a/packages/core/src/pubsub/pubsub-ratelimit.ts
+++ b/packages/core/src/pubsub/pubsub-ratelimit.ts
@@ -48,13 +48,11 @@ export class PubsubRateLimit
    * @param logger
    * @param queriesPerSecond - Max number of query messages that can be published per second
    *   before they start to queue up.
-   * @param maxQueuedQueries - Max number of messages that are allowed in the queue.
    */
   constructor(
     private readonly pubsub: ObservableWithNext<PubsubMessage>,
     private readonly logger: DiagnosticsLogger,
-    private readonly queriesPerSecond: number,
-    private readonly maxQueuedQueries: number
+    private readonly queriesPerSecond: number
   ) {
     super((subscriber) => {
       pubsub.subscribe(subscriber)
@@ -71,10 +69,11 @@ export class PubsubRateLimit
    * @param message
    */
   next(message: PubsubMessage): Subscription {
+    const maxQueuedQueries = this.queriesPerSecond * 10
     if (message.typ === MsgType.QUERY) {
-      if (this._queryQueue.size >= this.maxQueuedQueries) {
+      if (this._queryQueue.size >= maxQueuedQueries) {
         throw new Error(
-          `Cannot publish query message to pubsub because we have exceeded the maximum allowed rate. Cannot have more than ${this.maxQueuedQueries} queued queries.`
+          `Cannot publish query message to pubsub because we have exceeded the maximum allowed rate. Cannot have more than ${maxQueuedQueries} queued queries.`
         )
       }
       return from(this._queryQueue.run(this._publishQuery.bind(this, message))).subscribe()


### PR DESCRIPTION
Tested manually

I thought about adding this fully to the ceramic config and daemon config file, but given that query rate limiting is likely going away soon with tipsync, I figured it might be better just to use an env var as a quick fix that we can easily remove later.