### PR TITLE
fix(core): Add undefined type to did setter

### DIFF
--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -107,7 +107,7 @@ export class CeramicClient implements CeramicApi {
    * Sets the DID instance that will be used to author commits to streams.
    * @param did
    */
-  set did(did: DID) {
+  set did(did: DID | undefined) {
     this.context.did = did
   }
 


### PR DESCRIPTION
I was trying to run the code inside the MetaMask Snaps system, and it didn't want to compile. After adding an optional undefined type, as stated in the diff, the code runs.

## Description

There has not been any open issue regarding this. It seems to happen in MetaMask Snaps only, which run in a separate environment from MetaMask extension and browser. It works as expected when running the code in the browser or node.js environment.

The bug shows already when connecting to the Clay Ceramic Testnet.

## How Has This Been Tested?

- [x] Tried to compile the MetaMask Snap code after applying the change

To reproduce:
Implement the connection in MetaMask Snaps as in the [tutorial here](https://developers.ceramic.network/tools/self-id/write/#using-the-selfid-class). When compiling the MetaMask Snap, the error fires.

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation
