### PR TITLE
feat(cli): use env vars to override config file

### DIFF
--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -28,7 +28,6 @@ const DEFAULT_DAEMON_CONFIG_FILENAME = new URL('daemon.config.json', DEFAULT_CON
 const DEFAULT_CLI_CONFIG_FILENAME = new URL('client.config.json', DEFAULT_CONFIG_PATH)
 const LEGACY_CLI_CONFIG_FILENAME = new URL('config.json', DEFAULT_CONFIG_PATH) // todo(1615): Remove this backwards compatibility support
 const DEFAULT_INDEXING_DB_FILENAME = new URL('./indexing.sqlite', DEFAULT_CONFIG_PATH)
-const DEFAULT_METRICS_EXPORTER_ENABLED = false
 const DEFAULT_METRICS_EXPORTER_PORT = 9090
 
 const DEFAULT_DAEMON_CONFIG = DaemonConfig.fromObject({
@@ -37,7 +36,7 @@ const DEFAULT_DAEMON_CONFIG = DaemonConfig.fromObject({
   ipfs: { mode: IpfsMode.BUNDLED },
   logger: { 'log-level': LogLevel.important, 'log-to-files': false },
   metrics: {
-    'metrics-exporter-enabled': DEFAULT_METRICS_EXPORTER_ENABLED,
+    'metrics-exporter-enabled': false,
     'metrics-port': DEFAULT_METRICS_EXPORTER_PORT,
   },
   network: { name: Networks.TESTNET_CLAY },
@@ -118,9 +117,9 @@ export class CeramicCliUtils {
     const config = await this._loadDaemonConfig(configFilepath)
 
     // Environment variables override values from config file
-    if (envVarExists(process.env.CERAMIC_INDEXING_DB_URI)) config.indexing.db = process.env.CERAMIC_INDEXING_DB_URI
-    if (envVarExists(process.env.CERAMIC_METRICS_EXPORTER_ENABLED)) config.metrics.metricsExporterEnabled = Boolean(process.env.CERAMIC_METRICS_EXPORTER_ENABLED)
-    if (envVarExists(process.env.CERAMIC_METRICS_PORT)) config.metrics.metricsPort = Number(process.env.CERAMIC_METRICS_PORT)
+    if (process.env.CERAMIC_INDEXING_DB_URI) config.indexing.db = process.env.CERAMIC_INDEXING_DB_URI
+    if (process.env.CERAMIC_METRICS_EXPORTER_ENABLED) config.metrics.metricsExporterEnabled = Boolean(process.env.CERAMIC_METRICS_EXPORTER_ENABLED)
+    if (process.env.CERAMIC_METRICS_PORT) config.metrics.metricsPort = Number(process.env.CERAMIC_METRICS_PORT)
 
     {
       // CLI flags override values from environment variables and config file
@@ -631,13 +630,4 @@ Please use the upgraded Glaze CLI instead.
 Please test with the new CLI before reporting any problems.
 ${pc.green('npm i -g @glazed/cli')}`
   )
-}
-
-/**
- * Checks if the variable has been set based on default assumptions for environment variables
- * @param envVar Any environment variable
- * @returns True if the environment variable is not undefined and not the empty string. False otherwise.
- */
-function envVarExists(envVar: any): boolean {
-  return (envVar != undefined && envVar != '')
 }


### PR DESCRIPTION
## Description

- Uses environment variables to override config file defaults (note: the hierarchy here is cli flags > env vars > config file > defaults)
- Adds env var for indexing db uri

## How Has This Been Tested?

- [x] ran js-ceramic locally and configured indexing with env var