### PR TITLE
chore: Beautify index api test

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "ceramic": "./bin/ceramic.js"
   },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --runInBand",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --runInBand --forceExit",
     "build": "npx tsc -p tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -20,12 +20,11 @@ import { firstValueFrom } from 'rxjs'
 import { filter } from 'rxjs/operators'
 import { randomString } from '@stablelib/random'
 import { CommitID, StreamID } from '@ceramicnetwork/streamid'
-import getPort from 'get-port'
 import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
 import { makeDID } from './make-did.js'
-import { DaemonConfig } from '../daemon-config.js'
 import fetch from 'cross-fetch'
 import { makeCeramicCore } from './make-ceramic-core.js'
+import { makeCeramicDaemon } from './make-ceramic-daemon.js'
 
 const seed = 'SEED'
 const MODEL_STREAM_ID = new StreamID(1, TestUtils.randomCID())
@@ -49,10 +48,8 @@ describe('Ceramic interop: core <> http-client', () => {
   beforeEach(async () => {
     tmpFolder = await tmp.dir({ unsafeCleanup: true })
     core = await makeCeramicCore(ipfs, tmpFolder.path, [MODEL_STREAM_ID].map(String))
-    const port = await getPort()
-    const apiUrl = 'http://localhost:' + port
-    daemon = new CeramicDaemon(core, DaemonConfig.fromObject({ 'http-api': { port } }))
-    await daemon.listen()
+    daemon = await makeCeramicDaemon(core)
+    const apiUrl = `http://localhost:${daemon.port}`
     client = new CeramicClient(apiUrl, { syncInterval: 500 })
 
     await core.setDID(makeDID(core, seed))

--- a/packages/cli/src/__tests__/ceramic-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-daemon.test.ts
@@ -94,7 +94,7 @@ describe('Ceramic interop: core <> http-client', () => {
 
   it('healthcheck fails if ipfs unreachable', async () => {
     const isOnlineSpy = jest.spyOn(ipfs, 'isOnline')
-    isOnlineSpy.mockRejectedValue(Error('ipfs is sad now'))
+    isOnlineSpy.mockRejectedValue(new Error('ipfs is sad now') as never)
     const res = await fetch(`http://localhost:${daemon.port}/api/v0/node/healthcheck`)
     expect(res.ok).toBeFalsy()
     const text = await res.text()
@@ -104,7 +104,7 @@ describe('Ceramic interop: core <> http-client', () => {
 
   it('healthcheck can skip ipfs check', async () => {
     const isOnlineSpy = jest.spyOn(ipfs, 'isOnline')
-    isOnlineSpy.mockRejectedValue(Error('ipfs is sad now'))
+    isOnlineSpy.mockRejectedValue(new Error('ipfs is sad now') as never)
     const res = await fetch(
       `http://localhost:${daemon.port}/api/v0/node/healthcheck?checkIpfs=false`
     )
@@ -147,7 +147,6 @@ describe('Ceramic interop: core <> http-client', () => {
     delete state2.log
     delete state1.metadata.unique
     delete state2.metadata.unique
-    delete state2.doctype
 
     expect(state1).toEqual(state2)
   })

--- a/packages/cli/src/__tests__/ceramic-error.test.ts
+++ b/packages/cli/src/__tests__/ceramic-error.test.ts
@@ -23,7 +23,7 @@ let tmpFolder: tmp.DirectoryResult
 
 function safeRead(filepath: string): string {
   if (fs.existsSync(filepath)) {
-    return fs.readFileSync(filepath).toString()
+    return fs.readFileSync(filepath, 'utf-8')
   } else {
     return ''
   }

--- a/packages/cli/src/__tests__/index-api.test.ts
+++ b/packages/cli/src/__tests__/index-api.test.ts
@@ -1,0 +1,133 @@
+import { jest } from '@jest/globals'
+import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
+import {
+  CommitType,
+  fetchJson,
+  IpfsApi,
+  StreamState,
+  StreamUtils,
+  TestUtils,
+} from '@ceramicnetwork/common'
+import { CeramicDaemon } from '../ceramic-daemon.js'
+import { makeCeramicCore } from './make-ceramic-core.js'
+import { makeCeramicDaemon } from './make-ceramic-daemon.js'
+import { makeDID } from './make-did.js'
+import tmp from 'tmp-promise'
+import { Ceramic } from '@ceramicnetwork/core'
+import { StreamID } from '@ceramicnetwork/streamid'
+import { CeramicClient } from '@ceramicnetwork/http-client'
+import { randomString } from '@stablelib/random'
+
+const MODEL_STREAM_ID = new StreamID(1, TestUtils.randomCID())
+const SEED = 'SEED'
+
+let ipfs: IpfsApi
+let daemon: CeramicDaemon
+let tmpFolder: tmp.DirectoryResult
+let core: Ceramic
+let client: CeramicClient
+
+beforeAll(async () => {
+  ipfs = await createIPFS()
+})
+
+afterAll(async () => {
+  await ipfs.stop()
+})
+
+beforeEach(async () => {
+  tmpFolder = await tmp.dir({ unsafeCleanup: true })
+  core = await makeCeramicCore(ipfs, tmpFolder.path, [MODEL_STREAM_ID].map(String))
+  daemon = await makeCeramicDaemon(core)
+  const apiUrl = `http://localhost:${daemon.port}`
+  client = new CeramicClient(apiUrl, { syncInterval: 500 })
+
+  await core.setDID(makeDID(core, SEED))
+  await client.setDID(makeDID(client, SEED))
+})
+
+afterEach(async () => {
+  await client.close()
+  await daemon.close()
+  await core.close()
+  await tmpFolder.cleanup()
+})
+
+describe('index api', () => {
+  describe('getCollection calls IndexAPI', () => {
+    test('model in query', async () => {
+      const query = new URL(`http://localhost:${daemon.port}/api/v0/collection`)
+      query.searchParams.set('model', MODEL_STREAM_ID.toString())
+      query.searchParams.set('first', '100')
+      const indexSpy = jest.spyOn(daemon.ceramic.index, 'queryIndex')
+      await fetchJson(query.toString())
+      expect(indexSpy).toBeCalledWith({
+        first: 100,
+        model: MODEL_STREAM_ID,
+      })
+    })
+    test('too much entries requested: forward pagination', async () => {
+      const query = new URL(`http://localhost:${daemon.port}/api/v0/collection`)
+      query.searchParams.set('model', MODEL_STREAM_ID.toString())
+      query.searchParams.set('first', '20000')
+      await expect(fetchJson(query.toString())).rejects.toThrow(/Requested too many entries: 20000/)
+    })
+    test('too much entries requested: forward pagination', async () => {
+      const query = new URL(`http://localhost:${daemon.port}/api/v0/collection`)
+      query.searchParams.set('model', MODEL_STREAM_ID.toString())
+      query.searchParams.set('last', '20000')
+      await expect(fetchJson(query.toString())).rejects.toThrow(/Requested too many entries: 20000/)
+    })
+    test('model, account in query', async () => {
+      const query = new URL(`http://localhost:${daemon.port}/api/v0/collection`)
+      query.searchParams.set('model', MODEL_STREAM_ID.toString())
+      const account = `did:key:${randomString(10)}`
+      query.searchParams.set('account', account)
+      query.searchParams.set('first', '100')
+      const indexSpy = jest.spyOn(daemon.ceramic.index, 'queryIndex')
+      await fetchJson(query.toString())
+      expect(indexSpy).toBeCalledWith({
+        first: 100,
+        model: MODEL_STREAM_ID,
+        account: account,
+      })
+    })
+    test('serialize StreamState', async () => {
+      const query = new URL(`http://localhost:${daemon.port}/api/v0/collection`)
+      query.searchParams.set('model', MODEL_STREAM_ID.toString())
+      query.searchParams.set('first', '100')
+      const original = daemon.ceramic.index.queryIndex.bind(daemon.ceramic.index)
+      const fauxStreamState = {
+        type: 0,
+        log: [
+          {
+            type: CommitType.GENESIS,
+            cid: TestUtils.randomCID(),
+          },
+        ],
+      } as unknown as StreamState
+      // Return faux but serializable StreamState
+      daemon.ceramic.index.queryIndex = async () => {
+        return {
+          edges: [
+            {
+              cursor: 'opaque-cursor',
+              node: fauxStreamState,
+            },
+          ],
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        }
+      }
+      // It gets serialized
+      const response = await fetchJson(query.toString())
+      expect(response.edges.length).toEqual(1)
+      // Check if it is indeed the same serialized state
+      expect(response.edges[0].node).toEqual(StreamUtils.serializeState(fauxStreamState))
+      // Get the original queryIndex method back
+      daemon.ceramic.index.queryIndex = original
+    })
+  })
+})

--- a/packages/cli/src/__tests__/make-ceramic-core.ts
+++ b/packages/cli/src/__tests__/make-ceramic-core.ts
@@ -1,0 +1,27 @@
+import { IpfsApi } from '@ceramicnetwork/common'
+import { Ceramic } from '@ceramicnetwork/core'
+import { TileDocumentHandler } from '@ceramicnetwork/stream-tile-handler'
+
+export async function makeCeramicCore(
+  ipfs: IpfsApi,
+  stateStoreDirectory: string,
+  modelsToIndex: Array<string>
+): Promise<Ceramic> {
+  const core = await Ceramic.create(ipfs, {
+    pubsubTopic: '/ceramic',
+    stateStoreDirectory,
+    anchorOnRequest: false,
+    indexing: {
+      db: `sqlite://${stateStoreDirectory}/ceramic.sqlite`,
+      models: modelsToIndex,
+    },
+  })
+
+  const handler = new TileDocumentHandler()
+  ;(handler as any).verifyJWS = (): Promise<void> => {
+    return
+  }
+  // @ts-ignore
+  core._streamHandlers.add(handler)
+  return core
+}

--- a/packages/cli/src/__tests__/make-ceramic-core.ts
+++ b/packages/cli/src/__tests__/make-ceramic-core.ts
@@ -5,7 +5,7 @@ import { TileDocumentHandler } from '@ceramicnetwork/stream-tile-handler'
 export async function makeCeramicCore(
   ipfs: IpfsApi,
   stateStoreDirectory: string,
-  modelsToIndex: Array<string>
+  modelsToIndex: Array<string> = []
 ): Promise<Ceramic> {
   const core = await Ceramic.create(ipfs, {
     pubsubTopic: '/ceramic',

--- a/packages/cli/src/__tests__/make-ceramic-daemon.ts
+++ b/packages/cli/src/__tests__/make-ceramic-daemon.ts
@@ -1,0 +1,11 @@
+import { Ceramic } from '@ceramicnetwork/core'
+import getPort from 'get-port'
+import { CeramicDaemon } from '../ceramic-daemon.js'
+import { DaemonConfig } from '../daemon-config.js'
+
+export async function makeCeramicDaemon(core: Ceramic): Promise<CeramicDaemon> {
+  const port = await getPort()
+  const daemon = new CeramicDaemon(core, DaemonConfig.fromObject({ 'http-api': { port } }))
+  await daemon.listen()
+  return daemon
+}

--- a/packages/stream-tests/package.json
+++ b/packages/stream-tests/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@ceramicnetwork/canary-integration",
+  "name": "@ceramicnetwork/stream-tests",
   "version": "2.4.1-rc.0",
   "private": true,
   "description": "Canary integration test for Ceramic components",
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --verbose --coverage --runInBand",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --verbose --coverage --runInBand --forceExit",
     "build": "npx tsc -p tsconfig.json",
     "lint": "npx eslint ./src --ext .js,.jsx,.ts,.tsx",
     "clean": "npx rimraf ./lib"


### PR DESCRIPTION
- Use Ceramic Client instead of fetchJSON
- Cover http-to-indexAPI flow.