### PR TITLE
chore: Use newer go-ipfs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,7 @@
     "dids": "^3.0.0-alpha.4",
     "ethr-did-resolver": "^5.0.3",
     "express": "^4.17.2",
-    "go-ipfs": "^0.11.0",
+    "go-ipfs": "^0.12.0",
     "ipfs-http-client": "^55.0.0",
     "ipfsd-ctl": "^10.0.5",
     "key-did-provider-ed25519": "^1.1.0",

--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -40,7 +40,7 @@
     "dag-jose": "^1.0.0",
     "express": "^4.17.2",
     "get-port": "^6.0.0",
-    "go-ipfs": "^0.11.0",
+    "go-ipfs": "^0.12.0",
     "ipfs-core": "~0.13.0",
     "ipfs-http-client": "^55.0.0",
     "ipfsd-ctl": "^10.0.5",


### PR DESCRIPTION
- Update to go-ipfs v0.12
- It works on Apple Silicon out of the box, no env variables needed.