### PR TITLE
fix(cli): use IPFS_PATH env var

### DIFF
--- a/packages/cli/src/build-ipfs-connection.util.ts
+++ b/packages/cli/src/build-ipfs-connection.util.ts
@@ -47,7 +47,7 @@ async function createGoIPFS(overrideConfig: Partial<ipfsClient.Options> = {}): P
   const gatewayPort = 9011
   const defaultConfig = {
     ipld: { codecs: [dagJose] },
-    repo: '~/.goipfs',
+    repo: process.env.IPFS_PATH || '~/.goipfs',
     config: {
       Pubsub: {
         Enabled: true,


### PR DESCRIPTION
We want the ipfs instance to use IPFS_PATH for its repo over our default value of '~/.go-ipfs`.