### PR TITLE
include cacao in CommitData when fetching log

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -46,7 +46,8 @@
     "logfmt": "^1.3.2",
     "multiformats": "^9.5.8",
     "rxjs": "^7.5.2",
-    "uint8arrays": "^3.0.0"
+    "uint8arrays": "^3.0.0",
+    "ceramic-cacao": "^0.0.16"
   },
   "devDependencies": {
     "@types/lodash.clonedeep": "^4.5.6",

--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -8,6 +8,7 @@ import { Observable } from 'rxjs'
 import type { RunningStateLike } from './running-state-like.js'
 import type { CeramicApi } from './ceramic-api.js'
 import { LoadOpts, SyncOptions } from './streamopts.js'
+import type { Cacao } from 'ceramic-cacao'
 
 /**
  * Describes signature status
@@ -122,6 +123,7 @@ export interface CommitData extends LogEntry {
   commit: any
   envelope?: DagJWS
   proof?: AnchorProof
+  capability?: Cacao
   /**
    * Do not time-check a signature.
    */

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -92,6 +92,17 @@ export class Utils {
       if (!linkedCommit) throw new Error(`No commit found for CID ${commit.link.toString()}`)
       commitData.commit = linkedCommit
       commitData.envelope = commit
+
+      if (commit.signatures && commit.signatures.length > 0) {
+        const protectedHeader = commit.signatures[0].protected
+        const decodedProtectedHeader = base64urlToJSON(protectedHeader)
+        if (decodedProtectedHeader.cap) {
+          const capIPFSUri = decodedProtectedHeader.cap
+          const capCID = CID.parse(capIPFSUri.replace('ipfs://', ''))
+          const cacao = await dispatcher.retrieveFromIPFS(capCID)
+          commitData.capability = cacao
+        }
+      }
     } else if (StreamUtils.isAnchorCommit(commit)) {
       commitData.type = CommitType.ANCHOR
       commitData.proof = await dispatcher.retrieveFromIPFS(commit.proof)

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -228,7 +228,7 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
     family: string,
     streamId: StreamID
   ): Promise<void> {
-    const cacao = await this._verifyCapabilityAuthz(commitData, context, streamId, family)
+    const cacao = await this._verifyCapabilityAuthz(commitData, streamId, family)
 
     const atTime = commitData.timestamp ? new Date(commitData.timestamp * 1000) : undefined
     await context.did.verifyJWS(commitData.envelope, {
@@ -249,18 +249,13 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
    */
   async _verifyCapabilityAuthz(
     commitData: CommitData,
-    context: Context,
     streamId: StreamID,
     family: string
   ): Promise<Cacao | null> {
-    const protectedHeader = commitData.envelope.signatures[0].protected
-    const decodedProtectedHeader = base64urlToJSON(protectedHeader)
+    const cacao = commitData.capability
 
-    if (!decodedProtectedHeader.cap) return null
+    if (!cacao) return null
 
-    const capIPFSUri = decodedProtectedHeader.cap
-    const capCID = CID.parse(capIPFSUri.replace('ipfs://', ''))
-    const cacao = (await context.ipfs.dag.get(capCID)).value as Cacao
     const resources = cacao.p.resources as string[]
     const payloadCID = commitData.envelope.link.toString()
 


### PR DESCRIPTION
## Description

Fetches and includes Cacao capability in `CommitData` when fetching log (`fetchLog`). Allows us to use the dispatcher to retrieve the capability object, which is more resilient than just calling `ipfs.dag.get(...)` as before.

## How Has This Been Tested?

Existing tests pass, including integration tests

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
