### PR TITLE
feat(core): Anchor Status for ceramic anchoring READY request status  

### DIFF
--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -169,6 +169,7 @@ export class EthereumAnchorService implements AnchorService {
     }
 
     switch (json.status) {
+      case 'READY':
       case 'PENDING':
         return {
           status: AnchorStatus.PENDING,


### PR DESCRIPTION
tested manually as there are no tests for this file (a known tech dept). 

I have chosen to represent READY requests as AnchorStatus.PENDING because READY is a CAS specific status for batching. 