### PR TITLE
Add Deprecation notice to all functions that have been moved to the Glaze CLI

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -87,6 +87,7 @@ jobs:
         run: |
           npm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
           npm run publish:latest $PUBLISH_ARGS
+          git push
       -
         name: Update and push code to `release-candidate` and `develop`
         if: ${{ steps.set-env.outputs.main == 'true' && steps.set-env.outputs.hotfix != 'true' }}
@@ -183,6 +184,7 @@ jobs:
         run: |
           npm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
           npm run publish:release-candidate $PUBLISH_ARGS
+          git push
       -
         name: Update and push code to `develop`
         if: ${{ steps.set-env.outputs.rc == 'true' && steps.set-env.outputs.hotfix != 'true' }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,7 +60,7 @@
     "morgan": "^1.10.0",
     "nft-did-resolver": "^1.0.0",
     "picocolors": "^1.0.0",
-    "pkh-did-resolver": "^0.3.3",
+    "pkh-did-resolver": "^0.3.8-rc.0",
     "reflect-metadata": "^0.1.13",
     "s3leveldown": "^2.2.1",
     "safe-did-resolver": "^0.0.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,6 +59,7 @@
     "levelup": "^4.4.0",
     "morgan": "^1.10.0",
     "nft-did-resolver": "^1.0.0",
+    "picocolors": "^1.0.0",
     "pkh-did-resolver": "^0.3.3",
     "reflect-metadata": "^0.1.13",
     "s3leveldown": "^2.2.1",

--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -106,7 +106,7 @@ program
       'that creating a document with identical content to an existing document will be a no-op.'
   )
   .option('--schema <schema>', 'Schema document ID')
