### PR TITLE
feat: Cache chainId requests to providers

### DIFF
--- a/packages/blockchain-utils-linking/package.json
+++ b/packages/blockchain-utils-linking/package.json
@@ -53,7 +53,8 @@
     "@tendermint/sig": "^0.6.0",
     "@zondax/filecoin-signing-tools": "^0.18.2",
     "eth-sig-util": "^3.0.1",
-    "ganache-core": "^2.13.2"
+    "ganache-core": "^2.13.2",
+    "mockdate": "^3.0.5"
   },
   "gitHead": "34eeee25597b0a60def72906c26d3afd6230aaf1"
 }

--- a/packages/blockchain-utils-linking/src/__tests__/__snapshots__/ethereum.test.ts.snap
+++ b/packages/blockchain-utils-linking/src/__tests__/__snapshots__/ethereum.test.ts.snap
@@ -8,9 +8,9 @@ Object {
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe 
-Timestamp: 0",
-  "signature": "0x4b71ddc9261244b86d19588c828b5867bf4cda399183190ecca86fbd1b3803c16b2158118a75f99cdf2a0e41bb61afde137c5e300c28301fc1db7c85349b49d31b",
-  "timestamp": 0,
+Timestamp: 1538352000",
+  "signature": "0x146cf11fa0472090d25b04d75c4159855c696549f2ae2ea47aea4aa89f8508a1234e3c2000622d9e3d02473bb77438d27d063024f82ec6326f1bcb6e5a3dc36b1b",
+  "timestamp": 1538352000,
   "type": "ethereum-eoa",
   "version": 2,
 }

--- a/packages/blockchain-utils-linking/src/__tests__/ethereum.test.ts
+++ b/packages/blockchain-utils-linking/src/__tests__/ethereum.test.ts
@@ -60,7 +60,7 @@ let provider: any
 let addresses: string[]
 let contractAddress: string
 
