### PR TITLE
chore(core): Interrupt blocked ipfs network i/o at shutdown

### DIFF
--- a/packages/common/src/context.ts
+++ b/packages/common/src/context.ts
@@ -5,12 +5,10 @@ import type { IpfsApi, LoggerProvider } from './index.js'
 
 /**
  * Encapsulates Ceramic context
- * TODO: Get this out of the ceramic-http-client and make fields required.
  */
 export interface Context {
   did?: DID
   ipfs?: IpfsApi // an ipfs instance
-  shutdownSignal?: AbortSignal
   anchorService?: AnchorService
   loggerProvider?: LoggerProvider
 

--- a/packages/common/src/context.ts
+++ b/packages/common/src/context.ts
@@ -5,10 +5,12 @@ import type { IpfsApi, LoggerProvider } from './index.js'
 
 /**
  * Encapsulates Ceramic context
+ * TODO: Get this out of the ceramic-http-client and make fields required.
  */
 export interface Context {
   did?: DID
   ipfs?: IpfsApi // an ipfs instance
+  shutdownSignal?: AbortSignal
   anchorService?: AnchorService
   loggerProvider?: LoggerProvider
 

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -435,8 +435,7 @@ describe('Ceramic API', () => {
       expect(Object.keys(streams).length).toEqual(6)
     })
 
-    // TODO(NET-1117) It hangs.
-    it.skip('can load streams for array of multiqueries even if streamid or path throws error', async () => {
+    it('can load streams for array of multiqueries even if streamid or path throws error', async () => {
       const queries = [
         {
           streamId: streamA.id,

--- a/packages/core/src/__tests__/ceramic-pinning.test.ts
+++ b/packages/core/src/__tests__/ceramic-pinning.test.ts
@@ -76,6 +76,8 @@ describe('Ceramic stream pinning', () => {
   })
 
   afterEach(async () => {
+    jest.resetAllMocks()
+    jest.restoreAllMocks()
     await ipfs1.stop()
     await tmpFolder.cleanup()
   })
@@ -215,8 +217,8 @@ describe('Ceramic stream pinning', () => {
       publish: false,
       pin: false,
     })
-    ceramic.pin.add(stream.id)
-    stream.update({ foo: 'baz' }, null, { anchor: false, publish: false })
+    await ceramic.pin.add(stream.id)
+    await stream.update({ foo: 'baz' }, null, { anchor: false, publish: false })
 
     expect(publishTipSpy).toBeCalledTimes(0)
 

--- a/packages/core/src/__tests__/dispatcher-mock-ipfs.test.ts
+++ b/packages/core/src/__tests__/dispatcher-mock-ipfs.test.ts
@@ -57,7 +57,6 @@ describe('Dispatcher with mock ipfs', () => {
       stateStore,
     } as unknown as PinStore
     repository.setDeps({ pinStore } as unknown as RepositoryDependencies)
-
     dispatcher = new Dispatcher(
       ipfs as unknown as IpfsApi,
       TOPIC,

--- a/packages/core/src/__tests__/dispatcher-mock-ipfs.test.ts
+++ b/packages/core/src/__tests__/dispatcher-mock-ipfs.test.ts
@@ -57,12 +57,14 @@ describe('Dispatcher with mock ipfs', () => {
       stateStore,
     } as unknown as PinStore
     repository.setDeps({ pinStore } as unknown as RepositoryDependencies)
+
     dispatcher = new Dispatcher(
       ipfs as unknown as IpfsApi,
       TOPIC,
       repository,
       loggerProvider.getDiagnosticsLogger(),
       loggerProvider.makeServiceLogger('pubsub'),
+      new AbortController().signal,
       10
     )
   })
@@ -211,7 +213,9 @@ describe('Dispatcher with mock ipfs', () => {
     // Store the query ID sent when the stream is registered so we can use it as the response ID later
     const publishArgs = ipfs.pubsub.publish.mock.calls[0]
     expect(publishArgs[0]).toEqual(TOPIC)
-    const queryMessageSent = JSON.parse(new TextDecoder().decode(publishArgs[1] as unknown as Uint8Array))
+    const queryMessageSent = JSON.parse(
+      new TextDecoder().decode(publishArgs[1] as unknown as Uint8Array)
+    )
     const queryID = queryMessageSent.id
 
     // Handle UPDATE message

--- a/packages/core/src/__tests__/dispatcher-real-ipfs.test.ts
+++ b/packages/core/src/__tests__/dispatcher-real-ipfs.test.ts
@@ -17,6 +17,7 @@ describe('Dispatcher with real ipfs over http', () => {
 
   let dispatcher: Dispatcher
   let ipfsClient: IpfsApi
+  let shutdownController: AbortController
 
   beforeAll(async () => {
     ipfsClient = await createIPFS()
@@ -30,12 +31,15 @@ describe('Dispatcher with real ipfs over http', () => {
       stateStore,
     } as unknown as PinStore
     repository.setDeps({ pinStore } as unknown as RepositoryDependencies)
+    shutdownController = new AbortController()
+
     dispatcher = new Dispatcher(
       ipfsClient,
       TOPIC,
       repository,
       loggerProvider.getDiagnosticsLogger(),
       loggerProvider.makeServiceLogger('pubsub'),
+      shutdownController.signal,
       10,
       new TaskQueue(),
       3000 // time out ipfs.dag.get after 3 seconds
@@ -50,6 +54,11 @@ describe('Dispatcher with real ipfs over http', () => {
     await TestUtils.delay(5000)
 
     await ipfsClient.stop()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    jest.restoreAllMocks()
   })
 
   it('basic ipfs http client functionality', async () => {
@@ -67,7 +76,17 @@ describe('Dispatcher with real ipfs over http', () => {
 
     // Make sure we tried 3 times to get the cid from ipfs, not just once
     expect(ipfsGetSpy).toBeCalledTimes(3)
-
-    ipfsGetSpy.mockRestore()
   })
+
+  it('interrupts on shutdown', async () => {
+    // This test has a shorter test timeout than the 'retries on timeout' test above
+    // (5 seconds instead of 30).  That means that if the retrieveCommit call actually goes through
+    // 3 retries that each take 3 seconds to time out, the test will take over 9 seconds and will
+    // fail due to test timeout.  If the test succeeds, that means that signaling the
+    // shutdownController successfully interrupted waiting on IPFS.
+
+    const getPromise = dispatcher.retrieveCommit(FAKE_CID)
+    shutdownController.abort()
+    await expect(getPromise).rejects.toThrow(/The user aborted a request/)
+  }, 5000)
 })

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -206,7 +206,6 @@ export class Ceramic implements CeramicApi {
       anchorService: modules.anchorService,
       ipfs: modules.ipfs,
       loggerProvider: modules.loggerProvider,
-      shutdownSignal: this._shutdownController.signal,
     }
     if (!this._gateway) {
       this.context.anchorService.ceramic = this

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -119,6 +119,7 @@ export interface CeramicModules {
   loggerProvider: LoggerProvider
   pinStoreFactory: PinStoreFactory
   repository: Repository
+  shutdownController: AbortController
 }
 
 /**
@@ -183,12 +184,14 @@ export class Ceramic implements CeramicApi {
   private readonly _validateStreams: boolean
   private readonly stateValidation: StateValidation
   private readonly _loadOptsOverride: LoadOpts
+  private readonly _shutdownController: AbortController
 
   constructor(modules: CeramicModules, params: CeramicParameters) {
     this._ipfsTopology = modules.ipfsTopology
     this.loggerProvider = modules.loggerProvider
     this._logger = modules.loggerProvider.getDiagnosticsLogger()
     this.repository = modules.repository
+    this._shutdownController = modules.shutdownController
     this.dispatcher = modules.dispatcher
     this.pin = this._buildPinApi()
     this._anchorValidator = modules.anchorValidator
@@ -203,6 +206,7 @@ export class Ceramic implements CeramicApi {
       anchorService: modules.anchorService,
       ipfs: modules.ipfs,
       loggerProvider: modules.loggerProvider,
+      shutdownSignal: this._shutdownController.signal,
     }
     if (!this._gateway) {
       this.context.anchorService.ceramic = this
@@ -421,12 +425,14 @@ export class Ceramic implements CeramicApi {
     const ipfsTopology = new IpfsTopology(ipfs, networkOptions.name, logger)
     const pinStoreFactory = new PinStoreFactory(ipfs, pinStoreOptions)
     const repository = new Repository(streamCacheLimit, concurrentRequestsLimit, logger)
+    const shutdownController = new AbortController()
     const dispatcher = new Dispatcher(
       ipfs,
       networkOptions.pubsubTopic,
       repository,
       logger,
       pubsubLogger,
+      shutdownController.signal,
       maxQueriesPerSecond
     )
 
@@ -446,6 +452,7 @@ export class Ceramic implements CeramicApi {
       loggerProvider,
       pinStoreFactory,
       repository,
+      shutdownController,
     }
 
     return [modules, params]
@@ -760,6 +767,7 @@ export class Ceramic implements CeramicApi {
    */
   async close(): Promise<void> {
     this._logger.imp('Closing Ceramic instance')
+    this._shutdownController.abort()
     await this.dispatcher.close()
     await this.repository.close()
     this._ipfsTopology.stop()


### PR DESCRIPTION
If we have outstanding requests to ipfs during shutdown, especially ones that will take along time, like loading a CID that doesn't exist, then shutdown blocks until those outstanding requests terminate.  We should be able to use an AbortController to proactively abort outstanding networking i/o when we begin shutdown.