### PR TITLE
feat(core): moving rate limiting message from warning to verbose

### DIFF
--- a/packages/core/src/pubsub/pubsub-ratelimit.ts
+++ b/packages/core/src/pubsub/pubsub-ratelimit.ts
@@ -100,7 +100,7 @@ export class PubsubRateLimit
       if (timeSinceOldestQuery < 1000) {
         // If it's been less than a second since the oldest query, sleep until it's been more than a
         // second
-        this.logger.warn(
+        this.logger.verbose(
           `More than ${this.queriesPerSecond} query messages published in less than a second. Query messages will be rate limited`
         )
         await this._clock.waitUntil(new Date(oldestQuery.getTime() + 1000))


### PR DESCRIPTION
## Description

To declutter production log messages, moving the pubsub rate limiting warning message from `warning` to `verbose` since rate limiting doesn't have any negative impact on actual data retention or message socialization.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x] Standard unit tests

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
