### PR TITLE
chore: Revive tests with js-ipfs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,4 +41,4 @@ workflows:
   build-and-test:
     jobs:
       - with-go-ipfs
-#      - with-js-ipfs TODO(NET-1106)
+      - with-js-ipfs

--- a/packages/3id-did-resolver/package.json
+++ b/packages/3id-did-resolver/package.json
@@ -25,7 +25,7 @@
     ".": "./lib/index.js"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/blockchain-utils-linking/package.json
+++ b/packages/blockchain-utils-linking/package.json
@@ -22,7 +22,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/blockchain-utils-validation/package.json
+++ b/packages/blockchain-utils-validation/package.json
@@ -22,7 +22,7 @@
     ".": "./lib/index.js"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --runInBand",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --runInBand --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/canary-integration/package.json
+++ b/packages/canary-integration/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Canary integration test for Ceramic components",
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --verbose --coverage --runInBand",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --verbose --coverage --runInBand --forceExit",
     "build": "npx tsc -p tsconfig.json",
     "lint": "npx eslint ./src --ext .js,.jsx,.ts,.tsx",
     "clean": "npx rimraf ./lib"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "ceramic": "./bin/ceramic.js"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --runInBand",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --runInBand --forceExit",
     "build": "npx tsc -p tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -28,7 +28,7 @@
     "./lib/loggers.js": "./lib/loggers-browser.js"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --passWithNoTests",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --passWithNoTests --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,7 @@
     ".": "./lib/index.js"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --runInBand",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --runInBand --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -433,7 +433,7 @@ describe('Ceramic API', () => {
       expect(Object.keys(streams).length).toEqual(6)
     })
 
