### PR TITLE
feat: Attempt to limit concurrent S3 reads

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
     "@ceramicnetwork/stream-tile": "^2.2.2",
     "@ceramicnetwork/streamid": "^2.1.0",
     "@stablelib/random": "^1.0.1",
+    "await-semaphore": "^0.1.3",
     "aws-sdk": "^2.1049.0",
     "commander": "^8.3.0",
     "cors": "^2.8.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,6 +58,7 @@
     "levelup": "^5.1.1",
     "morgan": "^1.10.0",
     "nft-did-resolver": "^2.0.0",
+    "p-queue": "^7.2.0",
     "picocolors": "^1.0.0",
     "pkh-did-resolver": "^1.0.2",
     "reflect-metadata": "^0.1.13",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,6 @@
     "@ceramicnetwork/stream-tile": "^2.2.2",
     "@ceramicnetwork/streamid": "^2.1.0",
     "@stablelib/random": "^1.0.1",
-    "await-semaphore": "^0.1.3",
     "aws-sdk": "^2.1049.0",
     "commander": "^8.3.0",
     "cors": "^2.8.5",

--- a/packages/cli/src/s3-state-store.ts
+++ b/packages/cli/src/s3-state-store.ts
@@ -4,14 +4,26 @@ import { StateStore } from '@ceramicnetwork/core'
 import LevelUp from 'levelup'
 import S3LevelDOWN from 's3leveldown'
 import toArray from 'stream-to-array'
+import PQueue from 'p-queue'
 
-const MAX_CONCURRENT_READS = 4000
+/**
+ * Maximum GET/HEAD requests per second to AWS S3
+ */
+const MAX_LOAD_RPS = 4000
 
 /**
  * Ceramic store for saving stream state to S3
  */
 export class S3StateStore implements StateStore {
   readonly #bucketName: string
+  /**
+   * Limit reading to +MAX_CONCURRENT_READS+ requests per second
+   */
+  readonly #loadingLimit = new PQueue({
+    intervalCap: MAX_LOAD_RPS,
+    interval: 1000,
+    carryoverConcurrencyCount: true,
+  })
   #store
 
   constructor(bucketName: string) {
@@ -43,19 +55,21 @@ export class S3StateStore implements StateStore {
    * @param streamId - stream ID
    */
   async load(streamId: StreamID): Promise<StreamState> {
-    try {
-      const state = await this.#store.get(streamId.baseID.toString())
-      if (state) {
-        return StreamUtils.deserializeState(JSON.parse(state))
-      } else {
-        return null
+    return this.#loadingLimit.add(async () => {
+      try {
+        const state = await this.#store.get(streamId.baseID.toString())
+        if (state) {
+          return StreamUtils.deserializeState(JSON.parse(state))
+        } else {
+          return null
+        }
+      } catch (err) {
+        if (err.notFound) {
+          return null // return null for non-existent entry
+        }
+        throw err
       }
-    } catch (err) {
-      if (err.notFound) {
-        return null // return null for non-existent entry
-      }
-      throw err
-    }
+    })
   }
 
   /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lru_map": "^0.4.1",
     "multiformats": "^9.5.8",
-    "p-queue": "^7.1.0",
+    "p-queue": "^7.2.0",
     "rxjs": "^7.5.2",
     "sqlite3": "^5.0.8",
     "uint8arrays": "^3.0.0"


### PR DESCRIPTION
Using Semaphore, nothing fancy. Semaphore limit is set based on the S3 minimum 5500 limit for GET/HEAD requests.

Although reality is a bit more complex, this might be a good first approach. According to the [docs](https://aws.amazon.com/premiumsupport/knowledge-center/s3-503-within-request-rate-prefix/) S3 is really flexible, but it requires the exponential backoff in the ideal case. IMO, it is a responsibility of s3leveldown ([issue](https://github.com/loune/s3leveldown/issues/13) created) to handle that.

I am not certain that the semaphore approach here makes sense, so feel free to say no to it.