### PR TITLE
feat(common): Remove 'controllers' accessor from Stream base class

### DIFF
--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -101,7 +101,6 @@ export interface StreamMetadata {
  */
 export interface StreamNext {
   content?: any
-  controllers?: Array<string>
   metadata?: StreamMetadata
 }
 

--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -187,10 +187,6 @@ export abstract class Stream extends Observable<StreamState> implements StreamSt
     return cloneDeep(next?.content ?? content)
   }
 
-  get controllers(): Array<string> {
-    return this.metadata.controllers
-  }
-
   get tip(): CID {
     return this.state$.value.log[this.state$.value.log.length - 1].cid
   }

--- a/packages/stream-caip10-link/src/caip10-link.ts
+++ b/packages/stream-caip10-link/src/caip10-link.ts
@@ -58,6 +58,10 @@ export class Caip10Link extends Stream {
     return cloneDeep(next?.metadata ?? metadata)
   }
 
+  get controllers(): Array<string> {
+    return this.metadata.controllers
+  }
+
   /**
    * Creates a Caip10Link for the given CAIP10 address. Initially created without a link to any DID,
    *   use 'setDid' to create the public link between the given CAIP10 account and a DID.

--- a/packages/stream-tile/src/tile-document.ts
+++ b/packages/stream-tile/src/tile-document.ts
@@ -166,6 +166,10 @@ export class TileDocument<T = Record<string, any>> extends Stream {
     return cloneDeep(next?.metadata ?? metadata)
   }
 
+  get controllers(): Array<string> {
+    return this.metadata.controllers
+  }
+
   /**
    * Creates a Tile document.
    * @param ceramic - Instance of CeramicAPI used to communicate with the Ceramic network


### PR DESCRIPTION
I did not add a `controller` accessor to `Model` or `ModelInstanceDocument`, as this can be easily accessed by `metadata.controller`.  I'm happy to add a `controller` accessor though if people think it's useful