### PR TITLE
WIP: Check for expired CACAOs when applying new commits

### DIFF
--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -115,6 +115,7 @@ export interface LogEntry {
   cid: CID
   type: CommitType
   timestamp?: number
+  expirationTime?: number
 }
 
 /**

--- a/packages/core/src/conflict-resolution.ts
+++ b/packages/core/src/conflict-resolution.ts
@@ -256,7 +256,7 @@ function checkForCacaoExpiration(state: StreamState): void {
           state
         ).toString()} has a CACAO that expired at ${entry.expirationTime}`
       )
-      err.expiredCommitCID = entry.cid
+      err.lastValidCommitCid = state.log[i - 1]?.cid || null
       // Keep iterating through the whole log so that we find the oldest commit that is expired.
     }
   }

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -107,7 +107,8 @@ export class Repository {
       (streamId, opts) => this.load(streamId, opts),
       // TODO (NET-1687): remove as part of refactor to push indexing into state-manager.ts
       this.indexStreamIfNeeded,
-      deps.indexing
+      deps.indexing,
+      this.inmemory
     )
   }
 

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -14,6 +14,7 @@ import {
   RunningStateLike,
   DiagnosticsLogger,
   StreamUtils,
+  CommitType,
 } from '@ceramicnetwork/common'
 import { RunningState } from './running-state.js'
 import type { CID } from 'multiformats/cid'
@@ -202,7 +203,7 @@ export class StateManager {
         )
         const resetState = await this.conflictResolution.snapshotAtCommit(
           state$.value,
-          err.expiredCommitCID
+          CommitID.make(state$.id, err.expiredCommitCID)
         )
         state$.next(resetState)
         await this._updateStateIfPinned(state$, true)

--- a/packages/stream-model-handler/src/model-handler.ts
+++ b/packages/stream-model-handler/src/model-handler.ts
@@ -4,6 +4,7 @@ import {
   CommitData,
   CommitType,
   Context,
+  LogEntry,
   SignatureStatus,
   SignatureUtils,
   StreamConstructor,
@@ -99,7 +100,6 @@ export class ModelHandler implements StreamHandler<Model> {
       throw Error('Model genesis commit must be signed')
     }
 
-
     if (!(payload.header.controllers && payload.header.controllers.length === 1)) {
       throw new Error('Exactly one controller must be specified')
     }
@@ -127,6 +127,13 @@ export class ModelHandler implements StreamHandler<Model> {
       )
     }
 
+    const logEntry: LogEntry = {
+      cid: commitData.cid,
+      type: CommitType.SIGNED,
+    }
+    if (commitData?.capability?.p?.exp) {
+      logEntry.expirationTime = Date.parse(commitData.capability.p.exp)
+    }
     const metadata = { controllers: [controller], model: modelStreamId }
     const state = {
       type: Model.STREAM_TYPE_ID,
@@ -134,7 +141,7 @@ export class ModelHandler implements StreamHandler<Model> {
       metadata,
       signature: SignatureStatus.SIGNED,
       anchorStatus: AnchorStatus.NOT_REQUESTED,
-      log: [{ cid: commitData.cid, type: CommitType.GENESIS }],
+      log: [logEntry],
     }
 
     await this._schemaValidator.validateSchema(state.content.schema)


### PR DESCRIPTION
Still a WIP.  There are some issues to iron out if the genesis commit itself has an expired CACAO, including removing the stream from the index in that case.  But this PR is getting complex enough that before I go too much further with it I wanted to get some more eyes on it and see if the general direction seems right.