### PR TITLE
Indexing configuration

### DIFF
--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -41,6 +41,7 @@ const DEFAULT_DAEMON_CONFIG = DaemonConfig.fromObject({
   },
   indexing: {
     db: `sqlite://${DEFAULT_INDEXING_DB_FILENAME.pathname}`,
+    models: [],
   },
 })
 

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -26,6 +26,7 @@ const DEFAULT_STATE_STORE_DIRECTORY = new URL('statestore/', DEFAULT_CONFIG_PATH
 const DEFAULT_DAEMON_CONFIG_FILENAME = new URL('daemon.config.json', DEFAULT_CONFIG_PATH)
 const DEFAULT_CLI_CONFIG_FILENAME = new URL('client.config.json', DEFAULT_CONFIG_PATH)
 const LEGACY_CLI_CONFIG_FILENAME = new URL('config.json', DEFAULT_CONFIG_PATH) // todo(1615): Remove this backwards compatibility support
+const DEFAULT_INDEXING_DB_FILENAME = new URL('./indexing.sqlite', DEFAULT_CONFIG_PATH)
 
 const DEFAULT_DAEMON_CONFIG = DaemonConfig.fromObject({
   anchor: {},
@@ -37,6 +38,9 @@ const DEFAULT_DAEMON_CONFIG = DaemonConfig.fromObject({
   'state-store': {
     mode: StateStoreMode.FS,
     'local-directory': DEFAULT_STATE_STORE_DIRECTORY.pathname,
+  },
+  indexing: {
+    db: `sqlite://${DEFAULT_INDEXING_DB_FILENAME.pathname}`,
   },
 })
 

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -1,10 +1,9 @@
 import os from 'os'
-import path from 'path'
 import pc from 'picocolors'
 import { randomBytes } from '@stablelib/random'
 import * as u8a from 'uint8arrays'
 
-import { promises as fs } from 'fs'
+import * as fs from 'fs/promises'
 
 import { Ed25519Provider } from 'key-did-provider-ed25519'
 import { CeramicClient } from '@ceramicnetwork/http-client'
@@ -20,11 +19,12 @@ import * as KeyDidResolver from 'key-did-resolver'
 import { Resolver } from 'did-resolver'
 import { DID } from 'dids'
 
-const DEFAULT_STATE_STORE_DIRECTORY = path.join(os.homedir(), '.ceramic', 'statestore')
-const DEFAULT_DAEMON_CONFIG_FILENAME = 'daemon.config.json'
-const DEFAULT_CLI_CONFIG_FILENAME = 'client.config.json'
-const LEGACY_CLI_CONFIG_FILENAME = 'config.json' // todo(1615): Remove this backwards compatibility support
-const DEFAULT_CONFIG_PATH = path.join(os.homedir(), '.ceramic')
+const HOMEDIR = new URL(`file://${os.homedir()}/`)
+const DEFAULT_CONFIG_PATH = new URL('.ceramic/', HOMEDIR)
+const DEFAULT_STATE_STORE_DIRECTORY = new URL('statestore/', DEFAULT_CONFIG_PATH)
+const DEFAULT_DAEMON_CONFIG_FILENAME = new URL('daemon.config.json', DEFAULT_CONFIG_PATH)
+const DEFAULT_CLI_CONFIG_FILENAME = new URL('client.config.json', DEFAULT_CONFIG_PATH)
+const LEGACY_CLI_CONFIG_FILENAME = new URL('config.json', DEFAULT_CONFIG_PATH) // todo(1615): Remove this backwards compatibility support
 
 const DEFAULT_DAEMON_CONFIG = DaemonConfig.fromObject({
   anchor: {},
@@ -35,7 +35,7 @@ const DEFAULT_DAEMON_CONFIG = DaemonConfig.fromObject({
   node: {},
   'state-store': {
     mode: StateStoreMode.FS,
-    'local-directory': DEFAULT_STATE_STORE_DIRECTORY,
+    'local-directory': DEFAULT_STATE_STORE_DIRECTORY.pathname,
   },
 })
 
@@ -513,26 +513,24 @@ export class CeramicCliUtils {
    * @private
    */
   private static async _loadCliConfigFileContents(): Promise<string> {
-    const fullCliConfigPath = path.join(DEFAULT_CONFIG_PATH, DEFAULT_CLI_CONFIG_FILENAME)
     try {
-      await fs.access(fullCliConfigPath)
-      return await fs.readFile(fullCliConfigPath, { encoding: 'utf8' })
+      await fs.access(DEFAULT_CLI_CONFIG_FILENAME)
+      return await fs.readFile(DEFAULT_CLI_CONFIG_FILENAME, { encoding: 'utf8' })
     } catch (e) {
       // Swallow error
     }
 
     // If nothing found in default config file path, check legacy path too
     // TODO(1615): Remove this backwards compatibility code
-    const legacyCliConfigPath = path.join(DEFAULT_CONFIG_PATH, LEGACY_CLI_CONFIG_FILENAME)
     try {
-      await fs.access(legacyCliConfigPath)
-      const fileContents = await fs.readFile(legacyCliConfigPath, { encoding: 'utf8' })
+      await fs.access(LEGACY_CLI_CONFIG_FILENAME)
+      const fileContents = await fs.readFile(LEGACY_CLI_CONFIG_FILENAME, { encoding: 'utf8' })
 
       console.warn(
-        `Legacy client config file detected at '${legacyCliConfigPath}', renaming to ${fullCliConfigPath}`
+        `Legacy client config file detected at '${LEGACY_CLI_CONFIG_FILENAME}', renaming to ${DEFAULT_CLI_CONFIG_FILENAME}`
       )
       try {
-        await fs.rename(legacyCliConfigPath, fullCliConfigPath)
+        await fs.rename(LEGACY_CLI_CONFIG_FILENAME, DEFAULT_CLI_CONFIG_FILENAME)
       } catch (err) {
         console.error(`Rename failed: ${err}`)
         throw err
@@ -549,29 +547,27 @@ export class CeramicCliUtils {
    * @private
    */
   static async _loadDaemonConfig(): Promise<DaemonConfig> {
-    const fullDaemonConfigPath = path.join(DEFAULT_CONFIG_PATH, DEFAULT_DAEMON_CONFIG_FILENAME)
     try {
-      await fs.access(fullDaemonConfigPath)
+      await fs.access(DEFAULT_DAEMON_CONFIG_FILENAME)
     } catch (err) {
       await this._saveConfig(DEFAULT_DAEMON_CONFIG, DEFAULT_DAEMON_CONFIG_FILENAME)
       return DEFAULT_DAEMON_CONFIG
     }
 
-    const fileContents = await fs.readFile(fullDaemonConfigPath, { encoding: 'utf8' })
+    const fileContents = await fs.readFile(DEFAULT_DAEMON_CONFIG_FILENAME, { encoding: 'utf8' })
     return DaemonConfig.fromString(fileContents)
   }
 
   /**
    * Save configuration file
    * @param config - CLI configuration
-   * @param filename - name of the config file
+   * @param filename - full path to the config file
    * @private
    */
-  static async _saveConfig(config: Record<string, any>, filename: string): Promise<void> {
-    await fs.mkdir(DEFAULT_CONFIG_PATH, { recursive: true }) // create dirs if there are no
-    const fullCliConfigPath = path.join(DEFAULT_CONFIG_PATH, filename)
-
-    await fs.writeFile(fullCliConfigPath, JSON.stringify(config, null, 2))
+  static async _saveConfig(config: Record<string, any>, filename: URL): Promise<void> {
+    const parentFolder = new URL('./', filename)
+    await fs.mkdir(parentFolder, { recursive: true }) // create dirs if there are no
+    await fs.writeFile(filename, JSON.stringify(config, null, 2))
   }
 
   /**

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -88,7 +88,8 @@ export class DaemonHTTPApiConfig {
   /**
    * Port to listen on.
    */
-  @jsonMember(AnyT, {serializer: inPort => {
+  @jsonMember(AnyT, {
+    serializer: (inPort) => {
       const validPort = Number(inPort)
       if (inPort == undefined || inPort == null) {
         return inPort
@@ -97,7 +98,7 @@ export class DaemonHTTPApiConfig {
         process.exit(1)
       }
       return validPort
-    }
+    },
   })
   port?: number
 
@@ -164,6 +165,13 @@ export class DaemonAnchorConfig {
    */
   @jsonMember(String, { name: 'ethereum-rpc-url' })
   ethereumRpcUrl?: string
+}
+
+@jsonObject
+@toJson
+export class IndexingConfig {
+  @jsonMember(String)
+  db?: string
 }
 
 @jsonObject
@@ -306,6 +314,12 @@ export class DaemonConfig {
    */
   @jsonMember(DaemonDidResolversConfig, { name: 'did-resolvers' })
   didResolvers?: DaemonDidResolversConfig
+
+  /**
+   * Options related to indexing
+   */
+  @jsonMember(IndexingConfig)
+  indexing?: IndexingConfig
 
   /**
    * Parses the given json string containing the contents of the config file and returns

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -185,7 +185,7 @@ export class IndexingConfig {
       return arr.map((s) => s.toString())
     },
   })
-  models: string[]
+  models: StreamID[]
 }
 
 @jsonObject

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata'
 import { jsonObject, jsonMember, jsonArrayMember, TypedJSON, toJson, AnyT } from 'typedjson'
+import { StreamID } from '@ceramicnetwork/streamid'
 
 /**
  * Whether the daemon should start its own bundled in-process ipfs node, or if it should connect
@@ -172,6 +173,19 @@ export class DaemonAnchorConfig {
 export class IndexingConfig {
   @jsonMember(String)
   db?: string
+
+  @jsonArrayMember(String, {
+    emitDefaultValue: true,
+    deserializer: (arr?: Array<string>) => {
+      if (!arr) return arr
+      return arr.map(StreamID.fromString)
+    },
+    serializer: (arr?: Array<StreamID>) => {
+      if (!arr) return arr
+      return arr.map((s) => s.toString())
+    },
+  })
+  models: string[]
 }
 
 @jsonObject

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -174,7 +174,7 @@ export class IndexingConfig {
   @jsonMember(String)
   db?: string
 
-  @jsonArrayMember(String, {
+  @jsonArrayMember(StreamID, {
     emitDefaultValue: true,
     deserializer: (arr?: Array<string>) => {
       if (!arr) return arr


### PR DESCRIPTION
- Pass `--config` option from CLI to actual code
- Read connection string for a database
- Specify models to index in the config file

Also: replace `path.resolve` with `URL`-based resolution.