### PR TITLE
feat(stream-tile-handler): Add support for specifying resources by family

### DIFF
--- a/packages/canary-integration/package.json
+++ b/packages/canary-integration/package.json
@@ -21,6 +21,7 @@
     "@ceramicnetwork/ipfs-daemon": "^2.0.0-alpha.3",
     "@ceramicnetwork/stream-caip10-link": "^2.0.0-alpha.3",
     "@ceramicnetwork/stream-tile": "^2.0.0-alpha.3",
+    "@stablelib/random": "^1.0.1",
     "@truffle/hdwallet-provider": "^2.0.0",
     "ceramic-cacao": "^0.0.16",
     "dids": "^3.0.0-alpha.9",

--- a/packages/canary-integration/src/__tests__/capability.test.ts
+++ b/packages/canary-integration/src/__tests__/capability.test.ts
@@ -10,12 +10,36 @@ import { randomBytes } from '@stablelib/random'
 import { SiweMessage, Cacao } from 'ceramic-cacao'
 import { createCeramic } from '../create-ceramic.js'
 
-let ipfs: IpfsApi
-let ceramic: CeramicApi
-let wallet: Wallet
-let didKey: DID
+
+const addCapToDid = async (wallet, didKey, resource) => {
+  // Create CACAO with did:key as aud
+  const siweMessage = new SiweMessage({
+    domain: 'service.org',
+    address: wallet.address,
+    chainId: '1',
+    statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
+    uri: didKey.id,
+    version: '1',
+    nonce: '23423423',
+    issuedAt: new Date().toISOString(),
+    resources: [resource],
+  })
+  // Sign CACAO with did:pkh
+  const signature = await wallet.signMessage(siweMessage.toMessage())
+  siweMessage.signature = signature
+  const capability = Cacao.fromSiweMessage(siweMessage)
+  // Create new did:key with capability attached
+  const didKeyWithCapability = didKey.withCapability(capability)
+  await didKeyWithCapability.authenticate()
+  return didKeyWithCapability
+}
 
 describe('CACAO Integration test', () => {
+  let ipfs: IpfsApi
+  let ceramic: CeramicApi
+  let wallet: Wallet
+  let didKey: DID
+
   beforeAll(async () => {
     ipfs = await createIPFS()
     ceramic = await createCeramic(ipfs)
@@ -34,243 +58,199 @@ describe('CACAO Integration test', () => {
     await ceramic.close()
   })
 
-  test('can update with streamId in capability', async () => {
-    // Create a determinstic tiledocument owned by the user
-    const deterministicDocument = await TileDocument.deterministic(ceramic, {
-      deterministic: true,
-      family: 'testCapabilities1',
-      controllers: [`did:pkh:eip155:1:${wallet.address}`],
-    })
+  describe('Resources using StreamId', () => {
+    test('can update with streamId in capability', async () => {
+      // Create a determinstic tiledocument owned by the user
+      const deterministicDocument = await TileDocument.deterministic(ceramic, {
+        deterministic: true,
+        family: 'testCapabilities1',
+        controllers: [`did:pkh:eip155:1:${wallet.address}`],
+      })
+      const streamId = deterministicDocument.id
+      const didKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://${streamId.toString()}`)
 
-    const streamId = deterministicDocument.id
-
-
-    // Create CACAO with did:key as aud
-    const siweMessage = new SiweMessage({
-      domain: 'service.org',
-      address: wallet.address,
-      chainId: '1',
-      statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
-      uri: didKey.id,
-      version: '1',
-      nonce: '23423423',
-      issuedAt: new Date().toISOString(),
-      resources: [`ceramic://${streamId.toString()}`],
-    })
-    // Sign CACAO with did:pkh
-    const signature = await wallet.signMessage(siweMessage.toMessage())
-    siweMessage.signature = signature
-    const capability = Cacao.fromSiweMessage(siweMessage)
-    // Create new did:key with capability attached
-    const didKeyWithCapability = didKey.withCapability(capability)
-    await didKeyWithCapability.authenticate()
-
-    await deterministicDocument.update({ foo: 'bar' }, null, {
-      asDID: didKeyWithCapability,
-      anchor: false,
-      publish: false,
-    })
-
-    expect(deterministicDocument.content).toEqual({ foo: 'bar' })
-  }, 30000)
-
-  test('does not allow updating if cacao issuer is not document controller', async () => {
-    // Create a determinstic tiledocument owned by the user
-    const deterministicDocument = await TileDocument.deterministic(ceramic, {
-      deterministic: true,
-      family: 'testCapabilities2',
-    })
-
-    const streamId = deterministicDocument.id
-
-    // Create CACAO with did:key as aud
-    const siweMessage = new SiweMessage({
-      domain: 'service.org',
-      address: wallet.address,
-      chainId: '1',
-      statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
-      uri: didKey.id,
-      version: '1',
-      nonce: '23423423',
-      issuedAt: new Date().toISOString(),
-      resources: [`ceramic://${streamId.toString()}`],
-    })
-    // Sign CACAO with did:pkh
-    const signature = await wallet.signMessage(siweMessage.toMessage())
-    siweMessage.signature = signature
-    const capability = Cacao.fromSiweMessage(siweMessage)
-    // Create new did:key with capability attached
-    const didKeyWithCapability = didKey.withCapability(capability)
-    await didKeyWithCapability.authenticate()
-
-    await expect(
-      deterministicDocument.update({ foo: 'baz' }, null, {
+      await deterministicDocument.update({ foo: 'bar' }, null, {
         asDID: didKeyWithCapability,
         anchor: false,
         publish: false,
       })
-    ).rejects.toThrow(/invalid_jws/)
-  }, 30000)
 
-  test('fails to update using capability with invalid resource', async () => {
-    // Create a determinstic tiledocument owned by the user
-    const deterministicDocument = await TileDocument.deterministic(ceramic, {
-      deterministic: true,
-      family: 'testCapabilities3',
-      controllers: [`did:pkh:eip155:1:${wallet.address}`],
-    })
+      expect(deterministicDocument.content).toEqual({ foo: 'bar' })
+    }, 30000)
 
-    // Create bad CACAO with did:key as aud
-    const badSiweMessage = new SiweMessage({
-      domain: 'service.org',
-      address: wallet.address,
-      statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
-      uri: didKey.id,
-      version: '1',
-      nonce: '23423423',
-      issuedAt: new Date().toISOString(),
-      resources: [`ceramic://abcdef`],
-    })
-    // Sign CACAO with did:pkh
-    const badSignature = await wallet.signMessage(badSiweMessage.toMessage())
-    badSiweMessage.signature = badSignature
-    const badCapability = Cacao.fromSiweMessage(badSiweMessage)
-    // Create new did:key with capability attached
-    const badDidKeyWithCapability = didKey.withCapability(badCapability)
-    await badDidKeyWithCapability.authenticate()
-
-    await expect(
-      deterministicDocument.update({ foo: 'baz' }, null, {
-        asDID: badDidKeyWithCapability,
-        anchor: false,
-        publish: false,
+    test('fails to update if cacao issuer is not document controller', async () => {
+      // Create a determinstic tiledocument owned by the user
+      const deterministicDocument = await TileDocument.deterministic(ceramic, {
+        deterministic: true,
+        family: 'testCapabilities2',
       })
-    ).rejects.toThrowError(
-      'Capability does not have appropriate permissions to update this TileDocument'
-    )
-  }, 30000)
+      const streamId = deterministicDocument.id
+      const didKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://${streamId.toString()}`)
 
-  test('can update stream with family resource', async () => {
-    const family = 'testFamily1'
-    // Create a determinstic tiledocument owned by the user
-    const deterministicDocument = await TileDocument.deterministic(ceramic, {
-      deterministic: true,
-      family,
-      controllers: [`did:pkh:eip155:1:${wallet.address}`],
-    })
+      await expect(
+        deterministicDocument.update({ foo: 'baz' }, null, {
+          asDID: didKeyWithCapability,
+          anchor: false,
+          publish: false,
+        })
+      ).rejects.toThrow(/invalid_jws/)
+    }, 30000)
 
-    const streamId = deterministicDocument.id
+    test('fails to update using capability with invalid resource', async () => {
+      // Create a determinstic tiledocument owned by the user
+      const deterministicDocument = await TileDocument.deterministic(ceramic, {
+        deterministic: true,
+        family: 'testCapabilities3',
+        controllers: [`did:pkh:eip155:1:${wallet.address}`],
+      })
+      const badDidKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://abcdef`)
 
-    // Create CACAO with did:key as aud
-    const siweMessage = new SiweMessage({
-      domain: 'service.org',
-      address: wallet.address,
-      chainId: '1',
-      statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
-      uri: didKey.id,
-      version: '1',
-      nonce: '23423423',
-      issuedAt: new Date().toISOString(),
-      resources: [`ceramic://*?family=${family}`],
-    })
-    // Sign CACAO with did:pkh
-    const signature = await wallet.signMessage(siweMessage.toMessage())
-    siweMessage.signature = signature
-    const capability = Cacao.fromSiweMessage(siweMessage)
-    // Create new did:key with capability attached
-    const didKeyWithCapability = didKey.withCapability(capability)
-    await didKeyWithCapability.authenticate()
+      await expect(
+        deterministicDocument.update({ foo: 'baz' }, null, {
+          asDID: badDidKeyWithCapability,
+          anchor: false,
+          publish: false,
+        })
+      ).rejects.toThrowError(
+        'Capability does not have appropriate permissions to update this TileDocument'
+      )
+    }, 30000)
+  })
 
-    await deterministicDocument.update({ foo: 'bar' }, null, {
-      asDID: didKeyWithCapability,
-      anchor: false,
-      publish: false,
-    })
+  describe('Resources using family', () => {
+    test('can update stream with family resource', async () => {
+      const family = 'testFamily1'
+      // Create a determinstic tiledocument owned by the user
+      const deterministicDocument = await TileDocument.deterministic(ceramic, {
+        deterministic: true,
+        family,
+        controllers: [`did:pkh:eip155:1:${wallet.address}`],
+      })
+      const streamId = deterministicDocument.id
+      const didKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://*?family=${family}`)
 
-    expect(deterministicDocument.content).toEqual({ foo: 'bar' })
-  }, 30000)
-
-  test('fails to update using capability with wrong family resource', async () => {
-    const family = 'testFamily1'
-    // Create a determinstic tiledocument owned by the user
-    const deterministicDocument = await TileDocument.deterministic(ceramic, {
-      deterministic: true,
-      family,
-      controllers: [`did:pkh:eip155:1:${wallet.address}`],
-    })
-
-    const streamId = deterministicDocument.id
-
-    // Create CACAO with did:key as aud
-    const siweMessage = new SiweMessage({
-      domain: 'service.org',
-      address: wallet.address,
-      chainId: '1',
-      statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
-      uri: didKey.id,
-      version: '1',
-      nonce: '23423423',
-      issuedAt: new Date().toISOString(),
-      resources: [`ceramic://*?family=${family}-wrong`],
-    })
-    // Sign CACAO with did:pkh
-    const signature = await wallet.signMessage(siweMessage.toMessage())
-    siweMessage.signature = signature
-    const capability = Cacao.fromSiweMessage(siweMessage)
-    // Create new did:key with capability attached
-    const didKeyWithCapability = didKey.withCapability(capability)
-    await didKeyWithCapability.authenticate()
-
-    await expect(
-      deterministicDocument.update({ foo: 'baz' }, null, {
+      await deterministicDocument.update({ foo: 'bar' }, null, {
         asDID: didKeyWithCapability,
         anchor: false,
         publish: false,
       })
-    ).rejects.toThrowError(
-      'Capability does not have appropriate permissions to update this TileDocument'
-    )
-  }, 30000)
 
-  test('fails to update using capability with empty family resource', async () => {
-    const family = 'testFamily1'
-    // Create a determinstic tiledocument owned by the user
-    const deterministicDocument = await TileDocument.deterministic(ceramic, {
-      deterministic: true,
-      family,
-      controllers: [`did:pkh:eip155:1:${wallet.address}`],
-    })
+      expect(deterministicDocument.content).toEqual({ foo: 'bar' })
+    }, 30000)
 
-    const streamId = deterministicDocument.id
+    test('fails to update using capability with wrong family resource', async () => {
+      const family = 'testFamily2'
+      // Create a determinstic tiledocument owned by the user
+      const deterministicDocument = await TileDocument.deterministic(ceramic, {
+        deterministic: true,
+        family,
+        controllers: [`did:pkh:eip155:1:${wallet.address}`],
+      })
+      const streamId = deterministicDocument.id
+      const didKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://*?family=${family}-wrong`)
 
-    // Create CACAO with did:key as aud
-    const siweMessage = new SiweMessage({
-      domain: 'service.org',
-      address: wallet.address,
-      chainId: '1',
-      statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
-      uri: didKey.id,
-      version: '1',
-      nonce: '23423423',
-      issuedAt: new Date().toISOString(),
-      resources: [`ceramic://*?family=`],
-    })
-    // Sign CACAO with did:pkh
-    const signature = await wallet.signMessage(siweMessage.toMessage())
-    siweMessage.signature = signature
-    const capability = Cacao.fromSiweMessage(siweMessage)
-    // Create new did:key with capability attached
-    const didKeyWithCapability = didKey.withCapability(capability)
-    await didKeyWithCapability.authenticate()
+      await expect(
+        deterministicDocument.update({ foo: 'baz' }, null, {
+          asDID: didKeyWithCapability,
+          anchor: false,
+          publish: false,
+        })
+      ).rejects.toThrowError(
+        'Capability does not have appropriate permissions to update this TileDocument'
+      )
+    }, 30000)
 
-    await expect(
-      deterministicDocument.update({ foo: 'baz' }, null, {
+    test('fails to update using capability with empty family resource', async () => {
+      const family = 'testFamily3'
+      // Create a determinstic tiledocument owned by the user
+      const deterministicDocument = await TileDocument.deterministic(ceramic, {
+        deterministic: true,
+        family,
+        controllers: [`did:pkh:eip155:1:${wallet.address}`],
+      })
+      const streamId = deterministicDocument.id
+      const didKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://*?family=`)
+
+      await expect(
+        deterministicDocument.update({ foo: 'baz' }, null, {
+          asDID: didKeyWithCapability,
+          anchor: false,
+          publish: false,
+        })
+      ).rejects.toThrowError(
+        'Capability does not have appropriate permissions to update this TileDocument'
+      )
+    }, 30000)
+
+    test('fails to update if cacao issuer is not document controller using family resource', async () => {
+      const family = 'testFamily4'
+      // Create a determinstic tiledocument owned by the user
+      const deterministicDocument = await TileDocument.deterministic(ceramic, {
+        deterministic: true,
+        family,
+      })
+      const streamId = deterministicDocument.id
+      const didKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://*?family=${family}`)
+
+      await expect(
+        deterministicDocument.update({ foo: 'baz' }, null, {
+          asDID: didKeyWithCapability,
+          anchor: false,
+          publish: false,
+        })
+      ).rejects.toThrow(/invalid_jws/)
+    }, 30000)
+
+    test('can create new stream with family resource', async () => {
+      const family = 'testFamily1'
+      const didKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://*?family=${family}`)
+
+      const doc = await TileDocument.create(ceramic, { foo: 'bar' }, {
+        family,
+        controllers: [`did:pkh:eip155:1:${wallet.address}`],
+      }, {
         asDID: didKeyWithCapability,
         anchor: false,
         publish: false,
       })
-    ).rejects.toThrowError(
-      'Capability does not have appropriate permissions to update this TileDocument'
-    )
-  }, 30000)
+
+      expect(doc.content).toEqual({ foo: 'bar' })
+      expect(doc.metadata.controllers).toEqual([`did:pkh:eip155:1:${wallet.address}`])
+      expect(doc.metadata.family).toEqual(family)
+    }, 30000)
+
+    test('can not create new stream with wrong family', async () => {
+      const family = 'testFamily1'
+      const didKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://*?family=${family}`)
+
+      await expect(
+        TileDocument.create(ceramic, { foo: 'bar' }, {
+          family: `${family}-wrong`,
+          controllers: [`did:pkh:eip155:1:${wallet.address}`],
+        }, {
+          asDID: didKeyWithCapability,
+          anchor: false,
+          publish: false,
+        })
+      ).rejects.toThrowError(
+        'Capability does not have appropriate permissions to update this TileDocument'
+      )
+    }, 30000)
+
+    test('can not create new stream without capability', async () => {
+      const family = 'testFamily1'
+      await expect(
+        TileDocument.create(ceramic, { foo: 'bar' }, {
+          family: `${family}`,
+          controllers: [`did:pkh:eip155:1:${wallet.address}`],
+        }, {
+          asDID: didKey,
+          anchor: false,
+          publish: false,
+        })
+      ).rejects.toThrowError(
+        /invalid_jws: not a valid verificationMethod for issuer:/
+      )
+    }, 30000)
+  })
 })

--- a/packages/canary-integration/src/__tests__/capability.test.ts
+++ b/packages/canary-integration/src/__tests__/capability.test.ts
@@ -6,175 +6,271 @@ import { Wallet } from 'ethers'
 import { Ed25519Provider } from 'key-did-provider-ed25519'
 import * as PkhDidResolver from 'pkh-did-resolver'
 import * as KeyDidResolver from 'key-did-resolver'
+import { randomBytes } from '@stablelib/random'
 import { SiweMessage, Cacao } from 'ceramic-cacao'
 import { createCeramic } from '../create-ceramic.js'
 
 let ipfs: IpfsApi
 let ceramic: CeramicApi
+let wallet: Wallet
+let didKey: DID
 
-beforeAll(async () => {
-  ipfs = await createIPFS()
-  ceramic = await createCeramic(ipfs)
-}, 120000)
+describe('CACAO Integration test', () => {
+  beforeAll(async () => {
+    ipfs = await createIPFS()
+    ceramic = await createCeramic(ipfs)
+    // Create a did:pkh for the user
+    wallet = Wallet.fromMnemonic(
+      'despair voyage estate pizza main slice acquire mesh polar short desk lyrics'
+    )
+    // Create did:key for the dApp
+    const didKeyProvider = new Ed25519Provider(randomBytes(32))
+    didKey = new DID({ provider: didKeyProvider, resolver: KeyDidResolver.getResolver() })
+    await didKey.authenticate()
+  }, 120000)
 
-afterAll(async () => {
-  await ipfs.stop()
-  await ceramic.close()
-})
-
-test('verifies capability with signed commit', async () => {
-  // Create a did:pkh for the user
-  const wallet = Wallet.fromMnemonic(
-    'despair voyage estate pizza main slice acquire mesh polar short desk lyrics'
-  )
-  const didPkh = new DID({ resolver: PkhDidResolver.getResolver() })
-  // Create a determinstic tiledocument owned by the user
-  const deterministicDocument = await TileDocument.deterministic(ceramic, {
-    deterministic: true,
-    family: 'testCapabilities1',
-    controllers: [`did:pkh:eip155:1:${wallet.address}`],
+  afterAll(async () => {
+    await ipfs.stop()
+    await ceramic.close()
   })
 
-  const streamId = deterministicDocument.id
+  test('can update with streamId in capability', async () => {
+    // Create a determinstic tiledocument owned by the user
+    const deterministicDocument = await TileDocument.deterministic(ceramic, {
+      deterministic: true,
+      family: 'testCapabilities1',
+      controllers: [`did:pkh:eip155:1:${wallet.address}`],
+    })
 
-  // Create did:key for the dApp
-  const seed = new Uint8Array([
-    69, 90, 79, 1, 19, 168, 234, 177, 16, 163, 37, 8, 233, 244, 36, 102, 130, 190, 102, 10, 239, 51,
-    191, 199, 40, 13, 2, 63, 94, 119, 183, 225,
-  ])
-  const didKeyProvider = new Ed25519Provider(seed)
-  const didKey = new DID({ provider: didKeyProvider, resolver: KeyDidResolver.getResolver() })
-  await didKey.authenticate()
+    const streamId = deterministicDocument.id
 
-  // Create CACAO with did:key as aud
-  const siweMessage = new SiweMessage({
-    domain: 'service.org',
-    address: wallet.address,
-    chainId: '1',
-    statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
-    uri: didKey.id,
-    version: '1',
-    nonce: '23423423',
-    issuedAt: new Date().toISOString(),
-    resources: [`ceramic://${streamId.toString()}`],
-  })
-  // Sign CACAO with did:pkh
-  const signature = await wallet.signMessage(siweMessage.toMessage())
-  siweMessage.signature = signature
-  const capability = Cacao.fromSiweMessage(siweMessage)
-  // Create new did:key with capability attached
-  const didKeyWithCapability = didKey.withCapability(capability)
-  await didKeyWithCapability.authenticate()
 
-  await deterministicDocument.update({ foo: 'bar' }, null, {
-    asDID: didKeyWithCapability,
-    anchor: false,
-    publish: false,
-  })
+    // Create CACAO with did:key as aud
+    const siweMessage = new SiweMessage({
+      domain: 'service.org',
+      address: wallet.address,
+      chainId: '1',
+      statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
+      uri: didKey.id,
+      version: '1',
+      nonce: '23423423',
+      issuedAt: new Date().toISOString(),
+      resources: [`ceramic://${streamId.toString()}`],
+    })
+    // Sign CACAO with did:pkh
+    const signature = await wallet.signMessage(siweMessage.toMessage())
+    siweMessage.signature = signature
+    const capability = Cacao.fromSiweMessage(siweMessage)
+    // Create new did:key with capability attached
+    const didKeyWithCapability = didKey.withCapability(capability)
+    await didKeyWithCapability.authenticate()
 
-  expect(deterministicDocument.content).toEqual({ foo: 'bar' })
-}, 30000)
-
-test('does not allow updating if cacao issuer is not document controller', async () => {
-  // Create a did:pkh for the user
-  const wallet = Wallet.fromMnemonic(
-    'despair voyage estate pizza main slice acquire mesh polar short desk lyrics'
-  )
-  const didPkh = new DID({ resolver: PkhDidResolver.getResolver() })
-  // Create a determinstic tiledocument owned by the user
-  const deterministicDocument = await TileDocument.deterministic(ceramic, {
-    deterministic: true,
-    family: 'testCapabilities2',
-  })
-
-  const streamId = deterministicDocument.id
-
-  // Create did:key for the dApp
-  const seed = new Uint8Array([
-    69, 90, 79, 1, 19, 168, 234, 177, 16, 163, 37, 8, 233, 244, 36, 102, 130, 190, 102, 10, 239, 51,
-    191, 199, 40, 13, 2, 63, 94, 119, 183, 225,
-  ])
-  const didKeyProvider = new Ed25519Provider(seed)
-  const didKey = new DID({ provider: didKeyProvider, resolver: KeyDidResolver.getResolver() })
-  await didKey.authenticate()
-
-  // Create CACAO with did:key as aud
-  const siweMessage = new SiweMessage({
-    domain: 'service.org',
-    address: wallet.address,
-    chainId: '1',
-    statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
-    uri: didKey.id,
-    version: '1',
-    nonce: '23423423',
-    issuedAt: new Date().toISOString(),
-    resources: [`ceramic://${streamId.toString()}`],
-  })
-  // Sign CACAO with did:pkh
-  const signature = await wallet.signMessage(siweMessage.toMessage())
-  siweMessage.signature = signature
-  const capability = Cacao.fromSiweMessage(siweMessage)
-  // Create new did:key with capability attached
-  const didKeyWithCapability = didKey.withCapability(capability)
-  await didKeyWithCapability.authenticate()
-
-  await expect(
-    deterministicDocument.update({ foo: 'baz' }, null, {
+    await deterministicDocument.update({ foo: 'bar' }, null, {
       asDID: didKeyWithCapability,
       anchor: false,
       publish: false,
     })
-  ).rejects.toThrow(/invalid_jws/)
-}, 30000)
 
-test('fails to verify capability with invalid resource', async () => {
-  // Create a did:pkh for the user
-  const wallet = Wallet.fromMnemonic(
-    'despair voyage estate pizza main slice acquire mesh polar short desk lyrics'
-  )
-  const didPkh = new DID({ resolver: PkhDidResolver.getResolver() })
-  // Create a determinstic tiledocument owned by the user
-  const deterministicDocument = await TileDocument.deterministic(ceramic, {
-    deterministic: true,
-    family: 'testCapabilities3',
-    controllers: [`did:pkh:eip155:1:${wallet.address}`],
-  })
+    expect(deterministicDocument.content).toEqual({ foo: 'bar' })
+  }, 30000)
 
-  // Create did:key for the dApp
-  const seed = new Uint8Array([
-    69, 90, 79, 1, 19, 168, 234, 177, 16, 163, 37, 8, 233, 244, 36, 102, 130, 190, 102, 10, 239, 51,
-    191, 199, 40, 13, 2, 63, 94, 119, 183, 225,
-  ])
-  const didKeyProvider = new Ed25519Provider(seed)
-  const didKey = new DID({ provider: didKeyProvider, resolver: KeyDidResolver.getResolver() })
-  await didKey.authenticate()
+  test('does not allow updating if cacao issuer is not document controller', async () => {
+    // Create a determinstic tiledocument owned by the user
+    const deterministicDocument = await TileDocument.deterministic(ceramic, {
+      deterministic: true,
+      family: 'testCapabilities2',
+    })
 
-  // Create bad CACAO with did:key as aud
-  const badSiweMessage = new SiweMessage({
-    domain: 'service.org',
-    address: wallet.address,
-    statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
-    uri: didKey.id,
-    version: '1',
-    nonce: '23423423',
-    issuedAt: new Date().toISOString(),
-    resources: [`ceramic://abcdef`],
-  })
-  // Sign CACAO with did:pkh
-  const badSignature = await wallet.signMessage(badSiweMessage.toMessage())
-  badSiweMessage.signature = badSignature
-  const badCapability = Cacao.fromSiweMessage(badSiweMessage)
-  // Create new did:key with capability attached
-  const badDidKeyWithCapability = didKey.withCapability(badCapability)
-  await badDidKeyWithCapability.authenticate()
+    const streamId = deterministicDocument.id
 
-  await expect(
-    deterministicDocument.update({ foo: 'baz' }, null, {
-      asDID: badDidKeyWithCapability,
+    // Create CACAO with did:key as aud
+    const siweMessage = new SiweMessage({
+      domain: 'service.org',
+      address: wallet.address,
+      chainId: '1',
+      statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
+      uri: didKey.id,
+      version: '1',
+      nonce: '23423423',
+      issuedAt: new Date().toISOString(),
+      resources: [`ceramic://${streamId.toString()}`],
+    })
+    // Sign CACAO with did:pkh
+    const signature = await wallet.signMessage(siweMessage.toMessage())
+    siweMessage.signature = signature
+    const capability = Cacao.fromSiweMessage(siweMessage)
+    // Create new did:key with capability attached
+    const didKeyWithCapability = didKey.withCapability(capability)
+    await didKeyWithCapability.authenticate()
+
+    await expect(
+      deterministicDocument.update({ foo: 'baz' }, null, {
+        asDID: didKeyWithCapability,
+        anchor: false,
+        publish: false,
+      })
+    ).rejects.toThrow(/invalid_jws/)
+  }, 30000)
+
+  test('fails to update using capability with invalid resource', async () => {
+    // Create a determinstic tiledocument owned by the user
+    const deterministicDocument = await TileDocument.deterministic(ceramic, {
+      deterministic: true,
+      family: 'testCapabilities3',
+      controllers: [`did:pkh:eip155:1:${wallet.address}`],
+    })
+
+    // Create bad CACAO with did:key as aud
+    const badSiweMessage = new SiweMessage({
+      domain: 'service.org',
+      address: wallet.address,
+      statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
+      uri: didKey.id,
+      version: '1',
+      nonce: '23423423',
+      issuedAt: new Date().toISOString(),
+      resources: [`ceramic://abcdef`],
+    })
+    // Sign CACAO with did:pkh
+    const badSignature = await wallet.signMessage(badSiweMessage.toMessage())
+    badSiweMessage.signature = badSignature
+    const badCapability = Cacao.fromSiweMessage(badSiweMessage)
+    // Create new did:key with capability attached
+    const badDidKeyWithCapability = didKey.withCapability(badCapability)
+    await badDidKeyWithCapability.authenticate()
+
+    await expect(
+      deterministicDocument.update({ foo: 'baz' }, null, {
+        asDID: badDidKeyWithCapability,
+        anchor: false,
+        publish: false,
+      })
+    ).rejects.toThrowError(
+      'Capability does not have appropriate permissions to update this TileDocument'
+    )
+  }, 30000)
+
+  test('can update stream with family resource', async () => {
+    const family = 'testFamily1'
+    // Create a determinstic tiledocument owned by the user
+    const deterministicDocument = await TileDocument.deterministic(ceramic, {
+      deterministic: true,
+      family,
+      controllers: [`did:pkh:eip155:1:${wallet.address}`],
+    })
+
+    const streamId = deterministicDocument.id
+
+    // Create CACAO with did:key as aud
+    const siweMessage = new SiweMessage({
+      domain: 'service.org',
+      address: wallet.address,
+      chainId: '1',
+      statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
+      uri: didKey.id,
+      version: '1',
+      nonce: '23423423',
+      issuedAt: new Date().toISOString(),
+      resources: [`ceramic://*?family=${family}`],
+    })
+    // Sign CACAO with did:pkh
+    const signature = await wallet.signMessage(siweMessage.toMessage())
+    siweMessage.signature = signature
+    const capability = Cacao.fromSiweMessage(siweMessage)
+    // Create new did:key with capability attached
+    const didKeyWithCapability = didKey.withCapability(capability)
+    await didKeyWithCapability.authenticate()
+
+    await deterministicDocument.update({ foo: 'bar' }, null, {
+      asDID: didKeyWithCapability,
       anchor: false,
       publish: false,
     })
-  ).rejects.toThrowError(
-    'Capability does not have appropriate permissions to update this TileDocument'
-  )
-}, 30000)
+
+    expect(deterministicDocument.content).toEqual({ foo: 'bar' })
+  }, 30000)
+
+  test('fails to update using capability with wrong family resource', async () => {
+    const family = 'testFamily1'
+    // Create a determinstic tiledocument owned by the user
+    const deterministicDocument = await TileDocument.deterministic(ceramic, {
+      deterministic: true,
+      family,
+      controllers: [`did:pkh:eip155:1:${wallet.address}`],
+    })
+
+    const streamId = deterministicDocument.id
+
+    // Create CACAO with did:key as aud
+    const siweMessage = new SiweMessage({
+      domain: 'service.org',
+      address: wallet.address,
+      chainId: '1',
+      statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
+      uri: didKey.id,
+      version: '1',
+      nonce: '23423423',
+      issuedAt: new Date().toISOString(),
+      resources: [`ceramic://*?family=${family}-wrong`],
+    })
+    // Sign CACAO with did:pkh
+    const signature = await wallet.signMessage(siweMessage.toMessage())
+    siweMessage.signature = signature
+    const capability = Cacao.fromSiweMessage(siweMessage)
+    // Create new did:key with capability attached
+    const didKeyWithCapability = didKey.withCapability(capability)
+    await didKeyWithCapability.authenticate()
+
+    await expect(
+      deterministicDocument.update({ foo: 'baz' }, null, {
+        asDID: didKeyWithCapability,
+        anchor: false,
+        publish: false,
+      })
+    ).rejects.toThrowError(
+      'Capability does not have appropriate permissions to update this TileDocument'
+    )
+  }, 30000)
+
+  test('fails to update using capability with empty family resource', async () => {
+    const family = 'testFamily1'
+    // Create a determinstic tiledocument owned by the user
+    const deterministicDocument = await TileDocument.deterministic(ceramic, {
+      deterministic: true,
+      family,
+      controllers: [`did:pkh:eip155:1:${wallet.address}`],
+    })
+
+    const streamId = deterministicDocument.id
+
+    // Create CACAO with did:key as aud
+    const siweMessage = new SiweMessage({
+      domain: 'service.org',
+      address: wallet.address,
+      chainId: '1',
+      statement: 'I accept the ServiceOrg Terms of Service: https://service.org/tos',
+      uri: didKey.id,
+      version: '1',
+      nonce: '23423423',
+      issuedAt: new Date().toISOString(),
+      resources: [`ceramic://*?family=`],
+    })
+    // Sign CACAO with did:pkh
+    const signature = await wallet.signMessage(siweMessage.toMessage())
+    siweMessage.signature = signature
+    const capability = Cacao.fromSiweMessage(siweMessage)
+    // Create new did:key with capability attached
+    const didKeyWithCapability = didKey.withCapability(capability)
+    await didKeyWithCapability.authenticate()
+
+    await expect(
+      deterministicDocument.update({ foo: 'baz' }, null, {
+        asDID: didKeyWithCapability,
+        anchor: false,
+        publish: false,
+      })
+    ).rejects.toThrowError(
+      'Capability does not have appropriate permissions to update this TileDocument'
+    )
+  }, 30000)
+})

--- a/packages/stream-tile/src/tile-document.ts
+++ b/packages/stream-tile/src/tile-document.ts
@@ -191,7 +191,8 @@ export class TileDocument<T = Record<string, any>> extends Stream {
       // document as there shouldn't be any existing state for this doc on the network.
       opts.syncTimeoutSeconds = 0
     }
-    const commit = await TileDocument.makeGenesis(ceramic, content, metadata)
+    const signer: CeramicSigner = opts.asDID ? { did: opts.asDID } : ceramic
+    const commit = await TileDocument.makeGenesis(signer, content, metadata)
     return ceramic.createStreamFromGenesis<TileDocument<T>>(
       TileDocument.STREAM_TYPE_ID,
       commit,


### PR DESCRIPTION
## Description

Currently you have to specify resources using the streamId. This creates a few problems:
#### SelfId SDK can't create streams on the flow within a particular Data Model
Seldom is a Data Model only one stream, rather it's a set of streams which are all referenced from the main Data Model record.

#### You have to know the DID of the user up front
This is problematic in future cases where WalletConnect will allow you to request a SIWE message on connection, basically reducing the flow of authenticating to one interaction. This greatly increases UX, but it means that we can't do the normal request address, then request signature flow.

### Solution
We introduce a new way to specify a Ceramic resource:
```
ceramic://*?family=<family-name>
```
This will allow the developer to specify the family used in a stream as the resource. Since many streams can share the same family this allows us to even create streams using this capability. In IDX we specify the family as the streamId of the definition, which gives us a good way to actually verify what the capability is meant to do (e.g. gives the app access to a particular data model).

## How Has This Been Tested?

Tests have been added to the canary integration:
- [x] Update a stream using a resource which specifies the family
- [x] Update a stream with the wrong family
- [x] Update a stream with null family
- [x] Update someone elses stream using family
- [x] Create a new stream using the family capability
- [x] Create a new stream using the wrong family capability

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

