### PR TITLE
Fix prev.equals error

### DIFF
--- a/packages/core/src/conflict-resolution.ts
+++ b/packages/core/src/conflict-resolution.ts
@@ -1,4 +1,4 @@
-import type { CID } from 'multiformats/cid'
+import { CID } from 'multiformats/cid'
 import {
   AnchorProof,
   AnchorStatus,
@@ -207,7 +207,7 @@ export async function fetchLog(
   const nextCommitData = await Utils.getCommitData(dispatcher, cid, stateLog.streamId, timestamp)
   // Update the running timestamp if it was updated via an anchor commit fetch
   timestamp = nextCommitData.timestamp
-  const prevCid: CID = nextCommitData.commit.prev
+  const prevCid: CID = CID.asCID(nextCommitData.commit.prev)
   if (!prevCid) {
     // Someone sent a tip that is a fake log, i.e. a log that at some point does not refer to a previous or genesis
     // commit.


### PR DESCRIPTION
## Description

This PR forces the `prev` property on commit data to be a CID to prevent the following error:

- When trying to update a tile document or a mid in the [indexing smoke tests](https://github.com/3box/ceramic-smoke-tests/blob/feat/indexing/src/__tests__/indexing-bug-repro.test.ts) we have been hitting this error.

```js
await midFromIndexer.replace(updatedContent)
```

```sh
HTTP request to 'http://localhost:7007/api/v0/commits' failed with status 'Internal Server Error': {"error":"commitData.commit.prev.equals is not a function"}
```

- It turns out the prev was not a CID, and therefore doesn't have the `equals` function attached. However it can be cast into a CID.


## How Has This Been Tested?

### Repro

1. Run the ceramic daemon (you can repro on any ceramic network)
```
CERAMIC_ENABLE_EXPERIMENTAL_COMPOSE_DB=true node packages/cli/bin/ceramic.js daemon
```

2. Run the smoke tests
```sh
git clone https://github.com/3box/ceramic-smoke-tests.git
cd ceramic-smoke-tests
git checkout feat/indexing
npm install
NODE_OPTIONS=--experimental-vm-modules jest src/__tests__/indexing-bug-repr
```

You will see the error in the smoke tests.

### Fix

1. Build js-ceramic from this branch
```
cd js-ceramic
git checkout fix/prev-cid-conflict-resolution
npm install
npm run build
```
2. Follow repro step 1 above to run the daemon
3. Follow repro step 2 above to run the smoke tests