### PR TITLE
Test that demonstrates stream instance independence behaviors between core and client

### DIFF
--- a/packages/cli/src/__tests__/ceramic-multi-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-multi-daemon.test.ts
@@ -152,4 +152,30 @@ describe('Ceramic interop between multiple daemons and http clients', () => {
     await doc2.sync({ sync: SyncOptions.PREFER_CACHE })
     expect(doc2.content).toEqual(updatedContent)
   })
+
+  it('stream instances are independent in core', async () => {
+    const initialContent = { state: 'initial' }
+    const updatedContent = { state: 'updated' }
+    const doc1A = await TileDocument.create(core1, initialContent, null, { anchor: false })
+
+    const doc2 = await TileDocument.load(core2, doc1A.id)
+    await doc2.update(updatedContent, null, {publish:false, anchor:false})
+
+    const doc1B = await TileDocument.load(core1, doc1A.id, {sync: SyncOptions.SYNC_ALWAYS})
+    expect(doc1B.content).toEqual(updatedContent)
+    expect(doc1A.content).toEqual(initialContent)
+  })
+
+  it('stream instances are independent in http client', async () => {
+    const initialContent = { state: 'initial' }
+    const updatedContent = { state: 'updated' }
+    const doc1A = await TileDocument.create(client1, initialContent, null, { anchor: false })
+
+    const doc2 = await TileDocument.load(client2, doc1A.id)
+    await doc2.update(updatedContent, null, {publish:false, anchor:false})
+
+    const doc1B = await TileDocument.load(client1, doc1A.id, {sync: SyncOptions.SYNC_ALWAYS})
+    expect(doc1B.content).toEqual(updatedContent)
+    expect(doc1A.content).toEqual(initialContent)
+  })
 })


### PR DESCRIPTION
Following up the discussion in https://github.com/ceramicnetwork/js-ceramic/pull/2358 with an example of how core and client differ, even without loading anything with CommitIDs