### PR TITLE
hotfix: set gossipsub seen cache ttl to 2 minutes

### DIFF
--- a/packages/ipfs-daemon/src/ipfs-daemon.ts
+++ b/packages/ipfs-daemon/src/ipfs-daemon.ts
@@ -7,8 +7,12 @@ import { DiagnosticsLogger, LogLevel, IpfsApi } from '@ceramicnetwork/common'
 import { convert } from 'blockcodec-to-ipld-format'
 import { HealthcheckServer } from './healthcheck-server'
 import { createRepo, StorageBackend } from './create-repo'
+import TimeCache from 'time-cache'
 import path from 'path'
 import os from 'os'
+
+// Set gossipsub cache TTL to 2 minutes since the current 30 second TTL has been ineffective in preventing pubsub floods
+const GOSSIPSUB_CACHE_TTL = 120
 
 const format = convert(dagJose)
 
@@ -210,6 +214,8 @@ export class IpfsDaemon {
 
   async start(): Promise<IpfsDaemon> {
     await this.ipfs.start()
+    // @ts-ignore
+    this.ipfs.libp2p.pubsub.seenCache = new TimeCache({validity: GOSSIPSUB_CACHE_TTL})
 
     if (this.api) {
       await this.api.start()

--- a/packages/ipfs-daemon/src/ipfs-daemon.ts
+++ b/packages/ipfs-daemon/src/ipfs-daemon.ts
@@ -110,9 +110,7 @@ export class IpfsDaemon {
         props.ipfsEnablePubsub ?? fromBooleanInput(process.env.IPFS_ENABLE_PUBSUB, true),
       // Set default gossipsub cache TTL to 2 minutes since the default 30 second TTL has been ineffective in preventing
       // pubsub floods
-      ipfsPubsubTtlSec:
-          props.ipfsPubsubTtlSec ||
-          (process.env.IPFS_PUBSUB_TTL_SEC != null ? parseInt(process.env.IPFS_PUBSUB_TTL_SEC) : 120),
+      ipfsPubsubTtlSec: props.ipfsPubsubTtlSec || Number(process.env.IPFS_PUBSUB_TTL_SEC) || 120,
       ipfsPubsubTopics:
         props.ipfsPubsubTopics ??
         (process.env.IPFS_PUBSUB_TOPICS ? process.env.IPFS_PUBSUB_TOPICS.split(' ') : []),
@@ -122,9 +120,7 @@ export class IpfsDaemon {
       useCentralizedPeerDiscovery: useCentralizedPeerDiscovery,
       healthcheckEnabled:
         props.healthcheckEnabled ?? fromBooleanInput(process.env.HEALTHCHECK_ENABLED, false),
-      healthcheckPort:
-        props.healthcheckPort ||
-        (process.env.HEALTHCHECK_PORT != null ? parseInt(process.env.HEALTHCHECK_PORT) : 8011),
+      healthcheckPort: props.healthcheckPort || Number(process.env.HEALTHCHECK_PORT) || 8011,
       logger: props.logger ?? new DiagnosticsLogger(LogLevel.important, false),
     }
 

--- a/packages/ipfs-daemon/src/ipfs-daemon.ts
+++ b/packages/ipfs-daemon/src/ipfs-daemon.ts
@@ -213,6 +213,10 @@ export class IpfsDaemon {
 
   async start(): Promise<IpfsDaemon> {
     await this.ipfs.start()
+    // The following line replaces the Gossipsub `seenCache` created with the default 30 second timeout with one that
+    // uses a configurable (2 minute default) timeout.
+    // This *must* be done after the line above because the `libp2p` field is added to the IPFS object only after it has
+    // been started.
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     this.ipfs.libp2p.pubsub.seenCache = new TimeCache({validity: this.configuration.ipfsPubsubTtlSec})

--- a/packages/ipfs-daemon/src/ipfs-daemon.ts
+++ b/packages/ipfs-daemon/src/ipfs-daemon.ts
@@ -217,6 +217,7 @@ export class IpfsDaemon {
     // uses a configurable (2 minute default) timeout.
     // This *must* be done after the line above because the `libp2p` field is added to the IPFS object only after it has
     // been started.
+    // Ref: https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-core/src/components/index.js#L200
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     this.ipfs.libp2p.pubsub.seenCache = new TimeCache({validity: this.configuration.ipfsPubsubTtlSec})

--- a/packages/ipfs-daemon/src/ipfs-daemon.ts
+++ b/packages/ipfs-daemon/src/ipfs-daemon.ts
@@ -213,6 +213,7 @@ export class IpfsDaemon {
 
   async start(): Promise<IpfsDaemon> {
     await this.ipfs.start()
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     this.ipfs.libp2p.pubsub.seenCache = new TimeCache({validity: this.configuration.ipfsPubsubTtlSec})
 


### PR DESCRIPTION
## Set Gossipsub seen cache TTL to 2 minutes

Set gossipsub cache TTL to 2 minutes since the current 30 second TTL has been ineffective in preventing pubsub floods.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x] Connect to Clay and ensure that libp2p messages are retained in the cache for 2 minutes

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.

- [js-libp2p issue](https://github.com/libp2p/js-libp2p/issues/1043) describing the pubsub flood
- [js-libp2p-gossipsub v0.9.2](https://github.com/ChainSafe/js-libp2p-gossipsub/tree/v0.9.2) (version used in Ceramic 1.x)
- [Gossipsub `seenCache`](https://github.com/ChainSafe/js-libp2p-gossipsub/blob/v0.9.2/ts/index.ts#L170)
- [TimeCache](https://github.com/daviddias/time-cache)