### PR TITLE
fix(core): Creating a stream via a multiquery should pin it

### DIFF
--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -707,10 +707,10 @@ export class Ceramic implements CeramicApi {
       throw new Error('Given genesis commit is not deterministic')
     }
 
-    const genesisCID = await this.ipfs.dag.put(genesis)
-    if (!streamRef.cid.equals(genesisCID)) {
+    const stream = await this.createStreamFromGenesis(streamRef.type, genesis)
+    if (!streamRef.equals(stream.id)) {
       throw new Error(
-        `Given StreamID CID ${streamRef.cid.toString()} does not match given genesis content`
+        `StreamID ${stream.id.toString()} generated does not match expected StreamID ${streamRef.toString()} determined from genesis content in multiquery request`
       )
     }
   }


### PR DESCRIPTION
I don't really *love* this approach.  I think it's weird to use a query as a backdoor way to create a stream.  But that's what we did when we introduced https://github.com/ceramicnetwork/js-ceramic/issues/1647 so this seems like the only way to make the behavior actually correct.