### PR TITLE
feat(3id-did-resolver): throw error on failed multiquery

### DIFF
--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -194,6 +194,7 @@ const resolve = async (
   }
   const resp = await ceramic.multiQuery(query)
 
+  if (!resp[didId]) throw new Error(`Failed to properly resolve 3ID, stream ${didId} not found in response.`)
   const latestVersionState = resp[didId].state
   const commitIdStr = commitId?.toString() || Object.keys(resp).find((k) => k !== didId)
   const requestedVersionState = resp[commitIdStr]?.state || latestVersionState


### PR DESCRIPTION
Disco team reported the following error: 
```
Uncaught (in promise) Error: Failed to resolve did:3:kjzl6cwe1jw145cszwj09gmsiolltkxvr75uxm40c6zpi3i58ltg78gg1o3c4xo?version-id=0#i31x2JpQ5fbVLsy: invalidDid, TypeError: Cannot read properties of undefined (reading 'state')
```

I suspect this might be because of a multiquery that is not properly resolving. However, it's been difficult to replicate the issue. In this PR an error is thrown if this happens, so that we can validate the hypothesis the next time this error happens.