### PR TITLE
feat: Push setting of 'throwOnInvalidCommit' flag down into applyCommit endpoint

### DIFF
--- a/packages/stream-caip10-link/src/caip10-link.ts
+++ b/packages/stream-caip10-link/src/caip10-link.ts
@@ -31,6 +31,8 @@ const DEFAULT_CREATE_OPTS = {
   pin: true,
   sync: SyncOptions.PREFER_CACHE,
 }
+// TODO: Remove 'throwOnInvalidCommit' once the minimum supported Ceramic version includes
+// the fix from NET-1717
 const DEFAULT_UPDATE_OPTS = { anchor: true, publish: true, throwOnInvalidCommit: true }
 const DEFAULT_LOAD_OPTS = { sync: SyncOptions.PREFER_CACHE }
 

--- a/packages/stream-model-instance/src/model-instance-document.ts
+++ b/packages/stream-model-instance/src/model-instance-document.ts
@@ -70,6 +70,8 @@ const DEFAULT_DETERMINISTIC_OPTS = {
   sync: SyncOptions.PREFER_CACHE,
 }
 const DEFAULT_LOAD_OPTS = { sync: SyncOptions.PREFER_CACHE }
+// TODO: Remove 'throwOnInvalidCommit' once the minimum supported Ceramic version includes
+// the fix from NET-1717
 const DEFAULT_UPDATE_OPTS = { anchor: true, publish: true, throwOnInvalidCommit: true }
 
 async function _ensureAuthenticated(signer: CeramicSigner) {

--- a/packages/stream-model/src/model.ts
+++ b/packages/stream-model/src/model.ts
@@ -149,7 +149,8 @@ export class Model extends Stream {
     metadata?: ModelMetadataArgs
   ): Promise<Model> {
     Model.assertComplete(content)
-
+    // TODO: Remove 'throwOnInvalidCommit' once the minimum supported Ceramic version includes
+    // the fix from NET-1717
     const opts: CreateOpts = {
       publish: true,
       anchor: true,

--- a/packages/stream-tile/src/tile-document.ts
+++ b/packages/stream-tile/src/tile-document.ts
@@ -75,6 +75,8 @@ const DEFAULT_CREATE_OPTS = {
   sync: SyncOptions.PREFER_CACHE,
 }
 const DEFAULT_LOAD_OPTS = { sync: SyncOptions.PREFER_CACHE }
+// TODO: Remove 'throwOnInvalidCommit' once the minimum supported Ceramic version includes
+// the fix from NET-1717
 const DEFAULT_UPDATE_OPTS = { anchor: true, publish: true, throwOnInvalidCommit: true }
 
 /**


### PR DESCRIPTION
Small code cleanup in advance of follow-up PR (https://github.com/ceramicnetwork/js-ceramic/pull/2397).  Removes the necessity of clients setting this field, so if we add more streamtypes in the future we won't always have to remember to set this.