### PR TITLE
chore: add warnings to auth providers other than ethereum [NET-1578]

### DIFF
--- a/packages/blockchain-utils-linking/src/cosmos.ts
+++ b/packages/blockchain-utils-linking/src/cosmos.ts
@@ -45,7 +45,11 @@ export class CosmosAuthProvider implements AuthProvider {
     private readonly provider: any,
     private readonly address: string,
     private readonly chainRef: string
-  ) {}
+  ) {
+    console.warn(
+      'WARN: CosmosAuthProvider is not fully supported. You may encounter issues using this.'
+    )
+  }
 
   async authenticate(message: string): Promise<string> {
     const accountID = await this.accountId()

--- a/packages/blockchain-utils-linking/src/eosio.ts
+++ b/packages/blockchain-utils-linking/src/eosio.ts
@@ -10,7 +10,11 @@ const maxWordLength = 12
 export class EosioAuthProvider implements AuthProvider {
   readonly isAuthProvider = true
 
-  constructor(private readonly provider: any, private readonly address: string) {}
+  constructor(private readonly provider: any, private readonly address: string) {
+    console.warn(
+      'WARN: EosioAuthProvider is not fully supported. You may encounter issues using this.'
+    )
+  }
 
   async accountId(): Promise<AccountId> {
     const chainId = toCAIPChainId(await this.provider.getChainId())

--- a/packages/blockchain-utils-linking/src/filecoin.ts
+++ b/packages/blockchain-utils-linking/src/filecoin.ts
@@ -7,7 +7,11 @@ import * as uint8arrays from 'uint8arrays'
 export class FilecoinAuthProvider implements AuthProvider {
   readonly isAuthProvider = true
 
-  constructor(private readonly provider: any, private readonly address: string) {}
+  constructor(private readonly provider: any, private readonly address: string) {
+    console.warn(
+      'WARN: FilecoinAuthProvider is not fully supported. You may encounter issues using this.'
+    )
+  }
 
   async accountId(): Promise<AccountId> {
     const prefix = this.address[0]

--- a/packages/blockchain-utils-linking/src/near.ts
+++ b/packages/blockchain-utils-linking/src/near.ts
@@ -22,7 +22,11 @@ export class NearAuthProvider implements AuthProvider {
     private readonly near: any,
     private readonly accountName: string,
     private readonly chainRef: string
-  ) {}
+  ) {
+    console.warn(
+      'WARN: NearAuthProvider is not fully supported. You may encounter issues using this.'
+    )
+  }
 
   async authenticate(message: string): Promise<string> {
     const key = await this.near.connection.signer.keyStore.getKey(this.chainRef, this.accountName)

--- a/packages/blockchain-utils-linking/src/polkadot.ts
+++ b/packages/blockchain-utils-linking/src/polkadot.ts
@@ -11,7 +11,11 @@ const CHAIN_ID = 'polkadot:b0a8d493285c2df73290dfb7e61f870f'
 export class PolkadotAuthProvider implements AuthProvider {
   readonly isAuthProvider = true
 
-  constructor(private readonly provider: any, private readonly address: string) {}
+  constructor(private readonly provider: any, private readonly address: string) {
+    console.warn(
+      'WARN: PolkadotAuthProvider is not fully supported. You may encounter issues using this.'
+    )
+  }
 
   async authenticate(message: string): Promise<string> {
     throw new Error(`Not Implemented: PolkadotAuthProvider#authenticate, ${message}`)

--- a/packages/blockchain-utils-linking/src/solana.ts
+++ b/packages/blockchain-utils-linking/src/solana.ts
@@ -15,7 +15,11 @@ export class SolanaAuthProvider implements AuthProvider {
     private readonly provider: any,
     private readonly address: string,
     private readonly chainRef: string
-  ) {}
+  ) {
+    console.warn(
+      'WARN: SolanaAuthProvider is not fully supported. You may encounter issues using this.'
+    )
+  }
 
   async accountId(): Promise<AccountId> {
     return new AccountId({

--- a/packages/blockchain-utils-linking/src/tezos.ts
+++ b/packages/blockchain-utils-linking/src/tezos.ts
@@ -70,6 +70,10 @@ export class TezosAuthProvider implements AuthProvider {
     if (provider.signer === undefined) {
       throw new Error('a `Signer` is required to use the `TezosAuthProvider`')
     }
+
+    console.warn(
+      'WARN: TezosAuthProvider is not fully supported. You may encounter issues using this.'
+    )
   }
 
   /**


### PR DESCRIPTION
## Description

Auth providers other than Ethereum don't have full support, and often result in bugs for end developers when attempting to use them. This PR adds a warning to all auth providers other than Ethereum letting developers know about this.

## How Has This Been Tested?

No tests.

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
