### PR TITLE
feat: Implement IndexAPI on http client side

### DIFF
--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -634,6 +634,7 @@ describe('Ceramic interop: core <> http-client', () => {
       test('model in query', async () => {
         const query = new URL(`http://localhost:${daemon.port}/api/v0/collection`)
         query.searchParams.set('model', MODEL_STREAM_ID.toString())
+        query.searchParams.set('first', '100')
         const indexSpy = jest.spyOn(daemon.ceramic.index, 'queryIndex')
         await fetchJson(query.toString())
         expect(indexSpy).toBeCalledWith({
@@ -645,6 +646,7 @@ describe('Ceramic interop: core <> http-client', () => {
         const query = new URL(`http://localhost:${daemon.port}/api/v0/collection`)
         query.searchParams.set('model', MODEL_STREAM_ID.toString())
         query.searchParams.set('account', randomString(10))
+        query.searchParams.set('first', '100')
         const indexSpy = jest.spyOn(daemon.ceramic.index, 'queryIndex')
         await fetchJson(query.toString())
         expect(indexSpy).toBeCalledWith({
@@ -656,6 +658,7 @@ describe('Ceramic interop: core <> http-client', () => {
       test('serialize StreamState', async () => {
         const query = new URL(`http://localhost:${daemon.port}/api/v0/collection`)
         query.searchParams.set('model', MODEL_STREAM_ID.toString())
+        query.searchParams.set('first', '100')
         const original = daemon.ceramic.index.queryIndex.bind(daemon.ceramic.index)
         const fauxStreamState = {
           type: 0,

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -453,8 +453,7 @@ export class CeramicDaemon {
 
   async getCollection(req: Request, res: Response): Promise<void> {
     const httpQuery = parseQueryObject(req.query)
-    const defaultPagination = { first: 100 }
-    const query = collectionQuery(httpQuery, defaultPagination)
+    const query = collectionQuery(httpQuery)
     const indexResponse = await this.ceramic.index.queryIndex(query)
     res.json({
       entries: indexResponse.entries.map(StreamUtils.serializeState),

--- a/packages/cli/src/daemon/__tests__/collection-query.test.ts
+++ b/packages/cli/src/daemon/__tests__/collection-query.test.ts
@@ -1,51 +1,46 @@
-import { collectionQuery, parsePagination } from '../collection-query.js'
+import { collectionQuery, InvalidPaginationError, parsePagination } from '../collection-query.js'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { TestUtils } from '@ceramicnetwork/common'
-
-const DEFAULT_PAGINATION = { first: Math.floor(Math.random() * 100) }
 
 describe('parsePagination', () => {
   test('parse forward pagination', () => {
     const query = { first: 10, after: 'foo', bar: 'baz', before: 'blah' }
-    expect(parsePagination(query, DEFAULT_PAGINATION)).toEqual({ first: 10, after: 'foo' })
+    expect(parsePagination(query)).toEqual({ first: 10, after: 'foo' })
   })
   test('parse backward pagination', () => {
     const query = { last: 10, before: 'foo', bar: 'baz', after: 'blah' }
-    expect(parsePagination(query, DEFAULT_PAGINATION)).toEqual({ last: 10, before: 'foo' })
+    expect(parsePagination(query)).toEqual({ last: 10, before: 'foo' })
   })
   test('prefer forward', () => {
-    expect(parsePagination({ first: 10, last: 10 }, DEFAULT_PAGINATION)).toEqual({ first: 10 })
+    expect(parsePagination({ first: 10, last: 10 })).toEqual({ first: 10 })
   })
-  test('use default', () => {
+  test('throw if can not parse', () => {
     // Empty input
-    expect(parsePagination({}, DEFAULT_PAGINATION)).toEqual(DEFAULT_PAGINATION)
+    expect(() => parsePagination({})).toThrow(InvalidPaginationError)
     // Non-integer first
-    expect(parsePagination({ first: 0.3 }, DEFAULT_PAGINATION)).toEqual(DEFAULT_PAGINATION)
+    expect(() => parsePagination({ first: 0.3 })).toThrow(InvalidPaginationError)
     // Negative first
-    expect(parsePagination({ first: -10 }, DEFAULT_PAGINATION)).toEqual(DEFAULT_PAGINATION)
+    expect(() => parsePagination({ first: -10 })).toThrow(InvalidPaginationError)
     // Non-integer last
-    expect(parsePagination({ last: 0.3 }, DEFAULT_PAGINATION)).toEqual(DEFAULT_PAGINATION)
+    expect(() => parsePagination({ last: 0.3 })).toThrow(InvalidPaginationError)
     // Negative last
-    expect(parsePagination({ last: -10 }, DEFAULT_PAGINATION)).toEqual(DEFAULT_PAGINATION)
+    expect(() => parsePagination({ last: -10 })).toThrow(InvalidPaginationError)
   })
 })
 
 describe('collectionQuery', () => {
   const model = new StreamID(1, TestUtils.randomCID())
   test('parse model', () => {
-    const parsed = collectionQuery({ first: 10, model: model.toString() }, DEFAULT_PAGINATION)
+    const parsed = collectionQuery({ first: 10, model: model.toString() })
     expect(parsed).toEqual({ first: 10, model: model })
   })
   test('throw on invalid model', () => {
     expect(() => {
-      collectionQuery({ first: 10, model: 'garbage' }, DEFAULT_PAGINATION)
+      collectionQuery({ first: 10, model: 'garbage' })
     }).toThrow()
   })
   test('pass account', () => {
-    const parsed = collectionQuery(
-      { first: 10, model: model.toString(), account: 'did:key:foo' },
-      DEFAULT_PAGINATION
-    )
+    const parsed = collectionQuery({ first: 10, model: model.toString(), account: 'did:key:foo' })
     expect(parsed).toEqual({ first: 10, model: model, account: 'did:key:foo' })
   })
 })

--- a/packages/common/src/utils/http-utils.ts
+++ b/packages/common/src/utils/http-utils.ts
@@ -10,7 +10,7 @@ interface FetchOpts {
   signal?: AbortSignal
 }
 
-export async function fetchJson(url: string, opts: FetchOpts = {}): Promise<any> {
+export async function fetchJson(url: URL | string, opts: FetchOpts = {}): Promise<any> {
   if (opts.body) {
     Object.assign(opts, {
       body: JSON.stringify(opts.body),
@@ -25,7 +25,7 @@ export async function fetchJson(url: string, opts: FetchOpts = {}): Promise<any>
     ? mergeAbortSignals([opts.signal, timedAbortSignal.signal])
     : timedAbortSignal.signal
 
-  const res = await fetch(url, opts).finally(() => timedAbortSignal.clear())
+  const res = await fetch(String(url), opts).finally(() => timedAbortSignal.clear())
 
   if (!res.ok) {
     const text = await res.text()

--- a/packages/http-client/src/__tests__/document.test.ts
+++ b/packages/http-client/src/__tests__/document.test.ts
@@ -28,7 +28,7 @@ test('emit on distinct changes', async () => {
     ],
   } as unknown as StreamState
 
-  const state$ = new Document(initial, '', 1000)
+  const state$ = new Document(initial, 'https://example.com', 1000)
   // Disable background polling to avoid getting an error from node-fetch since there's no
   // daemon listening to receive the requests.
   state$._syncState = async function () {
@@ -87,7 +87,7 @@ describe('periodic subscription', () => {
         },
       ],
     } as unknown as StreamState
-    const document = new Document(initial, '', SYNC_INTERVAL)
+    const document = new Document(initial, 'https://example.com', SYNC_INTERVAL)
     // Every Document#_syncState we commit when it was called.
     // Also we track how many invocations happened to stop after enough samples are acquired.
     const invocations = []
@@ -118,7 +118,7 @@ describe('periodic subscription', () => {
         },
       ],
     } as unknown as StreamState
-    const document = new Document(initial, '', SYNC_INTERVAL)
+    const document = new Document(initial, 'https://example.com', SYNC_INTERVAL)
     // Every Document#_syncState we commit when it was called.
     // Also we track how many invocations happened to stop after enough samples are acquired.
     const invocations = []

--- a/packages/http-client/src/__tests__/remote-index-api.test.ts
+++ b/packages/http-client/src/__tests__/remote-index-api.test.ts
@@ -1,0 +1,51 @@
+import { jest } from '@jest/globals'
+import { RemoteIndexApi } from '../remote-index-api.js'
+import { CommitType, fetchJson, StreamState, TestUtils } from '@ceramicnetwork/common'
+import { StreamID } from '@ceramicnetwork/streamid'
+
+const FAUX_ENDPOINT = new URL('https://example.com')
+const MODEL = new StreamID(1, TestUtils.randomCID())
+
+const EMPTY_RESPONSE = {
+  entries: [],
+  pageInfo: {},
+}
+const FAUX_STREAM_STATE = {
+  type: 0,
+  log: [
+    {
+      type: CommitType.GENESIS,
+      cid: TestUtils.randomCID(),
+    },
+  ],
+} as unknown as StreamState
+
+test('model in query', async () => {
+  const fauxFetch = jest.fn(async () => EMPTY_RESPONSE) as typeof fetchJson
+  const indexApi = new RemoteIndexApi(FAUX_ENDPOINT, fauxFetch)
+  const result = await indexApi.queryIndex({ model: MODEL, first: 5 })
+  expect(result).toEqual(EMPTY_RESPONSE)
+  expect(fauxFetch).toBeCalledWith(new URL(`https://example.com/collection?model=${MODEL}&first=5`))
+})
+
+test('model, account in query', async () => {
+  const fauxFetch = jest.fn(async () => EMPTY_RESPONSE) as typeof fetchJson
+  const indexApi = new RemoteIndexApi(FAUX_ENDPOINT, fauxFetch)
+  const result = await indexApi.queryIndex({ model: MODEL, account: 'did:key:foo', first: 5 })
+  expect(result).toEqual(EMPTY_RESPONSE)
+  expect(fauxFetch).toBeCalledWith(
+    new URL(
+      `https://example.com/collection?model=${MODEL}&account=${encodeURIComponent(
+        'did:key:foo'
+      )}&first=5`
+    )
+  )
+})
+
+test('serialize stream stte', async () => {
+  const response = { ...EMPTY_RESPONSE, entries: [FAUX_STREAM_STATE] }
+  const fauxFetch = jest.fn(async () => response) as typeof fetchJson
+  const indexApi = new RemoteIndexApi(FAUX_ENDPOINT, fauxFetch)
+  const result = await indexApi.queryIndex({ model: MODEL, account: 'did:key:foo', first: 5 })
+  expect(result.entries[0]).toEqual(FAUX_STREAM_STATE)
+})

--- a/packages/http-client/src/__tests__/remote-index-api.test.ts
+++ b/packages/http-client/src/__tests__/remote-index-api.test.ts
@@ -42,7 +42,7 @@ test('model, account in query', async () => {
   )
 })
 
-test('serialize stream stte', async () => {
+test('serialize stream state', async () => {
   const response = { ...EMPTY_RESPONSE, entries: [FAUX_STREAM_STATE] }
   const fauxFetch = jest.fn(async () => response) as typeof fetchJson
   const indexApi = new RemoteIndexApi(FAUX_ENDPOINT, fauxFetch)

--- a/packages/http-client/src/__tests__/remote-index-api.test.ts
+++ b/packages/http-client/src/__tests__/remote-index-api.test.ts
@@ -22,7 +22,8 @@ const FAUX_STREAM_STATE = {
 
 test('model in query', async () => {
   const fauxFetch = jest.fn(async () => EMPTY_RESPONSE) as typeof fetchJson
-  const indexApi = new RemoteIndexApi(FAUX_ENDPOINT, fauxFetch)
+  const indexApi = new RemoteIndexApi(FAUX_ENDPOINT)
+  ;(indexApi as any)._fetchJson = fauxFetch
   const result = await indexApi.queryIndex({ model: MODEL, first: 5 })
   expect(result).toEqual(EMPTY_RESPONSE)
   expect(fauxFetch).toBeCalledWith(new URL(`https://example.com/collection?model=${MODEL}&first=5`))
@@ -30,7 +31,8 @@ test('model in query', async () => {
 
 test('model, account in query', async () => {
   const fauxFetch = jest.fn(async () => EMPTY_RESPONSE) as typeof fetchJson
-  const indexApi = new RemoteIndexApi(FAUX_ENDPOINT, fauxFetch)
+  const indexApi = new RemoteIndexApi(FAUX_ENDPOINT)
+  ;(indexApi as any)._fetchJson = fauxFetch
   const result = await indexApi.queryIndex({ model: MODEL, account: 'did:key:foo', first: 5 })
   expect(result).toEqual(EMPTY_RESPONSE)
   expect(fauxFetch).toBeCalledWith(
@@ -45,7 +47,8 @@ test('model, account in query', async () => {
 test('serialize stream state', async () => {
   const response = { ...EMPTY_RESPONSE, entries: [FAUX_STREAM_STATE] }
   const fauxFetch = jest.fn(async () => response) as typeof fetchJson
-  const indexApi = new RemoteIndexApi(FAUX_ENDPOINT, fauxFetch)
+  const indexApi = new RemoteIndexApi(FAUX_ENDPOINT)
+  ;(indexApi as any)._fetchJson = fauxFetch
   const result = await indexApi.queryIndex({ model: MODEL, account: 'did:key:foo', first: 5 })
   expect(result.entries[0]).toEqual(FAUX_STREAM_STATE)
 })

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -1,4 +1,4 @@
-import { combineURLs, typeStreamID } from './utils.js'
+import { typeStreamID } from './utils.js'
 import { Document } from './document.js'
 
 import type { DID } from 'dids'

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -28,7 +28,7 @@ import { StreamID, CommitID, StreamRef } from '@ceramicnetwork/streamid'
 import { RemotePinApi } from './remote-pin-api.js'
 import { RemoteIndexApi } from './remote-index-api.js'
 
-const API_PATH = '/api/v0'
+const API_PATH = '/api/v0/'
 const CERAMIC_HOST = 'http://localhost:7007'
 
 /**
@@ -60,7 +60,7 @@ export interface CeramicClientConfig {
  * Ceramic client implementation
  */
 export class CeramicClient implements CeramicApi {
-  private readonly _apiUrl: string
+  private readonly _apiUrl: URL
   /**
    * _streamCache stores handles to Documents that been handed out. This allows us
    * to update the state within the Document object when we learn about changes
@@ -81,7 +81,7 @@ export class CeramicClient implements CeramicApi {
   constructor(apiHost: string = CERAMIC_HOST, config: Partial<CeramicClientConfig> = {}) {
     this._config = { ...DEFAULT_CLIENT_CONFIG, ...config }
 
-    this._apiUrl = combineURLs(apiHost, API_PATH)
+    this._apiUrl = new URL(API_PATH, apiHost)
     // this._streamCache = new LRUMap(config.streamCacheLimit) Not now. We do not know what to do when stream is evicted on HTTP client.
     this._streamCache = new Map()
 
@@ -158,7 +158,8 @@ export class CeramicClient implements CeramicApi {
       }
     })
 
-    const results = await fetchJson(this._apiUrl + '/multiqueries', {
+    const url = new URL('./multiqueries', this._apiUrl)
+    const results = await fetchJson(url, {
       method: 'post',
       body: {
         queries: queriesJSON,

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -88,7 +88,7 @@ export class CeramicClient implements CeramicApi {
     this.context = { api: this }
 
     this.pin = new RemotePinApi(this._apiUrl)
-    this.index = new RemoteIndexApi()
+    this.index = new RemoteIndexApi(this._apiUrl)
 
     this._streamConstructors = {
       [Caip10Link.STREAM_TYPE_ID]: Caip10Link,

--- a/packages/http-client/src/remote-index-api.ts
+++ b/packages/http-client/src/remote-index-api.ts
@@ -1,7 +1,9 @@
 import type { BaseQuery, IndexApi, Page, Pagination, StreamState } from '@ceramicnetwork/common'
 
 export class RemoteIndexApi implements IndexApi {
-  queryIndex(query: BaseQuery & Pagination): Promise<Page<StreamState>> {
+  constructor(private readonly _apiUrl: string) {}
+
+  async queryIndex(query: BaseQuery & Pagination): Promise<Page<StreamState>> {
     throw new Error(`NotImplemented: RemoteIndexApi::queryIndex`)
   }
 }

--- a/packages/http-client/src/remote-index-api.ts
+++ b/packages/http-client/src/remote-index-api.ts
@@ -5,9 +5,10 @@ import { StreamUtils, fetchJson } from '@ceramicnetwork/common'
  * IndexAPI implementation on top of HTTP endpoint.
  */
 export class RemoteIndexApi implements IndexApi {
+  private readonly _fetchJson: typeof fetchJson = fetchJson
   private readonly _collectionURL: URL
 
-  constructor(apiUrl: URL, private readonly fetchJsonFn: typeof fetchJson = fetchJson) {
+  constructor(apiUrl: URL) {
     this._collectionURL = new URL('./collection', apiUrl)
   }
 
@@ -19,7 +20,7 @@ export class RemoteIndexApi implements IndexApi {
     for (const key in query) {
       queryURL.searchParams.set(key, query[key])
     }
-    const response = await this.fetchJsonFn(queryURL)
+    const response = await this._fetchJson(queryURL)
     const entries = response.entries.map(StreamUtils.deserializeState)
     return {
       entries: entries,

--- a/packages/http-client/src/remote-index-api.ts
+++ b/packages/http-client/src/remote-index-api.ts
@@ -5,6 +5,7 @@ import { StreamUtils, fetchJson } from '@ceramicnetwork/common'
  * IndexAPI implementation on top of HTTP endpoint.
  */
 export class RemoteIndexApi implements IndexApi {
+  // Stored as a member to make it easier to inject a mock in unit tests
   private readonly _fetchJson: typeof fetchJson = fetchJson
   private readonly _collectionURL: URL
 

--- a/packages/http-client/src/remote-index-api.ts
+++ b/packages/http-client/src/remote-index-api.ts
@@ -1,9 +1,29 @@
 import type { BaseQuery, IndexApi, Page, Pagination, StreamState } from '@ceramicnetwork/common'
+import { StreamUtils, fetchJson } from '@ceramicnetwork/common'
 
+/**
+ * IndexAPI implementation on top of HTTP endpoint.
+ */
 export class RemoteIndexApi implements IndexApi {
-  constructor(private readonly _apiUrl: URL) {}
+  private readonly _collectionURL: URL
 
+  constructor(apiUrl: URL, private readonly fetchJsonFn: typeof fetchJson = fetchJson) {
+    this._collectionURL = new URL('./collection', apiUrl)
+  }
+
+  /**
+   * Issue a query to `/collection` endpoint.
+   */
   async queryIndex(query: BaseQuery & Pagination): Promise<Page<StreamState>> {
-    throw new Error(`NotImplemented: RemoteIndexApi::queryIndex`)
+    const queryURL = new URL(this._collectionURL)
+    for (const key in query) {
+      queryURL.searchParams.set(key, query[key])
+    }
+    const response = await this.fetchJsonFn(queryURL)
+    const entries = response.entries.map(StreamUtils.deserializeState)
+    return {
+      entries: entries,
+      pageInfo: response.pageInfo,
+    }
   }
 }

--- a/packages/http-client/src/remote-index-api.ts
+++ b/packages/http-client/src/remote-index-api.ts
@@ -1,7 +1,7 @@
 import type { BaseQuery, IndexApi, Page, Pagination, StreamState } from '@ceramicnetwork/common'
 
 export class RemoteIndexApi implements IndexApi {
-  constructor(private readonly _apiUrl: string) {}
+  constructor(private readonly _apiUrl: URL) {}
 
   async queryIndex(query: BaseQuery & Pagination): Promise<Page<StreamState>> {
     throw new Error(`NotImplemented: RemoteIndexApi::queryIndex`)

--- a/packages/http-client/src/remote-pin-api.ts
+++ b/packages/http-client/src/remote-pin-api.ts
@@ -6,30 +6,32 @@ import { PublishOpts } from '@ceramicnetwork/common'
  * PinApi for Ceramic HTTP client
  */
 export class RemotePinApi implements PinApi {
-  constructor(private readonly _apiUrl: string) {}
+  constructor(private readonly _apiUrl: URL) {}
 
   async add(streamId: StreamID, force?: boolean): Promise<void> {
     const args: any = {}
     if (force) {
       args.force = true
     }
-    await fetchJson(this._apiUrl + '/pins' + `/${streamId.toString()}`, {
+    const url = new URL(`./pins/${streamId}`, this._apiUrl)
+    await fetchJson(url, {
       method: 'post',
       body: args,
     })
   }
 
   async rm(streamId: StreamID, opts?: PublishOpts): Promise<void> {
-    await fetchJson(this._apiUrl + '/pins' + `/${streamId.toString()}`, {
+    const url = new URL(`./pins/${streamId}`, this._apiUrl)
+    await fetchJson(url, {
       method: 'delete',
       body: { opts },
     })
   }
 
   async ls(streamId?: StreamID): Promise<AsyncIterable<string>> {
-    let url = this._apiUrl + '/pins'
+    let url = new URL('./pins', this._apiUrl)
     if (streamId) {
-      url += `/${streamId.toString()}`
+      url = new URL(`./pins/${streamId.toString()}`, this._apiUrl)
     }
     const result = await fetchJson(url)
     const { pinnedStreamIds } = result

--- a/packages/http-client/src/utils.ts
+++ b/packages/http-client/src/utils.ts
@@ -3,11 +3,3 @@ import { StreamID } from '@ceramicnetwork/streamid'
 export function typeStreamID(streamId: StreamID | string): StreamID {
   return typeof streamId === 'string' ? StreamID.fromString(streamId) : streamId
 }
-
-export function combineURLs(baseURL, relativeURL) {
-  return relativeURL ? baseURL.replace(/\/+$/, '') + '/' + relativeURL.replace(/^\/+/, '') : baseURL
-}
-
-export async function delay(mills: number): Promise<void> {
-  await new Promise<void>((resolve) => setTimeout(() => resolve(), mills))
-}


### PR DESCRIPTION
Core part:
- Make RemoteIndexApi call HTTP endpoint

Housekeeping:
- Use native JS URL extensively. We do not need `query-string` package anymore.