### PR TITLE
chore: fix polkadot tests

### DIFF
--- a/packages/blockchain-utils-linking/jest.config.json
+++ b/packages/blockchain-utils-linking/jest.config.json
@@ -7,5 +7,6 @@
   },
   "transform": {
     "^.+\\.tsx?$": "babel-jest"
-  }
+  },
+  "resolver": "jest-resolver-enhanced"
 }

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -227,8 +227,9 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
   ): Promise<void> {
     const cacao = await this._verifyCapabilityAuthz(commitData, context, streamId, family)
 
+    const atTime = commitData.timestamp ? new Date(commitData.timestamp * 1000) : undefined
     await context.did.verifyJWS(commitData.envelope, {
-      atTime: new Date(commitData.timestamp * 1000),
+      atTime: atTime,
       issuer: controller,
       disableTimecheck: commitData.disableTimecheck,
       capability: cacao,


### PR DESCRIPTION
Root cause: Jest resolver is buggy. It tries to import CJS by default; some packages do not properly specify conditional exports, which leads to a failure.

The misbehavior is solved in upcoming Jest v28. We can not use it though right now: it changed the way mocks work, which breaks other tests.

Changes: use `jest-resolver-enhanced` for `blockchain-utils-linking` package to overcome Jest resolver limitations.

Also, to make tests fully green again, fixed an issue in TileHandler. Pass `atTime` option to `did` signature verification only if commit has a timestamp. CC @haardikk21 