### PR TITLE
fix(core): Use package, not relative path to metrics

### DIFF
--- a/packages/core/src/pubsub/pubsub-message.ts
+++ b/packages/core/src/pubsub/pubsub-message.ts
@@ -1,8 +1,7 @@
 import { StreamID } from '@ceramicnetwork/streamid'
 import { CID } from 'multiformats/cid'
 import { UnreachableCaseError, toCID } from '@ceramicnetwork/common'
-// use ugly paths until we register the npm package
-import {Metrics, METRIC_NAMES} from '../../../metrics/lib/metrics-setup.js'
+import { Metrics, METRIC_NAMES } from '@ceramicnetwork/metrics'
 import * as dagCBOR from '@ipld/dag-cbor'
 import { create as createDigest } from 'multiformats/hashes/digest'
 import * as sha256 from '@stablelib/sha256'
@@ -73,8 +72,7 @@ export function buildQueryMessage(streamId: StreamID): QueryMessage {
 }
 
 export function serialize(message: PubsubMessage): Uint8Array {
-
-  Metrics.count(METRIC_NAMES.PUBSUB_PUBLISHED, 1, {"typ": message.typ}) // really attempted to publish...
+  Metrics.count(METRIC_NAMES.PUBSUB_PUBLISHED, 1, { typ: message.typ }) // really attempted to publish...
   switch (message.typ) {
     case MsgType.QUERY: {
       return textEncoder.encode(
@@ -101,7 +99,7 @@ export function serialize(message: PubsubMessage): Uint8Array {
         doc: message.stream.toString(),
         stream: message.stream.toString(),
         tip: message.tip.toString(),
-        ...(message.model && { model: message.model.toString() })
+        ...(message.model && { model: message.model.toString() }),
       }
       return textEncoder.encode(JSON.stringify(payload))
     }
@@ -123,7 +121,7 @@ export function deserialize(message: any): PubsubMessage {
   const parsed = JSON.parse(asString)
 
   const typ = parsed.typ as MsgType
-  Metrics.count(METRIC_NAMES.PUBSUB_RECEIVED, 1, {"typ": typ})
+  Metrics.count(METRIC_NAMES.PUBSUB_RECEIVED, 1, { typ: typ })
   switch (typ) {
     case MsgType.UPDATE: {
       // TODO don't take streamid from 'doc' once we no longer interop with nodes older than v1.0.0
@@ -133,7 +131,7 @@ export function deserialize(message: any): PubsubMessage {
         typ: MsgType.UPDATE,
         stream,
         tip: toCID(parsed.tip),
-        ...(parsed.model && { model: StreamID.fromString(parsed.model) })
+        ...(parsed.model && { model: StreamID.fromString(parsed.model) }),
       }
     }
     case MsgType.RESPONSE: {


### PR DESCRIPTION
Apparently, we forgot to replace one of the relative imports with `@ceramicnetwork/metrics` import. The PR fixes that.

I hope it is the last occurrence of the relative imports.

CC @gvelez17 