### PR TITLE
feat(core): Add env var to skip ipfs data persistence check at startup

### DIFF
--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -533,6 +533,10 @@ export class Ceramic implements CeramicApi {
    * as expected.
    */
   async _checkIPFSPersistence(): Promise<void> {
+    if (process.env.CERAMIC_SKIP_IPFS_PERSISTENCE_STARTUP_CHECK) {
+      return
+    }
+
     const state = await this.repository.randomPinnedStreamState()
     if (!state) {
       this._logger.warn(


### PR DESCRIPTION
The gateway doesn't actually have the real IPFS data for the streams it has in its state store (which is all copied from other node's state stores), so it always fails the ipfs data startup check