### PR TITLE
fix: user more real request to the collection endpoint

### DIFF
--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -645,14 +645,15 @@ describe('Ceramic interop: core <> http-client', () => {
       test('model, account in query', async () => {
         const query = new URL(`http://localhost:${daemon.port}/api/v0/collection`)
         query.searchParams.set('model', MODEL_STREAM_ID.toString())
-        query.searchParams.set('account', randomString(10))
+        const account = `did:key:${randomString(10)}`
+        query.searchParams.set('account', account)
         query.searchParams.set('first', '100')
         const indexSpy = jest.spyOn(daemon.ceramic.index, 'queryIndex')
         await fetchJson(query.toString())
         expect(indexSpy).toBeCalledWith({
           first: 100,
           model: MODEL_STREAM_ID,
-          account: query.searchParams.get('account'),
+          account: account,
         })
       })
       test('serialize StreamState', async () => {


### PR DESCRIPTION
Fixes flaky test for /api/v0/collection endpoint by using `did:key:{random}` as account field.