### PR TITLE
feat: add gnosis chain and goerli to supported networks [NET-1556]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 > **Project status**: **`Clay` testnet is now live. 🚀** <br/>
 > Clay is a decentralized public network ready for experimental application development and testing. It anchors documents on the Ethereum Ropsten and Rinkeby testnets. It is the last major milestone before `Fire` mainnet, which is under development and will launch in late Q1 2021. Documents published on Clay will _not_ be portable to Fire.
 
-> June 2022: As Rinkeby and Ropsten are on their way to being deprecated, Clay will be shifting to using the Gnosis Chain (xDAI) for anchoring documents. Documents published on Rinkeby/Ropsten through Clay will _not_ be ported over to Gnosis.
+> June 2022: As Rinkeby and Ropsten are on their way to being deprecated, Clay will be shifting to using the Gnosis Chain (previously xDAI) for anchoring streams. Streams published on Rinkeby/Ropsten through Clay will _not_ be ported over to Gnosis.
 
 ## Clients
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![js-ceramic](https://uploads-ssl.webflow.com/5e4b58d7f08158ece0209bbd/5fa2c8f21ad1fe0422b1dd60_js-ceramic-small.png)
 
 # js-ceramic
+
 ![ceramicnetwork](https://circleci.com/gh/ceramicnetwork/js-ceramic.svg?style=shield)
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://lbesson.mit-license.org/)
 [![](https://img.shields.io/badge/Chat%20on-Discord-orange.svg?style=flat)](https://discord.gg/6VRZpGP)
@@ -9,17 +10,19 @@
 **js-ceramic** is a monorepo containing the TypeScript implementation of the Ceramic protocol. If you are unfamiliar with Ceramic, see the [website](https://ceramic.network) or [overview](https://github.com/ceramicnetwork/ceramic) for more information.
 
 > **Project status**: **`Clay` testnet is now live. 🚀** <br/>
-> Clay is a decentralized public network ready for experimental application development and testing. It anchors documents on the Ethereum Ropsten and Rinkeby testnets. It is the last major milestone before `Fire` mainnet, which is under development and will launch in late Q1 2021. Documents published on Clay will *not* be portable to Fire.
+> Clay is a decentralized public network ready for experimental application development and testing. It anchors documents on the Ethereum Ropsten and Rinkeby testnets. It is the last major milestone before `Fire` mainnet, which is under development and will launch in late Q1 2021. Documents published on Clay will _not_ be portable to Fire.
+
+> June 2022: As Rinkeby and Ropsten are on their way to being deprecated, Clay will be shifting to using the Gnosis Chain (xDAI) for anchoring documents. Documents published on Rinkeby/Ropsten through Clay will _not_ be ported over to Gnosis.
 
 ## Clients
 
 `js-ceramic` provides three JavaScript clients that offer different ways to interact with the Ceramic network.
 
-| Client | Package | Description | Current Version |
-| -- | -- | -- | -- |
-| Core | @ceramicnetwork/core | Full JavaScript protocol implementation | [![npm](https://img.shields.io/npm/v/@ceramicnetwork/core)](https://www.npmjs.com/package/@ceramicnetwork/core) |
-| CLI | @ceramicnetwork/cli | CLI and HTTP daemon | [![npm](https://img.shields.io/npm/v/@ceramicnetwork/cli)](https://www.npmjs.com/package/@ceramicnetwork/cli) |
-| HTTP | @ceramicnetwork/http-client | HTTP client that can interact with a remote Ceramic daemon | [![npm](https://img.shields.io/npm/v/@ceramicnetwork/http-client)](https://www.npmjs.com/package/@ceramicnetwork/http-client) |
+| Client | Package                     | Description                                                | Current Version                                                                                                               |
+| ------ | --------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Core   | @ceramicnetwork/core        | Full JavaScript protocol implementation                    | [![npm](https://img.shields.io/npm/v/@ceramicnetwork/core)](https://www.npmjs.com/package/@ceramicnetwork/core)               |
+| CLI    | @ceramicnetwork/cli         | CLI and HTTP daemon                                        | [![npm](https://img.shields.io/npm/v/@ceramicnetwork/cli)](https://www.npmjs.com/package/@ceramicnetwork/cli)                 |
+| HTTP   | @ceramicnetwork/http-client | HTTP client that can interact with a remote Ceramic daemon | [![npm](https://img.shields.io/npm/v/@ceramicnetwork/http-client)](https://www.npmjs.com/package/@ceramicnetwork/http-client) |
 
 > For performance reasons it is recommended that you use the HTTP client if you are building an application.
 
@@ -37,10 +40,10 @@ Full documentation on installation and usage can be found on the [Ceramic docume
 - For bugs and feature requests: [Create an issue on Github](https://github.com/ceramicnetwork/js-ceramic/issues)
 
 ## Contributing
+
 We are happy to accept small and large contributions, feel free to make a suggestion or submit a pull request.
 
 Check out the [Development](./DEVELOPMENT.md) section to learn how to navigate the code in this repo.
-
 
 ## Maintainers
 

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
@@ -24,6 +24,8 @@ const ETH_CHAIN_ID_MAPPINGS: Record<string, EthNetwork> = {
   'eip155:1': { network: 'mainnet', chain: 'ETH', chainId: 1, networkId: 1, type: 'Production' },
   'eip155:3': { network: 'ropsten', chain: 'ETH', chainId: 3, networkId: 3, type: 'Test' },
   'eip155:4': { network: 'rinkeby', chain: 'ETH', chainId: 4, networkId: 4, type: 'Test' },
+  'eip155:5': { network: 'goerli', chain: 'ETH', chainId: 5, networkId: 5, type: 'Test' },
+  'eip155:100': { network: 'mainnet', chain: 'Gnosis', chainId: 100, networkId: 100, type: 'Test' },
 }
 
 const BASE_CHAIN_ID = 'eip155'

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -69,8 +69,8 @@ const DEFAULT_LOCAL_ETHEREUM_RPC = 'http://localhost:7545' // default Ganache po
 const SUPPORTED_CHAINS_BY_NETWORK = {
   [Networks.MAINNET]: ['eip155:1'], // Ethereum mainnet
   [Networks.ELP]: ['eip155:1'], // Ethereum mainnet
-  [Networks.TESTNET_CLAY]: ['eip155:3', 'eip155:4'], // Ethereum Ropsten, Rinkeby
-  [Networks.DEV_UNSTABLE]: ['eip155:3', 'eip155:4'], // Ethereum Ropsten, Rinkeby
+  [Networks.TESTNET_CLAY]: ['eip155:3', 'eip155:4', 'eip155:100'], // Ethereum Ropsten, Rinkeby, Gnosis Chain
+  [Networks.DEV_UNSTABLE]: ['eip155:3', 'eip155:4', 'eip155:5'], // Ethereum Ropsten, Rinkeby, Goerli
   [Networks.LOCAL]: ['eip155:1337'], // Ganache
   [Networks.INMEMORY]: ['inmemory:12345'], // Our fake in-memory anchor service chainId
 }


### PR DESCRIPTION
## Description

Rinkeby and Ropsten testnets are on their way to being deprecated. This PR lays the foundation to add support for Gnosis Chain and Goerli Testnet to Ceramic. The plan is to use Gnosis Chain mainnet for Clay testnet, and Goerli for Dev.

## How Has This Been Tested?

No tests.

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
