### PR TITLE
feat: Store first anchored time in the indexing database

### DIFF
--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -648,6 +648,7 @@ export class Ceramic implements CeramicApi {
       streamID: stream.id,
       controller: stream.metadata.controller,
       lastAnchor: last_anchor_ts,
+      firstAnchor: null,
     }
     await this._index.indexStream(STREAM_CONTENT)
   }

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -23,7 +23,8 @@ import {
   AnchorValidator,
   AnchorStatus,
   IndexApi,
-  StreamState,
+  CommitType,
+  StreamState
 } from '@ceramicnetwork/common'
 
 import { DID } from 'dids'
@@ -46,7 +47,7 @@ import * as path from 'path'
 import type { DatabaseIndexApi } from './indexing/database-index-api.js'
 import { LocalIndexApi } from './indexing/local-index-api.js'
 import { makeIndexApi } from './initialization/make-index-api.js'
-import { RunningState } from './state-management/running-state'
+import { RunningState } from './state-management/running-state.js'
 
 const DEFAULT_CACHE_LIMIT = 500 // number of streams stored in the cache
 const DEFAULT_QPS_LIMIT = 10 // Max number of pubsub query messages that can be published per second without rate limiting
@@ -635,20 +636,26 @@ export class Ceramic implements CeramicApi {
    * @param stream
    * @private
    */
-  private async indexStreamIfNeeded(stream) {
+  private async indexStreamIfNeeded(stream: Stream): Promise<void> {
     if (!stream.metadata.model) {
       return
     }
 
-    const last_anchor_ts = stream.state$.value.metadata.anchorProof
-      ? new Date(stream.state$.value.metadata.anchorProof.blockTimestamp * 1000)
-      : null
+    const asDate = (unixTimestamp: number | null | undefined) => {
+      return unixTimestamp ? new Date(unixTimestamp * 1000) : null
+    }
+
+    // TODO(NET-1614) Test that the timestamps are correctly passed to the Index API.
+    const lastAnchor = asDate(stream.state.anchorProof?.blockTimestamp)
+    const firstAnchor = asDate(
+      stream.state.log.find((log) => log.type == CommitType.ANCHOR)?.timestamp
+    )
     const STREAM_CONTENT = {
       model: stream.metadata.model,
       streamID: stream.id,
       controller: stream.metadata.controller,
-      lastAnchor: last_anchor_ts,
-      firstAnchor: null,
+      lastAnchor: lastAnchor,
+      firstAnchor: firstAnchor,
     }
     await this._index.indexStream(STREAM_CONTENT)
   }

--- a/packages/core/src/indexing/database-index-api.ts
+++ b/packages/core/src/indexing/database-index-api.ts
@@ -6,6 +6,7 @@ export interface IndexStreamArgs {
   readonly model: StreamID
   readonly controller: string
   readonly lastAnchor: Date | null
+  readonly firstAnchor: Date | null
 }
 
 /**

--- a/packages/core/src/indexing/sqlite/__tests__/read-csv-fixture.util.ts
+++ b/packages/core/src/indexing/sqlite/__tests__/read-csv-fixture.util.ts
@@ -25,6 +25,7 @@ export function readCsvFixture(filepath: URL) {
             ? new Date(Number(row.last_anchored_at) * 1000)
             : undefined,
           createdAt: row.created_at ? new Date(Number(row.created_at) * 1000) : undefined,
+          firstAnchor: null,
         })
       })
       .on('error', (error) => reject(error))

--- a/packages/core/src/indexing/sqlite/__tests__/sqlite-index-api.test.ts
+++ b/packages/core/src/indexing/sqlite/__tests__/sqlite-index-api.test.ts
@@ -87,6 +87,7 @@ describe('indexStream', () => {
     streamID: StreamID.fromString(STREAM_ID_B),
     controller: CONTROLLER,
     lastAnchor: null,
+    firstAnchor: null
   }
 
   let indexApi: SqliteIndexApi
@@ -118,6 +119,7 @@ describe('indexStream', () => {
       ...STREAM_CONTENT,
       updatedAt: updateTime,
       lastAnchor: updateTime,
+      firstAnchor: null
     }
     // It updates the fields if a stream is present.
     await indexApi.indexStream(updatedStreamContent)

--- a/packages/core/src/indexing/sqlite/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/sqlite/migrations/1-create-model-table.ts
@@ -5,6 +5,7 @@ export async function createModelTable(dbConnection: Knex, tableName: string) {
     table.string('stream_id', 1024).primary().unique().notNullable()
     table.string('controller_did', 1024).notNullable()
     table.integer('last_anchored_at').nullable()
+    table.integer('first_anchored_at').nullable()
     table.integer('created_at').notNullable()
     table.integer('updated_at').notNullable()
 
@@ -12,5 +13,10 @@ export async function createModelTable(dbConnection: Knex, tableName: string) {
     table.index(['created_at'], `idx_${tableName}_created_at`)
     table.index(['updated_at'], `idx_${tableName}_updated_at`)
     table.index(['last_anchored_at', 'created_at'], `idx_${tableName}_last_anchored_at_created_at`)
+    table.index(['first_anchored_at'], `idx_${tableName}_first_anchored_at`)
+    table.index(
+      ['first_anchored_at', 'created_at'],
+      `idx_${tableName}_first_anchored_at_created_at`
+    )
   })
 }

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -41,6 +41,7 @@ export class SqliteIndexApi implements DatabaseIndexApi {
         stream_id: String(args.streamID),
         controller_did: String(args.controller),
         last_anchored_at: asTimestamp(args.lastAnchor),
+        first_anchored_at: asTimestamp(args.firstAnchor),
         created_at: asTimestamp(args.createdAt) || now,
         updated_at: asTimestamp(args.updatedAt) || now,
       })


### PR DESCRIPTION
It is a breaking change, but we are free _now_ to do this.