### PR TITLE
NET-901 serde for cacao blocks

### DIFF
--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -36,6 +36,9 @@ export class StreamUtils {
     if (StreamUtils.isSignedCommitContainer(cloned)) {
       cloned.jws.link = cloned.jws.link.toString()
       cloned.linkedBlock = u8a.toString(cloned.linkedBlock, 'base64')
+      if (cloned.cacaoBlock) {
+        cloned.cacaoBlock = u8a.toString(cloned.cacaoBlock, 'base64')
+      }
       return cloned
     }
 
@@ -67,6 +70,9 @@ export class StreamUtils {
     if (StreamUtils.isSignedCommitContainer(cloned)) {
       cloned.jws.link = toCID(cloned.jws.link)
       cloned.linkedBlock = u8a.fromString(cloned.linkedBlock, 'base64')
+      if (cloned.cacaoBlock) {
+        cloned.cacaoBlock = u8a.fromString(cloned.cacaoBlock, 'base64')
+      }
       return cloned
     }
 


### PR DESCRIPTION
## Description

Resolves NET-901

Adds serialization/deserialization of CACAO blocks over HTTP

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Test A (e.g. Test A - New test that ... ran in local, docker, and dev unstable.)
- [ ] Test B

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
