### PR TITLE
fix(stream-tile-handler): load historical commits with CACAOs

### DIFF
--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -175,7 +175,7 @@ describe('Ceramic integration', () => {
       let stream2 = await TileDocument.createFromGenesis(ceramic2, logCommits[0].value, {
         anchor: false,
         publish: false,
-        sync: 2, // NEVER_SYNC
+        sync: SyncOptions.NEVER_SYNC
       })
       for (let i = 1; i < logCommits.length; i++) {
         stream2 = await ceramic2.applyCommit(stream2.id, logCommits[i].value, {

--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -140,7 +140,12 @@ describe('Ceramic integration', () => {
       await TestUtils.waitForState(
         stream3,
         2000,
-        (state) => StreamUtils.statesEqual(state, stream1.state),
+        (state) => {
+          // The timestamp deleted here will only be present if the log
+          // is synced from the network. Log[1] is a signed commit.
+          delete state.log[1].timestamp
+          return StreamUtils.statesEqual(state, stream1.state)
+	},
         () => {
           throw new Error(`streamtype3.state should equal streamtype1.state`)
         }
@@ -170,6 +175,7 @@ describe('Ceramic integration', () => {
       let stream2 = await TileDocument.createFromGenesis(ceramic2, logCommits[0].value, {
         anchor: false,
         publish: false,
+        sync: 2, // NEVER_SYNC
       })
       for (let i = 1; i < logCommits.length; i++) {
         stream2 = await ceramic2.applyCommit(stream2.id, logCommits[i].value, {

--- a/packages/stream-model-instance-handler/src/__tests__/__snapshots__/model-instance-document-handler.test.ts.snap
+++ b/packages/stream-model-instance-handler/src/__tests__/__snapshots__/model-instance-document-handler.test.ts.snap
@@ -381,6 +381,7 @@ Object {
         ],
         "version": 1,
       },
+      "timestamp": 1647037687.383,
       "type": 0,
     },
   ],

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -119,13 +119,15 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     await this._validateContent(modelStream, payload.data, true)
     await this._validateHeader(modelStream, payload.header)
 
+    const entry = { cid: commitData.cid, type: CommitType.SIGNED } as CommitData
+    if (commitData.timestamp) entry.timestamp = commitData.timestamp 
     return {
       type: ModelInstanceDocument.STREAM_TYPE_ID,
       content: payload.data || {},
       metadata,
       signature: SignatureStatus.SIGNED,
       anchorStatus: AnchorStatus.NOT_REQUESTED,
-      log: [{ cid: commitData.cid, type: CommitType.GENESIS }],
+      log: [entry],
     }
   }
 
@@ -169,7 +171,9 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     nextState.signature = SignatureStatus.SIGNED
     nextState.anchorStatus = AnchorStatus.NOT_REQUESTED
     nextState.content = newContent
-    nextState.log.push({ cid: commitData.cid, type: CommitType.SIGNED })
+    const entry = { cid: commitData.cid, type: CommitType.SIGNED } as CommitData
+    if (commitData.timestamp) entry.timestamp = commitData.timestamp 
+    nextState.log.push(entry)
 
     return nextState
   }

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -119,7 +119,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     await this._validateContent(modelStream, payload.data, true)
     await this._validateHeader(modelStream, payload.header)
 
-    const entry = { cid: commitData.cid, type: CommitType.SIGNED } as CommitData
+    const entry = { cid: commitData.cid, type: CommitType.GENESIS } as CommitData
     if (commitData.timestamp) entry.timestamp = commitData.timestamp 
     return {
       type: ModelInstanceDocument.STREAM_TYPE_ID,

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -119,7 +119,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     await this._validateContent(modelStream, payload.data, true)
     await this._validateHeader(modelStream, payload.header)
 
-    const entry = { cid: commitData.cid, type: CommitType.GENESIS } as CommitData
+    const entry = { cid: commitData.cid, type: CommitType.GENESIS } as LogEntry
     if (commitData.timestamp) entry.timestamp = commitData.timestamp 
     return {
       type: ModelInstanceDocument.STREAM_TYPE_ID,
@@ -171,7 +171,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     nextState.signature = SignatureStatus.SIGNED
     nextState.anchorStatus = AnchorStatus.NOT_REQUESTED
     nextState.content = newContent
-    const entry = { cid: commitData.cid, type: CommitType.SIGNED } as CommitData
+    const entry = { cid: commitData.cid, type: CommitType.SIGNED } as LogEntry
     if (commitData.timestamp) entry.timestamp = commitData.timestamp 
     nextState.log.push(entry)
 

--- a/packages/stream-tile-handler/src/__tests__/__snapshots__/tile-document-handler.test.ts.snap
+++ b/packages/stream-tile-handler/src/__tests__/__snapshots__/tile-document-handler.test.ts.snap
@@ -202,6 +202,7 @@ Object {
         ],
         "version": 1,
       },
+      "timestamp": 1647037687.383,
       "type": 0,
     },
   ],

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -100,7 +100,7 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
       throw new Error('Exactly one controller must be specified')
     }
 
-    const entry = { cid: commitData.cid, type: CommitType.SIGNED } as CommitData
+    const entry = { cid: commitData.cid, type: CommitType.GENESIS } as CommitData
     if (commitData.timestamp) entry.timestamp = commitData.timestamp 
     const state = {
       type: TileDocument.STREAM_TYPE_ID,

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -100,13 +100,15 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
       throw new Error('Exactly one controller must be specified')
     }
 
+    const entry = { cid: commitData.cid, type: CommitType.SIGNED } as CommitData
+    if (commitData.timestamp) entry.timestamp = commitData.timestamp 
     const state = {
       type: TileDocument.STREAM_TYPE_ID,
       content: payload.data || {},
       metadata: payload.header,
       signature: isSigned ? SignatureStatus.SIGNED : SignatureStatus.GENESIS,
       anchorStatus: AnchorStatus.NOT_REQUESTED,
-      log: [{ cid: commitData.cid, type: CommitType.GENESIS }],
+      log: [entry],
     }
 
     if (state.metadata.schema) {

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -171,7 +171,9 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
     nextState.signature = SignatureStatus.SIGNED
     nextState.anchorStatus = AnchorStatus.NOT_REQUESTED
 
-    nextState.log.push({ cid: commitData.cid, type: CommitType.SIGNED })
+    const entry = { cid: commitData.cid, type: CommitType.SIGNED } as CommitData
+    if (commitData.timestamp) entry.timestamp = commitData.timestamp 
+    nextState.log.push(entry)
 
     const oldContent = state.next?.content ?? state.content
     const oldMetadata = state.next?.metadata ?? state.metadata

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -100,7 +100,7 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
       throw new Error('Exactly one controller must be specified')
     }
 
-    const entry = { cid: commitData.cid, type: CommitType.GENESIS } as CommitData
+    const entry = { cid: commitData.cid, type: CommitType.GENESIS } as LogEntry
     if (commitData.timestamp) entry.timestamp = commitData.timestamp 
     const state = {
       type: TileDocument.STREAM_TYPE_ID,
@@ -173,7 +173,7 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
     nextState.signature = SignatureStatus.SIGNED
     nextState.anchorStatus = AnchorStatus.NOT_REQUESTED
 
-    const entry = { cid: commitData.cid, type: CommitType.SIGNED } as CommitData
+    const entry = { cid: commitData.cid, type: CommitType.SIGNED } as LogEntry
     if (commitData.timestamp) entry.timestamp = commitData.timestamp 
     nextState.log.push(entry)
 


### PR DESCRIPTION
Timestamp information was not properly propagated to the event log.