### PR TITLE
bump dids and use `Date` for `atTime`

### DIFF
--- a/packages/canary-integration/package.json
+++ b/packages/canary-integration/package.json
@@ -24,7 +24,7 @@
     "@stablelib/random": "^1.0.1",
     "@truffle/hdwallet-provider": "^2.0.0",
     "ceramic-cacao": "^0.0.16",
-    "dids": "^3.0.0-alpha.11",
+    "dids": "^3.0.0-alpha.12",
     "ethers": "^5.5.4",
     "ganache-core": "^2.13.2",
     "key-did-provider-ed25519": "^1.1.0",

--- a/packages/canary-integration/package.json
+++ b/packages/canary-integration/package.json
@@ -24,7 +24,7 @@
     "@stablelib/random": "^1.0.1",
     "@truffle/hdwallet-provider": "^2.0.0",
     "ceramic-cacao": "^0.0.16",
-    "dids": "^3.0.0-alpha.9",
+    "dids": "^3.0.0-alpha.11",
     "ethers": "^5.5.4",
     "ganache-core": "^2.13.2",
     "key-did-provider-ed25519": "^1.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
     "cors": "^2.8.5",
     "dag-jose": "^1.0.0",
     "did-resolver": "^3.1.5",
-    "dids": "^3.0.0-alpha.11",
+    "dids": "^3.0.0-alpha.12",
     "ethr-did-resolver": "^5.0.3",
     "express": "^4.17.2",
     "go-ipfs": "^0.12.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
     "cors": "^2.8.5",
     "dag-jose": "^1.0.0",
     "did-resolver": "^3.1.5",
-    "dids": "^3.0.0-alpha.9",
+    "dids": "^3.0.0-alpha.11",
     "ethr-did-resolver": "^5.0.3",
     "express": "^4.17.2",
     "go-ipfs": "^0.12.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -51,7 +51,7 @@
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/logfmt": "^1.2.2",
     "@types/node": "^17.0.5",
-    "dids": "^3.0.0-alpha.9",
+    "dids": "^3.0.0-alpha.11",
     "ipfs-core-types": "~0.9.0",
     "json-schema-to-typescript": "^10.1.5",
     "typescript-json-schema": "^0.52.0"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -51,7 +51,7 @@
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/logfmt": "^1.2.2",
     "@types/node": "^17.0.5",
-    "dids": "^3.0.0-alpha.11",
+    "dids": "^3.0.0-alpha.12",
     "ipfs-core-types": "~0.9.0",
     "json-schema-to-typescript": "^10.1.5",
     "typescript-json-schema": "^0.52.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "ajv": "^8.8.2",
     "ajv-formats": "^2.1.1",
     "await-semaphore": "^0.1.3",
-    "dids": "^3.0.0-alpha.9",
+    "dids": "^3.0.0-alpha.11",
     "it-first": "^1.0.7",
     "level-ts": "^2.1.0",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "ajv": "^8.8.2",
     "ajv-formats": "^2.1.1",
     "await-semaphore": "^0.1.3",
-    "dids": "^3.0.0-alpha.11",
+    "dids": "^3.0.0-alpha.12",
     "it-first": "^1.0.7",
     "level-ts": "^2.1.0",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -41,7 +41,7 @@
     "rxjs": "^7.5.2"
   },
   "devDependencies": {
-    "dids": "^3.0.0-alpha.11",
+    "dids": "^3.0.0-alpha.12",
     "multiformats": "^9.5.8"
   },
   "gitHead": "34eeee25597b0a60def72906c26d3afd6230aaf1"

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -41,7 +41,7 @@
     "rxjs": "^7.5.2"
   },
   "devDependencies": {
-    "dids": "^3.0.0-alpha.9",
+    "dids": "^3.0.0-alpha.11",
     "multiformats": "^9.5.8"
   },
   "gitHead": "34eeee25597b0a60def72906c26d3afd6230aaf1"

--- a/packages/stream-caip10-link/package.json
+++ b/packages/stream-caip10-link/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@ceramicnetwork/blockchain-utils-linking": "^2.0.0-alpha.3",
-    "dids": "^3.0.0-alpha.9"
+    "dids": "^3.0.0-alpha.11"
   },
   "gitHead": "4f42c6ac204ad25e66efda4e24aed12c339b3c98"
 }

--- a/packages/stream-caip10-link/package.json
+++ b/packages/stream-caip10-link/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@ceramicnetwork/blockchain-utils-linking": "^2.0.0-alpha.3",
-    "dids": "^3.0.0-alpha.11"
+    "dids": "^3.0.0-alpha.12"
   },
   "gitHead": "4f42c6ac204ad25e66efda4e24aed12c339b3c98"
 }

--- a/packages/stream-tile-handler/package.json
+++ b/packages/stream-tile-handler/package.json
@@ -44,7 +44,7 @@
     "@types/lodash.clonedeep": "^4.5.6",
     "ceramic-cacao": "^0.0.16",
     "did-resolver": "^3.1.5",
-    "dids": "^3.0.0-alpha.9",
+    "dids": "^3.0.0-alpha.11",
     "key-did-resolver": "^2.0.0-alpha.3",
     "multiformats": "^9.5.8"
   },

--- a/packages/stream-tile-handler/package.json
+++ b/packages/stream-tile-handler/package.json
@@ -44,7 +44,7 @@
     "@types/lodash.clonedeep": "^4.5.6",
     "ceramic-cacao": "^0.0.16",
     "did-resolver": "^3.1.5",
-    "dids": "^3.0.0-alpha.11",
+    "dids": "^3.0.0-alpha.12",
     "key-did-resolver": "^2.0.0-alpha.3",
     "multiformats": "^9.5.8"
   },

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -223,12 +223,12 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
     context: Context,
     controller: string,
     family: string,
-    streamId: StreamID,
+    streamId: StreamID
   ): Promise<void> {
     const cacao = await this._verifyCapabilityAuthz(commitData, context, streamId, family)
 
     await context.did.verifyJWS(commitData.envelope, {
-      atTime: commitData.timestamp,
+      atTime: new Date(commitData.timestamp * 1000),
       issuer: controller,
       disableTimecheck: commitData.disableTimecheck,
       capability: cacao,


### PR DESCRIPTION
## Description

Related to NET-1253

Bumps `dids` and uses `Date` instead of `number` for `atTime` when calling `verifyJWS`

## How Has This Been Tested?

NOTE: Unable to test it locally yet due to some ESM import issues. Believe @stephhuynh18 is looking more into it.

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Test A (e.g. Test A - New test that ... ran in local, docker, and dev unstable.)
- [ ] Test B

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
