### PR TITLE
feat(stream-tile): use dids capability iss as controller when capabil…

### DIFF
--- a/packages/canary-integration/src/__tests__/capability.test.ts
+++ b/packages/canary-integration/src/__tests__/capability.test.ts
@@ -246,13 +246,12 @@ describe('CACAO Integration test', () => {
       test('can not create new stream with wrong family', async () => {
         const family = 'testFamily1'
         const didKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://*?family=${family}`)
+        ceramic.did = didKeyWithCapability
 
         await expect(
           TileDocument.create(ceramic, { foo: 'bar' }, {
             family: `${family}-wrong`,
-            controllers: [`did:pkh:eip155:1:${wallet.address}`],
           }, {
-            asDID: didKeyWithCapability,
             anchor: false,
             publish: false,
           })
@@ -264,12 +263,11 @@ describe('CACAO Integration test', () => {
       test('can create new stream with family resource', async () => {
         const family = 'testFamily1'
         const didKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://*?family=${family}`)
+        ceramic.did = didKeyWithCapability
 
         const doc = await TileDocument.create(ceramic, { foo: 'bar' }, {
           family,
-          controllers: [`did:pkh:eip155:1:${wallet.address}`],
         }, {
-          asDID: didKeyWithCapability,
           anchor: false,
           publish: false,
         })

--- a/packages/canary-integration/src/__tests__/capability.test.ts
+++ b/packages/canary-integration/src/__tests__/capability.test.ts
@@ -303,7 +303,7 @@ describe('CACAO Integration test', () => {
       expect(deterministicDocument.content).toEqual({ foo: 'bar' })
     }, 30000)
 
-    test('create using capability with wildcard * resource', async () => {
+    test('create the c', async () => {
       const didKeyWithCapability = await addCapToDid(wallet, didKey, `ceramic://*`)
 
       const doc = await TileDocument.create(ceramic, { foo: 'bar' }, {
@@ -332,7 +332,6 @@ describe('CACAO Integration test', () => {
       ceramic.did = didKeyWithCapability
 
       await deterministicDocument.update({ foo: 'bar' }, null, {
-        asDID: didKeyWithCapability,
         anchor: false,
         publish: false,
       })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "ajv": "^8.8.2",
     "ajv-formats": "^2.1.1",
     "await-semaphore": "^0.1.3",
-    "dids": "^3.0.0",
+    "dids": "^3.1.0",
     "it-first": "^1.0.7",
     "level-ts": "^2.1.0",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/stream-tile/src/tile-document.ts
+++ b/packages/stream-tile/src/tile-document.ts
@@ -376,15 +376,8 @@ export class TileDocument<T = Record<string, any>> extends Stream {
     if (!metadata.controllers || metadata.controllers.length === 0) {
       if (signer.did) {
         await _ensureAuthenticated(signer)
-        // When did has capability, the did issuer of the capability is the stream controller 
-        let controller
-        try {
-          controller = signer.did.capability.p.iss
-        } catch(e) {
-          controller = signer.did.id
-        }
-
-        metadata.controllers = [controller]
+        // When did has parent, it has a capability, the did issuer (parent) of the capability is the stream controller 
+        metadata.controllers = [signer.did.hasParent ? signer.did.parent : signer.did.id]
       } else {
         throw new Error('No controllers specified')
       }

--- a/packages/stream-tile/src/tile-document.ts
+++ b/packages/stream-tile/src/tile-document.ts
@@ -376,7 +376,15 @@ export class TileDocument<T = Record<string, any>> extends Stream {
     if (!metadata.controllers || metadata.controllers.length === 0) {
       if (signer.did) {
         await _ensureAuthenticated(signer)
-        metadata.controllers = [signer.did.id]
+        // When did has capability, the did issuer of the capability is the stream controller 
+        let controller
+        try {
+          controller = signer.did.capability.p.iss
+        } catch(e) {
+          controller = signer.did.id
+        }
+
+        metadata.controllers = [controller]
       } else {
         throw new Error('No controllers specified')
       }


### PR DESCRIPTION
~~DRAFT - waits on DIDs package~~

Reference [SIWE+ spec](https://www.notion.so/threebox/CACAO-DID-PKH-SIWE-Client-Libraries-5ce1f1f6e8c7417683c2b63e07f91cef#741885cca9d94532afee11a46621ab7d) for motivation. Allows devs to use DIDs w/ capability and ceramic without having to know an implementation detail of CACAO (ie controller is cap issuer, and did w/cap is the signer) 