### PR TITLE
fix(stream-tile-handler,stream-model-handler,stream-model-instance-handler): Don't cache schemas

### DIFF
--- a/packages/stream-model-handler/src/schema-utils.ts
+++ b/packages/stream-model-handler/src/schema-utils.ts
@@ -1,58 +1,57 @@
-
 import ajv, { SchemaObject } from 'ajv/dist/2020.js'
 
 /**
  * A type that we use to check if object properties within JSON Schema schemas
  * allow for additional properties.
- * 
+ *
  * According to JSON Schema standard, object properties within a valid schema have
  * type field set to 'object' and an optional additionalProperties field that can have a boolean
  * value or a value which is another JSON Schema property schema describing the shape of allowed additional properties
  */
 type JSONSchemaObjectType = {
-  type: 'object',
+  type: 'object'
   additionalProperties?: boolean
 }
 
 /**
  * Takes the schema and applies the fn function to it and its object properties recursively.
- * 
+ *
  * @param schema a SchemaObject schema from JSON Schema standard
  * @param fn a function taking schema's properties and calls recursiveMap recursively on them, if they're object properties
- * 
+ *
  */
 function recursiveMap(schema: SchemaObject, fn: (schemaProperty: object) => void) {
   fn(schema)
   Object.getOwnPropertyNames(schema).forEach((schemaPropertyName) => {
-    if (schema[schemaPropertyName] !== null && typeof(schema[schemaPropertyName]) == "object") {
-      recursiveMap(schema[schemaPropertyName], fn);
+    if (schema[schemaPropertyName] !== null && typeof schema[schemaPropertyName] == 'object') {
+      recursiveMap(schema[schemaPropertyName], fn)
     }
   })
 }
 
 /**
  * A typescript type guard function to verify if the input is a JSONSchemaObjectType
- * 
+ *
  * @param schema - input of any type
  * @returns true iff schema is not null or underfined and it has a type property which equals to 'object'
- * 
+ *
  * We use this function to traverse JSON Schema schemas and check which property describes an object.
  * According to JSON Schema standard, object properties have type fields set to 'object'.
  */
 function isObjectJSONSchema(schema: any): schema is JSONSchemaObjectType {
-  return schema &&  schema.type === 'object'
+  return schema && schema.type === 'object'
 }
 
 /**
  * Verifies that a JSON Schema schema has additional properties disabled, if it's an object schema
- * 
+ *
  * @param schema: a SchemaObject schema
  * @throws if the schema is an object schema that allows for additional properties
  */
 function validateAdditionalProperties(schema: SchemaObject): void {
   if (isObjectJSONSchema(schema)) {
     if (schema.additionalProperties !== false) {
-      throw new Error("All objects in schema need to have additional properties disabled")
+      throw new Error('All objects in schema need to have additional properties disabled')
     }
   }
 }
@@ -68,10 +67,12 @@ export class SchemaValidation {
     unevaluated: false,
   })
 
-  public async validateSchema(
-    schema: SchemaObject
-  ): Promise<void> {
+  public async validateSchema(schema: SchemaObject): Promise<void> {
     const isValid = await this._validator.validateSchema(schema)
+
+    // Remove schema from the Ajv instance's cache, otherwise the ajv cache grows unbounded
+    this._validator.removeSchema(schema)
+
     if (!isValid) {
       const errorMessages = this._validator.errorsText()
       throw new Error(`Validation Error: ${errorMessages}`)

--- a/packages/stream-model-instance-handler/src/schema-utils.ts
+++ b/packages/stream-model-instance-handler/src/schema-utils.ts
@@ -18,11 +18,12 @@ export class SchemaValidation {
     addFormats(this._validator)
   }
 
-  public validateSchema(
-    content: Record<string, any>,
-    schema: SchemaObject
-  ) {
+  public validateSchema(content: Record<string, any>, schema: SchemaObject) {
     const isValid = this._validator.validate(schema, content)
+
+    // Remove schema from the Ajv instance's cache, otherwise the ajv cache grows unbounded
+    this._validator.removeSchema(schema)
+
     if (!isValid) {
       const errorMessages = this._validator.errorsText()
       throw new Error(`Validation Error: ${errorMessages}`)

--- a/packages/stream-tile-handler/src/schema-utils.ts
+++ b/packages/stream-tile-handler/src/schema-utils.ts
@@ -37,6 +37,10 @@ export class SchemaValidation {
 
   private _validate(content: Record<string, any>, schema: Record<string, any>): void {
     const isValid = this._validator.validate(schema, content)
+
+    // Remove schema from the Ajv instance's cache, otherwise the ajv cache grows unbounded
+    this._validator.removeSchema(schema)
+
     if (!isValid) {
       const errorMessages = this._validator.errorsText()
       throw new Error(`Validation Error: ${errorMessages}`)


### PR DESCRIPTION
@ukstv could you double-check that this fixes the memory growth when associated with validating schemas (both for streams that share a schema and for streams with different schemas)?