-    it('can load streams for array of multiqueries even if streamid or path throws error', async () => {
+    it.skip('can load streams for array of multiqueries even if streamid or path throws error', async () => {
       const queries = [
         {
           streamId: streamA.id,

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -320,7 +320,7 @@ describe('Ceramic API', () => {
     afterAll(async () => {
       await ceramic.close()
       await tmpFolder.cleanup()
-    })
+    }, 10000)
 
     it('can load linked stream path, returns expected form', async () => {
       const streams = await ceramic._loadLinkedStreams(

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -1,4 +1,3 @@
-import { jest } from '@jest/globals'
 import tmp from 'tmp-promise'
 import { Ceramic, CeramicConfig } from '../ceramic.js'
 import { Ed25519Provider } from 'key-did-provider-ed25519'
@@ -35,7 +34,6 @@ const generateStringOfSize = (size): string => {
 }
 
 describe('Ceramic API', () => {
-  jest.setTimeout(60000)
   let ipfs: IpfsApi
 
   const stringMapSchema = {
@@ -522,6 +520,6 @@ describe('Ceramic API', () => {
       expect(states[1]).toEqual(streamFStates[1])
       expect(states[2]).toEqual(streamFStates[2])
       expect(states[3]).toEqual(streamF.state)
-    })
+    }, 60000)
   })
 })

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -433,7 +433,7 @@ describe('Ceramic API', () => {
       expect(Object.keys(streams).length).toEqual(6)
     })
 
-    it.skip('can load streams for array of multiqueries even if streamid or path throws error', async () => {
+    it('can load streams for array of multiqueries even if streamid or path throws error', async () => {
       const queries = [
         {
           streamId: streamA.id,

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -320,7 +320,7 @@ describe('Ceramic API', () => {
     afterAll(async () => {
       await ceramic.close()
       await tmpFolder.cleanup()
-    }, 10000)
+    }, 120000)
 
     it('can load linked stream path, returns expected form', async () => {
       const streams = await ceramic._loadLinkedStreams(

--- a/packages/core/src/__tests__/dispatcher-real-ipfs.test.ts
+++ b/packages/core/src/__tests__/dispatcher-real-ipfs.test.ts
@@ -1,16 +1,17 @@
 import { jest } from '@jest/globals'
-import { Dispatcher } from '../dispatcher'
-import CID from 'cids'
+import { Dispatcher } from '../dispatcher.js'
+import { CID } from 'multiformats/cid'
 import { LoggerProvider, IpfsApi, TestUtils } from '@ceramicnetwork/common'
-import { Repository, RepositoryDependencies } from '../state-management/repository'
+import { Repository, RepositoryDependencies } from '../state-management/repository.js'
 import tmp from 'tmp-promise'
-import { LevelStateStore } from '../store/level-state-store'
-import { PinStore } from '../store/pin-store'
+import { LevelStateStore } from '../store/level-state-store.js'
+import { PinStore } from '../store/pin-store.js'
 import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
-import { TaskQueue } from '../pubsub/task-queue'
+import { TaskQueue } from '../pubsub/task-queue.js'
+import { delay } from './delay.js'
 
 const TOPIC = '/ceramic'
-const FAKE_CID = new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
+const FAKE_CID = CID.parse('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
 
 describe('Dispatcher with real ipfs over http', () => {
   jest.setTimeout(1000 * 30)
@@ -72,7 +73,7 @@ describe('Dispatcher with real ipfs over http', () => {
     const ipfsGetSpy = jest.spyOn(ipfsClient.dag, 'get')
 
     // try to load a CID that ipfs doesn't know about.  It will timeout
-    await expect(dispatcher.retrieveCommit(FAKE_CID)).rejects.toThrow(/context deadline exceeded/)
+    await expect(dispatcher.retrieveCommit(FAKE_CID)).rejects.toThrow(/(context deadline exceeded|request timed out)/)
 
     // Make sure we tried 3 times to get the cid from ipfs, not just once
     expect(ipfsGetSpy).toBeCalledTimes(3)
@@ -86,7 +87,8 @@ describe('Dispatcher with real ipfs over http', () => {
     // shutdownController successfully interrupted waiting on IPFS.
 
     const getPromise = dispatcher.retrieveCommit(FAKE_CID)
+    await delay(300) // Apparently, with js-ipfs, we need some extra time.
     shutdownController.abort()
-    await expect(getPromise).rejects.toThrow(/The user aborted a request/)
-  }, 5000)
+    await expect(getPromise).rejects.toThrow(/aborted/)
+  }, 50000)
 })

--- a/packages/core/src/__tests__/dispatcher-real-ipfs.test.ts
+++ b/packages/core/src/__tests__/dispatcher-real-ipfs.test.ts
@@ -72,7 +72,8 @@ describe('Dispatcher with real ipfs over http', () => {
   it('retries on timeout', async () => {
     const ipfsGetSpy = jest.spyOn(ipfsClient.dag, 'get')
 
-    // try to load a CID that ipfs doesn't know about.  It will timeout
+    // try to load a CID that ipfs doesn't know about.  It will timeout.
+    // Timeout error message is different depending on if we are talking to a go-ipfs or js-ipfs instance
     await expect(dispatcher.retrieveCommit(FAKE_CID)).rejects.toThrow(/(context deadline exceeded|request timed out)/)
 
     // Make sure we tried 3 times to get the cid from ipfs, not just once

--- a/packages/core/src/__tests__/dispatcher-real-ipfs.test.ts
+++ b/packages/core/src/__tests__/dispatcher-real-ipfs.test.ts
@@ -88,7 +88,12 @@ describe('Dispatcher with real ipfs over http', () => {
     // shutdownController successfully interrupted waiting on IPFS.
 
     const getPromise = dispatcher.retrieveCommit(FAKE_CID)
-    await delay(300) // Apparently, with js-ipfs, we need some extra time.
+    // Apparently, js-ipfs does not react on already triggered AbortSignal.
+    // So we have to add a timeout to make sure an ipfs function is called before the signal is triggered.
+    const isJsIpfsNode = Boolean((ipfsClient as any).preload) // Exists on js-ipfs node, and is not present on ipfs-http-client.
+    if (isJsIpfsNode) {
+      await delay(1000)
+    }
     shutdownController.abort()
     await expect(getPromise).rejects.toThrow(/aborted/)
   }, 50000)

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -30,7 +30,7 @@
     "prebuild": "npm run clean",
     "lint": "npx eslint ./src --ext .js,.jsx,.ts,.tsx",
     "clean": "npx rimraf ./lib",
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --passWithNoTests"
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --passWithNoTests --forceExit"
   },
   "dependencies": {
     "@ceramicnetwork/common": "^2.0.0-alpha.2",

--- a/packages/key-did-resolver/package.json
+++ b/packages/key-did-resolver/package.json
@@ -25,7 +25,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -25,7 +25,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --passWithNoTests",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --passWithNoTests --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/pinning-aggregation/package.json
+++ b/packages/pinning-aggregation/package.json
@@ -19,7 +19,7 @@
     ".": "./lib/index.js"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/pinning-crust-backend/package.json
+++ b/packages/pinning-crust-backend/package.json
@@ -19,7 +19,7 @@
     ".": "./lib/index.js"
   },
   "scripts": {
-    "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --silent --coverage",
+    "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --silent --coverage --forceExit",
     "build": "../../node_modules/.bin/tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/pinning-ipfs-backend/package.json
+++ b/packages/pinning-ipfs-backend/package.json
@@ -17,7 +17,7 @@
     ".": "./lib/index.js"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/pinning-powergate-backend/package.json
+++ b/packages/pinning-powergate-backend/package.json
@@ -19,7 +19,7 @@
     ".": "./lib/index.js"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/pkh-did-resolver/package.json
+++ b/packages/pkh-did-resolver/package.json
@@ -25,7 +25,7 @@
     ".": "./lib/index.js"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/stream-caip10-link-handler/package.json
+++ b/packages/stream-caip10-link-handler/package.json
@@ -24,7 +24,7 @@
     ".": "./lib/index.js"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --coverage",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --coverage --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/stream-tile-handler/package.json
+++ b/packages/stream-tile-handler/package.json
@@ -23,7 +23,7 @@
     ".": "./lib/index.js"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/streamid/package.json
+++ b/packages/streamid/package.json
@@ -20,7 +20,7 @@
     ".": "./lib/index.js"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --forceExit",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",


### PR DESCRIPTION
It works. One caveat: had to add `--forceExit` to every jest invocation. Guess, it is because js-ipfs does not clean all the resources after stopped.