### PR TITLE
fix(core): Allow loading multiple CommitIDs for the same stream in parallel

### DIFF
--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -176,6 +176,12 @@ export class StreamUtils {
       }
     }
 
+    if (state.anchorStatus != base.anchorStatus) {
+      // Re-creating a state object from the exact same set of commits can still lose information,
+      // such as whether or not an anchor has been requested.
+      return false
+    }
+
     return true
   }
 

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -455,7 +455,7 @@ describe('Ceramic integration', () => {
       const ceramic1 = await createCeramic(ipfs1, false)
       const ceramic2 = await createCeramic(ipfs2, false)
 
-      const NUM_UPDATES = 15
+      const NUM_UPDATES = 20
       const stream = await TileDocument.create(ceramic1, { counter: 0 }, null, { anchor: false })
       for (let i = 1; i < NUM_UPDATES; i++) {
         await stream.update({ counter: i }, null, { anchor: false, publish: false })

--- a/packages/core/src/state-management/execution-queue.ts
+++ b/packages/core/src/state-management/execution-queue.ts
@@ -1,5 +1,5 @@
 import { NamedTaskQueue } from './named-task-queue'
-import { StreamID } from '@ceramicnetwork/streamid'
+import { CommitID, StreamID } from '@ceramicnetwork/streamid'
 import { DiagnosticsLogger } from '@ceramicnetwork/common'
 import { Semaphore } from 'await-semaphore'
 import { TaskQueueLike } from '../pubsub/task-queue'
@@ -23,7 +23,7 @@ export class ExecutionQueue {
   /**
    * Return execution lane for a stream.
    */
-  forStream(streamId: StreamID): TaskQueueLike {
+  forStream(streamId: StreamID | CommitID): TaskQueueLike {
     return {
       add: (task) => {
         return this.tasks.add(streamId.toString(), () => {

--- a/packages/core/src/state-management/running-state.ts
+++ b/packages/core/src/state-management/running-state.ts
@@ -35,7 +35,7 @@ export class RunningState extends StreamStateSubject implements RunningStateLike
   }
 
   get isPinned(): boolean {
-    return this.pinnedCommits != null
+    return this.pinnedCommits && this.pinnedCommits.size > 0
   }
 
   /**

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -109,7 +109,7 @@ export class StateManager {
    * @param commitId - Requested commit.
    */
   async atCommit(state$: RunningStateLike, commitId: CommitID): Promise<SnapshotState> {
-    return this.executionQ.forStream(commitId.baseID).run(async () => {
+    return this.executionQ.forStream(commitId).run(async () => {
       const snapshot = await this.conflictResolution.snapshotAtCommit(state$.value, commitId)
 
       // If the provided CommitID is ahead of what we have in the cache, then we should update


### PR DESCRIPTION
This is a re-apply of 3290a66db7f4063aac1df3781bef2962442740e2 after it was
reverted in 8c73805991e1f3d960f5451af8fa795fb260fef2.