### PR TITLE
feat: Add a method to CeramicAPI that transforms raw StreamState to an instance of Streamtype

### DIFF
--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -1,5 +1,5 @@
 import type { DID } from 'dids'
-import type { Stream, StreamHandler, CeramicCommit, AnchorStatus } from './stream.js'
+import type { Stream, StreamHandler, CeramicCommit, AnchorStatus, StreamState } from './stream.js'
 import type { CreateOpts, LoadOpts, PublishOpts, UpdateOpts } from './streamopts.js'
 import type { StreamID, CommitID } from '@ceramicnetwork/streamid'
 import type { LoggerProvider } from './logger-provider.js'
@@ -133,6 +133,13 @@ export interface CeramicApi extends CeramicSigner {
    * stream.
    */
   getSupportedChains(): Promise<Array<string>>
+
+  /**
+   * Turns +state+ into a Stream instance of the appropriate StreamType.
+   * Does not add the resulting instance to a cache.
+   * @param state SreamState for a stream.
+   */
+  buildStreamFromState<T extends Stream = Stream>(state: StreamState): Promise<T>
 
   /**
    * Closes Ceramic instance

--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -137,9 +137,9 @@ export interface CeramicApi extends CeramicSigner {
   /**
    * Turns +state+ into a Stream instance of the appropriate StreamType.
    * Does not add the resulting instance to a cache.
-   * @param state SreamState for a stream.
+   * @param state StreamState for a stream.
    */
-  buildStreamFromState<T extends Stream = Stream>(state: StreamState): Promise<T>
+  buildStreamFromState<T extends Stream = Stream>(state: StreamState): T
 
   /**
    * Closes Ceramic instance

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -7,10 +7,11 @@ import {
   SyncOptions,
   GenesisCommit,
   MultiQuery,
+  CeramicApi,
 } from '@ceramicnetwork/common'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { StreamID, CommitID } from '@ceramicnetwork/streamid'
-import { swarmConnect, withFleet } from '@ceramicnetwork/ipfs-daemon'
+import { createIPFS, swarmConnect, withFleet } from '@ceramicnetwork/ipfs-daemon'
 import { Ceramic } from '../ceramic.js'
 import { createCeramic as vanillaCreateCeramic } from './create-ceramic.js'
 import first from 'it-first'
@@ -668,5 +669,27 @@ describe('Ceramic integration', () => {
       await expect(stream.update({ date: 'invalid-date' })).rejects.toThrow()
       await ceramic.close()
     })
+  })
+})
+
+describe('buildStreamFromState', () => {
+  let ipfs: IpfsApi
+  let ceramic: CeramicApi
+  beforeEach(async () => {
+    ipfs = await createIPFS()
+    ceramic = await createCeramic(ipfs)
+  })
+
+  afterEach(async () => {
+    await ceramic.close()
+    await ipfs.stop()
+  })
+
+  test('build instance of Streamtype', async () => {
+    const tile = await TileDocument.create(ceramic, { hello: 'world' })
+    const created = ceramic.buildStreamFromState(tile.state)
+    expect(created).toBeInstanceOf(TileDocument)
+    expect(created.id).toEqual(tile.id)
+    expect(created.content).toEqual(tile.content)
   })
 })

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -46,6 +46,7 @@ import * as path from 'path'
 import type { DatabaseIndexApi } from './indexing/database-index-api.js'
 import { LocalIndexApi } from './indexing/local-index-api.js'
 import { makeIndexApi } from './initialization/make-index-api.js'
+import { RunningState } from './state-management/running-state'
 
 const DEFAULT_CACHE_LIMIT = 500 // number of streams stored in the cache
 const DEFAULT_QPS_LIMIT = 10 // Max number of pubsub query messages that can be published per second without rate limiting
@@ -859,10 +860,10 @@ export class Ceramic implements CeramicApi {
   /**
    * Turns +state+ into a Stream instance of the appropriate StreamType.
    * Does not add the resulting instance to a cache.
-   * @param state SreamState for a stream.
+   * @param state StreamState for a stream.
    */
-  buildStreamFromState<T extends Stream = Stream>(state: StreamState): Promise<T> {
-    throw new Error('FIXME buildStreamFromState') // FIXME buildStreamFromState
+  buildStreamFromState<T extends Stream = Stream>(state: StreamState): T {
+    return streamFromState<T>(this.context, this._streamHandlers, state, this.repository.updates$)
   }
 
   /**

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -23,6 +23,7 @@ import {
   AnchorValidator,
   AnchorStatus,
   IndexApi,
+  StreamState,
 } from '@ceramicnetwork/common'
 
 import { DID } from 'dids'
@@ -853,6 +854,15 @@ export class Ceramic implements CeramicApi {
    */
   async getSupportedChains(): Promise<Array<string>> {
     return this._supportedChains
+  }
+
+  /**
+   * Turns +state+ into a Stream instance of the appropriate StreamType.
+   * Does not add the resulting instance to a cache.
+   * @param state SreamState for a stream.
+   */
+  buildStreamFromState<T extends Stream = Stream>(state: StreamState): Promise<T> {
+    throw new Error('FIXME buildStreamFromState') // FIXME buildStreamFromState
   }
 
   /**

--- a/packages/http-client/src/__tests__/ceramic-http-client.test.ts
+++ b/packages/http-client/src/__tests__/ceramic-http-client.test.ts
@@ -36,6 +36,15 @@ const second = {
 } as unknown as StreamState
 const streamId = new StreamID(0, FAKE_CID_1)
 
+describe('buildStreamFromState', () => {
+  test('build instance of Streamtype', async () => {
+    const client = new CeramicClient(API_URL)
+    const a = client.buildStreamFromState(initial)
+    expect(a).toBeInstanceOf(TileDocument)
+    expect(a.id.cid).toEqual(FAKE_CID_1)
+  })
+})
+
 describe('applyCommit', () => {
   describe('document not in cache', () => {
     test('add to cache', async () => {

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -127,10 +127,10 @@ export class CeramicClient implements CeramicApi {
     const found = this._streamCache.get(stream.id.toString())
     if (found) {
       if (!StreamUtils.statesEqual(stream.state, found.state)) found.next(stream.state)
-      return this.buildStream<T>(found)
+      return this.buildStreamFromDocument<T>(found)
     } else {
       this._streamCache.set(stream.id.toString(), stream)
-      return this.buildStream<T>(stream)
+      return this.buildStreamFromDocument<T>(stream)
     }
   }
 
@@ -147,7 +147,7 @@ export class CeramicClient implements CeramicApi {
       stream = await Document.load(streamRef, this._apiUrl, this._config.syncInterval, opts)
       this._streamCache.set(stream.id.toString(), stream)
     }
-    return this.buildStream<T>(stream)
+    return this.buildStreamFromDocument<T>(stream)
   }
 
   async multiQuery(queries: Array<MultiQuery>, timeout?: number): Promise<Record<string, Stream>> {
@@ -171,7 +171,7 @@ export class CeramicClient implements CeramicApi {
       const [k, v] = e
       const state = StreamUtils.deserializeState(v)
       const stream = new Document(state, this._apiUrl, this._config.syncInterval)
-      acc[k] = this.buildStream(stream)
+      acc[k] = this.buildStreamFromDocument(stream)
       return acc
     }, {})
   }
@@ -198,10 +198,10 @@ export class CeramicClient implements CeramicApi {
     const fromCache = this._streamCache.get(effectiveStreamId.toString())
     if (fromCache) {
       fromCache.next(document.state)
-      return this.buildStream<T>(document)
+      return this.buildStreamFromDocument<T>(document)
     } else {
       this._streamCache.set(effectiveStreamId.toString(), document)
-      return this.buildStream<T>(document)
+      return this.buildStreamFromDocument<T>(document)
     }
   }
 
@@ -224,18 +224,11 @@ export class CeramicClient implements CeramicApi {
     this._streamConstructors[streamHandler.name] = streamHandler.stream_constructor
   }
 
-  findStreamConstructor<T extends Stream>(type: number) {
-    const constructor = this._streamConstructors[type]
-    if (constructor) {
-      return constructor as StreamConstructor<T>
-    } else {
-      throw new Error(`Failed to find constructor for stream ${type}`)
-    }
-  }
-
-  private buildStream<T extends Stream = Stream>(stream: Document) {
-    const streamConstructor = this.findStreamConstructor<T>(stream.state.type)
-    return new streamConstructor(stream, this.context)
+  private buildStreamFromDocument<T extends Stream = Stream>(stream: Document): T {
+    const type = stream.state.type
+    const streamConstructor = this._streamConstructors[type]
+    if (!streamConstructor) throw new Error(`Failed to find constructor for stream ${type}`)
+    return new streamConstructor(stream, this.context) as T
   }
 
   async setDID(did: DID): Promise<void> {

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -19,6 +19,7 @@ import {
   SyncOptions,
   AnchorStatus,
   IndexApi,
+  StreamState,
 } from '@ceramicnetwork/common'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { Caip10Link } from '@ceramicnetwork/stream-caip10-link'
@@ -222,6 +223,15 @@ export class CeramicClient implements CeramicApi {
 
   addStreamHandler<T extends Stream>(streamHandler: StreamHandler<T>): void {
     this._streamConstructors[streamHandler.name] = streamHandler.stream_constructor
+  }
+
+  /**
+   * Turns +state+ into a Stream instance of the appropriate StreamType.
+   * Does not add the resulting instance to a cache.
+   * @param state SreamState for a stream.
+   */
+  buildStreamFromState<T extends Stream = Stream>(state: StreamState): Promise<T> {
+    throw new Error('FIXME buildStreamFromState') // FIXME buildStreamFromState
   }
 
   private buildStreamFromDocument<T extends Stream = Stream>(stream: Document): T {

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -228,10 +228,11 @@ export class CeramicClient implements CeramicApi {
   /**
    * Turns +state+ into a Stream instance of the appropriate StreamType.
    * Does not add the resulting instance to a cache.
-   * @param state SreamState for a stream.
+   * @param state StreamState for a stream.
    */
-  buildStreamFromState<T extends Stream = Stream>(state: StreamState): Promise<T> {
-    throw new Error('FIXME buildStreamFromState') // FIXME buildStreamFromState
+  buildStreamFromState<T extends Stream = Stream>(state: StreamState): T {
+    const stream$ = new Document(state, this._apiUrl, this._config.syncInterval)
+    return this.buildStreamFromDocument(stream$) as T
   }
 
   private buildStreamFromDocument<T extends Stream = Stream>(stream: Document): T {


### PR DESCRIPTION
`ceramic.buildStreamFromState(streamState)` builds an instance of a corresponding Streamtype based on the StreamState.
Works on Core and Client.

@pawartur @PaulLeCam 