### PR TITLE
fix(cli): added daemon-config port number coercion and validation

### DIFF
--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -1,7 +1,7 @@
 import { program } from 'commander'
 import pc from 'picocolors'
 
-import { CeramicCliUtils } from '../ceramic-cli-utils.js'
+import { CeramicCliUtils, parsePort } from '../ceramic-cli-utils.js'
 
 program
   .command('daemon')
@@ -22,7 +22,7 @@ program
     `The S3 bucket name to use for storing pinned stream state. If not provided pinned stream state will only be saved locally but not to S3. Deprecated.`
   )
   .option('--gateway', 'Makes read only endpoints available. It is disabled by default')
-  .option('--port <int>', 'Port daemon is available on. Default is 7007')
+  .option('--port <int>', 'Port daemon is available on. Default is 7007', parsePort)
   .option('--hostname <string>', 'Host daemon is available on. Default is 0.0.0.0')
   .option('--debug', 'Enable debug logging level. Default is false')
   .option('--verbose', 'Enable verbose logging level. Default is false')

--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -1,7 +1,7 @@
 import { program } from 'commander'
 import pc from 'picocolors'
 
-import { CeramicCliUtils, parsePort } from '../ceramic-cli-utils.js'
+import { CeramicCliUtils } from '../ceramic-cli-utils.js'
 
 program
   .command('daemon')
@@ -22,7 +22,7 @@ program
     `The S3 bucket name to use for storing pinned stream state. If not provided pinned stream state will only be saved locally but not to S3. Deprecated.`
   )
   .option('--gateway', 'Makes read only endpoints available. It is disabled by default')
-  .option('--port <int>', 'Port daemon is available on. Default is 7007', parsePort)
+  .option('--port <int>', 'Port daemon is available on. Default is 7007')
   .option('--hostname <string>', 'Host daemon is available on. Default is 0.0.0.0')
   .option('--debug', 'Enable debug logging level. Default is false')
   .option('--verbose', 'Enable verbose logging level. Default is false')

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -599,8 +599,22 @@ export class CeramicCliUtils {
 const depreciationNotice = () => {
   console.log(
     `${pc.red(pc.bold('This command has been deprecated.'))}
-Please use the upgraded Glaze CLI instead. 
-Please test with the new CLI before reporting any problems. 
+Please use the upgraded Glaze CLI instead.
+Please test with the new CLI before reporting any problems.
 ${pc.green('npm i -g @glazed/cli')}`
   )
+}
+
+/**
+ * Helper function to parse and validate port passed
+ * by CLI switch --port for custom daemon startup
+ * @param inPort
+ */
+export function parsePort(inPort: string) {
+  const validPort = Number(inPort)
+  if (isNaN(validPort) || validPort > 65535) {
+    console.error('Invalid port number passed.')
+    process.exit(1)
+  }
+  return validPort
 }

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -604,17 +604,3 @@ Please test with the new CLI before reporting any problems.
 ${pc.green('npm i -g @glazed/cli')}`
   )
 }
-
-/**
- * Helper function to parse and validate port passed
- * by CLI switch --port for custom daemon startup
- * @param inPort
- */
-export function parsePort(inPort: string) {
-  const validPort = Number(inPort)
-  if (isNaN(validPort) || validPort > 65535) {
-    console.error('Invalid port number passed.')
-    process.exit(1)
-  }
-  return validPort
-}

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -75,6 +75,7 @@ export class DaemonStateStoreConfig {
 /**
  * Ceramic Daemon options for configuring behavior related to the HTTP API.
  */
+
 @jsonObject
 @toJson
 export class DaemonHTTPApiConfig {
@@ -87,7 +88,17 @@ export class DaemonHTTPApiConfig {
   /**
    * Port to listen on.
    */
-  @jsonMember(Number)
+  @jsonMember(AnyT, {serializer: inPort => {
+      const validPort = Number(inPort)
+      if (inPort == undefined || inPort == null) {
+        return inPort
+      } else if (isNaN(validPort) || validPort > 65535) {
+        console.error('Invalid port number passed.')
+        process.exit(1)
+      }
+      return validPort
+    }
+  })
   port?: number
 
   /**


### PR DESCRIPTION
## Description

Introduces a custom serializer to properly parse & validate port property passed to daemon-config either via CLI switch option `--port`, `daemon.config.json` or `ENV` variables.

This will solve the daemon being unable to start with a custom port that might be passed as a wrong type due to tool/system limitations (e.g. Docker passes strings vs the expected number type).

## How Has This Been Tested?

- [ ] ran included unit tests
- [ ] ran locally via command line CLI switch
`node ceramic.js daemon` -> OK (defaults to 7007)
`node ceramic.js daemon --port 7009` -> OK
`node ceramic.js daemon --port "7009"` -> OK
`node ceramic.js daemon --port 70000` -> NG (_Expected_: exceeds valid port length)
`node ceramic.js daemon --port "S09"` -> NG (_Expected_: non-number/valid port)

- [ ] started daemon via local `$HOME/.ceramic/daemon.config.json` file & cycle port between `7008`, `"7008"` & `"S09"` to confirm CLI switch behaviour

```
{
  "anchor": {},
  "http-api": {
    "cors-allowed-origins": [
      ".*"
    ],
    "port": "7008"
  },
  "ipfs": {
    "mode": "bundled"
  },
  "logger": {
    "log-level": 2,
    "log-to-files": false
  },
  "network": {
    "name": "testnet-clay"
  },
  "node": {},
  "state-store": {
    "mode": "fs",
    "local-directory": "/Users/Alex/.ceramic/statestore"
  }
}```

- [ ] ran daemon via ENV with matching test cases