### PR TITLE
chore: Fix libp2p-mplex version

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,6 +77,7 @@
     "@types/stream-to-array": "^2.3.0",
     "get-port": "^5.1.1",
     "ipfs-core": "~0.7.1",
+    "libp2p-mplex": "0.10.6",
     "rxjs": "^7.0.0",
     "tmp-promise": "^2.0.2"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,7 @@
     "ipfs-core": "~0.7.1",
     "key-did-provider-ed25519": "^1.1.0",
     "key-did-resolver": "^1.4.5-rc.0",
+    "libp2p-mplex": "0.10.6",
     "mockdate": "^3.0.5",
     "tmp-promise": "^2.0.2"
   },

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -42,7 +42,8 @@
     "ipfs-core": "~0.7.1",
     "ipfs-core-types": "~0.5.1",
     "ipfs-http-gateway": "~0.4.2",
-    "ipfs-http-server": "~0.5.1"
+    "ipfs-http-server": "~0.5.1",
+    "libp2p-mplex": "0.10.6"
   },
   "devDependencies": {
     "@types/express": "^4.17.8",


### PR DESCRIPTION
Make it all run on Node v14.