### PR TITLE
Revert "temporarily log the full headers from dapps in the wild - PLAT-535"

### DIFF
--- a/packages/cli/src/daemon/log-requests.ts
+++ b/packages/cli/src/daemon/log-requests.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express'
 import morgan from 'morgan'
 
 const ACCESS_LOG_FMT =
-  'ip=:remote-addr ts=:date[iso] method=:method original_url=:original-url base_url=:base-url path=:path:params http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=":user-agent" elapsed_ms=:total-time[3] error_message=":error-message" error_code=:error-code full_headers=:full-headers'
+  'ip=:remote-addr ts=:date[iso] method=:method original_url=:original-url base_url=:base-url path=:path:params http_version=:http-version req_header:req[header] status=:status content_length=:res[content-length] content_type=":res[content-type]" ref=:referrer user_agent=":user-agent" elapsed_ms=:total-time[3] error_message=":error-message" error_code=:error-code'
 
 export function logRequests(loggerProvider: LoggerProvider): any[] {
   morgan.token<Request, Response>('error-message', (req, res: Response) => {
@@ -20,9 +20,6 @@ export function logRequests(loggerProvider: LoggerProvider): any[] {
   })
   morgan.token<Request, Response>('path', (req) => {
     return req.path
-  })
-  morgan.token<Request, Response>('full-headers', (req) => {
-    return JSON.stringify(req.headers) // look at all the headers just for now
   })
   morgan.token<Request, Response>('params', (req) => {
     if (req.params) {


### PR DESCRIPTION
Reverts ceramicnetwork/js-ceramic#2165 - will deploy this in a few days after gathering data.