### PR TITLE
feat: Add path expansion to config file handling

### DIFF
--- a/packages/cli/src/__tests__/daemon-config.test.ts
+++ b/packages/cli/src/__tests__/daemon-config.test.ts
@@ -1,0 +1,52 @@
+import tmp from 'tmp-promise'
+import { writeFile } from 'node:fs/promises'
+import { DaemonConfig } from '../daemon-config'
+import { homedir } from 'node:os'
+
+describe('reading from file', () => {
+  let folder: tmp.DirectoryResult
+  let configFilepath: URL
+  beforeEach(async () => {
+    folder = await tmp.dir({ unsafeCleanup: true })
+    const base = new URL(`file://${folder.path}/`)
+    configFilepath = new URL(`./config.json`, base)
+  })
+  afterEach(async () => {
+    await folder.cleanup()
+  })
+
+  test('read config from file', async () => {
+    const config = {}
+    await writeFile(configFilepath, JSON.stringify(config))
+    await expect(DaemonConfig.fromFile(configFilepath)).resolves.toBeInstanceOf(DaemonConfig)
+  })
+  test('expand relative path', async () => {
+    const config = {
+      logger: {
+        'log-directory': './log-dir',
+      },
+      'state-store': {
+        'local-directory': './statestore',
+      },
+    }
+    await writeFile(configFilepath, JSON.stringify(config))
+    const read = await DaemonConfig.fromFile(configFilepath)
+    expect(read.logger.logDirectory).toEqual(new URL('./log-dir', configFilepath).pathname)
+    expect(read.stateStore.localDirectory).toEqual(new URL('./statestore', configFilepath).pathname)
+  })
+  test('expand home-dir path', async () => {
+    const config = {
+      logger: {
+        'log-directory': '~/log-dir',
+      },
+      'state-store': {
+        'local-directory': '~/statestore',
+      },
+    }
+    await writeFile(configFilepath, JSON.stringify(config))
+    const read = await DaemonConfig.fromFile(configFilepath)
+    const home = new URL(`file://${homedir()}/`)
+    expect(read.logger.logDirectory).toEqual(new URL('./log-dir', home).pathname)
+    expect(read.stateStore.localDirectory).toEqual(new URL('./statestore', home).pathname)
+  })
+})

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -581,9 +581,7 @@ export class CeramicCliUtils {
       await this._saveConfig(DEFAULT_DAEMON_CONFIG, filepath)
       return DEFAULT_DAEMON_CONFIG
     }
-
-    const fileContents = await fs.readFile(filepath, { encoding: 'utf8' })
-    return DaemonConfig.fromString(fileContents)
+    return DaemonConfig.fromFile(filepath)
   }
 
   /**

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata'
 import { jsonObject, jsonMember, jsonArrayMember, TypedJSON, toJson, AnyT } from 'typedjson'
 import { StreamID } from '@ceramicnetwork/streamid'
+import fs from 'fs/promises'
 
 /**
  * Whether the daemon should start its own bundled in-process ipfs node, or if it should connect
@@ -360,6 +361,11 @@ export class DaemonConfig {
     const jsonObject = JSON.parse(jsonString)
 
     return this.fromObject(jsonObject)
+  }
+
+  static async fromFile(filepath: URL): Promise<DaemonConfig> {
+    const content = await fs.readFile(filepath, { encoding: 'utf8' })
+    return DaemonConfig.fromString(content)
   }
 
   static fromObject(json: Record<string, any>): DaemonConfig {

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -5,7 +5,7 @@ import { readFile } from 'node:fs/promises'
 import { homedir } from 'os'
 
 /**
- * Replace `~/` with `<homedir>/` absolute path.
+ * Replace `~/` with `<homedir>/` absolute path, and `~+/` with `<cwd>/`.
  * @param input Relative path.
  */
 function expandHomedir(input: string): string {
@@ -15,7 +15,7 @@ function expandHomedir(input: string): string {
 /**
  * If +input+ path is relative to +configFilepath+, return absolute filepath.
  *
- * Includes expansion of `~/` to home directory. See [[expandHomedir]].
+ * Includes expansion of `~/` to home directory, and of `~+/` to current working dir. See [[expandHomedir]].
  * @param input Relative path to resolve.
  * @param configFilepath Base folder used for path resolution.
  */

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -4,14 +4,12 @@ import { StreamID } from '@ceramicnetwork/streamid'
 import { readFile } from 'node:fs/promises'
 import { homedir } from 'os'
 
-const HOME_DIR = `${homedir()}/`.replace(/\/\/$/, '')
-
 /**
  * Replace `~/` with `<homedir>/` absolute path.
  * @param input Relative path.
  */
 function expandHomedir(input: string): string {
-  return input.replace(/^~\//, HOME_DIR)
+  return input.replace(/^~\+(?=$|\/|\\)/, process.cwd()).replace(/^~(?=$|\/|\\)/, homedir())
 }
 
 /**


### PR DESCRIPTION
Handle:
- `~/` is replaced with `os.homedir()`,
- `./`, `../` are resolved against the config file path,
for:
- `config.logger.logDirectory`,
- `config.stateStore.localDirectory`.