### PR TITLE
feat: Bypass maxEventListeners warning by using homegrown signalling

### DIFF
--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -19,6 +19,7 @@ import * as KeyDidResolver from 'key-did-resolver'
 import { Resolver } from 'did-resolver'
 import { DID } from 'dids'
 import { handleHeapdumpSignal } from './daemon/handle-heapdump-signal.js'
+import { handleSigintSignal } from './daemon/handle-sigint-signal.js'
 
 const HOMEDIR = new URL(`file://${os.homedir()}/`)
 const CWD = new URL(`file://${process.cwd()}/`)
@@ -198,6 +199,7 @@ export class CeramicCliUtils {
     const daemon = await CeramicDaemon.create(config)
 
     handleHeapdumpSignal(new URL('./', configFilepath), daemon.diagnosticsLogger)
+    handleSigintSignal(daemon)
     return daemon
   }
 

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -612,8 +612,7 @@ export class CeramicDaemon {
    * Close Ceramic daemon
    */
   async close(): Promise<void> {
-    await this.ceramic.close()
-    return new Promise<void>((resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       if (!this.server) resolve()
       this.server.close((err) => {
         if (err) {
@@ -623,5 +622,6 @@ export class CeramicDaemon {
         }
       })
     })
+    await this.ceramic.close()
   }
 }

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -612,6 +612,7 @@ export class CeramicDaemon {
    * Close Ceramic daemon
    */
   async close(): Promise<void> {
+    await this.ceramic.close()
     return new Promise<void>((resolve, reject) => {
       if (!this.server) resolve()
       this.server.close((err) => {

--- a/packages/cli/src/daemon/handle-sigint-signal.ts
+++ b/packages/cli/src/daemon/handle-sigint-signal.ts
@@ -1,0 +1,21 @@
+import { CeramicDaemon } from '../ceramic-daemon.js'
+
+export function handleSigintSignal(daemon: CeramicDaemon) {
+  let shutdownInProgress: Promise<void> | undefined
+  process.on('SIGINT', () => {
+    if (shutdownInProgress) {
+      // If multiple signals received while shutting down
+      process.stdout.write('Shutting down...\n')
+    } else {
+      shutdownInProgress = daemon
+        .close()
+        .then(() => {
+          process.exit(0)
+        })
+        .catch((error) => {
+          console.error(error)
+          process.exit(1)
+        })
+    }
+  })
+}

--- a/packages/core/src/__tests__/dispatcher-mock-ipfs.test.ts
+++ b/packages/core/src/__tests__/dispatcher-mock-ipfs.test.ts
@@ -10,6 +10,7 @@ import { LevelStateStore } from '../store/level-state-store.js'
 import { PinStore } from '../store/pin-store.js'
 import { RunningState } from '../state-management/running-state.js'
 import { StateManager } from '../state-management/state-manager.js'
+import { ShutdownSignal } from '../shutdown-signal.js'
 
 const TOPIC = '/ceramic'
 const FAKE_CID = CID.parse('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
@@ -65,7 +66,7 @@ describe('Dispatcher with mock ipfs', () => {
       repository,
       loggerProvider.getDiagnosticsLogger(),
       loggerProvider.makeServiceLogger('pubsub'),
-      new AbortController().signal,
+      new ShutdownSignal(),
       10
     )
   })

--- a/packages/core/src/__tests__/shutdown-signal.test.ts
+++ b/packages/core/src/__tests__/shutdown-signal.test.ts
@@ -1,0 +1,34 @@
+import { ShutdownSignal } from '../shutdown-signal.js'
+
+const fn = (abortSignal: AbortSignal) => {
+  return new Promise<string>((resolve, reject) => {
+    if (abortSignal.aborted) reject(new Error(`aborted before run`))
+    abortSignal.addEventListener('abort', () => {
+      reject(new Error(`aborted after run`))
+    })
+    new Promise((resolve1) => setTimeout(resolve1, 500)).then(() => resolve('ok'))
+  })
+}
+
+test('abort on complete', async () => {
+  const signal = new ShutdownSignal()
+  const result = signal.abortable((abortSignal) => fn(abortSignal))
+  signal.abort()
+  await expect(result).rejects.toThrow(new Error(`aborted after run`))
+  expect(signal.observers).toEqual([])
+})
+
+test('abort when completed', async () => {
+  const signal = new ShutdownSignal()
+  signal.abort()
+  const result = signal.abortable((abortSignal) => fn(abortSignal))
+  await expect(result).rejects.toThrow(new Error(`aborted before run`))
+  expect(signal.observers).toEqual([])
+})
+
+test('run then abort', async () => {
+  const signal = new ShutdownSignal()
+  await expect(signal.abortable((abortSignal) => fn(abortSignal))).resolves.toEqual('ok')
+  expect(signal.observers).toEqual([])
+  signal.abort()
+})

--- a/packages/core/src/shutdown-signal.ts
+++ b/packages/core/src/shutdown-signal.ts
@@ -1,0 +1,45 @@
+import { Observer, Subject } from 'rxjs'
+
+/**
+ * Kind of AbortController.signal used to indicate of a Ceramic instance is about to shutdown.
+ *
+ * Unlike native AbortController and AbortSignal, ShutdownSignal do not limit number of subscribers.
+ */
+export class ShutdownSignal {
+  private subject: Subject<void> = new Subject()
+
+  /**
+   * Subscribers to the signal.
+   */
+  get observers(): Array<Observer<void>> {
+    return this.subject.observers
+  }
+
+  /**
+   * Send "abort" signal to the subscribers.
+   */
+  abort(): void {
+    this.subject.complete()
+  }
+
+  /**
+   * Pass a shutdown signal to a function using `AbortSignal`.
+   *
+   * If ShutdownSignal is aborted, or when it is aborted, the passed AbortSignal gets aborted as well.
+   */
+  abortable<T>(fn: (abortSignal: AbortSignal) => Promise<T>): Promise<T> {
+    const controller = new AbortController()
+    const onAbort = () => {
+      controller.abort()
+    }
+    const subscription = this.subject.subscribe({
+      complete: () => {
+        onAbort()
+      },
+    })
+    if (this.subject.isStopped) controller.abort()
+    return fn(controller.signal).finally(() => {
+      subscription.unsubscribe()
+    })
+  }
+}


### PR DESCRIPTION
AbortController.signal uses native Node.js `events`. It emits a warning to console, when number of listeners gets bigger than some predefined number. You can easily increase the number if you use vanilla EventEmitter. Unfortunately, an instance of EventEmitter is unavailable if you use AbortController and AbortSignal. So, the only option is to set the limit globally.

But, you can not reliably do that, as basically every IPFS call creates a listener. You just can not determine reliably the upper bound for that number. And even if you do that, you would interfere with all the EventEmitters.

So, instead, the PR uses rxjs-based entity to pass the shutdown signal inside Ceramic.