### PR TITLE
fix(core): Only use the execution and loading queues when applying commits or loading over pubsub

### DIFF
--- a/packages/core/src/__tests__/ceramic-anchor.test.ts
+++ b/packages/core/src/__tests__/ceramic-anchor.test.ts
@@ -317,7 +317,7 @@ describe('Ceramic anchoring', () => {
     // @ts-ignore
     const c2anchorValidator = ceramic2._anchorValidator
     const validateChainInclusionSpy = jest.spyOn(c2anchorValidator, 'validateChainInclusion')
-    validateChainInclusionSpy.mockRejectedValueOnce(new Error("blockNumbers don't match"))
+    validateChainInclusionSpy.mockRejectedValue(new Error("blockNumbers don't match"))
 
     // Even though validating the anchor commit fails, the stream should still be loaded successfully
     // just with the anchor commit missing.

--- a/packages/core/src/__tests__/dispatcher-mock-ipfs.test.ts
+++ b/packages/core/src/__tests__/dispatcher-mock-ipfs.test.ts
@@ -229,9 +229,12 @@ describe('Dispatcher with mock ipfs', () => {
     const queryID = queryMessageSent.id
 
     // Handle UPDATE message without model
-    dispatcher.repository.stateManager.update = jest.fn()
+    dispatcher.repository.stateManager.handlePubsubUpdate = jest.fn()
     await dispatcher.handleMessage({ typ: MsgType.UPDATE, stream: FAKE_STREAM_ID, tip: FAKE_CID })
-    expect(dispatcher.repository.stateManager.update).toBeCalledWith(state$.id, FAKE_CID)
+    expect(dispatcher.repository.stateManager.handlePubsubUpdate).toBeCalledWith(
+      state$.id,
+      FAKE_CID
+    )
 
     const continuationState = {
       ...initialState,
@@ -254,7 +257,10 @@ describe('Dispatcher with mock ipfs', () => {
     // Handle RESPONSE message
     const tips = new Map().set(FAKE_STREAM_ID.toString(), FAKE_CID2)
     await dispatcher.handleMessage({ typ: MsgType.RESPONSE, id: queryID, tips: tips })
-    expect(dispatcher.repository.stateManager.update).toBeCalledWith(stream2.id, FAKE_CID2)
+    expect(dispatcher.repository.stateManager.handlePubsubUpdate).toBeCalledWith(
+      stream2.id,
+      FAKE_CID2
+    )
   })
 
   it('handle message correctly with model', async () => {
@@ -279,13 +285,16 @@ describe('Dispatcher with mock ipfs', () => {
     const state$ = await register(initialState)
 
     // Handle UPDATE message with model
-    dispatcher.repository.stateManager.update = jest.fn()
+    dispatcher.repository.stateManager.handlePubsubUpdate = jest.fn()
     await dispatcher.handleMessage({
       typ: MsgType.UPDATE,
       stream: FAKE_STREAM_ID,
       tip: FAKE_CID,
       model: FAKE_MODEL,
     })
-    expect(dispatcher.repository.stateManager.update).toBeCalledWith(state$.id, FAKE_CID)
+    expect(dispatcher.repository.stateManager.handlePubsubUpdate).toBeCalledWith(
+      state$.id,
+      FAKE_CID
+    )
   })
 })

--- a/packages/core/src/__tests__/local-pin-api.test.ts
+++ b/packages/core/src/__tests__/local-pin-api.test.ts
@@ -19,7 +19,7 @@ const streamState = {
 const state$ = new RunningState(streamState, true)
 const repository = {
   load: jest.fn(() => Promise.resolve(state$)),
-  get: jest.fn(() => Promise.resolve(state$)),
+  fromMemoryOrStore: jest.fn(() => Promise.resolve(state$)),
   pin: jest.fn(),
   unpin: jest.fn(),
   list: jest.fn(),

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -310,7 +310,7 @@ export class Dispatcher {
     const { stream: streamId, tip, model } = message
     // TODO: add cache of cids here so that we don't emit event
     // multiple times if we get the message from more than one peer.
-    this.repository.stateManager.update(streamId, tip)
+    this.repository.stateManager.handlePubsubUpdate(streamId, tip)
     // TODO: Handle 'anchorService' if present in message
   }
 
@@ -355,7 +355,7 @@ export class Dispatcher {
             "'"
         )
       }
-      this.repository.stateManager.update(expectedStreamID, newTip)
+      this.repository.stateManager.handlePubsubUpdate(expectedStreamID, newTip)
       // TODO Iterate over all streams in 'tips' object and process the new tip for each
     }
   }

--- a/packages/core/src/local-pin-api.ts
+++ b/packages/core/src/local-pin-api.ts
@@ -19,7 +19,7 @@ export class LocalPinApi implements PinApi {
   }
 
   async rm(streamId: StreamID, opts?: PublishOpts): Promise<void> {
-    const state$ = await this.repository.get(streamId)
+    const state$ = await this.repository.fromMemoryOrStore(streamId)
     if (!state$) {
       this.logger.verbose(`Cannot unpin stream ${streamId.toString()} as it isn't pinned`)
       return


### PR DESCRIPTION
When testing https://github.com/ceramicnetwork/js-ceramic/pull/2258, I noticed the log message was getting printed very often, even with without me sending any requests to my local node.  I investigated further and found that we were filling up the execution and loading queues entirely with messages from pubsub, for streams that aren't even pinned where we won't even wind up actually loading or applying any commits.

This change puts the check for seeing if the stream exists in the state store or in memory cache outside of the loading and execution queue concurrency bottlenecks, and only uses those queues when actually loading a stream over pubsub or applying an actual commit to current state.

I don't know if this issue can really fully explain all the issues that gitcoin is seeing, but it probably isn't helping, and fixing this will let the log message from https://github.com/ceramicnetwork/js-ceramic/pull/2258 be more meaningful