### PR TITLE
Switch level-state-store.test.ts to use a real LevelDB instance instead of a mock

### DIFF
--- a/packages/common/src/utils/test-utils.ts
+++ b/packages/common/src/utils/test-utils.ts
@@ -3,6 +3,12 @@ import { filter } from 'rxjs/operators'
 import { BehaviorSubject, lastValueFrom } from 'rxjs'
 import { RunningStateLike } from '../running-state-like.js'
 import { StreamID } from '@ceramicnetwork/streamid'
+import { CID } from 'multiformats/cid'
+import * as uint8arrays from 'uint8arrays'
+import * as random from '@stablelib/random'
+import { decode as decodeMultiHash } from 'multiformats/hashes/digest'
+
+const SHA256_CODE = 0x12
 
 class FakeRunningState extends BehaviorSubject<StreamState> implements RunningStateLike {
   readonly id: StreamID
@@ -50,5 +56,13 @@ export class TestUtils {
     return new Promise<void>((resolve) => {
       setTimeout(() => resolve(), ms)
     })
+  }
+
+  static randomCID(): CID {
+    const body = uint8arrays.concat([
+      uint8arrays.fromString('1220', 'base16'),
+      random.randomBytes(32),
+    ])
+    return CID.create(1, SHA256_CODE, decodeMultiHash(body))
   }
 }

--- a/packages/core/src/__tests__/conflict-resolution.test.ts
+++ b/packages/core/src/__tests__/conflict-resolution.test.ts
@@ -2,7 +2,7 @@ import { CID } from 'multiformats/cid'
 import { decode as decodeMultiHash } from 'multiformats/hashes/digest'
 import * as uint8arrays from 'uint8arrays'
 import * as sha256 from '@stablelib/sha256'
-import { AnchorStatus, CommitType, LogEntry, StreamState } from '@ceramicnetwork/common'
+import { AnchorStatus, CommitType, LogEntry, StreamState, TestUtils } from '@ceramicnetwork/common'
 import { fetchLog, HistoryLog, pickLogToAccept } from '../conflict-resolution.js'
 import * as random from '@stablelib/random'
 import { Dispatcher } from '../dispatcher.js'
@@ -206,14 +206,6 @@ describe('fetchLog', () => {
     },
   } as unknown as Dispatcher
 
-  function randomCID() {
-    const body = uint8arrays.concat([
-      uint8arrays.fromString('1220', 'base16'),
-      random.randomBytes(32),
-    ])
-    return CID.create(1, SHA256_CODE, decodeMultiHash(body))
-  }
-
   function logEntry(type: CommitType, prev?: CID): LogEntry {
     const body = uint8arrays.concat([
       uint8arrays.fromString('1220', 'base16'),
@@ -222,7 +214,7 @@ describe('fetchLog', () => {
     const cid = CID.create(1, SHA256_CODE, decodeMultiHash(body))
     if (type == CommitType.ANCHOR) {
       const timestamp = Math.floor(Math.random() * 100000)
-      const proofCID = randomCID()
+      const proofCID = TestUtils.randomCID()
       cidCommits[proofCID.toString()] = {
         blockTimestamp: timestamp,
       }
@@ -238,7 +230,7 @@ describe('fetchLog', () => {
     } else {
       if (prev) {
         // signed
-        const link = randomCID()
+        const link = TestUtils.randomCID()
         cidCommits[link.toString()] = { prev: prev }
         cidCommits[cid.toString()] = {
           link: link,
@@ -286,7 +278,7 @@ describe('fetchLog', () => {
   })
   test('not in log', async () => {
     const a = logEntry(CommitType.GENESIS)
-    const b = randomCID()
+    const b = TestUtils.randomCID()
     cidCommits[b.toString()] = {}
     const history = new HistoryLog(fauxDispatcher, [a])
 

--- a/packages/core/src/store/level-state-store.ts
+++ b/packages/core/src/store/level-state-store.ts
@@ -18,17 +18,13 @@ import path from 'path'
 // See also https://github.com/nodejs/node/blob/master/doc/api/esm.md#commonjs-namespaces,
 const LevelC = (levelTs as any).default as unknown as typeof Level
 
-// Jest can barely mock modules when running in ESM mode. Some of our tests though rely on `level-ts` package
-// being mocked and spied on. Instead of making testing code incredibly ugly, we make dependency on `level-ts` explicit.
-// Now we can pass a carefully crafted mock object to spy on.
-const defaultLevelFactory = (path: string) => new LevelC(path)
 /**
  * Ceramic store for saving stream state to a local leveldb instance
  */
 export class LevelStateStore implements StateStore {
   #store: Level
 
-  constructor(private storeRoot: string, private readonly levelFactory = defaultLevelFactory) {}
+  constructor(private storeRoot: string) {}
 
   /**
    * Gets internal db
@@ -46,7 +42,7 @@ export class LevelStateStore implements StateStore {
     if (fs) {
       fs.mkdirSync(storePath, { recursive: true }) // create dir if it doesn't exist
     }
-    this.#store = this.levelFactory(storePath)
+    this.#store = new LevelC(storePath)
   }
 
   /**


### PR DESCRIPTION
More realistic test coverage, plus easier to extend the test in the future.  Will build on this in next PR