### PR TITLE
chore(core): increase blocknumber that turns on smart contract anchor validation for ganache networks 

### DIFF
--- a/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
@@ -56,7 +56,7 @@ const BLOCK_THRESHHOLDS = {
   'eip155:3': 1000000000, //ropsten
   'eip155:5': 1000000000, //goerli
   'eip155:100': 1000000000, //gnosis
-  'eip155:1337': 1, //ganache
+  'eip155:1337': 1000000, //ganache
 }
 const ANCHOR_CONTRACT_ADDRESSES = {
   'eip155:1': '0xD3f84Cf6Be3DD0EB16dC89c972f7a27B441A39f2', //mainnet


### PR DESCRIPTION
This allows us to test version 1 and version 2 anchors in CAS by using different starting block numbers