### PR TITLE
feat(core,model-handler,model-instance-handler): Disable indexing and query features by default until they are ready

### DIFF
--- a/packages/canary-integration/src/__tests__/capability.test.ts
+++ b/packages/canary-integration/src/__tests__/capability.test.ts
@@ -73,6 +73,8 @@ describe('CACAO Integration test', () => {
   let MODEL_STREAM_ID_2: StreamID
 
   beforeAll(async () => {
+    process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING = 'true'
+
     ipfs = await createIPFS()
     ceramic = await createCeramic(ipfs)
     // Create a did:pkh for the user

--- a/packages/canary-integration/src/__tests__/model-instance-document.test.ts
+++ b/packages/canary-integration/src/__tests__/model-instance-document.test.ts
@@ -53,6 +53,8 @@ describe('ModelInstanceDocument API http-client tests', () => {
   let midMetadata: ModelInstanceDocumentMetadata
 
   beforeAll(async () => {
+    process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING = 'true'
+
     ipfs = await createIPFS()
     core = await createCeramic(ipfs)
 
@@ -232,6 +234,8 @@ describe('ModelInstanceDocument API multi-node tests', () => {
   let midMetadata: ModelInstanceDocumentMetadata
 
   beforeAll(async () => {
+    process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING = 'true'
+
     ipfs0 = await createIPFS()
     ipfs1 = await createIPFS()
     ceramic0 = await createCeramic(ipfs0)

--- a/packages/canary-integration/src/__tests__/model.test.ts
+++ b/packages/canary-integration/src/__tests__/model.test.ts
@@ -20,6 +20,8 @@ describe('Model API http-client tests', () => {
   let ceramic: CeramicClient
 
   beforeAll(async () => {
+    process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING = 'true'
+
     ipfs = await createIPFS()
     core = await createCeramic(ipfs)
 
@@ -168,6 +170,8 @@ describe('Model API multi-node tests', () => {
   let ceramic1: Ceramic
 
   beforeAll(async () => {
+    process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING = 'true'
+
     ipfs0 = await createIPFS()
     ipfs1 = await createIPFS()
     ceramic0 = await createCeramic(ipfs0)

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -7,10 +7,7 @@ import { StreamID, CommitID } from '@ceramicnetwork/streamid'
 import cloneDeep from 'lodash.clonedeep'
 import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
 import { createCeramic } from './create-ceramic.js'
-import {
-  ModelInstanceDocument,
-  ModelInstanceDocumentMetadata,
-} from '@ceramicnetwork/stream-model-instance'
+import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
 import { Model, ModelAccountRelation, ModelDefinition } from '@ceramicnetwork/stream-model'
 
 /**
@@ -61,6 +58,8 @@ describe('Ceramic API', () => {
   }
 
   beforeAll(async () => {
+    process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING = 'true'
+
     ipfs = await createIPFS()
   })
 

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -502,6 +502,12 @@ export class Ceramic implements CeramicApi {
         this._logger.warn(`Starting in read-only gateway mode. All write operations will fail`)
       }
 
+      if (process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING) {
+        this._logger.warn(
+          `Warning: indexing and query APIs are experimental and still under active development.  Please do not create Composites, Models, or ModelInstanceDocument streams, or use any of the new GraphQL query APIs on mainnet until they are officially released`
+        )
+      }
+
       if (doPeerDiscovery) {
         await this._ipfsTopology.start()
       }

--- a/packages/core/src/indexing/local-index-api.ts
+++ b/packages/core/src/indexing/local-index-api.ts
@@ -22,6 +22,10 @@ export class LocalIndexApi implements IndexApi {
   ) {}
 
   private _shouldIndexStream(args: StreamID): Boolean {
+    if (!this.databaseIndexApi) {
+      return false
+    }
+
     return this.databaseIndexApi.getActiveModelsToIndex().some(function (streamId) {
       return String(streamId) === String(args)
     })

--- a/packages/core/src/initialization/make-index-api.ts
+++ b/packages/core/src/initialization/make-index-api.ts
@@ -28,6 +28,9 @@ export function makeIndexApi(
   network: Networks,
   logger: DiagnosticsLogger
 ): DatabaseIndexApi | undefined {
+  if (!process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING) {
+    return undefined
+  }
   if (!indexingConfig) {
     logger.warn(`Indexing is not configured. Please add the indexing settings to your config file`)
     return undefined

--- a/packages/stream-model-handler/src/__tests__/model-handler.test.ts
+++ b/packages/stream-model-handler/src/__tests__/model-handler.test.ts
@@ -233,6 +233,8 @@ describe('ModelHandler', () => {
   let signerUsingOldKey: CeramicSigner
 
   beforeAll(async () => {
+    process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING = 'true'
+
     const recs: Record<string, any> = {}
     const ipfs = {
       dag: {

--- a/packages/stream-model-handler/src/model-handler.ts
+++ b/packages/stream-model-handler/src/model-handler.ts
@@ -67,6 +67,15 @@ export class ModelHandler implements StreamHandler<Model> {
     context: Context,
     state?: StreamState
   ): Promise<StreamState> {
+    if (!process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING) {
+      context.loggerProvider
+        .getDiagnosticsLogger()
+        .err(
+          'Indexing is an experimental feature and is not yet supported in production. To enable for testing purposes only, set the CERAMIC_ENABLE_EXPERIMENTAL_INDEXING environment variable'
+        )
+      throw new Error('Indexing is not enabled')
+    }
+
     if (state == null) {
       // apply genesis
       return this._applyGenesis(commitData, context)

--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -212,6 +212,8 @@ describe('ModelInstanceDocumentHandler', () => {
   let signerUsingOldKey: CeramicSigner
 
   beforeAll(async () => {
+    process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING = 'true'
+
     const recs: Record<string, any> = {}
     const ipfs = {
       dag: {

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -53,6 +53,15 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     context: Context,
     state?: StreamState
   ): Promise<StreamState> {
+    if (!process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING) {
+      context.loggerProvider
+        .getDiagnosticsLogger()
+        .err(
+          'Indexing is an experimental feature and is not yet supported in production. To enable for testing purposes only, set the CERAMIC_ENABLE_EXPERIMENTAL_INDEXING environment variable'
+        )
+      throw new Error('Indexing is not enabled')
+    }
+
     if (state == null) {
       // apply genesis
       return this._applyGenesis(commitData, context)


### PR DESCRIPTION
This PR puts all indexing and query functionality behind an environment variable flag guard temporarily.  If users discover the new functionality and start creating models or MIDs on mainnet, then any breaking changes we make to those streamtypes as part of testing and finalizing the release would break any existing streams of those streamtypes on the network.  Worse, even if we don't make breaking changes, any MID or Model streams created on mainnet before the necessary changes are in place on the CAS to enable indexing from anchors would never get picked up by indexers performing a historical sync.  We shouldn't have any Model or MID streams created on mainnet until the anchors being performed on mainnet are indexable.

As soon as we're ready to release indexing for real, we should remove this environment variable entirely.