### PR TITLE
feat(stream-tile-handler): add cacao wildcard resource support

### DIFF
--- a/packages/canary-integration/src/__tests__/capability.test.ts
+++ b/packages/canary-integration/src/__tests__/capability.test.ts
@@ -280,4 +280,39 @@ describe('CACAO Integration test', () => {
       }, 30000)
     })
   })
+
+  describe('Resources using wildcard', () => {
+    test('update using capability with wildcard * resource', async () => {
+      // Create a determinstic tiledocument owned by the user
+      const deterministicDocument = await TileDocument.deterministic(ceramic, {
+        deterministic: true,
+        family: 'testfamily',
+        controllers: [`did:pkh:eip155:1:${wallet.address}`],
+      })
+      const didKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://*`)
+
+      await deterministicDocument.update({ foo: 'bar' }, null, {
+        asDID: didKeyWithCapability,
+        anchor: false,
+        publish: false,
+      })
+
+      expect(deterministicDocument.content).toEqual({ foo: 'bar' })
+    }, 30000)
+
+    test('create using capability with wildcard * resource', async () => {
+      const didKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://*`)
+
+      const doc = await TileDocument.create(ceramic, { foo: 'bar' }, {
+        controllers: [`did:pkh:eip155:1:${wallet.address}`],
+      }, {
+        asDID: didKeyWithCapability,
+        anchor: false,
+        publish: false,
+      })
+
+      expect(doc.content).toEqual({ foo: 'bar' })
+      expect(doc.metadata.controllers).toEqual([`did:pkh:eip155:1:${wallet.address}`])
+    }, 30000)
+  })
 })

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -259,14 +259,11 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
     const resources = cacao.p.resources as string[]
     const payloadCID = commitData.envelope.link.toString()
 
-    if (resources.includes(`ceramic://*`)) {
-      throw new Error(`Capability resource is not allowed`)
-    }
-
     if (
+      !resources.includes(`ceramic://*`) &&
       !resources.includes(`ceramic://${streamId.toString()}`) &&
       !resources.includes(`ceramic://${streamId.toString()}?payload=${payloadCID}`) &&
-      !(family && resources.includes(`ceramic://*?family=${family}`))
+      !(family && resources.includes(`ceramic://*?family=${family}`)) 
     ) {
       throw new Error(
         `Capability does not have appropriate permissions to update this TileDocument`


### PR DESCRIPTION
Adds cacao wildcard resource support

Reference [SIWE+ spec](https://www.notion.so/threebox/CACAO-DID-PKH-SIWE-Client-Libraries-5ce1f1f6e8c7417683c2b63e07f91cef#741885cca9d94532afee11a46621ab7d) for motivation. 

Tests for create/update using wildcard resource capability. 

Does change validation a bit, but adds not removes, dont have any version/upgrade concerns at moment