### PR TITLE
temporarily log the full headers from dapps in the wild - PLAT-535

### DIFF
--- a/packages/cli/src/daemon/log-requests.ts
+++ b/packages/cli/src/daemon/log-requests.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express'
 import morgan from 'morgan'
 
 const ACCESS_LOG_FMT =
-  'ip=:remote-addr ts=:date[iso] method=:method original_url=:original-url base_url=:base-url path=:path:params http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=":user-agent" elapsed_ms=:total-time[3] error_message=":error-message" error_code=:error-code'
+  'ip=:remote-addr ts=:date[iso] method=:method original_url=:original-url base_url=:base-url path=:path:params http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=":user-agent" elapsed_ms=:total-time[3] error_message=":error-message" error_code=:error-code full_headers=:full-headers'
 
 export function logRequests(loggerProvider: LoggerProvider): any[] {
   morgan.token<Request, Response>('error-message', (req, res: Response) => {
@@ -20,6 +20,9 @@ export function logRequests(loggerProvider: LoggerProvider): any[] {
   })
   morgan.token<Request, Response>('path', (req) => {
     return req.path
+  })
+  morgan.token<Request, Response>('full-headers', (req) => {
+    return JSON.stringify(req.headers) // look at all the headers just for now
   })
   morgan.token<Request, Response>('params', (req) => {
     if (req.params) {


### PR DESCRIPTION
## Description

In order to determine what metrics we are able to gather about partners and dapps using Ceramic, we need to examine the full headers produced by dapps in the wild.  The only way to reliably gather this is by temporarily logging full headers in the wild, ie at least on clay.

## How Has This Been Tested?

This is only modifying a well exercised log pathway, the smoke tests should be sufficient.

## PR checklist

Before submitting this PR, please make sure:

- [x ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.

See https://www.notion.so/threebox/js-ceramic-instrumentation-8e1baf720b764b7ab0cf1e25d8a50da1