### PR TITLE
feat: Make IndexAPI call the database

### DIFF
--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -203,7 +203,6 @@ export class Ceramic implements CeramicApi {
     this._gateway = params.gateway
     this._networkOptions = params.networkOptions
     this._loadOptsOverride = params.loadOptsOverride
-    this._index = new LocalIndexApi(modules.indexing)
 
     this.context = {
       api: this,
@@ -234,6 +233,7 @@ export class Ceramic implements CeramicApi {
       anchorService: modules.anchorService,
       conflictResolution: conflictResolution,
     })
+    this._index = new LocalIndexApi(modules.indexing, this.repository, this._logger)
   }
 
   get index(): IndexApi {

--- a/packages/core/src/indexing/__tests__/index-api.test.ts
+++ b/packages/core/src/indexing/__tests__/index-api.test.ts
@@ -1,0 +1,69 @@
+import { jest } from '@jest/globals'
+import type { DatabaseIndexApi } from '../database-index-api.js'
+import type { Repository } from '../../state-management/repository.js'
+import type { DiagnosticsLogger, Page, StreamState } from '@ceramicnetwork/common'
+import { IndexApi } from '../index-api.js'
+import { CommitType, SyncOptions, TestUtils } from '@ceramicnetwork/common'
+import { randomString } from '@stablelib/random'
+
+const randomInt = (max: number) => Math.floor(Math.random() * max)
+
+describe('with database backend', () => {
+  test('return page from the database', async () => {
+    const query = { model: 'foo', first: randomInt(100) }
+    const backendPage: Page<string> = {
+      entries: Array.from({ length: query.first }).map(() => randomString(3)),
+      pageInfo: {
+        hasPreviousPage: true,
+        hasNextPage: true,
+        startCursor: 'startCursor',
+        endCursor: 'endCursor',
+      },
+    }
+    const pageFn = jest.fn(async () => backendPage)
+    const loadFn = jest.fn(async (streamId: any) => {
+      const fauxStreamState = {
+        type: 1,
+        content: streamId,
+        log: [{ cid: TestUtils.randomCID(), type: CommitType.GENESIS }],
+      } as unknown as StreamState
+      return TestUtils.runningState(fauxStreamState)
+    })
+    const fauxBackend = { page: pageFn } as unknown as DatabaseIndexApi
+    const fauxRepository = { load: loadFn } as unknown as Repository
+    const fauxLogger = {} as DiagnosticsLogger
+    const indexApi = new IndexApi(fauxBackend, fauxRepository, fauxLogger)
+    const response = await indexApi.queryIndex(query)
+    // Call databaseIndexApi::page function
+    expect(pageFn).toBeCalledTimes(1)
+    expect(pageFn).toBeCalledWith(query)
+    // We pass pageInfo through
+    expect(response.pageInfo).toEqual(backendPage.pageInfo)
+    // Transform from StreamId to StreamState via repository.load
+    expect(loadFn).toBeCalledTimes(query.first)
+    backendPage.entries.forEach((fauxStreamId) => {
+      expect(loadFn).toBeCalledWith(fauxStreamId, { sync: SyncOptions.NEVER_SYNC })
+    })
+    expect(response.entries.map((e) => e.content)).toEqual(backendPage.entries)
+  })
+})
+
+describe('without database backend', () => {
+  test('return an empty response', async () => {
+    const fauxRepository = {} as unknown as Repository
+    const warnFn = jest.fn()
+    const fauxLogger = { warn: warnFn } as unknown as DiagnosticsLogger
+    const indexApi = new IndexApi(undefined, fauxRepository, fauxLogger)
+    const response = await indexApi.queryIndex({ model: 'foo', first: 5 })
+    // Return an empty response
+    expect(response).toEqual({
+      entries: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
+    })
+    // Log a warning
+    expect(warnFn).toBeCalledTimes(1)
+  })
+})

--- a/packages/core/src/indexing/database-index-api.ts
+++ b/packages/core/src/indexing/database-index-api.ts
@@ -20,7 +20,7 @@ export interface DatabaseIndexApi {
   indexStream(args: IndexStreamArgs): Promise<void>
 
   /**
-   * Query the index
+   * Query the index.
    */
   page(query: BaseQuery & Pagination): Promise<Page<StreamID>>
 

--- a/packages/core/src/indexing/local-index-api.ts
+++ b/packages/core/src/indexing/local-index-api.ts
@@ -1,15 +1,51 @@
-import type { BaseQuery, IndexApi, Page, Pagination, StreamState } from '@ceramicnetwork/common'
+import type {
+  BaseQuery,
+  IndexApi,
+  Page,
+  Pagination,
+  StreamState,
+  DiagnosticsLogger,
+} from '@ceramicnetwork/common'
+import { SyncOptions } from '@ceramicnetwork/common'
 import type { DatabaseIndexApi } from './database-index-api.js'
-import { NotImplementedError } from './not-implemented-error.js'
+import type { Repository } from '../state-management/repository.js'
 
+/**
+ * API to query an index.
+ */
 export class LocalIndexApi implements IndexApi {
-  constructor(private readonly databaseIndexApi: DatabaseIndexApi | undefined) {}
+  constructor(
+    private readonly databaseIndexApi: DatabaseIndexApi | undefined,
+    private readonly repository: Repository,
+    private readonly logger: DiagnosticsLogger
+  ) {}
 
-  queryIndex(query: BaseQuery & Pagination): Promise<Page<StreamState>> {
-    throw new NotImplementedError('IndexApi::queryIndex')
-  }
-
-  async init(): Promise<void> {
-    await this.databaseIndexApi.init()
+  /**
+   * Query the index. Ask an indexing database for a list of StreamIDs,
+   * and convert them to corresponding StreamState instances via `Repository::load`.
+   */
+  async queryIndex(query: BaseQuery & Pagination): Promise<Page<StreamState>> {
+    if (this.databaseIndexApi) {
+      const page = await this.databaseIndexApi.page(query)
+      const streamStates = await Promise.all(
+        page.entries.map(async (streamId) => {
+          const running = await this.repository.load(streamId, { sync: SyncOptions.NEVER_SYNC })
+          return running.state
+        })
+      )
+      return {
+        ...page,
+        entries: streamStates,
+      }
+    } else {
+      this.logger.warn(`Indexing is not configured. Unable to serve query ${JSON.stringify(query)}`)
+      return {
+        entries: [],
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+        },
+      }
+    }
   }
 }

--- a/packages/core/src/indexing/local-index-api.ts
+++ b/packages/core/src/indexing/local-index-api.ts
@@ -30,6 +30,7 @@ export class LocalIndexApi implements IndexApi {
     if (this.databaseIndexApi) {
       const page = await this.databaseIndexApi.page(query)
       const streamStates = await Promise.all(
+        // For database queries we bypass the stream cache and repository loading queue
         page.entries.map((streamId) => this.repository.streamState(streamId))
       )
       return {

--- a/packages/core/src/indexing/local-index-api.ts
+++ b/packages/core/src/indexing/local-index-api.ts
@@ -33,8 +33,8 @@ export class LocalIndexApi implements IndexApi {
         page.entries.map((streamId) => this.repository.streamState(streamId))
       )
       return {
-        ...page,
         entries: streamStates,
+        pageInfo: page.pageInfo,
       }
     } else {
       this.logger.warn(`Indexing is not configured. Unable to serve query ${JSON.stringify(query)}`)

--- a/packages/core/src/indexing/local-index-api.ts
+++ b/packages/core/src/indexing/local-index-api.ts
@@ -48,4 +48,8 @@ export class LocalIndexApi implements IndexApi {
       }
     }
   }
+
+  async init(): Promise<void> {
+    await this.databaseIndexApi.init()
+  }
 }


### PR DESCRIPTION
Potential controversies:
- We might have indexing database backend not configured. It makes the `queryIndex` method return an empty page. We also log a warning for every query.
- Use `Repository::streamState` to load StreamState for StreamID. We assume that a state store always contains StreamState for an indexed stream.

Base branch is not `development` to reduce mental overhead for reviewing.