### PR TITLE
fix(blockchain-utils-linking,blockchain-utils-validation,canary-integration): Disable flaky polkadot tests

### DIFF
--- a/packages/blockchain-utils-linking/src/__tests__/polkadot.test.ts
+++ b/packages/blockchain-utils-linking/src/__tests__/polkadot.test.ts
@@ -48,13 +48,13 @@ afterAll(() => {
   jest.clearAllMocks()
 })
 
-test('accountId', async () => {
+test.skip('accountId', async () => {
   const provider = new SingleAccountSigner(registry, keyPairSr25519)
   const authProvider = new PolkadotAuthProvider(provider, keyPairSr25519.address)
   await expect(authProvider.accountId()).resolves.toMatchSnapshot()
 })
 
-describe('createLink', () => {
+describe.skip('createLink', () => {
   test('create proof with sr25519', async () => {
     const provider = new SingleAccountSigner(registry, keyPairSr25519)
     const authProvider = new PolkadotAuthProvider(provider, keyPairSr25519.address)

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/polkadot.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/polkadot.test.ts
@@ -33,7 +33,7 @@ class SingleAccountSigner implements Signer {
   }
 }
 
-describe('Blockchain: Polkadot', () => {
+describe.skip('Blockchain: Polkadot', () => {
   const registry = new TypeRegistry()
   let keyPairSr25519: KeyringPair, keyPairEd25519: KeyringPair, keyPairSecp256k: KeyringPair
 

--- a/packages/canary-integration/src/__tests__/caip10/polkadot.test.ts
+++ b/packages/canary-integration/src/__tests__/caip10/polkadot.test.ts
@@ -40,46 +40,48 @@ let keyPairSr25519: KeyringPair, keyPairEd25519: KeyringPair, keyPairSecp256k: K
 let ceramic: CeramicApi
 let ipfs: IpfsApi
 
-beforeAll(async () => {
-  ipfs = await createIPFS()
-  ceramic = await createCeramic(ipfs)
-  await cryptoWaitReady()
-  keyPairSr25519 = keyringSr25519.addFromSeed(seed)
-  keyPairEd25519 = keyringEd25519.addFromSeed(seed)
-  keyPairSecp256k = keyringSecp256k.addFromSeed(seed)
-}, 120000)
+describe.skip('Polkadot Caip10 tests', () => {
+  beforeAll(async () => {
+    ipfs = await createIPFS()
+    ceramic = await createCeramic(ipfs)
+    await cryptoWaitReady()
+    keyPairSr25519 = keyringSr25519.addFromSeed(seed)
+    keyPairEd25519 = keyringEd25519.addFromSeed(seed)
+    keyPairSecp256k = keyringSecp256k.addFromSeed(seed)
+  }, 120000)
 
-afterAll(async () => {
-  await ceramic.close()
-  await ipfs?.stop()
-}, 120000)
+  afterAll(async () => {
+    await ceramic.close()
+    await ipfs?.stop()
+  }, 120000)
 
-test('happy path', async () => {
-  await Promise.all(
-    [keyPairSr25519, keyPairEd25519, keyPairSecp256k].map(async (keyPair) => {
-      const provider = new SingleAccountSigner(registry, keyPair)
-      const authProvider = new linking.PolkadotAuthProvider(provider, keyPair.address)
-      await happyPath(ceramic, authProvider)
-    })
-  )
-}, 120000)
+  test('happy path', async () => {
+    await Promise.all(
+      [keyPairSr25519, keyPairEd25519, keyPairSecp256k].map(async (keyPair) => {
+        const provider = new SingleAccountSigner(registry, keyPair)
+        const authProvider = new linking.PolkadotAuthProvider(provider, keyPair.address)
+        await happyPath(ceramic, authProvider)
+      })
+    )
+  }, 120000)
 
-test('wrong proof', async () => {
-  await Promise.all(
-    [keyPairSr25519, keyPairEd25519, keyPairSecp256k].map(async (keyPair) => {
-      const provider = new SingleAccountSigner(registry, keyPair)
-      const authProvider = new linking.PolkadotAuthProvider(provider, keyPair.address)
-      await wrongProof(ceramic, authProvider)
-    })
-  )
-}, 120000)
+  test('wrong proof', async () => {
+    await Promise.all(
+      [keyPairSr25519, keyPairEd25519, keyPairSecp256k].map(async (keyPair) => {
+        const provider = new SingleAccountSigner(registry, keyPair)
+        const authProvider = new linking.PolkadotAuthProvider(provider, keyPair.address)
+        await wrongProof(ceramic, authProvider)
+      })
+    )
+  }, 120000)
 
-test('clear did', async () => {
-  await Promise.all(
-    [keyPairSr25519, keyPairEd25519, keyPairSecp256k].map(async (keyPair) => {
-      const provider = new SingleAccountSigner(registry, keyPair)
-      const authProvider = new linking.PolkadotAuthProvider(provider, keyPair.address)
-      await clearDid(ceramic, authProvider)
-    })
-  )
-}, 120000)
+  test('clear did', async () => {
+    await Promise.all(
+      [keyPairSr25519, keyPairEd25519, keyPairSecp256k].map(async (keyPair) => {
+        const provider = new SingleAccountSigner(registry, keyPair)
+        const authProvider = new linking.PolkadotAuthProvider(provider, keyPair.address)
+        await clearDid(ceramic, authProvider)
+      })
+    )
+  }, 120000)
+})


### PR DESCRIPTION
The tests are flaky and fail often.  Polkadot support was added by a community member and we (3BoxLabs) never committed to maintaining support for it.  We're not going to go out of our way to break polkadot support, but we're also not going to spend any resources making sure it keeps working either.  Until such a time as the 3BoxLabs team is ready to commit to maintaining support for linking/validating wallet signatures from non-ethereum chains, lets disable the tests so they don't cause our build pipelines to randomly fail.  Of course other community members are welcome and encouraged to build and maintain support for other chains on their own.