### PR TITLE
remove cross-fetch import

### DIFF
--- a/packages/common/src/utils/http-utils.ts
+++ b/packages/common/src/utils/http-utils.ts
@@ -1,4 +1,3 @@
-import fetch from 'cross-fetch'
 import { mergeAbortSignals, TimedAbortSignal } from './abort-signal-utils.js'
 
 const DEFAULT_FETCH_TIMEOUT = 60 * 1000 * 3 // 3 minutes


### PR DESCRIPTION
`cross-fetch` package creates issues while trying to use `@ceramicnetwork/http-client` in a chrome-browser extension (within a background script).
```
error while trying to authenticate:  ReferenceError: XMLHttpRequest is not defined
    at browser-ponyfill.js:462:1
    at new Promise (<anonymous>)
    at fetch (browser-ponyfill.js:455:1)
    at fetchJson (http-utils.js:16:1)
    at Function.createFromGenesis (document.js:42:1)
    at CeramicClient.createStreamFromGenesis (ceramic-http-client.js:40:1)
    at Function.createFromGenesis (tile-document.js:97:1)
    at TileLoader.deterministic (index.js:112:1)
    at async ThreeIDX.loadAuthLink (three-idx.js:122:1)
    at async ThreeIDX.loadIDX (three-idx.js:164:1)
```

The issue is that chrome extension doesn't provide `XMLHttpRequest` access within background script. Only **fetch** API is available

PS:
Any way to make `cross-fetch`optional ?