### PR TITLE
Throw during model stream validation, if any of the objects within mo…

### DIFF
--- a/packages/stream-model-handler/src/schema-utils.ts
+++ b/packages/stream-model-handler/src/schema-utils.ts
@@ -6,12 +6,11 @@ type JSONSchemaObjectType = {
   additionalProperties?: boolean
 }
 
-function traverseSchemaRecursivelyAndApplyFunction(o: SchemaObject, fn: (o: object) => void) {
-  fn(o)
-  Object.getOwnPropertyNames(o).forEach( (name) => {
-    fn.apply(this,[o[name]]);  
-    if (o[name] !== null && typeof(o[name])=="object") {
-      traverseSchemaRecursivelyAndApplyFunction(o[name], fn);
+function applyFuntionToSchemaAndItsObjectPropsRecursively(schema: SchemaObject, fn: (schemaProperty: object) => void) {
+  fn(schema)
+  Object.getOwnPropertyNames(schema).forEach((schemaPropertyName) => {
+    if (schema[schemaPropertyName] !== null && typeof(schema[schemaPropertyName]) == "object") {
+      applyFuntionToSchemaAndItsObjectPropsRecursively(schema[schemaPropertyName], fn);
     }
   })
 }
@@ -47,6 +46,6 @@ export class SchemaValidation {
       const errorMessages = this._validator.errorsText()
       throw new Error(`Validation Error: ${errorMessages}`)
     }
-    traverseSchemaRecursivelyAndApplyFunction(schema, validateObjectHaveAdditionalPropertiesForbidden)
+    applyFuntionToSchemaAndItsObjectPropsRecursively(schema, validateObjectHaveAdditionalPropertiesForbidden)
   }
 }

--- a/packages/stream-model-handler/src/schema-utils.ts
+++ b/packages/stream-model-handler/src/schema-utils.ts
@@ -6,11 +6,15 @@ type JSONSchemaObjectType = {
   additionalProperties?: boolean
 }
 
-function applyFuntionToSchemaAndItsObjectPropsRecursively(schema: SchemaObject, fn: (schemaProperty: object) => void) {
+function recursiveMap(schema: SchemaObject, fn: (schemaProperty: object) => void) {
+  /**
+   * Takes the schema and applies the fn function to it,
+   * Next, it iterates through all schema's object-type properties and applies itself recursively to them 
+   */
   fn(schema)
   Object.getOwnPropertyNames(schema).forEach((schemaPropertyName) => {
     if (schema[schemaPropertyName] !== null && typeof(schema[schemaPropertyName]) == "object") {
-      applyFuntionToSchemaAndItsObjectPropsRecursively(schema[schemaPropertyName], fn);
+      recursiveMap(schema[schemaPropertyName], fn);
     }
   })
 }
@@ -19,7 +23,11 @@ function isObjectJSONSchema(schema: any): schema is JSONSchemaObjectType {
   return schema &&  schema.type === 'object'
 }
 
-function validateObjectHaveAdditionalPropertiesForbidden(schema: SchemaObject): void {
+function validateAdditionalProperties(schema: SchemaObject): void {
+  /**
+   * Checks if schema is of JSONSchemaObjectType type and if so
+   * if makes if the schema has additionalProperties set to false (it throws an error otherwise)
+   */
   if (isObjectJSONSchema(schema)) {
     if (schema.additionalProperties !== false) {
       throw new Error("All objects in schema need to have additional properties disabled")
@@ -46,6 +54,6 @@ export class SchemaValidation {
       const errorMessages = this._validator.errorsText()
       throw new Error(`Validation Error: ${errorMessages}`)
     }
-    applyFuntionToSchemaAndItsObjectPropsRecursively(schema, validateObjectHaveAdditionalPropertiesForbidden)
+    recursiveMap(schema, validateAdditionalProperties)
   }
 }

--- a/packages/stream-model-handler/src/schema-utils.ts
+++ b/packages/stream-model-handler/src/schema-utils.ts
@@ -1,6 +1,33 @@
 
 import ajv, { AnySchema } from 'ajv/dist/2020.js'
 
+type JSONSchemaObjectType = {
+  type: 'object',
+  additionalProperties?: boolean
+}
+
+function traverseObjectRecursivelyAndApplyFunction(o, fn) {
+  fn(o)
+  for (const i in o) {
+    fn.apply(this,[i,o[i]]);  
+    if (o[i] !== null && typeof(o[i])=="object") {
+      traverseObjectRecursivelyAndApplyFunction(o[i], fn);
+    }
+  }
+}
+
+function isObjectJSONSchema(schema: any): schema is JSONSchemaObjectType {
+  return schema &&  schema.type === 'object'
+}
+
+function validateObjectHaveAdditionalPropertiesForbidden(schema: AnySchema): void {
+  if (isObjectJSONSchema(schema)) {
+    if (schema.additionalProperties !== false) {
+      throw new Error("All objects in schema need to have additional properties disabled")
+    }
+  }
+}
+
 export class SchemaValidation {
   STANDARD_VERSION = '2020-12'
 
@@ -20,5 +47,6 @@ export class SchemaValidation {
       const errorMessages = this._validator.errorsText()
       throw new Error(`Validation Error: ${errorMessages}`)
     }
+    traverseObjectRecursivelyAndApplyFunction(schema, validateObjectHaveAdditionalPropertiesForbidden)
   }
 }

--- a/packages/stream-model-handler/src/schema-utils.ts
+++ b/packages/stream-model-handler/src/schema-utils.ts
@@ -1,16 +1,27 @@
 
 import ajv, { SchemaObject } from 'ajv/dist/2020.js'
 
+/**
+ * A type that we use to check if object properties within JSON Schema schemas
+ * allow for additional properties.
+ * 
+ * According to JSON Schema standard, object properties within a valid schema have
+ * type field set to 'object' and an optional additionalProperties field that can have a boolean
+ * value or a value which is another JSON Schema property schema describing the shape of allowed additional properties
+ */
 type JSONSchemaObjectType = {
   type: 'object',
   additionalProperties?: boolean
 }
 
+/**
+ * Takes the schema and applies the fn function to it and its object properties recursively.
+ * 
+ * @param schema a SchemaObject schema from JSON Schema standard
+ * @param fn a function taking schema's properties and calls recursiveMap recursively on them, if they're object properties
+ * 
+ */
 function recursiveMap(schema: SchemaObject, fn: (schemaProperty: object) => void) {
-  /**
-   * Takes the schema and applies the fn function to it,
-   * Next, it iterates through all schema's object-type properties and applies itself recursively to them 
-   */
   fn(schema)
   Object.getOwnPropertyNames(schema).forEach((schemaPropertyName) => {
     if (schema[schemaPropertyName] !== null && typeof(schema[schemaPropertyName]) == "object") {
@@ -19,15 +30,26 @@ function recursiveMap(schema: SchemaObject, fn: (schemaProperty: object) => void
   })
 }
 
+/**
+ * A typescript type guard function to verify if the input is a JSONSchemaObjectType
+ * 
+ * @param schema - input of any type
+ * @returns true iff schema is not null or underfined and it has a type property which equals to 'object'
+ * 
+ * We use this function to traverse JSON Schema schemas and check which property describes an object.
+ * According to JSON Schema standard, object properties have type fields set to 'object'.
+ */
 function isObjectJSONSchema(schema: any): schema is JSONSchemaObjectType {
   return schema &&  schema.type === 'object'
 }
 
+/**
+ * Verifies that a JSON Schema schema has additional properties disabled, if it's an object schema
+ * 
+ * @param schema: a SchemaObject schema
+ * @throws if the schema is an object schema that allows for additional properties
+ */
 function validateAdditionalProperties(schema: SchemaObject): void {
-  /**
-   * Checks if schema is of JSONSchemaObjectType type and if so
-   * if makes if the schema has additionalProperties set to false (it throws an error otherwise)
-   */
   if (isObjectJSONSchema(schema)) {
     if (schema.additionalProperties !== false) {
       throw new Error("All objects in schema need to have additional properties disabled")


### PR DESCRIPTION
…del's schema doesn't have additional properties disabled

## Description

We shouldn't allow models to use schemas that allow additional properties.  The Model streamtype should error if a user tries to create a schema that doesn't explicitly set additionalProperties:false

## How Has This Been Tested?

- [x] Built and ran ceramic daemon locally
- [x] Added additional test cased to the suite testing `packages/stream-model-handler/schema-utils/SchemaValidation`

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
