### PR TITLE
fix(core): check value of indexing env var

### DIFF
--- a/packages/core/src/initialization/make-index-api.ts
+++ b/packages/core/src/initialization/make-index-api.ts
@@ -31,6 +31,9 @@ export function makeIndexApi(
   if (!process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING) {
     return undefined
   }
+  if (process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING == "" || process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING == "false") {
+    return undefined
+  }
   if (network == Networks.MAINNET || network == Networks.ELP) {
     // TODO enable ComposeDB on mainnet once mainnet anchors are indexable.
     throw new Error(`ComposeDB indexing features are not yet supported on mainnet`)

--- a/packages/core/src/initialization/make-index-api.ts
+++ b/packages/core/src/initialization/make-index-api.ts
@@ -28,10 +28,7 @@ export function makeIndexApi(
   network: Networks,
   logger: DiagnosticsLogger
 ): DatabaseIndexApi | undefined {
-  if (!process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING) {
-    return undefined
-  }
-  if (process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING == "" || process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING == "false") {
+  if (!process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING || !Boolean(process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING)) {
     return undefined
   }
   if (network == Networks.MAINNET || network == Networks.ELP) {

--- a/packages/core/src/initialization/make-index-api.ts
+++ b/packages/core/src/initialization/make-index-api.ts
@@ -28,7 +28,7 @@ export function makeIndexApi(
   network: Networks,
   logger: DiagnosticsLogger
 ): DatabaseIndexApi | undefined {
-  if (!process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING || !Boolean(process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING)) {
+  if (process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING != 'true') {
     return undefined
   }
   if (network == Networks.MAINNET || network == Networks.ELP) {


### PR DESCRIPTION
Setting this var to false on our infra enabled indexing.

I wrongly assumed that the value would be checked, but I think we should always check the value of an env var, rather than just the presence of it.