### PR TITLE
Add `documentVersion` view to model type definitions

### DIFF
--- a/packages/stream-model/src/model.ts
+++ b/packages/stream-model/src/model.ts
@@ -71,9 +71,10 @@ export enum ModelAccountRelation {
  *
  * Currently supported types of view properties:
  * - 'documentAccount': view properties of this type have the MID's controller DID as values
+ * - 'documentVersion': view properties of this type have the MID's commit ID as values
  *
  */
-export type ModelViewDefinition = { type: 'documentAccount' }
+export type ModelViewDefinition = { type: 'documentAccount' } | { type: 'documentVersion' }
 
 /**
  * A mapping between model's property names and types of view properties


### PR DESCRIPTION
Following our call yesterday, we need to add support for the `documentVersion` view to expose the version to set in mutations.