-beforeAll(async () => {
+beforeEach(async () => {
   provider = ganache.provider(GANACHE_CONF)
   addresses = await send(provider, encodeRpcMessage('eth_accounts'))
   // ganache-core doesn't support personal_sign -.-
@@ -84,7 +84,7 @@ beforeAll(async () => {
   MockDate.set('2018-10-01') // So that the anchors happen at a predictable blockNumber/blockTimestamp
 })
 
-afterAll(() => {
+afterEach(() => {
   MockDate.reset()
   jest.clearAllMocks()
 })

--- a/packages/blockchain-utils-linking/src/__tests__/ethereum.test.ts
+++ b/packages/blockchain-utils-linking/src/__tests__/ethereum.test.ts
@@ -92,20 +92,20 @@ afterAll(() => {
 describe('isEthAddress', () => {
   test('detect eth address correctly', async () => {
     const notEthAddr = '0xabc123'
-    expect(await ethereum.isEthAddress(notEthAddr)).toBeFalsy()
-    expect(await ethereum.isEthAddress(addresses[0])).toBeTruthy()
+    expect(ethereum.isEthAddress(notEthAddr)).toBeFalsy()
+    expect(ethereum.isEthAddress(addresses[0])).toBeTruthy()
   })
 })
 
 describe('isERC1271', () => {
   test('detect erc1271 address', async () => {
     const acc1 = new AccountId({ address: addresses[0], chainId: 'eip155:1' })
-    expect(await ethereum.isERC1271(acc1, provider)).toEqual(false)
+    await expect(ethereum.isERC1271(acc1, provider)).resolves.toEqual(false)
     const acc2 = new AccountId({
       address: contractAddress,
       chainId: 'eip155:1',
     })
-    expect(await ethereum.isERC1271(acc2, provider)).toEqual(true)
+    await expect(ethereum.isERC1271(acc2, provider)).resolves.toEqual(true)
   })
 })
 
@@ -127,9 +127,9 @@ describe('createLink', () => {
       address: contractAddress,
       chainId: 'eip155:' + GANACHE_CHAIN_ID,
     })
-    expect(
-      await ethereum.createLink(testDid, acc, provider, { skipTimestamp: true })
-    ).toMatchSnapshot()
+    await expect(
+      ethereum.createLink(testDid, acc, provider, { skipTimestamp: true })
+    ).resolves.toMatchSnapshot()
   })
 
   test('throw if erc1271 is on wrong chain', async () => {
@@ -183,6 +183,7 @@ describe('EthereumAuthProvider', () => {
       expect.objectContaining({ jsonrpc: '2.0', method: 'eth_chainId', params: [] }),
       expect.anything()
     )
+    providerSpy.mockClear()
     // And returned value is returned from cache
     const first = results[0]
     results.forEach((r) => {
@@ -197,6 +198,7 @@ describe('EthereumAuthProvider', () => {
       const accountId = await auth.accountId()
       expect(accountId.address).toBe(addresses[0])
       expect(spy).toHaveBeenCalledTimes(1)
+      spy.mockClear()
     })
 
     test('request', async () => {
@@ -209,6 +211,7 @@ describe('EthereumAuthProvider', () => {
       const accountId = await auth.accountId()
       expect(accountId.address).toBe(addresses[0])
       expect(spy).toHaveBeenCalledTimes(1)
+      spy.mockClear()
     })
 
     test('send', async () => {
@@ -220,6 +223,7 @@ describe('EthereumAuthProvider', () => {
       const accountId = await auth.accountId()
       expect(accountId.address).toBe(addresses[0])
       expect(spy).toHaveBeenCalledTimes(1)
+      spy.mockClear()
     })
   })
 })

--- a/packages/blockchain-utils-linking/src/__tests__/ethereum.test.ts
+++ b/packages/blockchain-utils-linking/src/__tests__/ethereum.test.ts
@@ -4,6 +4,7 @@ import ganache from 'ganache-core'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { Contract, ContractFactory } from '@ethersproject/contracts'
 import * as sigUtils from 'eth-sig-util'
+import MockDate from 'mockdate'
 import * as ethereum from '../ethereum.js'
 import { OcapParams, OcapTypes } from '../ocap-util.js'
 import { encodeRpcMessage } from '../util.js'
@@ -80,10 +81,11 @@ beforeAll(async () => {
   })
   await send(provider, encodeRpcMessage('eth_sendTransaction', [unsignedTx]))
   contractAddress = Contract.getContractAddress(unsignedTx)
-  global.Date.now = jest.fn().mockImplementation(() => 666)
+  MockDate.set('2018-10-01') // So that the anchors happen at a predictable blockNumber/blockTimestamp
 })
 
 afterAll(() => {
+  MockDate.reset()
   jest.clearAllMocks()
 })
 

--- a/packages/blockchain-utils-linking/src/__tests__/ethereum.test.ts
+++ b/packages/blockchain-utils-linking/src/__tests__/ethereum.test.ts
@@ -167,6 +167,28 @@ describe('EthereumAuthProvider', () => {
     const auth = new ethereum.EthereumAuthProvider(provider, address)
     await expect(auth.withAddress(address).createLink(testDid)).resolves.toMatchSnapshot()
   })
+  test('accountId', async () => {
+    const address = addresses[0]
+    const auth = new ethereum.EthereumAuthProvider(provider, address)
+    const providerSpy = jest.spyOn(provider, 'sendAsync')
+    const results = []
+    // No matter how many times `::accountId` is called
+    for (let m = 0; m <= Math.floor(Math.random() * 10) + 1; m++) {
+      const accountId = await auth.accountId()
+      results.push(accountId)
+    }
+    // Provider is asked just once
+    expect(providerSpy).toHaveBeenCalledTimes(1)
+    expect(providerSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ jsonrpc: '2.0', method: 'eth_chainId', params: [] }),
+      expect.anything()
+    )
+    // And returned value is returned from cache
+    const first = results[0]
+    results.forEach((r) => {
+      expect(r).toBe(first)
+    })
+  })
 
   describe('various providers', () => {
     test('sendAsync', async () => {

--- a/packages/blockchain-utils-linking/src/__tests__/ethereum.test.ts
+++ b/packages/blockchain-utils-linking/src/__tests__/ethereum.test.ts
@@ -173,7 +173,7 @@ describe('EthereumAuthProvider', () => {
     const providerSpy = jest.spyOn(provider, 'sendAsync')
     const results = []
     // No matter how many times `::accountId` is called
-    for (let m = 0; m <= Math.floor(Math.random() * 10) + 1; m++) {
+    for (let m = 0; m <= 10; m++) {
       const accountId = await auth.accountId()
       results.push(accountId)
     }

--- a/packages/blockchain-utils-linking/src/ethereum.ts
+++ b/packages/blockchain-utils-linking/src/ethereum.ts
@@ -158,9 +158,14 @@ async function createEthLink(
   return proof
 }
 
+const chainIdCache = new WeakMap<any, number>()
 async function validateChainId(account: AccountId, provider: any): Promise<void> {
-  const chainIdHex = await safeSend(provider, 'eth_chainId', [])
-  const chainId = parseInt(chainIdHex, 16)
+  let chainId = chainIdCache.get(provider)
+  if (!chainId) {
+    const chainIdHex = await safeSend(provider, 'eth_chainId', [])
+    chainId = parseInt(chainIdHex, 16)
+    chainIdCache.set(provider, chainId)
+  }
   if (chainId !== parseInt(account.chainId.reference)) {
     throw new Error(
       `ChainId in provider (${chainId}) is different from AccountId (${account.chainId.reference})`

--- a/packages/blockchain-utils-linking/src/ethereum.ts
+++ b/packages/blockchain-utils-linking/src/ethereum.ts
@@ -136,9 +136,11 @@ export async function isERC1271(account: AccountId, provider: any): Promise<bool
   return Boolean(bytecode && bytecode !== '0x' && bytecode !== '0x0' && bytecode !== '0x00')
 }
 
-export function normalizeAccountId(account: AccountId): AccountId {
-  account.address = account.address.toLowerCase()
-  return account
+export function normalizeAccountId(input: AccountId): AccountId {
+  return new AccountId({
+    address: input.address.toLowerCase(),
+    chainId: input.chainId,
+  })
 }
 
 function utf8toHex(message: string): string {

--- a/packages/blockchain-utils-linking/src/ethereum.ts
+++ b/packages/blockchain-utils-linking/src/ethereum.ts
@@ -17,7 +17,7 @@ type EthProviderOpts = {
 const CHAIN_NAMESPACE = 'eip155'
 
 const chainIdCache = new WeakMap<any, number>()
-export async function requestChainId(provider: any): Promise<number> {
+async function requestChainId(provider: any): Promise<number> {
   let chainId = chainIdCache.get(provider)
   if (!chainId) {
     const chainIdHex = await safeSend(provider, 'eth_chainId', [])

--- a/packages/blockchain-utils-linking/src/ethereum.ts
+++ b/packages/blockchain-utils-linking/src/ethereum.ts
@@ -21,6 +21,7 @@ const CHAIN_NAMESPACE = 'eip155'
  */
 export class EthereumAuthProvider implements AuthProvider {
   readonly isAuthProvider = true
+  private _accountId: AccountId | undefined
 
   constructor(
     private readonly provider: any,
@@ -29,12 +30,15 @@ export class EthereumAuthProvider implements AuthProvider {
   ) {}
 
   async accountId(): Promise<AccountId> {
-    const chainIdHex = await safeSend(this.provider, 'eth_chainId', [])
-    const chainId = parseInt(chainIdHex, 16)
-    return new AccountId({
-      address: this.address,
-      chainId: `${CHAIN_NAMESPACE}:${chainId}`,
-    })
+    if (!this._accountId) {
+      const chainIdHex = await safeSend(this.provider, 'eth_chainId', [])
+      const chainId = parseInt(chainIdHex, 16)
+      this._accountId = new AccountId({
+        address: this.address,
+        chainId: `${CHAIN_NAMESPACE}:${chainId}`,
+      })
+    }
+    return this._accountId
   }
 
   async authenticate(message: string): Promise<string> {

--- a/packages/canary-integration/src/__tests__/caip10/ethereum.test.ts
+++ b/packages/canary-integration/src/__tests__/caip10/ethereum.test.ts
@@ -8,6 +8,7 @@ import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
 import { createCeramic } from '../../create-ceramic'
 import { Caip10Link } from '@ceramicnetwork/stream-caip10-link'
 import { happyPath, clearDid } from './caip-flows'
+import { AccountId } from 'caip'
 
 const CONTRACT_WALLET_ABI = [
   {
@@ -120,8 +121,11 @@ describe('externally-owned account', () => {
   test('invalid proof', async () => {
     const authProvider = new EthereumAuthProvider(provider, addresses[0])
     const accountId = await authProvider.accountId()
-    accountId.address = addresses[1]
-    const caip = await Caip10Link.fromAccount(ceramic, accountId)
+    const wrongAccountId = new AccountId({
+      address: addresses[1],
+      chainId: accountId.chainId
+    })
+    const caip = await Caip10Link.fromAccount(ceramic, wrongAccountId)
     await expect(caip.setDid(ceramic.did, authProvider)).rejects.toThrow(
       /Address doesn't match stream controller/
     )


### PR DESCRIPTION
From [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap):

> A WeakMap is a collection of key/value pairs whose keys must be objects, with values of any arbitrary JavaScript type, and which does not create strong references to its keys. That is, an object’s presence as a key in a WeakMap does not prevent the object from being garbage collected. Once an object used as a key has been collected, its corresponding values in any WeakMap become candidates for garbage collection as well — as long as they aren't strongly referred to elsewhere.

Here we utilise WeakMap to effectively attach chainId property to an ethereum provider, as long as the provider is available somewhere in JS memory.

A chainId value is set in the weak map the first time chainId is requested. It stays cached as long as provider object is available, i.e. until it is garbage-collected. Similar to LRU Cache, with a difference being expulsion of cached value is based on key being garbage collected.

It seems to be supported widely enough, so we should consider it as safe to use: https://caniuse.com/?search=weakmap