### PR TITLE
chore(common,core): Deprecate anchorScheduledFor

### DIFF
--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -141,6 +141,11 @@ export interface StreamState {
   metadata: StreamMetadata
   signature: SignatureStatus
   anchorStatus: AnchorStatus
+  /**
+   * 'anchorScheduledFor' is not an accurate representation of when the stream will be anchored, and will be removed
+   * in a future version
+   * @deprecated
+   */
   anchorScheduledFor?: number // only present when anchor status is pending
   anchorProof?: AnchorProof // the anchor proof of the latest anchor, only present when anchor status is anchored
   log: Array<LogEntry>

--- a/packages/core/src/anchor/anchor-service-response.ts
+++ b/packages/core/src/anchor/anchor-service-response.ts
@@ -7,6 +7,11 @@ export interface AnchorServiceResponse {
   readonly cid: CID
   readonly status: string
   readonly message: string
+  /**
+   * 'anchorScheduledFor' is not an accurate representation of when the stream will be anchored, and will be removed
+   * in a future version
+   * @deprecated
+   */
   readonly anchorScheduledFor?: number
   readonly anchorCommit?: CID
 }


### PR DESCRIPTION
People in the community are getting confused by it (https://github.com/gitcoinco/dPopp/issues/247).
Now that the anchor service does not anchor on a reliable interval `anchorScheduledFor` is not accurate and keeping it around is just misleading and confusing.  We should get rid of it entirely soon, but for now let's at least mark it as deprecated