### PR TITLE
feat(core): Pinning a ModelInstanceDocument should also pin its Model

### DIFF
--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -24,7 +24,7 @@ import {
   AnchorStatus,
   IndexApi,
   CommitType,
-  StreamState
+  StreamState,
 } from '@ceramicnetwork/common'
 
 import { DID } from 'dids'
@@ -436,8 +436,8 @@ export class Ceramic implements CeramicApi {
       : DEFAULT_QPS_LIMIT
 
     const ipfsTopology = new IpfsTopology(ipfs, networkOptions.name, logger)
-    const pinStoreFactory = new PinStoreFactory(ipfs, pinStoreOptions)
     const repository = new Repository(streamCacheLimit, concurrentRequestsLimit, logger)
+    const pinStoreFactory = new PinStoreFactory(ipfs, repository, pinStoreOptions)
     const shutdownController = new AbortController()
     const dispatcher = new Dispatcher(
       ipfs,

--- a/packages/core/src/store/__tests__/state-store-integration.test.ts
+++ b/packages/core/src/store/__tests__/state-store-integration.test.ts
@@ -16,6 +16,7 @@ import { CID } from 'multiformats/cid'
 import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
 import { createCeramic } from '../../__tests__/create-ceramic.js'
 import { RunningState } from '../../state-management/running-state.js'
+import { Repository } from '../../state-management/repository.js'
 
 const FAKE_CID = CID.parse('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
 
@@ -27,6 +28,10 @@ const ipfs = {
     add: jest.fn(),
   },
 } as unknown as IpfsApi
+
+const repository = {
+  load: jest.fn(),
+} as unknown as Repository
 
 describe('Level data store', () => {
   let store: PinStore
@@ -43,7 +48,7 @@ describe('Level data store', () => {
 
   beforeEach(async () => {
     const levelPath = (await tmp.dir({ unsafeCleanup: true })).path
-    const storeFactory = new PinStoreFactory(ipfs, {
+    const storeFactory = new PinStoreFactory(ipfs, repository, {
       stateStoreDirectory: levelPath,
       pinningEndpoints: ['ipfs+context'],
       networkName: 'inmemory',
@@ -129,7 +134,7 @@ describe('Level data store', () => {
 
   it('pins in different networks', async () => {
     const levelPath = (await tmp.dir({ unsafeCleanup: true })).path
-    const storeFactoryLocal = new PinStoreFactory(ipfs, {
+    const storeFactoryLocal = new PinStoreFactory(ipfs, repository, {
       stateStoreDirectory: levelPath,
       pinningEndpoints: ['ipfs+context'],
       networkName: 'local',
@@ -142,7 +147,7 @@ describe('Level data store', () => {
     await localStore.close()
 
     // Now create a net pin store for a different ceramic network
-    const storeFactoryInMemory = new PinStoreFactory(ipfs, {
+    const storeFactoryInMemory = new PinStoreFactory(ipfs, repository, {
       stateStoreDirectory: levelPath,
       pinningEndpoints: ['ipfs+context'],
       networkName: 'inmemory',

--- a/packages/stream-tests/src/__tests__/model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/model-instance-document.test.ts
@@ -106,6 +106,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
     expect(doc.state.anchorStatus).toEqual(AnchorStatus.PENDING)
     expect(doc.metadata.model.toString()).toEqual(model.id.toString())
     await expect(isPinned(ceramic, doc.id)).resolves.toBeTruthy()
+    await expect(isPinned(ceramic, doc.metadata.model)).resolves.toBeTruthy()
   })
 
   test('Create and update doc', async () => {
@@ -220,6 +221,16 @@ describe('ModelInstanceDocument API http-client tests', () => {
     await expect(isPinned(ceramic, doc.id)).resolves.toBeTruthy()
     await doc.replace(CONTENT1, { pin: false })
     await expect(isPinned(ceramic, doc.id)).resolves.toBeFalsy()
+  })
+
+  test(`Pinning a ModelInstanceDocument pins its Model`, async () => {
+    // Unpin Model streams so we can test that pinning the MID causes the Model to become pinned
+    await ceramic.pin.rm(model.id)
+    await expect(isPinned(ceramic, model.id)).resolves.toBeFalsy()
+
+    const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
+    await expect(isPinned(ceramic, doc.id)).resolves.toBeTruthy()
+    await expect(isPinned(ceramic, model.id)).resolves.toBeTruthy()
   })
 })
 


### PR DESCRIPTION
I had really been hoping on using this to make stream pinning behavior streamtype-specific so each StreamHandler could specify its own behavior for when streams of that type get pinned. That way the model-specific pinning logic wouldn't have to live in a generic codepath that applies to all streamtypes. But doing that would have been a much bigger refactor and so in the interest of time and simplicity this seemed like the more straightforward change that gets us what we need.