### PR TITLE
[NET-1240] Update default CACAO expiration time to be 1 day later

### DIFF
--- a/packages/blockchain-utils-linking/src/ethereum.ts
+++ b/packages/blockchain-utils-linking/src/ethereum.ts
@@ -84,7 +84,7 @@ export class EthereumAuthProvider implements AuthProvider {
     // NOTE: To allow proper customization of the expiry date, we need a solid library to represent
     // time durations that includes edge cases. We should not try dealing with timestamps ourselves.
     const now = new Date()
-    const oneWeekLater = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+    const oneDayLater = new Date(now.getTime() + 24 * 60 * 60 * 1000)
 
     const siweMessage = new SiweMessage({
       domain: domain,
@@ -94,7 +94,7 @@ export class EthereumAuthProvider implements AuthProvider {
       version: opts.version ?? '1',
       nonce: opts.nonce ?? randomString(10),
       issuedAt: now.toISOString(),
-      expirationTime: opts.expirationTime ?? oneWeekLater.toISOString(),
+      expirationTime: opts.expirationTime ?? oneDayLater.toISOString(),
       chainId: (await this.accountId()).chainId.reference,
       resources: (opts.resources ?? []).concat(
         streams.map((s) => (typeof s === 'string' ? StreamID.fromString(s) : s).toUrl())


### PR DESCRIPTION
## Description

Small patch to update the default CACAO expiration time to be 1 day, instead of 1 week.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Test A (e.g. Test A - New test that ... ran in local, docker, and dev unstable.)
- [ ] Test B

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
