### PR TITLE
fix(canary-integration): Increase test fixture cleanup timeout

### DIFF
--- a/packages/canary-integration/src/__tests__/capability.test.ts
+++ b/packages/canary-integration/src/__tests__/capability.test.ts
@@ -59,7 +59,7 @@ describe('CACAO Integration test', () => {
   afterAll(async () => {
     await ipfs.stop()
     await ceramic.close()
-  })
+  }, 30000)
 
   describe('Updates without CACAO should fail', () => {
 


### PR DESCRIPTION
I don't really understand why @zachferland's recent commit would have made this teardown take longer.
I suspect that wasn't actually the root cause, and the issue was some upstream package getting updated and slowing down, although it is suspicious that the test that keeps failing is exactly the test file that zach's recent commit touched.  Something fishy is definitely going on here, but hopefully increasing the timeout on the teardown here will help