### PR TITLE
feat(core): Reject client-initiated updates that build on stale state

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -193,9 +193,9 @@ function validatePort(inPort) {
  * @param opts
  */
 function markShouldRejectConflicts(opts) {
-  if (opts.throwOnInvalidCommit === undefined) {
-    opts.throwOnInvalidCommit = true
-  }
+  opts.throwOnInvalidCommit = opts.throwOnInvalidCommit ?? true
+  opts.throwOnConflict = opts.throwOnConflict ?? true
+  opts.throwIfStale = opts.throwIfStale ?? true
 }
 
 /**

--- a/packages/common/src/streamopts.ts
+++ b/packages/common/src/streamopts.ts
@@ -60,6 +60,19 @@ export interface InternalOpts {
    * @private
    */
   throwOnInvalidCommit?: boolean
+
+  /**
+   * If true, when applying commits to a stream will throw an Error if any commit is rejected due to conflict resolution
+   * @private
+   */
+  throwOnConflict?: boolean
+
+  /**
+   * If true, when applying commits to a stream will throw an Error if the log does not build directly on top of the
+   * local state.
+   * @private
+   */
+  throwIfStale?: boolean
 }
 
 /**

--- a/packages/common/src/utils/test-utils.ts
+++ b/packages/common/src/utils/test-utils.ts
@@ -29,25 +29,25 @@ export class TestUtils {
    * Given a stream and a predicate that operates on the stream state, continuously waits for
    * changes to the stream until the predicate returns true.
    * @param stream
-   * @param timeout - how long to wait for
+   * @param timeoutMs - how long to wait for, in milliseconds
    * @param predicate - function that takes the stream's StreamState as input and returns true when this function can stop waiting
    * @param onFailure - function called if we time out before the predicate becomes true
    */
   static async waitForState(
     stream: Stream,
-    timeout: number,
+    timeoutMs: number,
     predicate: (state: StreamState) => boolean,
-    onFailure: () => void
+    onFailure: (state: StreamState) => void
   ): Promise<void> {
     if (predicate(stream.state)) return
-    const timeoutPromise = new Promise((resolve) => setTimeout(resolve, timeout))
+    const timeoutPromise = new Promise((resolve) => setTimeout(resolve, timeoutMs))
     // We do not expect this promise to return anything, so set `defaultValue` to `undefined`
     const completionPromise = lastValueFrom(stream.pipe(filter((state) => predicate(state))), {
       defaultValue: undefined,
     })
     await Promise.race([timeoutPromise, completionPromise])
     if (!predicate(stream.state)) {
-      onFailure()
+      onFailure(stream.state)
     }
   }
 

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -149,7 +149,7 @@ describe('Ceramic API', () => {
       // should be rejected by conflict resolution
       expect(streamOg.state.log.length).toEqual(1)
       await expect(streamOg.update(contentRejected)).rejects.toThrow(
-        /rejected by conflict resolution/
+        /rejected because it builds on stale state/
       )
       expect(streamOg.state.log.length).toEqual(1)
 

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -186,6 +186,81 @@ describe('Ceramic integration', () => {
     })
   })
 
