### PR TITLE
Allow empty states for indexed streams

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -477,11 +477,12 @@ export class CeramicDaemon {
     const httpQuery = parseQueryObject(req.query)
     const query = collectionQuery(httpQuery)
     const indexResponse = await this.ceramic.index.queryIndex(query)
+
     res.json({
       edges: indexResponse.edges.map((e) => {
         return {
           cursor: e.cursor,
-          node: StreamUtils.serializeState(e.node),
+          node: e.node ? StreamUtils.serializeState(e.node) : null,
         }
       }),
       pageInfo: indexResponse.pageInfo,

--- a/packages/common/src/index-api.ts
+++ b/packages/common/src/index-api.ts
@@ -36,7 +36,7 @@ export interface BaseQuery {
  * API to query an index.
  */
 export interface IndexApi {
-  queryIndex(query: BaseQuery & Pagination): Promise<Page<StreamState>>
+  queryIndex(query: BaseQuery & Pagination): Promise<Page<StreamState | null>>
 }
 
 export type Edge<T> = {

--- a/packages/core/src/indexing/__tests__/local-index-api.test.ts
+++ b/packages/core/src/indexing/__tests__/local-index-api.test.ts
@@ -68,7 +68,7 @@ describe('with database backend', () => {
     }
     const pageFn = jest.fn(async () => backendPage)
     const streamStateFn = jest.fn(async (streamId: any) => {
-      throw Error(`Can't get the stream state`)
+      return undefined
     })
     const fauxBackend = { page: pageFn } as unknown as DatabaseIndexApi
     const fauxRepository = { streamState: streamStateFn } as unknown as Repository

--- a/packages/core/src/indexing/__tests__/local-index-api.test.ts
+++ b/packages/core/src/indexing/__tests__/local-index-api.test.ts
@@ -51,14 +51,14 @@ describe('with database backend', () => {
   })
 
   test('return empty page from the database if cannot retrieve stream state', async () => {
-    const query = { model: 'foo', first: randomInt(100) }
+    const query = { model: 'foo', first: 1 }
     const backendPage: Page<string> = {
-      edges: Array.from({ length: query.first }).map(() => {
-        return {
+      edges: [
+        {
           cursor: randomString(32),
           node: null,
         }
-      }),
+      ],
       pageInfo: {
         hasPreviousPage: false,
         hasNextPage: false,
@@ -89,7 +89,8 @@ describe('with database backend', () => {
     backendPage.edges.forEach((edge) => {
       expect(streamStateFn).toBeCalledWith(edge.node)
     })
-    expect(response.edges.map((e) => e.node.content)).toEqual(backendPage.edges.map((e) => e.node))
+    expect(response.edges.length).toEqual(1)
+    expect(response.edges[0].node).toEqual(null)
   })
 })
 

--- a/packages/core/src/indexing/__tests__/local-index-api.test.ts
+++ b/packages/core/src/indexing/__tests__/local-index-api.test.ts
@@ -73,14 +73,15 @@ describe('with database backend', () => {
     const fauxBackend = { page: pageFn } as unknown as DatabaseIndexApi
     const fauxRepository = { streamState: streamStateFn } as unknown as Repository
     const fauxLogger = {
-      warn: (content: string | Record<string, unknown> | Error) => {
+      warn: jest.fn((content: string | Record<string, unknown> | Error) => {
         console.log(content)
-      }
-    } as DiagnosticsLogger
+      })
+    } as unknown as DiagnosticsLogger
     const indexApi = new LocalIndexApi(fauxBackend, fauxRepository, fauxLogger)
     const response = await indexApi.queryIndex(query)
     // Call databaseIndexApi::page function
     expect(pageFn).toBeCalledTimes(1)
+    expect(fauxLogger.warn).toBeCalledTimes(1)
     expect(pageFn).toBeCalledWith(query)
     // We pass pageInfo through
     expect(response.pageInfo).toEqual(backendPage.pageInfo)

--- a/packages/core/src/indexing/__tests__/local-index-api.test.ts
+++ b/packages/core/src/indexing/__tests__/local-index-api.test.ts
@@ -4,6 +4,7 @@ import type { Repository } from '../../state-management/repository.js'
 import type { DiagnosticsLogger, Page } from '@ceramicnetwork/common'
 import { randomString } from '@stablelib/random'
 import { LocalIndexApi } from '../local-index-api.js'
+import { LogStyle } from '@ceramicnetwork/common'
 
 const randomInt = (max: number) => Math.floor(Math.random() * max)
 
@@ -34,6 +35,48 @@ describe('with database backend', () => {
     const fauxBackend = { page: pageFn } as unknown as DatabaseIndexApi
     const fauxRepository = { streamState: streamStateFn } as unknown as Repository
     const fauxLogger = {} as DiagnosticsLogger
+    const indexApi = new LocalIndexApi(fauxBackend, fauxRepository, fauxLogger)
+    const response = await indexApi.queryIndex(query)
+    // Call databaseIndexApi::page function
+    expect(pageFn).toBeCalledTimes(1)
+    expect(pageFn).toBeCalledWith(query)
+    // We pass pageInfo through
+    expect(response.pageInfo).toEqual(backendPage.pageInfo)
+    // Transform from StreamId to StreamState via Repository::streamState
+    expect(streamStateFn).toBeCalledTimes(query.first)
+    backendPage.edges.forEach((edge) => {
+      expect(streamStateFn).toBeCalledWith(edge.node)
+    })
+    expect(response.edges.map((e) => e.node.content)).toEqual(backendPage.edges.map((e) => e.node))
+  })
+
+  test('return empty page from the database if cannot retrieve stream state', async () => {
+    const query = { model: 'foo', first: randomInt(100) }
+    const backendPage: Page<string> = {
+      edges: Array.from({ length: query.first }).map(() => {
+        return {
+          cursor: randomString(32),
+          node: null,
+        }
+      }),
+      pageInfo: {
+        hasPreviousPage: false,
+        hasNextPage: false,
+        startCursor: 'startCursor',
+        endCursor: 'endCursor',
+      },
+    }
+    const pageFn = jest.fn(async () => backendPage)
+    const streamStateFn = jest.fn(async (streamId: any) => {
+      throw Error(`Can't get the stream state`)
+    })
+    const fauxBackend = { page: pageFn } as unknown as DatabaseIndexApi
+    const fauxRepository = { streamState: streamStateFn } as unknown as Repository
+    const fauxLogger = {
+      warn: (content: string | Record<string, unknown> | Error) => {
+        console.log(content)
+      }
+    } as DiagnosticsLogger
     const indexApi = new LocalIndexApi(fauxBackend, fauxRepository, fauxLogger)
     const response = await indexApi.queryIndex(query)
     // Call databaseIndexApi::page function

--- a/packages/core/src/indexing/local-index-api.ts
+++ b/packages/core/src/indexing/local-index-api.ts
@@ -55,11 +55,10 @@ export class LocalIndexApi implements IndexApi {
       const edges = await Promise.all(
         // For database queries we bypass the stream cache and repository loading queue
         page.edges.map(async (edge) => {
-          let node: StreamState = null
-          try {
-            node = await this.repository.streamState(edge.node)
-          } catch (e) {
+          let node: StreamState = await this.repository.streamState(edge.node)
+          if (node === undefined) {
             this.logger.warn(`Cannot get stream state from repository. Unable to serve query ${JSON.stringify(query)}`)
+            node = null
           }
 
           return {


### PR DESCRIPTION
## Allow empty states for indexed streams

It may happen that a stream is indexed, but it's not possible to retrieve it from the repository (e.g. because it wasn't pinned, was unpinned or perhaps other reasons). In such case, we don't want to (for now at least) an index query to throw an error, but we want to return nulls instead.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Ran the tests

## PR checklist

Before submitting this PR, please make sure:

- [X] I have tagged the relevant reviewers and interested parties

