### PR TITLE
chore(core): Always log streamId on errors loading commits from IPFS

### DIFF
--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -221,7 +221,7 @@ describe('Ceramic API', () => {
 
       const expected = []
       for (const { cid } of stream.state.log) {
-        const commit = await ceramic.dispatcher.retrieveCommit(cid)
+        const commit = await ceramic.dispatcher.retrieveCommit(cid, stream.id)
         expected.push({
           cid: cid.toString(),
           value: await StreamUtils.convertCommitToSignedCommitContainer(commit, ipfs),

--- a/packages/core/src/__tests__/dispatcher-mock-ipfs.test.ts
+++ b/packages/core/src/__tests__/dispatcher-mock-ipfs.test.ts
@@ -107,7 +107,7 @@ describe('Dispatcher with mock ipfs', () => {
 
   it('retrieves commit correctly', async () => {
     ipfs.dag.get.mockReturnValueOnce({ value: 'data' })
-    expect(await dispatcher.retrieveCommit(FAKE_CID)).toEqual('data')
+    expect(await dispatcher.retrieveCommit(FAKE_CID, FAKE_STREAM_ID)).toEqual('data')
 
     expect(ipfs.dag.get.mock.calls.length).toEqual(1)
     expect(ipfs.dag.get.mock.calls[0][0]).toEqual(FAKE_CID)
@@ -116,7 +116,7 @@ describe('Dispatcher with mock ipfs', () => {
   it('retries on timeout', async () => {
     ipfs.dag.get.mockRejectedValueOnce({ code: 'ERR_TIMEOUT' })
     ipfs.dag.get.mockReturnValueOnce({ value: 'data' })
-    expect(await dispatcher.retrieveCommit(FAKE_CID)).toEqual('data')
+    expect(await dispatcher.retrieveCommit(FAKE_CID, FAKE_STREAM_ID)).toEqual('data')
 
     expect(ipfs.dag.get.mock.calls.length).toEqual(2)
     expect(ipfs.dag.get.mock.calls[0][0]).toEqual(FAKE_CID)
@@ -126,15 +126,15 @@ describe('Dispatcher with mock ipfs', () => {
   it('caches and retrieves commit correctly', async () => {
     const ipfsSpy = ipfs.dag.get
     ipfsSpy.mockReturnValueOnce({ value: 'data' })
-    expect(await dispatcher.retrieveCommit(FAKE_CID)).toEqual('data')
+    expect(await dispatcher.retrieveCommit(FAKE_CID, FAKE_STREAM_ID)).toEqual('data')
     // Commit not found in cache so IPFS lookup performed and cache updated
     expect(ipfsSpy).toBeCalledTimes(1)
-    expect(await dispatcher.retrieveCommit(FAKE_CID)).toEqual('data')
+    expect(await dispatcher.retrieveCommit(FAKE_CID, FAKE_STREAM_ID)).toEqual('data')
     // Commit found in cache so IPFS lookup skipped (IPFS lookup count unchanged)
     const clonedCID = CID.parse(FAKE_CID.toString())
     expect(clonedCID !== FAKE_CID).toEqual(true)
     expect(ipfsSpy).toBeCalledTimes(1)
-    expect(await dispatcher.retrieveCommit(clonedCID)).toEqual('data')
+    expect(await dispatcher.retrieveCommit(clonedCID, FAKE_STREAM_ID)).toEqual('data')
     // Commit found in cache with different instance of same CID (IPFS lookup count unchanged)
     expect(ipfsSpy).toBeCalledTimes(1)
     expect(ipfsSpy.mock.calls[0][0]).toEqual(FAKE_CID)
@@ -287,6 +287,5 @@ describe('Dispatcher with mock ipfs', () => {
       model: FAKE_MODEL,
     })
     expect(dispatcher.repository.stateManager.update).toBeCalledWith(state$.id, FAKE_CID)
-
   })
 })

--- a/packages/core/src/anchor/memory/in-memory-anchor-service.ts
+++ b/packages/core/src/anchor/memory/in-memory-anchor-service.ts
@@ -121,14 +121,14 @@ export class InMemoryAnchorService implements AnchorService, AnchorValidator {
           const commitData = await Utils.getCommitData(
             this.#dispatcher,
             req.cid,
-            null,
-            req.streamId
+            req.streamId,
+            null
           )
           if (this.#verifySignatures && StreamUtils.isSignedCommitData(commitData)) {
             await this.verifySignedCommit(commitData.envelope)
           }
 
-          const log = await this._loadCommitHistory(req.cid)
+          const log = await this._loadCommitHistory(req.cid, req.streamId)
           const candidate = new Candidate(req.cid, req.streamId, log)
 
           if (!result[candidate.key]) {
@@ -200,12 +200,12 @@ export class InMemoryAnchorService implements AnchorService, AnchorValidator {
    * @param commitId - Start CID
    * @private
    */
-  async _loadCommitHistory(commitId: CID): Promise<CID[]> {
+  async _loadCommitHistory(commitId: CID, streamId: StreamID): Promise<CID[]> {
     const history: CID[] = []
 
     let currentCommitId = commitId
     for (;;) {
-      const commitData = await Utils.getCommitData(this.#dispatcher, currentCommitId)
+      const commitData = await Utils.getCommitData(this.#dispatcher, currentCommitId, streamId)
       if (StreamUtils.isAnchorCommitData(commitData)) {
         return history
       }

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -807,7 +807,7 @@ export class Ceramic implements CeramicApi {
 
     const results = await Promise.all(
       state.log.map(async ({ cid }) => {
-        const commit = await this.dispatcher.retrieveCommit(cid)
+        const commit = await this.dispatcher.retrieveCommit(cid, effectiveStreamId)
         return {
           cid: cid.toString(),
           value: await StreamUtils.convertCommitToSignedCommitContainer(commit, this.ipfs),

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -140,19 +140,15 @@ export class Dispatcher {
    * @param cid - Commit CID
    * @param streamId - StreamID of the stream the commit belongs to, used for logging.
    */
-  async retrieveCommit(cid: CID | string, streamId?: StreamID): Promise<any> {
+  async retrieveCommit(cid: CID | string, streamId: StreamID): Promise<any> {
     try {
       const result = await this._getFromIpfs(cid)
       await this._restrictCommitSize(cid)
       return result
     } catch (e) {
-      if (streamId) {
-        this._logger.err(
-          `Error while loading commit CID ${cid.toString()} from IPFS for stream ${streamId.toString()}: ${e}`
-        )
-      } else {
-        this._logger.err(`Error while loading commit CID ${cid.toString()} from IPFS: ${e}`)
-      }
+      this._logger.err(
+        `Error while loading commit CID ${cid.toString()} from IPFS for stream ${streamId.toString()}: ${e}`
+      )
       throw e
     }
   }
@@ -270,7 +266,7 @@ export class Dispatcher {
    * @param tip - Commit CID
    */
   publishTip(streamId: StreamID, tip: CID, model?: StreamID): Subscription {
-    return this.publish({ typ: MsgType.UPDATE, stream: streamId, tip, model})
+    return this.publish({ typ: MsgType.UPDATE, stream: streamId, tip, model })
   }
 
   /**

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -125,7 +125,7 @@ export class Repository {
   private async fromNetwork(streamId: StreamID): Promise<RunningState> {
     const handler = this.#deps.handlers.get(streamId.typeName)
     const genesisCid = streamId.cid
-    const commitData = await Utils.getCommitData(this.#deps.dispatcher, genesisCid)
+    const commitData = await Utils.getCommitData(this.#deps.dispatcher, genesisCid, streamId)
     if (commitData == null) {
       throw new Error(`No genesis commit found with CID ${genesisCid.toString()}`)
     }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -72,8 +72,8 @@ export class Utils {
   static async getCommitData(
     dispatcher: Dispatcher,
     cid: CID,
-    timestamp?: number,
-    streamId?: StreamID
+    streamId: StreamID,
+    timestamp?: number
   ): Promise<CommitData> {
     const commit = await dispatcher.retrieveCommit(cid, streamId)
     if (!commit) throw new Error(`No commit found for CID ${cid.toString()}`)


### PR DESCRIPTION
Makes the `streamId` argument to `Dispatcher.retrieveCommit` mandatory, which means that anytime there is an error loading a commit from IPFS we will have the StreamID it belongs to in the log message