-  .description('Create a new document \x1b[31;1;m[Depreciated]\x1b[0m')
+  .description('Create a new document \x1b[31;1;m[Deprecated]\x1b[0m')
   .action(async (streamtype, { content, onlyGenesis, controllers, deterministic, schema }) => {
     if (streamtype != 'tile') {
       throw new Error("CLI does not currently support creating stream types other than 'tile'")
@@ -125,41 +125,41 @@ program
   .option('--content <content>', 'Update document content')
   .option('--controllers <controllers>', 'Change controllers of this document (only 3ID)')
   .option('--schema <schema>', 'Change the schema CommitID')
-  .description('Update the content of a document \x1b[31;1;m[Depreciated]\x1b[0m')
+  .description('Update the content of a document \x1b[31;1;m[Deprecated]\x1b[0m')
   .action(async (streamId, { content, controllers, schema }) => {
     await CeramicCliUtils.update(streamId, content, controllers, schema)
   })
 
 program
   .command('show <streamId> [<anchor>]')
-  .description('Show the content of a stream \x1b[31;1;m[Depreciated]\x1b[0m')
+  .description('Show the content of a stream \x1b[31;1;m[Deprecated]\x1b[0m')
   .action(async (streamId) => {
     await CeramicCliUtils.show(streamId)
   })
 
 program
   .command('state <streamId> [<anchor>]')
-  .description('Show the state of a stream \x1b[31;1;m[Depreciated]\x1b[0m')
+  .description('Show the state of a stream \x1b[31;1;m[Deprecated]\x1b[0m')
   .action(async (streamId) => {
     await CeramicCliUtils.state(streamId)
   })
 
 program
   .command('watch <streamId>')
-  .description('Watch for updates in a stream \x1b[31;1;m[Depreciated]\x1b[0m')
+  .description('Watch for updates in a stream \x1b[31;1;m[Deprecated]\x1b[0m')
   .action(async (streamId) => {
     await CeramicCliUtils.watch(streamId)
   })
 
 program
   .command('commits <streamId>')
-  .description('List stream commits \x1b[31;1;m[Depreciated]\x1b[0m')
+  .description('List stream commits \x1b[31;1;m[Deprecated]\x1b[0m')
   .action(async (streamId) => {
     await CeramicCliUtils.commits(streamId)
   })
 
 const schemas = program.command('schema')
-schemas.description('Ceramic schemas \x1b[31;1;m[Depreciated]\x1b[0m')
+schemas.description('Ceramic schemas \x1b[31;1;m[Deprecated]\x1b[0m')
 
 schemas
   .command('create <new-content>')
@@ -175,7 +175,7 @@ schemas
       'that creating a schema document with identical content to an existing schema document ' +
       'will be a no-op.'
   )
-  .description('Create a new schema \x1b[31;1;m[Depreciated]\x1b[0m')
+  .description('Create a new schema \x1b[31;1;m[Deprecated]\x1b[0m')
   .action(async (content, { onlyGenesis, controllers, deterministic }) => {
     await CeramicCliUtils.schemaCreateDoc(content, controllers, onlyGenesis, deterministic)
   })
@@ -183,31 +183,31 @@ schemas
 schemas
   .command('update <streamId> <new-content>')
   .option('--controllers <controllers>', 'Change controllers of this document (only 3ID)')
-  .description('Update the content of a schema \x1b[31;1;m[Depreciated]\x1b[0m')
+  .description('Update the content of a schema \x1b[31;1;m[Deprecated]\x1b[0m')
   .action(async (streamId, content, { controllers }) => {
     await CeramicCliUtils.schemaUpdateDoc(streamId, content, controllers)
   })
 
 const pin = program.command('pin')
-pin.description('Ceramic local pinning API \x1b[31;1;m[Depreciated]\x1b[0m')
+pin.description('Ceramic local pinning API \x1b[31;1;m[Deprecated]\x1b[0m')
 
 pin
   .command('add <streamId>')
-  .description('Pin stream \x1b[31;1;m[Depreciated]\x1b[0m')
+  .description('Pin stream \x1b[31;1;m[Deprecated]\x1b[0m')
   .action(async (streamId) => {
     await CeramicCliUtils.pinAdd(streamId)
   })
 
 pin
   .command('rm <streamId>')
-  .description('Unpin stream \x1b[31;1;m[Depreciated]\x1b[0m`')
+  .description('Unpin stream \x1b[31;1;m[Deprecated]\x1b[0m`')
   .action(async (streamId) => {
     await CeramicCliUtils.pinRm(streamId)
   })
 
 pin
   .command('ls [<streamId>]')
-  .description('List pinned streams \x1b[31;1;m[Depreciated]\x1b[0m`')
+  .description('List pinned streams \x1b[31;1;m[Deprecated]\x1b[0m`')
   .action(async (streamId) => {
     await CeramicCliUtils.pinLs(streamId)
   })

--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -1,4 +1,5 @@
 import program from 'commander'
+import pc from 'picocolors'
 
 import { CeramicCliUtils } from '../ceramic-cli-utils'
 
@@ -106,7 +107,7 @@ program
       'that creating a document with identical content to an existing document will be a no-op.'
   )
   .option('--schema <schema>', 'Schema document ID')
-  .description('Create a new document \x1b[31;1;m[Deprecated]\x1b[0m')
+  .description(`Create a new document ${pc.red(pc.bold('[Deprecated]'))}`)
   .action(async (streamtype, { content, onlyGenesis, controllers, deterministic, schema }) => {
     if (streamtype != 'tile') {
       throw new Error("CLI does not currently support creating stream types other than 'tile'")
@@ -125,41 +126,41 @@ program
   .option('--content <content>', 'Update document content')
   .option('--controllers <controllers>', 'Change controllers of this document (only 3ID)')
   .option('--schema <schema>', 'Change the schema CommitID')
-  .description('Update the content of a document \x1b[31;1;m[Deprecated]\x1b[0m')
+  .description(`Update the content of a document ${pc.red(pc.bold('[Deprecated]'))}`)
   .action(async (streamId, { content, controllers, schema }) => {
     await CeramicCliUtils.update(streamId, content, controllers, schema)
   })
 
 program
   .command('show <streamId> [<anchor>]')
-  .description('Show the content of a stream \x1b[31;1;m[Deprecated]\x1b[0m')
+  .description(`Show the content of a stream ${pc.red(pc.bold('[Deprecated]'))}`)
   .action(async (streamId) => {
     await CeramicCliUtils.show(streamId)
   })
 
 program
   .command('state <streamId> [<anchor>]')
-  .description('Show the state of a stream \x1b[31;1;m[Deprecated]\x1b[0m')
+  .description(`Show the state of a stream ${pc.red(pc.bold('[Deprecated]'))}`)
   .action(async (streamId) => {
     await CeramicCliUtils.state(streamId)
   })
 
 program
   .command('watch <streamId>')
-  .description('Watch for updates in a stream \x1b[31;1;m[Deprecated]\x1b[0m')
+  .description(`Watch for updates in a stream ${pc.red(pc.bold('[Deprecated]'))}`)
   .action(async (streamId) => {
     await CeramicCliUtils.watch(streamId)
   })
 
 program
   .command('commits <streamId>')
-  .description('List stream commits \x1b[31;1;m[Deprecated]\x1b[0m')
+  .description(`List stream commits ${pc.red(pc.bold('[Deprecated]'))}`)
   .action(async (streamId) => {
     await CeramicCliUtils.commits(streamId)
   })
 
 const schemas = program.command('schema')
-schemas.description('Ceramic schemas \x1b[31;1;m[Deprecated]\x1b[0m')
+schemas.description(`('Ceramic schemas ${pc.red(pc.bold('[Deprecated]'))}`)
 
 schemas
   .command('create <new-content>')
@@ -175,7 +176,7 @@ schemas
       'that creating a schema document with identical content to an existing schema document ' +
       'will be a no-op.'
   )
-  .description('Create a new schema \x1b[31;1;m[Deprecated]\x1b[0m')
+  .description(`Create a new schema ${pc.red(pc.bold('[Deprecated]'))}`)
   .action(async (content, { onlyGenesis, controllers, deterministic }) => {
     await CeramicCliUtils.schemaCreateDoc(content, controllers, onlyGenesis, deterministic)
   })
@@ -183,31 +184,31 @@ schemas
 schemas
   .command('update <streamId> <new-content>')
   .option('--controllers <controllers>', 'Change controllers of this document (only 3ID)')
-  .description('Update the content of a schema \x1b[31;1;m[Deprecated]\x1b[0m')
+  .description(`Update the content of a schema ${pc.red(pc.bold('[Deprecated]'))}`)
   .action(async (streamId, content, { controllers }) => {
     await CeramicCliUtils.schemaUpdateDoc(streamId, content, controllers)
   })
 
 const pin = program.command('pin')
-pin.description('Ceramic local pinning API \x1b[31;1;m[Deprecated]\x1b[0m')
+pin.description(`('Ceramic local pinning API ${pc.red(pc.bold('[Deprecated]'))}`)
 
 pin
   .command('add <streamId>')
-  .description('Pin stream \x1b[31;1;m[Deprecated]\x1b[0m')
+  .description(`Pin stream ${pc.red(pc.bold('[Deprecated]'))}`)
   .action(async (streamId) => {
     await CeramicCliUtils.pinAdd(streamId)
   })
 
 pin
   .command('rm <streamId>')
-  .description('Unpin stream \x1b[31;1;m[Deprecated]\x1b[0m`')
+  .description(`Unpin stream ${pc.red(pc.bold('[Deprecated]'))}`)
   .action(async (streamId) => {
     await CeramicCliUtils.pinRm(streamId)
   })
 
 pin
   .command('ls [<streamId>]')
-  .description('List pinned streams \x1b[31;1;m[Deprecated]\x1b[0m`')
+  .description(`List pinned streams ${pc.red(pc.bold('[Deprecated]'))}`)
   .action(async (streamId) => {
     await CeramicCliUtils.pinLs(streamId)
   })

--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -106,7 +106,7 @@ program
       'that creating a document with identical content to an existing document will be a no-op.'
   )
   .option('--schema <schema>', 'Schema document ID')
-  .description('Create a new document')
+  .description('Create a new document \x1b[31;1;m[Depreciated]\x1b[0m')
   .action(async (streamtype, { content, onlyGenesis, controllers, deterministic, schema }) => {
     if (streamtype != 'tile') {
       throw new Error("CLI does not currently support creating stream types other than 'tile'")
@@ -125,41 +125,41 @@ program
   .option('--content <content>', 'Update document content')
   .option('--controllers <controllers>', 'Change controllers of this document (only 3ID)')
   .option('--schema <schema>', 'Change the schema CommitID')
-  .description('Update the content of a document')
+  .description('Update the content of a document \x1b[31;1;m[Depreciated]\x1b[0m')
   .action(async (streamId, { content, controllers, schema }) => {
     await CeramicCliUtils.update(streamId, content, controllers, schema)
   })
 
 program
   .command('show <streamId> [<anchor>]')
-  .description('Show the content of a stream')
+  .description('Show the content of a stream \x1b[31;1;m[Depreciated]\x1b[0m')
   .action(async (streamId) => {
     await CeramicCliUtils.show(streamId)
   })
 
 program
   .command('state <streamId> [<anchor>]')
-  .description('Show the state of a stream')
+  .description('Show the state of a stream \x1b[31;1;m[Depreciated]\x1b[0m')
   .action(async (streamId) => {
     await CeramicCliUtils.state(streamId)
   })
 
 program
   .command('watch <streamId>')
-  .description('Watch for updates in a stream')
+  .description('Watch for updates in a stream \x1b[31;1;m[Depreciated]\x1b[0m')
   .action(async (streamId) => {
     await CeramicCliUtils.watch(streamId)
   })
 
 program
   .command('commits <streamId>')
-  .description('List stream commits')
+  .description('List stream commits \x1b[31;1;m[Depreciated]\x1b[0m')
   .action(async (streamId) => {
     await CeramicCliUtils.commits(streamId)
   })
 
 const schemas = program.command('schema')
-schemas.description('Ceramic schemas')
+schemas.description('Ceramic schemas \x1b[31;1;m[Depreciated]\x1b[0m')
 
 schemas
   .command('create <new-content>')
@@ -175,7 +175,7 @@ schemas
       'that creating a schema document with identical content to an existing schema document ' +
       'will be a no-op.'
   )
-  .description('Create a new schema')
+  .description('Create a new schema \x1b[31;1;m[Depreciated]\x1b[0m')
   .action(async (content, { onlyGenesis, controllers, deterministic }) => {
     await CeramicCliUtils.schemaCreateDoc(content, controllers, onlyGenesis, deterministic)
   })
@@ -183,31 +183,31 @@ schemas
 schemas
   .command('update <streamId> <new-content>')
   .option('--controllers <controllers>', 'Change controllers of this document (only 3ID)')
-  .description('Update the content of a schema')
+  .description('Update the content of a schema \x1b[31;1;m[Depreciated]\x1b[0m')
   .action(async (streamId, content, { controllers }) => {
     await CeramicCliUtils.schemaUpdateDoc(streamId, content, controllers)
   })
 
 const pin = program.command('pin')
-pin.description('Ceramic local pinning API')
+pin.description('Ceramic local pinning API \x1b[31;1;m[Depreciated]\x1b[0m')
 
 pin
   .command('add <streamId>')
-  .description('Pin stream')
+  .description('Pin stream \x1b[31;1;m[Depreciated]\x1b[0m')
   .action(async (streamId) => {
     await CeramicCliUtils.pinAdd(streamId)
   })
 
 pin
   .command('rm <streamId>')
-  .description('Unpin stream')
+  .description('Unpin stream \x1b[31;1;m[Depreciated]\x1b[0m`')
   .action(async (streamId) => {
     await CeramicCliUtils.pinRm(streamId)
   })
 
 pin
   .command('ls [<streamId>]')
-  .description('List pinned streams')
+  .description('List pinned streams \x1b[31;1;m[Depreciated]\x1b[0m`')
   .action(async (streamId) => {
     await CeramicCliUtils.pinLs(streamId)
   })

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -594,7 +594,7 @@ export class CeramicCliUtils {
 
 const depreciationNotice = () => {
   console.log(
-    `\n\x1b[31;1;mThis command has been depreciated.
+    `\n\x1b[31;1;mThis command has been deprecated.
 \x1b[0mPlease use the upgraded Glaze CLI instead. 
 Please test with the new CLI before reporting any problems. 
 \x1b[32;1;mnpm i -g @glazed/cli`

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -1,5 +1,6 @@
 import os from 'os'
 import path from 'path'
+import pc from 'picocolors'
 import { randomBytes } from '@stablelib/random'
 import * as u8a from 'uint8arrays'
 
@@ -453,6 +454,7 @@ export class CeramicCliUtils {
     const cliConfig = await this._loadCliConfig()
 
     console.log(JSON.stringify(cliConfig, null, 2))
+    depreciationNotice()
   }
 
   /**
@@ -475,6 +477,7 @@ export class CeramicCliUtils {
 
     console.log(`Ceramic CLI configuration ${variable} set to ${value}`)
     console.log(JSON.stringify(cliConfig))
+    depreciationNotice()
   }
 
   /**
@@ -489,6 +492,7 @@ export class CeramicCliUtils {
 
     console.log(`Ceramic CLI configuration ${variable} unset`)
     console.log(JSON.stringify(cliConfig, null, 2))
+    depreciationNotice()
   }
 
   /**
@@ -594,9 +598,9 @@ export class CeramicCliUtils {
 
 const depreciationNotice = () => {
   console.log(
-    `\n\x1b[31;1;mThis command has been deprecated.
-\x1b[0mPlease use the upgraded Glaze CLI instead. 
+    `${pc.red(pc.bold('This command has been deprecated.'))}
+Please use the upgraded Glaze CLI instead. 
 Please test with the new CLI before reporting any problems. 
-\x1b[32;1;mnpm i -g @glazed/cli`
+${pc.green('npm i -g @glazed/cli')}`
   )
 }

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -191,6 +191,7 @@ export class CeramicCliUtils {
 
       console.log(doc.id)
       console.log(JSON.stringify(doc.content, null, 2))
+      depreciationNotice()
     })
   }
 
@@ -228,6 +229,7 @@ export class CeramicCliUtils {
       await doc.update(parsedContent, metadata)
 
       console.log(JSON.stringify(doc.content, null, 2))
+      depreciationNotice()
     })
   }
 
@@ -239,6 +241,7 @@ export class CeramicCliUtils {
     await CeramicCliUtils._runWithCeramicClient(async (ceramic: CeramicApi) => {
       const stream = await TileDocument.load(ceramic, streamRef)
       console.log(JSON.stringify(stream.content, null, 2))
+      depreciationNotice()
     })
   }
 
@@ -250,6 +253,7 @@ export class CeramicCliUtils {
     await CeramicCliUtils._runWithCeramicClient(async (ceramic: CeramicApi) => {
       const stream = await ceramic.loadStream(streamRef)
       console.log(JSON.stringify(StreamUtils.serializeState(stream.state), null, 2))
+      depreciationNotice()
     })
   }
 
@@ -263,6 +267,7 @@ export class CeramicCliUtils {
     await CeramicCliUtils._runWithCeramicClient(async (ceramic: CeramicApi) => {
       const doc = await TileDocument.load(ceramic, id)
       console.log(JSON.stringify(doc.content, null, 2))
+      depreciationNotice()
       doc.subscribe(() => {
         console.log('--- document changed ---')
         console.log(JSON.stringify(doc.content, null, 2))
@@ -281,6 +286,7 @@ export class CeramicCliUtils {
       const stream = await ceramic.loadStream(id)
       const commits = stream.allCommitIds.map((v) => v.toString())
       console.log(JSON.stringify(commits, null, 2))
+      depreciationNotice()
     })
   }
 
@@ -351,6 +357,7 @@ export class CeramicCliUtils {
     await CeramicCliUtils._runWithCeramicClient(async (ceramic: CeramicApi) => {
       const result = await ceramic.pin.add(id)
       console.log(JSON.stringify(result, null, 2))
+      depreciationNotice()
     })
   }
 
@@ -364,6 +371,7 @@ export class CeramicCliUtils {
     await CeramicCliUtils._runWithCeramicClient(async (ceramic: CeramicApi) => {
       const result = await ceramic.pin.rm(id)
       console.log(JSON.stringify(result, null, 2))
+      depreciationNotice()
     })
   }
 
@@ -582,4 +590,13 @@ export class CeramicCliUtils {
     }
     return controllers.includes(',') ? controllers.split(',') : [controllers]
   }
+}
+
+const depreciationNotice = () => {
+  console.log(
+    `\n\x1b[31;1;mThis command has been depreciated.
+\x1b[0mPlease use the upgraded Glaze CLI instead. 
+Please test with the new CLI before reporting any problems. 
+\x1b[32;1;mnpm i -g @glazed/cli`
+  )
 }


### PR DESCRIPTION
## Deprecate all functions that have been transitioned over to the Glaze CLI.

We are now providing an alert after most functions that looks like the following: 
 
![Screen Shot 2022-01-12 at 11 24 49 AM](https://user-images.githubusercontent.com/10778536/149180370-cfc68671-24d3-4af2-9091-0d2c5733513f.png)

The updated help looks like the following: 
![Screen Shot 2022-01-12 at 11 24 05 AM](https://user-images.githubusercontent.com/10778536/149180215-a5382510-4290-4b8b-adad-33a11437e04e.png)

## How Has This Been Tested?

The deprecation notice has been run multiple times to ensure that it behaves properly & ANSI escapes were used to ensure no issues with colors/different Operating Systems.

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation
