### PR TITLE
Feat/stream model schema validation net 1452

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ lerna-debug.log
 *.iml
 docs/
 .run/
+.yarn.lock
+.DS_Store
 
 packages/*/lib/
 packages/*/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ lerna-debug.log
 *.iml
 docs/
 .run/
-.yarn.lock
-.DS_Store
 
 packages/*/lib/
 packages/*/node_modules/

--- a/packages/stream-model-handler/src/__tests__/__snapshots__/model-handler.test.ts.snap
+++ b/packages/stream-model-handler/src/__tests__/__snapshots__/model-handler.test.ts.snap
@@ -10,8 +10,21 @@ Object {
   "anchorStatus": 3,
   "content": Object {
     "accountRelation": "list",
-    "name": "myModel",
-    "schema": Object {},
+    "name": "MyModel",
+    "schema": Object {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": Object {
+        "stringPropName": Object {
+          "maxLength": 80,
+          "type": "string",
+        },
+      },
+      "required": Array [
+        "stringPropName",
+      ],
+      "type": "object",
+    },
   },
   "log": Array [
     Object {
@@ -183,8 +196,21 @@ Object {
   "anchorStatus": 0,
   "content": Object {
     "accountRelation": "list",
-    "name": "myModel",
-    "schema": Object {},
+    "name": "MyModel",
+    "schema": Object {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": Object {
+        "stringPropName": Object {
+          "maxLength": 80,
+          "type": "string",
+        },
+      },
+      "required": Array [
+        "stringPropName",
+      ],
+      "type": "object",
+    },
   },
   "log": Array [
     Object {
@@ -269,8 +295,21 @@ Object {
   "anchorStatus": 0,
   "content": Object {
     "accountRelation": "list",
-    "name": "myModel",
-    "schema": Object {},
+    "name": "MyModel",
+    "schema": Object {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": Object {
+        "stringPropName": Object {
+          "maxLength": 80,
+          "type": "string",
+        },
+      },
+      "required": Array [
+        "stringPropName",
+      ],
+      "type": "object",
+    },
   },
   "log": Array [
     Object {
@@ -475,8 +514,21 @@ Object {
   "next": Object {
     "content": Object {
       "accountRelation": "list",
-      "name": "myModel",
-      "schema": Object {},
+      "name": "MyModel",
+      "schema": Object {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": Object {
+          "stringPropName": Object {
+            "maxLength": 80,
+            "type": "string",
+          },
+        },
+        "required": Array [
+          "stringPropName",
+        ],
+        "type": "object",
+      },
     },
     "metadata": Object {
       "controllers": Array [

--- a/packages/stream-model-handler/src/__tests__/model-handler.test.ts
+++ b/packages/stream-model-handler/src/__tests__/model-handler.test.ts
@@ -319,7 +319,7 @@ describe('ModelHandler', () => {
     .toThrow(`Validation Error: data/$defs must be object, data/properties/stringPropName/type must be equal to one of the allowed values, data/properties/stringPropName/type must be array, data/properties/stringPropName/type must match a schema in anyOf, data/required must be array`)
   })
 
-  it('fails to make signed commit with invalid schema', async () => {
+  it('fails to apply signed commit with invalid schema', async () => {
     const modelHandler = new ModelHandler()
 
     const genesisCommit = (await Model._makeGenesis(

--- a/packages/stream-model-handler/src/__tests__/model-handler.test.ts
+++ b/packages/stream-model-handler/src/__tests__/model-handler.test.ts
@@ -78,9 +78,37 @@ const jwsForVersion1 = {
 const PLACEHOLDER_CONTENT = { name: 'myModel' }
 
 const FINAL_CONTENT = {
-  name: 'myModel',
-  schema: {},
+  name: 'MyModel',
   accountRelation: ModelAccountRelation.LIST,
+  schema: {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: 'object',
+    properties: {
+      stringPropName: {
+        type: 'string',
+        maxLength: 80,
+      },
+    },
+    additionalProperties: false,
+    required: ['stringPropName'],
+  },
+}
+
+const CONTENT_WITH_INVALID_SCHEMA = {
+  name: 'MyModel',
+  accountRelation: ModelAccountRelation.LIST,
+  schema: {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: 'object',
+    properties: {
+      stringPropName: {
+        type: 'CLEARLY_A_WRONG_TYPE',
+      },
+    },
+    $defs: ['$DEFS_SHOULD_BE_AN_OBJECT'],
+    additionalProperties: false,
+    required: 'THIS_SHOULD_BE_AN_ARRAY_OF_STRINGS',
+  },
 }
 
 const serialize = (data: any): any => {
@@ -270,6 +298,70 @@ describe('ModelHandler', () => {
 
   it('is constructed correctly', async () => {
     expect(modelHandler.name).toEqual('model')
+  })
+
+  it('fails to apply genesis commits with invalid schema', async () => {
+    const modelHandler = new ModelHandler()
+    const commit = (await Model._makeGenesis(context.api, CONTENT_WITH_INVALID_SCHEMA)) as SignedCommitContainer
+    await context.ipfs.dag.put(commit, FAKE_CID_1)
+
+    const payload = dagCBOR.decode(commit.linkedBlock)
+    await context.ipfs.dag.put(payload, commit.jws.link)
+
+    const commitData = {
+      cid: FAKE_CID_1,
+      type: CommitType.GENESIS,
+      commit: payload,
+      envelope: commit.jws,
+    }
+    expect(modelHandler.applyCommit(commitData, context))
+    .rejects
+    .toThrow(`Validation Error: data/$defs must be object, data/properties/stringPropName/type must be equal to one of the allowed values, data/properties/stringPropName/type must be array, data/properties/stringPropName/type must match a schema in anyOf, data/required must be array`)
+  })
+
+  it('fails to make signed commit with invalid schema', async () => {
+    const modelHandler = new ModelHandler()
+
+    const genesisCommit = (await Model._makeGenesis(
+      context.api,
+      PLACEHOLDER_CONTENT
+    )) as SignedCommitContainer
+    await context.ipfs.dag.put(genesisCommit, FAKE_CID_1)
+
+    const payload = dagCBOR.decode(genesisCommit.linkedBlock)
+    await context.ipfs.dag.put(payload, genesisCommit.jws.link)
+
+    // apply genesis
+    const genesisCommitData = {
+      cid: FAKE_CID_1,
+      type: CommitType.GENESIS,
+      commit: payload,
+      envelope: genesisCommit.jws,
+    }
+    const state = await modelHandler.applyCommit(genesisCommitData, context)
+
+    const state$ = TestUtils.runningState(state)
+    const doc = new Model(state$, context)
+    const signedCommit = (await doc._makeCommit(
+      context.api,
+      CONTENT_WITH_INVALID_SCHEMA
+    )) as SignedCommitContainer
+
+    await context.ipfs.dag.put(signedCommit, FAKE_CID_2)
+
+    const sPayload = dagCBOR.decode(signedCommit.linkedBlock)
+    await context.ipfs.dag.put(sPayload, signedCommit.jws.link)
+
+    // apply signed
+    const signedCommitData = {
+      cid: FAKE_CID_2,
+      type: CommitType.SIGNED,
+      commit: sPayload,
+      envelope: signedCommit.jws,
+    }
+    expect(modelHandler.applyCommit(signedCommitData, context, state))
+    .rejects
+    .toThrow(`Validation Error: data/$defs must be object, data/properties/stringPropName/type must be equal to one of the allowed values, data/properties/stringPropName/type must be array, data/properties/stringPropName/type must match a schema in anyOf, data/required must be array`)
   })
 
   it('makes genesis commits correctly', async () => {

--- a/packages/stream-model-handler/src/__tests__/schema-utils.test.ts
+++ b/packages/stream-model-handler/src/__tests__/schema-utils.test.ts
@@ -1,0 +1,40 @@
+import { SchemaValidation } from "../schema-utils"
+
+describe('SchemaValidation', () => {  
+  let schemaValidator: SchemaValidation
+
+  beforeAll(async () => {
+    schemaValidator = new SchemaValidation()
+  })
+
+  it('validates correct 2020-12 schema', async () => {
+    expect(schemaValidator.validateSchema({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: 'object',
+      props: {
+        stringPropName: {
+          type: 'string',
+          maxLength: 80,
+        },
+      },
+      additionallyProperties: false,
+      required: ['stringPropName'],
+    })).resolves.not.toThrow()
+  })
+  it('returns false for an incorrect 2020-12 schema', async () => {
+    expect(schemaValidator.validateSchema({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: 'object',
+      properties: {
+        stringPropName: {
+          type: 'CLEARLY_A_WRONG_TYPE',
+        },
+      },
+      $defs: ['$DEFS_SHOULD_BE_AN_OBJECT'],
+      additionalProperties: false,
+      required: 'THIS_SHOULD_BE_AN_ARRAY_OF_STRINGS',
+    }))
+    .rejects
+    .toThrow("Validation Error: data/$defs must be object, data/properties/stringPropName/type must be equal to one of the allowed values, data/properties/stringPropName/type must be array, data/properties/stringPropName/type must match a schema in anyOf, data/required must be array")
+  }) 
+})

--- a/packages/stream-model-handler/src/__tests__/schema-utils.test.ts
+++ b/packages/stream-model-handler/src/__tests__/schema-utils.test.ts
@@ -1,4 +1,4 @@
-import { SchemaValidation } from "../schema-utils"
+import { SchemaValidation } from "../schema-utils.js"
 
 describe('SchemaValidation', () => {  
   let schemaValidator: SchemaValidation

--- a/packages/stream-model-handler/src/model-handler.ts
+++ b/packages/stream-model-handler/src/model-handler.ts
@@ -14,11 +14,14 @@ import {
   StreamUtils,
 } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
+import { SchemaValidation } from './schema-utils'
 
 /**
  * Model stream handler implementation
  */
 export class ModelHandler implements StreamHandler<Model> {
+  private readonly _schemaValidator: SchemaValidation
+
   get type(): number {
     return Model.STREAM_TYPE_ID
   }
@@ -29,6 +32,10 @@ export class ModelHandler implements StreamHandler<Model> {
 
   get stream_constructor(): StreamConstructor<Model> {
     return Model
+  }
+
+  constructor() {
+    this._schemaValidator = new SchemaValidation()
   }
 
   /**
@@ -99,6 +106,10 @@ export class ModelHandler implements StreamHandler<Model> {
       log: [{ cid: commitData.cid, type: CommitType.GENESIS }],
     }
 
+    if (state.content.schema !== undefined) {
+      await this._schemaValidator.validateSchema(state.content.schema)
+    }
+    
     return state
   }
 
@@ -167,6 +178,10 @@ export class ModelHandler implements StreamHandler<Model> {
     nextState.next = {
       content: newContent,
       metadata, // No way to update metadata for Model streams
+    }
+
+    if (newContent.schema !== undefined) {
+      await this._schemaValidator.validateSchema(newContent.schema)
     }
 
     return nextState

--- a/packages/stream-model-handler/src/model-handler.ts
+++ b/packages/stream-model-handler/src/model-handler.ts
@@ -14,7 +14,7 @@ import {
   StreamUtils,
 } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
-import { SchemaValidation } from './schema-utils'
+import { SchemaValidation } from './schema-utils.js'
 
 /**
  * Model stream handler implementation

--- a/packages/stream-model-handler/src/schema-utils.ts
+++ b/packages/stream-model-handler/src/schema-utils.ts
@@ -1,0 +1,24 @@
+
+import ajv, { AnySchema } from 'ajv/dist/2020'
+
+export class SchemaValidation {
+  STANDARD_VERSION = '2020-12'
+
+  private readonly _validator = new ajv({
+    strict: true,
+    allErrors: true,
+    allowMatchingProperties: false,
+    ownProperties: false,
+    unevaluated: false,
+  })
+
+  public async validateSchema(
+    schema: AnySchema
+  ): Promise<void> {
+    const isValid = await this._validator.validateSchema(schema)
+    if (!isValid) {
+      const errorMessages = this._validator.errorsText()
+      throw new Error(`Validation Error: ${errorMessages}`)
+    }
+  }
+}

--- a/packages/stream-model-handler/src/schema-utils.ts
+++ b/packages/stream-model-handler/src/schema-utils.ts
@@ -1,5 +1,5 @@
 
-import ajv, { AnySchema } from 'ajv/dist/2020'
+import ajv, { AnySchema } from 'ajv/dist/2020.js'
 
 export class SchemaValidation {
   STANDARD_VERSION = '2020-12'

--- a/packages/stream-model/src/model.ts
+++ b/packages/stream-model/src/model.ts
@@ -18,7 +18,7 @@ import {
   GenesisHeader,
 } from '@ceramicnetwork/common'
 import { CommitID, StreamID, StreamRef } from '@ceramicnetwork/streamid'
-import type { JSONSchema } from 'json-schema-typed/draft-07'
+import type { JSONSchema } from 'json-schema-typed/draft-2020-12'
 import { CID } from 'multiformats/cid'
 import { create } from 'multiformats/hashes/digest'
 import { code, encode } from '@ipld/dag-cbor'


### PR DESCRIPTION
## Description

This is the second PR for the same feature. The first one was merged, but reverted because `ceramic.js deamon` was failing with a missing import:
```
$node bin/ceramic.js daemon
node:internal/errors:465
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/arturwdowiarski/src/js-ceramic/packages/stream-model-handler/lib/schema-utils' imported from /Users/arturwdowiarski/src/js-ceramic/packages/stream-model-handler/lib/model-handler.js
```

This problem was fixed and the PR is created again with this fix.

Original description:

Add ajv strict validation of json-schemas to Model

Use draft 2020-12 for validation: https://ajv.js.org/json-schema.html#draft-2020-12

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x] Built and ran ceramic daemon locally on this branch
- [x] Wrote tests for the new SchemaValidation class in packages/stream-model-handler
- [x] Wrote tests for the ModelHandler in packages/stream-model-handler to make sure commits are only applied to Models, if their schema conforms to JSON Schema standard (unless they don't have schema)


## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
