### PR TITLE
feat: Heapdump on SIGUSR2

### DIFF
--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -11,13 +11,14 @@ import { CeramicApi, LogLevel, Networks, StreamUtils } from '@ceramicnetwork/com
 import { StreamID, CommitID } from '@ceramicnetwork/streamid'
 
 import { CeramicDaemon } from './ceramic-daemon.js'
-import { DaemonConfig, IpfsMode, StateStoreMode, DaemonMetricsConfig } from './daemon-config.js'
+import { DaemonConfig, IpfsMode, StateStoreMode } from './daemon-config.js'
 import { TileDocument, TileMetadataArgs } from '@ceramicnetwork/stream-tile'
 
 import * as ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
 import * as KeyDidResolver from 'key-did-resolver'
 import { Resolver } from 'did-resolver'
 import { DID } from 'dids'
+import { handleHeapdumpSignal } from './daemon/handle-heapdump-signal.js'
 
 const HOMEDIR = new URL(`file://${os.homedir()}/`)
 const CWD = new URL(`file://${process.cwd()}/`)
@@ -27,7 +28,7 @@ const DEFAULT_DAEMON_CONFIG_FILENAME = new URL('daemon.config.json', DEFAULT_CON
 const DEFAULT_CLI_CONFIG_FILENAME = new URL('client.config.json', DEFAULT_CONFIG_PATH)
 const LEGACY_CLI_CONFIG_FILENAME = new URL('config.json', DEFAULT_CONFIG_PATH) // todo(1615): Remove this backwards compatibility support
 const DEFAULT_INDEXING_DB_FILENAME = new URL('./indexing.sqlite', DEFAULT_CONFIG_PATH)
-const DEFAULT_METRICS_EXPORTER_PORT = Number(process.env.METRICS_PORT)  || 9090
+const DEFAULT_METRICS_EXPORTER_PORT = Number(process.env.METRICS_PORT) || 9090
 const DEFAULT_METRICS_EXPORTER_ENABLED = process.env.METRICS_EXPORTER_ENABLED || false
 
 const DEFAULT_DAEMON_CONFIG = DaemonConfig.fromObject({
@@ -35,7 +36,10 @@ const DEFAULT_DAEMON_CONFIG = DaemonConfig.fromObject({
   'http-api': { 'cors-allowed-origins': [new RegExp('.*')] },
   ipfs: { mode: IpfsMode.BUNDLED },
   logger: { 'log-level': LogLevel.important, 'log-to-files': false },
-  metrics: { 'metrics-exporter-enabled': DEFAULT_METRICS_EXPORTER_ENABLED, 'metrics-port': DEFAULT_METRICS_EXPORTER_PORT },
+  metrics: {
+    'metrics-exporter-enabled': DEFAULT_METRICS_EXPORTER_ENABLED,
+    'metrics-port': DEFAULT_METRICS_EXPORTER_PORT,
+  },
   network: { name: Networks.TESTNET_CLAY },
   node: {},
   'state-store': {
@@ -184,6 +188,7 @@ export class CeramicCliUtils {
       }
     }
 
+    handleHeapdumpSignal(new URL('./', configFilepath))
     return CeramicDaemon.create(config)
   }
 

--- a/packages/cli/src/daemon/handle-heapdump-signal.ts
+++ b/packages/cli/src/daemon/handle-heapdump-signal.ts
@@ -1,0 +1,27 @@
+import { writeHeapSnapshot } from 'node:v8'
+import { appendFileSync } from 'node:fs'
+
+/**
+ * Return +timestamp+ formatted as ISO8601 string. No milliseconds.
+ * If not provided, +timestamp+ is `new Date()`, i.e. _now_.
+ */
+function timestamp(timestamp: Date = new Date()): string {
+  return timestamp.toISOString().replace(/\.\d+/, '')
+}
+
+/**
+ * Write heapdump to a file `ceramic-<timestamp>.heapsnapshot` in +folder+ on `SIGUSR2` signal.
+ * It takes time to make a heapdump. We log when the heapdumping starts and finishes in `${folder}/heapdump-progress` file.
+ *
+ * @param folder Folder that contains a heapdump.
+ */
+export function handleHeapdumpSignal(folder: URL): void {
+  process.on('SIGUSR2', () => {
+    const filepath = new URL(`./ceramic-${timestamp()}.heapsnapshot`, folder)
+    const notifierFilepath = new URL(`./heapdumping-progress`, folder)
+    const pid = process.pid
+    appendFileSync(notifierFilepath, `${timestamp()}: ${pid}: started: ${filepath.pathname}\n`)
+    writeHeapSnapshot(filepath.pathname)
+    appendFileSync(notifierFilepath, `${timestamp()}: ${pid}: finished: ${filepath.pathname}\n`)
+  })
+}


### PR DESCRIPTION
Make a heapdump when `SIGUSR2` signal is received. The heapdump is written to `<config-folder>/ceramic-<timestamp>.heapsnapshot`. 

It takes time to make a heapdump. We log when the heapdumping starts and finishes in `<config-folder>/heapdump-progress` text file.

The heapdump later can be analysed by Chrome DevTools.