+  it('Throw on update based on stale state', async () => {
+    await withFleet(2, async ([ipfs1, ipfs2]) => {
+      await swarmConnect(ipfs1, ipfs2)
+      const ceramic1 = await createCeramic(ipfs1, false)
+      const ceramic2 = await createCeramic(ipfs2, false)
+
+      const content0 = { data: 123 }
+      const content1 = { data: 123456 }
+      const content2 = { data: 'rejected' }
+
+      const streamOg = await TileDocument.deterministic(
+        ceramic1,
+        { family: 'test' },
+        { anchor: false, publish: false }
+      )
+      await streamOg.update(content0)
+
+      // Do a write via a different stream handle so the og handle doesn't know about it.
+      const streamCopy = await TileDocument.load(ceramic1, streamOg.id)
+      await streamCopy.update(content1)
+
+      expect(streamCopy.content).toEqual(content1)
+      expect(streamCopy.state.log.length).toEqual(3)
+      expect(streamOg.content).toEqual(content0)
+      expect(streamOg.state.log.length).toEqual(2)
+
+      // Do an update via the stale stream handle.  Its view of the log is out of date so its update
+      // should be rejected because it builds on a stale tip.
+      await expect(streamOg.update(content2)).rejects.toThrow(
+        /rejected because it builds on stale state/
+      )
+      expect(streamOg.state.log.length).toEqual(2)
+
+      // While we disallow creating commits based on a stale tip as part of a user request when the node already
+      // knows about an existing tip, if we hear about a conflicting tip via pubsub, we need to consider it. The node
+      // that created it may not have known about the existing tip when it did, and so now we need to use our conflict
+      // resolution rules to decide between the two equally valid tips.
+      const commit = await streamOg.makeCommit(ceramic1, content2)
+      const cid = await ceramic2.dispatcher.storeCommit(commit)
+      await ceramic2.dispatcher.publishTip(streamOg.id, cid)
+
+      // wait for the update to propagate to ceramic1
+      await TestUtils.waitForState(
+        streamOg,
+        10 * 1000,
+        (state) => state.next.content.data == content2.data,
+        (state) => {
+          throw new Error(
+            `content data should be ${content2.data} but was ${state.next.content.data}`
+          )
+        }
+      )
+
+      await streamOg.sync()
+      await streamCopy.sync()
+
+      // NOTE: this test relies on the commit for content2 to win the conflict resolution
+      // against the update for content1. That conflict resolution is done arbitrarily (but
+      // deterministically) by comparing the CIDs of the conflicting commits. If the IPLD encoding
+      // of these commits changed in the future for any reason and that changed the CIDs generated
+      // for these commits, then it could cause content1 to win the conflict here. That would negate
+      // the value of this test, which is designed to show that a node with an existing tip
+      // can learn about a conflicting branch of history via pubsub and still take it if it
+      // wins conflict resolution. If the CIDs changed and content1 started winning, we would need
+      // to change the commits until content2 started winning the CID comparison again.
+      expect(streamOg.content).toEqual(content2)
+      expect(streamCopy.content).toEqual(content2)
+      expect(streamOg.state.log.length).toEqual(3)
+      expect(streamCopy.state.log.length).toEqual(3)
+
+      await ceramic1.close()
+      await ceramic2.close()
+    })
+  })
+
   it('can utilize stream commit cache', async () => {
     await withFleet(2, async ([ipfs1, ipfs2]) => {
       await swarmConnect(ipfs1, ipfs2)


### PR DESCRIPTION
Builds on https://github.com/ceramicnetwork/js-ceramic/pull/2395

The goal of this change is to better handle the case where the client application authors a new update to a stream based on stale state.  Imagine that an application loads a stream and the stream handle stays open in the user's browser tab for a while, possibly hours or days.  In the meantime, new updates are made to the stream, possibly via a different Ceramic node powering a different app, or even possibly via the same Ceramic node and app, just in a different session.  Then the user tries to do an update via the original stream handle, which has an old, out of date version of the stream state in it's client-side view.  In this case, one of two things will happen: either the write will be rejected by conflict resolution, or it will succeed by winning the conflict resolution against the existing state on the node, and thus overriding an existing write.

With this change, if the user tries to initiate a write via the http-client but that write is built off of state the Ceramic node *already knows* is stale, the Ceramic node will proactively reject that write to preserve the data that it already knows about that has been around longer, over the new write that was authored based on a stale view of the data.

Note that this change has no affect to the conflict resolution rules applied when learning about a commit via pubsub.  The arbitrary-but-deterministic tie-break based on CID lexographic ordering still applies for commits learned via the network.  This is a special case to prefer existing data over new data when we know the new data is stale, as a way to minimize the number of writes that successfully get applied to a node and only to be later rejected.