### PR TITLE
feat: Use old caip format for proofs

### DIFF
--- a/packages/blockchain-utils-linking/src/__tests__/__snapshots__/cosmos.test.ts.snap
+++ b/packages/blockchain-utils-linking/src/__tests__/__snapshots__/cosmos.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Blockchain: Cosmos authenticate create proof for cosmoshub3 1`] = `"0x3
 
 exports[`Blockchain: Cosmos createLink create proof for cosmoshub3 1`] = `
 Object {
-  "account": "cosmos:cosmoshub-3:cosmos1gs6gu0w9xvqcfhm3nlhnmqkf8aphnsxyjlgpqd",
+  "account": "cosmos1gs6gu0w9xvqcfhm3nlhnmqkf8aphnsxyjlgpqd@cosmos:cosmoshub-3",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe 

--- a/packages/blockchain-utils-linking/src/__tests__/__snapshots__/eosio.test.ts.snap
+++ b/packages/blockchain-utils-linking/src/__tests__/__snapshots__/eosio.test.ts.snap
@@ -16,7 +16,7 @@ exports[`authenticate Telos Testnet 1`] = `"0x521674ea7031af056c7fcf69e2c3ff6f4b
 
 exports[`createLink generate proof on jungle testnet 1`] = `
 Object {
-  "account": "eosio:2a02a0053e5a8cf73a56ba0fda11e4d9:idx3idctest1",
+  "account": "idx3idctest1@eosio:2a02a0053e5a8cf73a56ba0fda11e4d9",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe 
@@ -30,7 +30,7 @@ Timestamp: 666",
 
 exports[`createLink generate proof on telos testnet 1`] = `
 Object {
-  "account": "eosio:1eaa0824707c8c16bd25145493bf062a:testuser1111",
+  "account": "testuser1111@eosio:1eaa0824707c8c16bd25145493bf062a",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe 

--- a/packages/blockchain-utils-linking/src/__tests__/__snapshots__/ethereum.test.ts.snap
+++ b/packages/blockchain-utils-linking/src/__tests__/__snapshots__/ethereum.test.ts.snap
@@ -4,7 +4,7 @@ exports[`EthereumAuthProvider authenticate 1`] = `"0x92d414fa574ea420dae28a58454
 
 exports[`EthereumAuthProvider createLink 1`] = `
 Object {
-  "account": "eip155:1337:0x8fe2c4516e920425e177658aaac451ca0463ed69",
+  "account": "0x8fe2c4516e920425e177658aaac451ca0463ed69@eip155:1337",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe 
@@ -39,7 +39,7 @@ exports[`authenticate correctly sign auth message 1`] = `"0xcf54e7560501fa53e3f7
 
 exports[`createLink create erc1271 proof correctly 1`] = `
 Object {
-  "account": "eip155:1337:0xbe6c27620b271dd76f1787cdef1f4375cff3fa1f",
+  "account": "0xbe6c27620b271dd76f1787cdef1f4375cff3fa1f@eip155:1337",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe",
@@ -51,7 +51,7 @@ did:3:bafysdfwefwe",
 
 exports[`createLink create ethereumEOA proof correctly 1`] = `
 Object {
-  "account": "eip155:1:0x8fe2c4516e920425e177658aaac451ca0463ed69",
+  "account": "0x8fe2c4516e920425e177658aaac451ca0463ed69@eip155:1",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe",

--- a/packages/blockchain-utils-linking/src/__tests__/__snapshots__/filecoin.test.ts.snap
+++ b/packages/blockchain-utils-linking/src/__tests__/__snapshots__/filecoin.test.ts.snap
@@ -38,7 +38,7 @@ exports[`authenticate testnet 1`] = `"APHUqaCLuyqunqfYJl8YAq3/p6oO9iiEAGkGQILzZA
 
 exports[`createLink generate proof on mainnet 1`] = `
 Object {
-  "account": "fil:f:f1ymbkm43ysdiruibji6c6m2iy5bxwbuv5d6cdqmy",
+  "account": "f1ymbkm43ysdiruibji6c6m2iy5bxwbuv5d6cdqmy@fil:f",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe 
@@ -52,7 +52,7 @@ Timestamp: 0",
 
 exports[`createLink generate proof on mainnet for BLS key 1`] = `
 Object {
-  "account": "fil:f:f3vbrwhphivdxyvs3pxpp54w73664bgxmb7ed4du4ohhu3dc6f5y264cs72yluw7mjbwnlrtzq543ys57plzka",
+  "account": "f3vbrwhphivdxyvs3pxpp54w73664bgxmb7ed4du4ohhu3dc6f5y264cs72yluw7mjbwnlrtzq543ys57plzka@fil:f",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe 
@@ -66,7 +66,7 @@ Timestamp: 0",
 
 exports[`createLink generate proof on testnet 1`] = `
 Object {
-  "account": "fil:t:t17lxg2i2otnl7mmpw2ocd6o4e3b4un3272vny6ka",
+  "account": "t17lxg2i2otnl7mmpw2ocd6o4e3b4un3272vny6ka@fil:t",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe 

--- a/packages/blockchain-utils-linking/src/__tests__/__snapshots__/near.test.ts.snap
+++ b/packages/blockchain-utils-linking/src/__tests__/__snapshots__/near.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Blockchain: NEAR authenticate create proof for testnet 1`] = `"885b8f01
 
 exports[`Blockchain: NEAR createLink create proof for testnet 1`] = `
 Object {
-  "account": "near:testnet:7beiSVU32rh5uqUcGqY3JfkB3y9p6Pc2Q1GFgcrtK65q",
+  "account": "7beiSVU32rh5uqUcGqY3JfkB3y9p6Pc2Q1GFgcrtK65q@near:testnet",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe 

--- a/packages/blockchain-utils-linking/src/__tests__/__snapshots__/polkadot.test.ts.snap
+++ b/packages/blockchain-utils-linking/src/__tests__/__snapshots__/polkadot.test.ts.snap
@@ -12,7 +12,7 @@ AccountId {
 
 exports[`createLink create proof with ed25519 1`] = `
 Object {
-  "account": "polkadot:b0a8d493285c2df73290dfb7e61f870f:5EEvMbuaJQxxPorGtzY2qUYqM3akRrnD36bZD4PomfpLdrtx",
+  "account": "5EEvMbuaJQxxPorGtzY2qUYqM3akRrnD36bZD4PomfpLdrtx@polkadot:b0a8d493285c2df73290dfb7e61f870f",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe 
@@ -26,7 +26,7 @@ Timestamp: 666",
 
 exports[`createLink create proof with secp256k 1`] = `
 Object {
-  "account": "polkadot:b0a8d493285c2df73290dfb7e61f870f:5GuAnwx9uKSQxKZB8moxoaX4ceehoCYu4XYMjJkKtm2QDgqC",
+  "account": "5GuAnwx9uKSQxKZB8moxoaX4ceehoCYu4XYMjJkKtm2QDgqC@polkadot:b0a8d493285c2df73290dfb7e61f870f",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe 
@@ -38,7 +38,7 @@ Timestamp: 666",
 }
 `;
 
-exports[`createLink create proof with sr25519 1`] = `"polkadot:b0a8d493285c2df73290dfb7e61f870f:5CXU7u72Gz9Jqo6FdAwzSsxX5JhdRwMj2UZ4xrAEoo3AyySx"`;
+exports[`createLink create proof with sr25519 1`] = `"5CXU7u72Gz9Jqo6FdAwzSsxX5JhdRwMj2UZ4xrAEoo3AyySx@polkadot:b0a8d493285c2df73290dfb7e61f870f"`;
 
 exports[`createLink create proof with sr25519 2`] = `
 "Link this account to your identity

--- a/packages/blockchain-utils-linking/src/__tests__/__snapshots__/solana.test.ts.snap
+++ b/packages/blockchain-utils-linking/src/__tests__/__snapshots__/solana.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Blockchain: Solana authenticate create proof for 5eykt4UsFv8P8NJdTREpY1
 
 exports[`Blockchain: Solana createLink create proof for 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp 1`] = `
 Object {
-  "account": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:2q7pyhPwAwZ3QMfZrnAbDhnh9mDUqycszcpf86VgQxhF",
+  "account": "2q7pyhPwAwZ3QMfZrnAbDhnh9mDUqycszcpf86VgQxhF@solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe 

--- a/packages/blockchain-utils-linking/src/__tests__/__snapshots__/tezos.test.ts.snap
+++ b/packages/blockchain-utils-linking/src/__tests__/__snapshots__/tezos.test.ts.snap
@@ -8,7 +8,7 @@ exports[`Blockchain: Tezos authenticate entropy replication for NetXdQprcVkpaWU 
 
 exports[`Blockchain: Tezos createLink create proof for NetXdQprcVkpaWU 1`] = `
 Object {
-  "account": "tezos:NetXdQprcVkpaWU:tz3Lfm6CyfSTZ7EgMckptZZGiPxzs9GK59At",
+  "account": "tz3Lfm6CyfSTZ7EgMckptZZGiPxzs9GK59At@tezos:NetXdQprcVkpaWU",
   "message": "Link this account to your identity
 
 did:3:bafysdfwefwe 

--- a/packages/blockchain-utils-linking/src/cosmos.ts
+++ b/packages/blockchain-utils-linking/src/cosmos.ts
@@ -1,6 +1,6 @@
 import { AccountId } from 'caip'
 import { AuthProvider } from './auth-provider.js'
-import { getConsentMessage, LinkProof } from './util.js'
+import { getConsentMessage, LinkProof, asOldCaipString } from './util.js'
 import type { Tx, SignMeta } from '@tendermint/sig'
 import { hash } from '@stablelib/sha256'
 import * as uint8arrays from 'uint8arrays'
@@ -71,7 +71,7 @@ export class CosmosAuthProvider implements AuthProvider {
       version: 2,
       message,
       signature,
-      account: accountID.toString(),
+      account: asOldCaipString(accountID),
       timestamp,
     }
   }

--- a/packages/blockchain-utils-linking/src/eosio.ts
+++ b/packages/blockchain-utils-linking/src/eosio.ts
@@ -1,6 +1,6 @@
 import { AuthProvider } from './auth-provider.js'
 import { AccountId } from 'caip'
-import { getConsentMessage, LinkProof } from './util.js'
+import { asOldCaipString, getConsentMessage, LinkProof } from './util.js'
 import { normalizeAccountId } from './ethereum.js'
 import * as sha256Stable from '@stablelib/sha256'
 import * as uint8arrays from 'uint8arrays'
@@ -37,7 +37,7 @@ export class EosioAuthProvider implements AuthProvider {
       type: 'eosio',
       message: consentMessage.message,
       signature: signedPayload,
-      account: accountID.toString(),
+      account: asOldCaipString(accountID),
       timestamp: consentMessage.timestamp,
     }
   }

--- a/packages/blockchain-utils-linking/src/ethereum.ts
+++ b/packages/blockchain-utils-linking/src/ethereum.ts
@@ -143,6 +143,10 @@ export function normalizeAccountId(input: AccountId): AccountId {
   })
 }
 
+export function asOldCaipString(input: AccountId): string {
+  return `${input.address}@${input.chainId.namespace}:${input.chainId.reference}`
+}
+
 function utf8toHex(message: string): string {
   const bytes = uint8arrays.fromString(message)
   const hex = uint8arrays.toString(bytes, 'base16')
@@ -164,7 +168,7 @@ async function createEthLink(
     type: ADDRESS_TYPES.ethereumEOA,
     message,
     signature,
-    account: account.toString(),
+    account: asOldCaipString(account),
   }
   if (!opts.skipTimestamp) proof.timestamp = timestamp
   return proof
@@ -190,7 +194,7 @@ async function createErc1271Link(
   await validateChainId(account, provider)
   return Object.assign(res, {
     type: ADDRESS_TYPES.erc1271,
-    account: account.toString(),
+    account: asOldCaipString(account),
   })
 }
 

--- a/packages/blockchain-utils-linking/src/ethereum.ts
+++ b/packages/blockchain-utils-linking/src/ethereum.ts
@@ -1,6 +1,6 @@
 import { AuthProvider } from './auth-provider.js'
 import { AccountId } from 'caip'
-import { encodeRpcMessage, getConsentMessage, LinkProof } from './util.js'
+import { asOldCaipString, encodeRpcMessage, getConsentMessage, LinkProof } from './util.js'
 import * as uint8arrays from 'uint8arrays'
 import * as sha256 from '@stablelib/sha256'
 import { Ocap, OcapParams, OcapTypes, buildOcapRequestMessage } from './ocap-util.js'
@@ -141,10 +141,6 @@ export function normalizeAccountId(input: AccountId): AccountId {
     address: input.address.toLowerCase(),
     chainId: input.chainId,
   })
-}
-
-export function asOldCaipString(input: AccountId): string {
-  return `${input.address}@${input.chainId.namespace}:${input.chainId.reference}`
 }
 
 function utf8toHex(message: string): string {

--- a/packages/blockchain-utils-linking/src/filecoin.ts
+++ b/packages/blockchain-utils-linking/src/filecoin.ts
@@ -1,6 +1,6 @@
 import { AuthProvider } from './auth-provider.js'
 import { AccountId } from 'caip'
-import { getConsentMessage, LinkProof } from './util.js'
+import { asOldCaipString, getConsentMessage, LinkProof } from './util.js'
 import type { MessageParams } from '@zondax/filecoin-signing-tools'
 import * as uint8arrays from 'uint8arrays'
 
@@ -31,7 +31,7 @@ export class FilecoinAuthProvider implements AuthProvider {
       type: 'eoa-tx',
       message: message,
       signature: signatureResponse.Signature.Data,
-      account: accountId.toString(),
+      account: asOldCaipString(accountId),
       timestamp: timestamp,
     }
   }

--- a/packages/blockchain-utils-linking/src/near.ts
+++ b/packages/blockchain-utils-linking/src/near.ts
@@ -1,6 +1,6 @@
 import { AccountId } from 'caip'
 import { AuthProvider } from './auth-provider.js'
-import { getConsentMessage, LinkProof } from './util.js'
+import { asOldCaipString, getConsentMessage, LinkProof } from './util.js'
 import * as uint8arrays from 'uint8arrays'
 import * as nearApiJs from 'near-api-js'
 import * as sha256 from '@stablelib/sha256'
@@ -43,7 +43,7 @@ export class NearAuthProvider implements AuthProvider {
       type: 'near',
       message,
       signature,
-      account: account.toString(),
+      account: asOldCaipString(account),
       timestamp,
     }
   }

--- a/packages/blockchain-utils-linking/src/polkadot.ts
+++ b/packages/blockchain-utils-linking/src/polkadot.ts
@@ -1,6 +1,6 @@
 import { AccountId } from 'caip'
 import { AuthProvider } from './auth-provider.js'
-import { getConsentMessage, LinkProof } from './util.js'
+import { asOldCaipString, getConsentMessage, LinkProof } from './util.js'
 import * as uint8arrays from 'uint8arrays'
 
 const stringHex = (str: string): string =>
@@ -31,7 +31,7 @@ export class PolkadotAuthProvider implements AuthProvider {
       type: 'eoa',
       message: message,
       signature: res.signature,
-      account: account.toString(),
+      account: asOldCaipString(account),
       timestamp: timestamp,
     }
   }

--- a/packages/blockchain-utils-linking/src/solana.ts
+++ b/packages/blockchain-utils-linking/src/solana.ts
@@ -1,6 +1,6 @@
 import { AccountId } from 'caip'
 import { AuthProvider } from './auth-provider.js'
-import { getConsentMessage, LinkProof } from './util.js'
+import { asOldCaipString, getConsentMessage, LinkProof } from './util.js'
 import * as uint8arrays from 'uint8arrays'
 import * as sha256 from '@stablelib/sha256'
 
@@ -46,7 +46,7 @@ export class SolanaAuthProvider implements AuthProvider {
       type: 'solana',
       message,
       signature,
-      account: accountID.toString(),
+      account: asOldCaipString(accountID),
       timestamp,
     }
   }

--- a/packages/blockchain-utils-linking/src/tezos.ts
+++ b/packages/blockchain-utils-linking/src/tezos.ts
@@ -1,6 +1,6 @@
 import { AccountId } from 'caip'
 import { AuthProvider } from './auth-provider.js'
-import { getConsentMessage, LinkProof } from './util.js'
+import { asOldCaipString, getConsentMessage, LinkProof } from './util.js'
 import { hash } from '@stablelib/sha256'
 import * as uint8arrays from 'uint8arrays'
 import type { Signer } from '@taquito/taquito'
@@ -100,7 +100,7 @@ export class TezosAuthProvider implements AuthProvider {
       version: 2,
       message,
       signature,
-      account: caipAccount.toString(),
+      account: asOldCaipString(caipAccount),
       timestamp,
     }
     return proof

--- a/packages/blockchain-utils-linking/src/util.ts
+++ b/packages/blockchain-utils-linking/src/util.ts
@@ -1,3 +1,5 @@
+import type { AccountId } from "caip"
+
 export interface LinkProof {
   version: number
   message: string
@@ -40,4 +42,8 @@ export function encodeRpcMessage(method: string, params?: any): any {
     method,
     params,
   }
+}
+
+export function asOldCaipString(input: AccountId): string {
+  return `${input.address}@${input.chainId.namespace}:${input.chainId.reference}`
 }

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/__snapshots__/ethereum.test.ts.snap
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/__snapshots__/ethereum.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`validate v0 and v1 proofs 1`] = `
 Object {
-  "account": "eip155:1:0x8fe2c4516e920425e177658aaac451ca0463ed69",
+  "account": "0x8fe2c4516e920425e177658aaac451ca0463ed69@eip155:1",
   "message": "Create a new 3Box profile
 
 - 
@@ -15,7 +15,7 @@ Your unique profile ID is did:3:bafysdfwefwe",
 
 exports[`validate v0 and v1 proofs 2`] = `
 Object {
-  "account": "eip155:1:0x8fe2c4516e920425e177658aaac451ca0463ed69",
+  "account": "0x8fe2c4516e920425e177658aaac451ca0463ed69@eip155:1",
   "message": "Create a new 3Box profile
 
 - 

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/ethereum.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/ethereum.test.ts
@@ -7,6 +7,7 @@ import * as providers from '@ethersproject/providers'
 import * as linking from '@ceramicnetwork/blockchain-utils-linking'
 import { proofs } from './fixtures.js'
 import type { LinkProof } from '@ceramicnetwork/blockchain-utils-linking'
+import { normalizeAccountId } from '@ceramicnetwork/common'
 
 const CONTRACT_WALLET_ABI = [
   {
@@ -125,7 +126,7 @@ test('validateLink: valid ethereumEOA proof with legacy account should return pr
   const authProvider = new linking.ethereum.EthereumAuthProvider(provider, addresses[0])
   const proof = await authProvider.createLink(testDid)
   const proofCopy = { ...proof }
-  const accountId = new AccountId(proof.account)
+  const accountId = normalizeAccountId(proof.account)
   proofCopy.account = `${accountId.address}@${accountId.chainId}`
   await expect(ethereum.validateLink(proofCopy)).resolves.toEqual(proof)
 })

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/tezos.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/tezos.test.ts
@@ -3,6 +3,7 @@ import { TezosAuthProvider, TezosProvider } from '@ceramicnetwork/blockchain-uti
 import { InMemorySigner } from '@taquito/signer'
 import { LinkProof } from '@ceramicnetwork/blockchain-utils-linking'
 import { AccountId, ChainId } from 'caip'
+import { normalizeAccountId } from '@ceramicnetwork/common'
 
 const did = 'did:3:bafysdfwefwe'
 const privateKey = 'p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1'
@@ -113,7 +114,7 @@ beforeAll(async () => {
 
   invalidSignatureProof = { ...validProof, signature: 'invalid' }
 
-  const accountId = AccountId.parse(validProof.account)
+  const accountId = normalizeAccountId(validProof.account)
   const chainId = new ChainId(accountId.chainId)
   const invalidAccount = new AccountId({
     address: accountId.address,

--- a/packages/blockchain-utils-validation/src/blockchains/ethereum.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/ethereum.ts
@@ -3,7 +3,7 @@ import { Contract } from '@ethersproject/contracts'
 import * as providers from '@ethersproject/providers'
 import { AccountId } from 'caip'
 import * as uint8arrays from 'uint8arrays'
-import { LinkProof } from '@ceramicnetwork/blockchain-utils-linking'
+import { LinkProof, asOldCaipString } from '@ceramicnetwork/blockchain-utils-linking'
 import { BlockchainHandler } from '../blockchain-handler.js'
 import { normalizeAccountId } from '@ceramicnetwork/common'
 
@@ -30,13 +30,14 @@ function getEthersProvider(chainId: string): any {
 }
 
 function toV2Proof(proof: LinkProof, address?: string): LinkProof {
-  proof.account = new AccountId({
+  const account = new AccountId({
     address: (proof.version === 1 ? proof.address : address) || '',
     chainId: {
       namespace,
       reference: proof.chainId ? proof.chainId.toString() : '1',
     },
-  }).toString()
+  })
+  proof.account = asOldCaipString(account)
   delete proof.address
   delete proof.chainId
   proof.version = 2
@@ -46,7 +47,7 @@ function toV2Proof(proof: LinkProof, address?: string): LinkProof {
 async function validateEoaLink(proof: LinkProof): Promise<LinkProof | null> {
   const recoveredAddr = verifyMessage(proof.message, proof.signature).toLowerCase()
   if (proof.version !== 2) proof = toV2Proof(proof, recoveredAddr)
-  const account = new AccountId(proof.account)
+  const account = normalizeAccountId(proof.account)
   if (account.address !== recoveredAddr) {
     return null
   }
@@ -55,7 +56,7 @@ async function validateEoaLink(proof: LinkProof): Promise<LinkProof | null> {
 
 async function validateErc1271Link(proof: LinkProof): Promise<LinkProof | null> {
   if (proof.version === 1) proof = toV2Proof(proof)
-  const account = new AccountId(proof.account)
+  const account = normalizeAccountId(proof.account)
   const provider = getEthersProvider(account.chainId.reference)
   const contract = new Contract(account.address, ERC1271_ABI, provider)
   const message = utf8toHex(proof.message)
@@ -65,16 +66,10 @@ async function validateErc1271Link(proof: LinkProof): Promise<LinkProof | null> 
 }
 
 async function validateLink(proof: LinkProof): Promise<LinkProof | null> {
-  // Handle legacy CAIP links
-  const proofCopy = { ...proof }
-  if (proofCopy.account) {
-    proofCopy.account = normalizeAccountId(proofCopy.account).toString()
-  }
-
-  if (proofCopy.type === ADDRESS_TYPES.erc1271) {
-    return await validateErc1271Link(proofCopy)
+  if (proof.type === ADDRESS_TYPES.erc1271) {
+    return validateErc1271Link(proof)
   } else {
-    return await validateEoaLink(proofCopy)
+    return validateEoaLink(proof)
   }
 }
 

--- a/packages/blockchain-utils-validation/src/blockchains/solana.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/solana.ts
@@ -1,8 +1,8 @@
 import { BlockchainHandler } from '../blockchain-handler.js'
 import { LinkProof } from '@ceramicnetwork/blockchain-utils-linking'
-import { AccountId } from 'caip'
 import * as uint8arrays from 'uint8arrays'
 import { verify } from '@stablelib/ed25519'
+import { normalizeAccountId } from '@ceramicnetwork/common'
 
 const verifySignature = async (
   pubKey: Uint8Array,
@@ -16,7 +16,8 @@ const verifySignature = async (
 const namespace = 'solana'
 
 export async function validateLink(proof: LinkProof): Promise<LinkProof | null> {
-  const pubKey = uint8arrays.fromString(new AccountId(proof.account).address, 'base58btc')
+  const account = normalizeAccountId(proof.account)
+  const pubKey = uint8arrays.fromString(account.address, 'base58btc')
   const msg = proof.message
   const sig = uint8arrays.fromString(proof.signature, 'base64')
   const is_sig_valid = await verifySignature(pubKey, msg, sig)


### PR DESCRIPTION
Apparently, found a bug in v2 client communicating with v1 daemon. v2 client should use old CAIP format string in proofs.