### PR TITLE
Accept `documentVersion` as model view type in handler validation

### DIFF
--- a/packages/stream-model-handler/src/__tests__/views-utils.test.ts
+++ b/packages/stream-model-handler/src/__tests__/views-utils.test.ts
@@ -3,7 +3,7 @@ import { ViewsValidation } from '../views-utils'
 import { ModelViewsDefinition } from '@ceramicnetwork/stream-model'
 
 const SCHEMA: JSONSchema.Object = {
-  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
   type: 'object',
   properties: {
     stringPropName: {
@@ -16,17 +16,18 @@ const SCHEMA: JSONSchema.Object = {
 }
 
 const VIEWS_VALID: ModelViewsDefinition = {
-  'owner': { type: 'documentAccount' }
+  owner: { type: 'documentAccount' },
+  version: { type: 'documentVersion' },
 }
 
 const VIEWS_INVALID_TYPE: ModelViewsDefinition = {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  'owner': { type: 'invalidType' }
+  owner: { type: 'invalidType' },
 }
 
 const VIEWS_DUPLICATED_PROPERTY: ModelViewsDefinition = {
-  'stringPropName': { type: 'documentAccount' }
+  stringPropName: { type: 'documentAccount' },
 }
 
 describe('ViewsValidation', () => {
@@ -54,4 +55,3 @@ describe('ViewsValidation', () => {
     }).toThrow(/view definition used with a property also present in schema/)
   })
 })
-

--- a/packages/stream-model-handler/src/views-utils.ts
+++ b/packages/stream-model-handler/src/views-utils.ts
@@ -1,17 +1,12 @@
 import type { JSONSchema } from 'json-schema-typed/draft-2020-12'
 import { ModelViewsDefinition } from '@ceramicnetwork/stream-model'
 
-const SUPPORTED_VIEW_TYPES = {
-  'documentAccount': true
-}
+const SUPPORTED_VIEW_TYPES = ['documentAccount', 'documentVersion']
 
 export class ViewsValidation {
-  public validateViews(
-    views: ModelViewsDefinition,
-    schema: JSONSchema.Object
-  ): void {
+  public validateViews(views: ModelViewsDefinition, schema: JSONSchema.Object): void {
     Object.entries(views).forEach(([key, value]) => {
-      if (!SUPPORTED_VIEW_TYPES[value.type]) {
+      if (!SUPPORTED_VIEW_TYPES.includes(value.type)) {
         throw new Error('unsupported model view definition type')
       }
       if (schema.properties[key] !== undefined) {


### PR DESCRIPTION
## Description

Follow-up on adding the `documentVersion` type for model views, adds the matching logic to the model handler.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x] Updated model handler tests

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
