### PR TITLE
fix: conditionally substitue format name

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -119,6 +119,8 @@ export class Utils {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     if (!ipfsApi.libp2p) {
+      // go-ipfs uses different names for codecs, we want to use the correct ones from js-ipfs-http-client
+      // If we are running in proc js-ipfs we should not be inside of this conditional.
       // The try catch behaviour of the js-ipfs-http-client was causing timing issues (socket hangup)
       // https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-client/src/block/put.js#L34
       if (format === 'dag-cbor') format = 'cbor'

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -116,10 +116,12 @@ export class Utils {
   ) {
     if (typeof cid === 'string') cid = CID.parse(cid.replace('ipfs://', ''))
     let format = await ipfsApi.codecs.getCodec(cid.code).then((f) => f.name)
-    // The try catch behaviour of the js-ipfs-http-client was causing timing issues (socket hangup)
-    // https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-client/src/block/put.js#L34
-    if (format === 'dag-cbor') format = 'cbor'
-    else if (format === 'dag-pb') format = 'protobuf'
+    if (!ipfsApi.libp2p) {
+      // The try catch behaviour of the js-ipfs-http-client was causing timing issues (socket hangup)
+      // https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-client/src/block/put.js#L34
+      if (format === 'dag-cbor') format = 'cbor'
+      else if (format === 'dag-pb') format = 'protobuf'
+    }
     const mhtype = await ipfsApi.hashers.getHasher(cid.multihash.code).then((mh) => mh.name)
     const version = cid.version
     await ipfsApi.block.put(block, { format, mhtype, version, signal })

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -116,6 +116,8 @@ export class Utils {
   ) {
     if (typeof cid === 'string') cid = CID.parse(cid.replace('ipfs://', ''))
     let format = await ipfsApi.codecs.getCodec(cid.code).then((f) => f.name)
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     if (!ipfsApi.libp2p) {
       // The try catch behaviour of the js-ipfs-http-client was causing timing issues (socket hangup)
       // https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-client/src/block/put.js#L34


### PR DESCRIPTION
Only substitute the format names if http-client is used (go-ipfs)