### PR TITLE
feat: Add allowQueriesBeforeHistoricalSync flag to config

### DIFF
--- a/packages/cli/src/__tests__/make-ceramic-daemon.ts
+++ b/packages/cli/src/__tests__/make-ceramic-daemon.ts
@@ -5,7 +5,15 @@ import { DaemonConfig } from '../daemon-config.js'
 
 export async function makeCeramicDaemon(core: Ceramic): Promise<CeramicDaemon> {
   const port = await getPort()
-  const daemon = new CeramicDaemon(core, DaemonConfig.fromObject({ 'http-api': { port } }))
+  const daemon = new CeramicDaemon(
+    core,
+    DaemonConfig.fromObject({
+      'http-api': { port },
+      indexing: {
+        'allow-queries-before-historical-sync': true,
+      },
+    })
+  )
   await daemon.listen()
   return daemon
 }

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -48,6 +48,7 @@ const DEFAULT_DAEMON_CONFIG = DaemonConfig.fromObject({
   },
   indexing: {
     db: `sqlite://${DEFAULT_INDEXING_DB_FILENAME.pathname}`,
+    'allow-queries-before-historical-sync': true,
     models: [],
   },
 })

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -474,7 +474,7 @@ export class CeramicDaemon {
 
   async getCollection(req: Request, res: Response): Promise<void> {
     // TODO(NET-1630) Throw if historical indexing is in progress
-    if (!this.opts.indexing.allowQueriesBeforeHistoricalSync) {
+    if (!this.opts.indexing?.allowQueriesBeforeHistoricalSync) {
       res.statusCode = 503
       throw new Error(`Index for historical data is not available`)
     }

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -473,6 +473,10 @@ export class CeramicDaemon {
   }
 
   async getCollection(req: Request, res: Response): Promise<void> {
+    if (!this.opts.indexing.allowQueriesBeforeHistoricalSync) {
+      res.statusCode = 503
+      throw new Error(`Index for historical data is not available`)
+    }
     const httpQuery = parseQueryObject(req.query)
     const query = collectionQuery(httpQuery)
     const indexResponse = await this.ceramic.index.queryIndex(query)

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -473,11 +473,6 @@ export class CeramicDaemon {
   }
 
   async getCollection(req: Request, res: Response): Promise<void> {
-    // TODO(NET-1630) Throw if historical indexing is in progress
-    if (!this.opts.indexing?.allowQueriesBeforeHistoricalSync) {
-      res.statusCode = 503
-      throw new Error(`Index for historical data is not available`)
-    }
     const httpQuery = parseQueryObject(req.query)
     const query = collectionQuery(httpQuery)
     const indexResponse = await this.ceramic.index.queryIndex(query)

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -473,6 +473,7 @@ export class CeramicDaemon {
   }
 
   async getCollection(req: Request, res: Response): Promise<void> {
+    // TODO(NET-1630) Throw if historical indexing is in progress
     if (!this.opts.indexing.allowQueriesBeforeHistoricalSync) {
       res.statusCode = 503
       throw new Error(`Index for historical data is not available`)

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -203,7 +203,9 @@ export class IndexingConfig {
   @jsonMember(String)
   db?: string
 
-  @jsonMember(Boolean)
+  @jsonMember(Boolean, {
+    name: 'allow-queries-before-historical-sync',
+  })
   allowQueriesBeforeHistoricalSync?: boolean = false
 
   @jsonArrayMember(StreamID, {

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -203,6 +203,9 @@ export class IndexingConfig {
   @jsonMember(String)
   db?: string
 
+  @jsonMember(Boolean)
+  allowQueriesBeforeHistoricalSync?: boolean = false
+
   @jsonArrayMember(StreamID, {
     emitDefaultValue: true,
     deserializer: (arr?: Array<string>) => {

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -197,17 +197,32 @@ export class DaemonAnchorConfig {
   ethereumRpcUrl?: string
 }
 
+/**
+ * Configuration options related to Index API.
+ */
 @jsonObject
 @toJson
 export class IndexingConfig {
+  /**
+   * Connection string to a database. Only sqlite and postgres are supported.
+   * Examples:
+   *  - `sqlite:///path/to/database.sqlite`,
+   *  - `postgres:///user:password@host:5432/database`
+   */
   @jsonMember(String)
   db?: string
 
+  /**
+   * Allow serving indexing queries if historical indexing is not done yet.
+   */
   @jsonMember(Boolean, {
     name: 'allow-queries-before-historical-sync',
   })
   allowQueriesBeforeHistoricalSync?: boolean = false
 
+  /**
+   * Models to index.
+   */
   @jsonArrayMember(StreamID, {
     emitDefaultValue: true,
     deserializer: (arr?: Array<string>) => {

--- a/packages/core/src/indexing/build-indexing.ts
+++ b/packages/core/src/indexing/build-indexing.ts
@@ -57,14 +57,22 @@ export function buildIndexing(indexingConfig: IndexingConfig): DatabaseIndexApi 
           filename: connectionString.pathname,
         },
       })
-      return new SqliteIndexApi(dbConnection, indexingConfig.models, indexingConfig.allowQueriesBeforeHistoricalSync)
+      return new SqliteIndexApi(
+        dbConnection,
+        indexingConfig.models,
+        indexingConfig.allowQueriesBeforeHistoricalSync
+      )
     }
     case 'postgres': {
       const dataSource = knex({
         client: 'pg',
         connection: connectionString.toString(),
       })
-      return new PostgresIndexApi(dataSource, indexingConfig.models, indexingConfig.allowQueriesBeforeHistoricalSync)
+      return new PostgresIndexApi(
+        dataSource,
+        indexingConfig.models,
+        indexingConfig.allowQueriesBeforeHistoricalSync
+      )
     }
     default:
       throw new UnsupportedDatabaseProtocolError(protocol)

--- a/packages/core/src/indexing/build-indexing.ts
+++ b/packages/core/src/indexing/build-indexing.ts
@@ -14,6 +14,11 @@ export type IndexingConfig = {
    * List of models to index.
    */
   models: Array<StreamID>
+
+  /**
+   * Allow a query only if historical sync is over.
+   */
+  allowQueriesBeforeHistoricalSync: boolean
 }
 
 export class UnsupportedDatabaseProtocolError extends Error {
@@ -52,14 +57,14 @@ export function buildIndexing(indexingConfig: IndexingConfig): DatabaseIndexApi 
           filename: connectionString.pathname,
         },
       })
-      return new SqliteIndexApi(dbConnection, indexingConfig.models)
+      return new SqliteIndexApi(dbConnection, indexingConfig.models, indexingConfig.allowQueriesBeforeHistoricalSync)
     }
     case 'postgres': {
       const dataSource = knex({
         client: 'pg',
         connection: connectionString.toString(),
       })
-      return new PostgresIndexApi(dataSource, indexingConfig.models)
+      return new PostgresIndexApi(dataSource, indexingConfig.models, indexingConfig.allowQueriesBeforeHistoricalSync)
     }
     default:
       throw new UnsupportedDatabaseProtocolError(protocol)

--- a/packages/core/src/indexing/index-query-not-available.error.ts
+++ b/packages/core/src/indexing/index-query-not-available.error.ts
@@ -1,0 +1,7 @@
+import type { StreamID } from '@ceramicnetwork/streamid'
+
+export class IndexQueryNotAvailableError extends Error {
+  constructor(model: StreamID |  string) {
+    super(`Index for historical data on ${model} is not available`)
+  }
+}

--- a/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
+++ b/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
@@ -4,7 +4,8 @@ import { StreamID } from '@ceramicnetwork/streamid'
 import knex, { Knex } from 'knex'
 import pgSetup from '@databases/pg-test/jest/globalSetup'
 import pgTeardown from '@databases/pg-test/jest/globalTeardown'
-import { asTableName } from '../../as-table-name.util'
+import { asTableName } from '../../as-table-name.util.js'
+import { IndexQueryNotAvailableError } from '../../index-query-not-available.error.js'
 
 const STREAM_ID_A = 'kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd'
 const STREAM_ID_B = 'kjzl6cwe1jw147dvq16zluojmraqvwdmbh61dx9e0c59i344lcrsgqfohexp60s'
@@ -56,7 +57,7 @@ describe('init', () => {
   describe('create tables', () => {
     test('create new table from scratch', async () => {
       const modelsToIndex = [StreamID.fromString(STREAM_ID_A)]
-      const indexApi = new PostgresIndexApi(dbConnection, modelsToIndex)
+      const indexApi = new PostgresIndexApi(dbConnection, modelsToIndex, true)
       await indexApi.init()
       const created = await listMidTables()
       const tableNames = modelsToIndex.map(asTableName)
@@ -66,7 +67,7 @@ describe('init', () => {
     test('create new table with existing ones', async () => {
       // First init with one model
       const modelsA = [StreamID.fromString(STREAM_ID_A)]
-      const indexApiA = new PostgresIndexApi(dbConnection, modelsA)
+      const indexApiA = new PostgresIndexApi(dbConnection, modelsA, true)
       await indexApiA.init()
       const createdA = await listMidTables()
       const tableNamesA = modelsA.map(asTableName)
@@ -74,7 +75,7 @@ describe('init', () => {
 
       // Next add another one
       const modelsB = [...modelsA, StreamID.fromString(STREAM_ID_B)]
-      const indexApiB = new PostgresIndexApi(dbConnection, modelsB)
+      const indexApiB = new PostgresIndexApi(dbConnection, modelsB, true)
       await indexApiB.init()
       const createdB = await listMidTables()
       const tableNamesB = modelsB.map(asTableName)
@@ -88,7 +89,7 @@ describe('close', () => {
     const fauxDbConnection = {
       destroy: jest.fn(),
     } as unknown as Knex
-    const indexApi = new PostgresIndexApi(fauxDbConnection, [])
+    const indexApi = new PostgresIndexApi(fauxDbConnection, [], true)
     await indexApi.close()
     expect(fauxDbConnection.destroy).toBeCalled()
   })
@@ -110,11 +111,12 @@ describe('indexStream', () => {
     streamID: StreamID.fromString(STREAM_ID_B),
     controller: CONTROLLER,
     lastAnchor: null,
+    firstAnchor: null,
   }
 
   let indexApi: PostgresIndexApi
   beforeEach(async () => {
-    indexApi = new PostgresIndexApi(dbConnection, MODELS_TO_INDEX)
+    indexApi = new PostgresIndexApi(dbConnection, MODELS_TO_INDEX, true)
     await indexApi.init()
   })
 
@@ -155,5 +157,25 @@ describe('indexStream', () => {
     expect(closeDates(updatedAt, updateTime)).toBeTruthy()
     const createdAt = new Date(raw.created_at)
     expect(closeDates(createdAt, createTime)).toBeTruthy()
+  })
+})
+
+describe('page', () => {
+  const FAUX_DB_CONNECTION = {} as unknown as Knex
+
+  test('call the order if historical sync is allowed', async () => {
+    const indexApi = new PostgresIndexApi(FAUX_DB_CONNECTION, [], true)
+    const mockPage = jest.fn(async () => {
+      return { edges: [], pageInfo: { hasNextPage: false, hasPreviousPage: false } }
+    })
+    indexApi.insertionOrder.page = mockPage
+    await indexApi.page({ model: STREAM_ID_A, first: 100 })
+    expect(mockPage).toBeCalled()
+  })
+  test('throw if historical sync is not allowed', async () => {
+    const indexApi = new PostgresIndexApi(FAUX_DB_CONNECTION, [], false)
+    await expect(indexApi.page({ model: STREAM_ID_A, first: 100 })).rejects.toThrow(
+      IndexQueryNotAvailableError
+    )
   })
 })

--- a/packages/core/src/indexing/postgres/postgres-index-api.ts
+++ b/packages/core/src/indexing/postgres/postgres-index-api.ts
@@ -1,14 +1,19 @@
 import { StreamID } from 'streamid/lib/stream-id.js'
 import type { BaseQuery, Pagination, Page } from '@ceramicnetwork/common'
 import type { DatabaseIndexApi, IndexStreamArgs } from '../database-index-api.js'
-import { initTables } from '../postgres/init-tables.js'
-import { InsertionOrder } from '../postgres/insertion-order.js'
+import { initTables } from './init-tables.js'
+import { InsertionOrder } from './insertion-order.js'
 import { asTableName } from '../as-table-name.util.js'
 import { Knex } from 'knex'
+import { IndexQueryNotAvailableError } from '../index-query-not-available.error'
 
 export class PostgresIndexApi implements DatabaseIndexApi {
-  private readonly insertionOrder: InsertionOrder
-  constructor(private readonly dbConnection: Knex, readonly modelsToIndex: Array<StreamID>) {
+  readonly insertionOrder: InsertionOrder
+  constructor(
+    private readonly dbConnection: Knex,
+    readonly modelsToIndex: Array<StreamID>,
+    private readonly allowQueriesBeforeHistoricalSync: boolean
+  ) {
     this.insertionOrder = new InsertionOrder(dbConnection)
   }
 
@@ -41,6 +46,10 @@ export class PostgresIndexApi implements DatabaseIndexApi {
   }
 
   async page(query: BaseQuery & Pagination): Promise<Page<StreamID>> {
+    // TODO(NET-1630) Throw if historical indexing is in progress
+    if (!this.allowQueriesBeforeHistoricalSync) {
+      throw new IndexQueryNotAvailableError(query.model)
+    }
     return this.insertionOrder.page(query)
   }
 

--- a/packages/core/src/indexing/postgres/postgres-index-api.ts
+++ b/packages/core/src/indexing/postgres/postgres-index-api.ts
@@ -5,7 +5,7 @@ import { initTables } from './init-tables.js'
 import { InsertionOrder } from './insertion-order.js'
 import { asTableName } from '../as-table-name.util.js'
 import { Knex } from 'knex'
-import { IndexQueryNotAvailableError } from '../index-query-not-available.error'
+import { IndexQueryNotAvailableError } from '../index-query-not-available.error.js'
 
 export class PostgresIndexApi implements DatabaseIndexApi {
   readonly insertionOrder: InsertionOrder

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -5,7 +5,7 @@ import type { DatabaseIndexApi, IndexStreamArgs } from '../database-index-api.js
 import { initTables } from './init-tables.js'
 import { asTableName } from '../as-table-name.util.js'
 import { InsertionOrder } from './insertion-order.js'
-import { IndexQueryNotAvailableError } from '../index-query-not-available.error'
+import { IndexQueryNotAvailableError } from '../index-query-not-available.error.js'
 
 /**
  * Convert `Date` to SQLite `INTEGER`.

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -5,6 +5,7 @@ import type { DatabaseIndexApi, IndexStreamArgs } from '../database-index-api.js
 import { initTables } from './init-tables.js'
 import { asTableName } from '../as-table-name.util.js'
 import { InsertionOrder } from './insertion-order.js'
+import { IndexQueryNotAvailableError } from '../index-query-not-available.error'
 
 /**
  * Convert `Date` to SQLite `INTEGER`.
@@ -18,8 +19,13 @@ export function asTimestamp(input: Date | null | undefined): number | null {
 }
 
 export class SqliteIndexApi implements DatabaseIndexApi {
-  private readonly insertionOrder: InsertionOrder
-  constructor(private readonly dbConnection: Knex, readonly modelsToIndex: Array<StreamID>) {
+  readonly insertionOrder: InsertionOrder
+
+  constructor(
+    private readonly dbConnection: Knex,
+    readonly modelsToIndex: Array<StreamID>,
+    private readonly allowQueriesBeforeHistoricalSync: boolean
+  ) {
     this.insertionOrder = new InsertionOrder(dbConnection)
   }
 
@@ -53,6 +59,10 @@ export class SqliteIndexApi implements DatabaseIndexApi {
   }
 
   async page(query: BaseQuery & Pagination): Promise<Page<StreamID>> {
+    // TODO(NET-1630) Throw if historical indexing is in progress
+    if (!this.allowQueriesBeforeHistoricalSync) {
+      throw new IndexQueryNotAvailableError(query.model)
+    }
     return this.insertionOrder.page(query)
   }
 


### PR DESCRIPTION
Add allowQueriesBeforeHistoricalSync to index config.

If set to `false`, calls to `/api/v0/collection` return 503 error "Index for historical data is not available".

CLI creates a new daemon config with the flag set to `true`.

For existing config files, if the flag is absent, default is `false`.