### PR TITLE
fix: evaluate string value of env vars as booleans

### DIFF
--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -120,7 +120,7 @@ export class CeramicCliUtils {
     if (process.env.CERAMIC_INDEXING_DB_URI)
       config.indexing.db = process.env.CERAMIC_INDEXING_DB_URI
     if (process.env.CERAMIC_METRICS_EXPORTER_ENABLED)
-      config.metrics.metricsExporterEnabled = Boolean(process.env.CERAMIC_METRICS_EXPORTER_ENABLED)
+      config.metrics.metricsExporterEnabled = process.env.CERAMIC_METRICS_EXPORTER_ENABLED == 'true'
     if (process.env.CERAMIC_METRICS_PORT)
       config.metrics.metricsPort = Number(process.env.CERAMIC_METRICS_PORT)
 

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -505,7 +505,7 @@ export class Ceramic implements CeramicApi {
         this._logger.warn(`Starting in read-only gateway mode. All write operations will fail`)
       }
 
-      if (process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING) {
+      if (process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING == 'true') {
         this._logger.warn(
           `Warning: indexing and query APIs are experimental and still under active development.  Please do not create Composites, Models, or ModelInstanceDocument streams, or use any of the new GraphQL query APIs on mainnet until they are officially released`
         )
@@ -548,7 +548,7 @@ export class Ceramic implements CeramicApi {
    * as expected.
    */
   async _checkIPFSPersistence(): Promise<void> {
-    if (process.env.CERAMIC_SKIP_IPFS_PERSISTENCE_STARTUP_CHECK) {
+    if (process.env.CERAMIC_SKIP_IPFS_PERSISTENCE_STARTUP_CHECK == 'true') {
       this._logger.warn(`Skipping IPFS persistence checks`)
       return
     }

--- a/packages/stream-model-handler/src/model-handler.ts
+++ b/packages/stream-model-handler/src/model-handler.ts
@@ -67,11 +67,11 @@ export class ModelHandler implements StreamHandler<Model> {
     context: Context,
     state?: StreamState
   ): Promise<StreamState> {
-    if (!process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING) {
+    if (process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING != 'true') {
       context.loggerProvider
         .getDiagnosticsLogger()
         .err(
-          'Indexing is an experimental feature and is not yet supported in production. To enable for testing purposes only, set the CERAMIC_ENABLE_EXPERIMENTAL_INDEXING environment variable'
+          'Indexing is an experimental feature and is not yet supported in production. To enable for testing purposes only, set the CERAMIC_ENABLE_EXPERIMENTAL_INDEXING environment variable to `true`'
         )
       throw new Error('Indexing is not enabled')
     }

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -60,11 +60,11 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     context: Context,
     state?: StreamState
   ): Promise<StreamState> {
-    if (!process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING) {
+    if (process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING != 'true') {
       context.loggerProvider
         .getDiagnosticsLogger()
         .err(
-          'Indexing is an experimental feature and is not yet supported in production. To enable for testing purposes only, set the CERAMIC_ENABLE_EXPERIMENTAL_INDEXING environment variable'
+          'Indexing is an experimental feature and is not yet supported in production. To enable for testing purposes only, set the CERAMIC_ENABLE_EXPERIMENTAL_INDEXING environment variable to `true`'
         )
       throw new Error('Indexing is not enabled')
     }


### PR DESCRIPTION
## Description

Instead of just checking the presence of an environment variable for a conditional, we should check its value so that node operators can set environment variables to false when needed.

This is motivated by an issue we had where we accidentally enabled indexing on our nodes in an attempt to gate the release of the feature by setting the environment variable `CERAMIC_ENABLE_EXPERIMENTAL_INDEXING = 'false'`.

## Note

**I think using variables from process.env directly should be avoided.**  Instead, let's evaluate the variable in one place and use that result elsewhere in the code.

E.g.
```js
const indexingEnabled = envVarToBoolean(process.env.CERAMIC_ENABLE_EXPERIMENTAL_INDEXING)
```

However this PR is a quick fix before deciding where to put this utility function and refactoring existing uses of process.env.

## How Has This Been Tested?

These demonstrate the incorrect way to use an env var for a boolean.
Notice
- SET_FALSE and SET_TRUE always evaluate to the same result
- UNSET should evaluate to the same result as SET_FALSE but doesn't
```js
> process.env.UNSET
undefined
> process.env.SET_FALSE = false
false
> process.env.SET_TRUE = true
true
> if (process.env.UNSET) console.log('unset is not true')
undefined
> if (process.env.SET_FALSE) console.log('false is not true')
false is not true
undefined
> if (process.env.SET_TRUE) console.log('true is true')
true is true
undefined
> if (!process.env.UNSET) console.log('unset is not true')
unset is not true
undefined
> if (!process.env.SET_FALSE) console.log('false is not true')
undefined
> if (!process.env.SET_TRUE) console.log('true is true')
undefined
> if (Boolean(process.env.UNSET)) console.log('unset is not true')
undefined
> if (Boolean(process.env.SET_FALSE)) console.log('false is not true')
false is not true
undefined
> if (Boolean(process.env.SET_TRUE)) console.log('true is true')
true is true
undefined
> if (!Boolean(process.env.UNSET)) console.log('unset is not true')
unset is not true
undefined
> if (!Boolean(process.env.SET_FALSE)) console.log('false is not true')
undefined
> if (!Boolean(process.env.SET_TRUE)) console.log('true is true')
undefined
```

This is the correct way

```js
> if (process.env.UNSET == 'true') console.log('unset is not true')
undefined
> if (process.env.SET_FALSE == 'true') console.log('false is not true')
undefined
> if (process.env.SET_TRUE == 'true') console.log('true is true')
true is true
undefined
> if (process.env.UNSET != 'true') console.log('unset is not true')
unset is not true
undefined
> if (process.env.SET_FALSE != 'true') console.log('false is not true')
false is not true
undefined
> if (process.env.SET_TRUE != 'true') console.log('true is true')
undefined
```

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [ ] ~I have updated the READMEs of affected packages~
- [ ] ~I have made corresponding changes to the documentation~

## References:

https://github.com/ceramicnetwork/js-ceramic/pull/2363
