### PR TITLE
Don't try to deserialize null stream states. Also added a few more co…

### DIFF
--- a/packages/common/src/__tests__/stream-utils.test.ts
+++ b/packages/common/src/__tests__/stream-utils.test.ts
@@ -2,6 +2,7 @@ import { CID } from 'multiformats/cid'
 import { AnchorStatus, CommitType, RawCommit, SignatureStatus, StreamState } from '../stream.js'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { StreamUtils } from '../utils/stream-utils.js'
+import { exec } from 'child_process'
 
 const FAKE_DID = 'did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7ydki'
 const FAKE_CID = CID.parse('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
@@ -59,4 +60,8 @@ test('Commit serialization round trip - unsigned genesis commit', async () => {
   const deserializedModel = StreamID.fromBytes(deserialized.header.model)
   expect(deserializedModel.type).toEqual(FAKE_STREAM_ID.type)
   expect(deserializedModel.cid.toString()).toEqual(FAKE_STREAM_ID.cid.toString())
+})
+
+test('StreamUtils.deserializeState returns null if given null as a param', async () => {
+  expect(StreamUtils.deserializeState(null)).toBeNull()
 })

--- a/packages/common/src/index-api.ts
+++ b/packages/common/src/index-api.ts
@@ -34,6 +34,8 @@ export interface BaseQuery {
 
 /**
  * API to query an index.
+ *
+ * Returns null, iff the stream state can't be retrieved from the repository.
  */
 export interface IndexApi {
   queryIndex(query: BaseQuery & Pagination): Promise<Page<StreamState | null>>

--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -138,10 +138,12 @@ export class StreamUtils {
   }
 
   /**
-   * Deserializes stream cloned from over the network transfer
+   * Deserializes stream cloned from over the network transfer. Returns null if given null as a param.
    * @param state - Stream cloned
    */
-  static deserializeState(state: any): StreamState {
+  static deserializeState(state: any | null): StreamState | null {
+    if (state === null) return null
+
     const cloned = cloneDeep(state)
 
     if (cloned.doctype) {

--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -142,7 +142,7 @@ export class StreamUtils {
    * @param state - Stream cloned
    */
   static deserializeState(state: any): StreamState | null {
-    if (state === null) return null
+    if (!state) return null
 
     const cloned = cloneDeep(state)
 

--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -141,7 +141,7 @@ export class StreamUtils {
    * Deserializes stream cloned from over the network transfer. Returns null if given null as a param.
    * @param state - Stream cloned
    */
-  static deserializeState(state: any | null): StreamState | null {
+  static deserializeState(state: any): StreamState | null {
     if (state === null) return null
 
     const cloned = cloneDeep(state)

--- a/packages/core/src/indexing/local-index-api.ts
+++ b/packages/core/src/indexing/local-index-api.ts
@@ -58,7 +58,7 @@ export class LocalIndexApi implements IndexApi {
           let node: StreamState = await this.repository.streamState(edge.node)
           if (node === undefined) {
             this.logger.warn(`
-            Did not find stream state for streamid ${edge.node.toString()} in our state store when serving an indexed query.
+            Did not find stream state in our state store when serving an indexed query.
             This may indicate a problem with data persistence of your state store, which can result in data loss.
             Please check that your state store is properly configured with strong persistence guarantees.
             This query may have incomplete results. Affected query: ${JSON.stringify(query)}


### PR DESCRIPTION
## Don't try to deserialize null stream states. Also added a few more comments and a better logger warn

As we made it possible for index queries to return null nodes in https://github.com/ceramicnetwork/js-ceramic/pull/2431 , it may happen now that an http-client tries to deserialise a null node that it had got from the index api. This PR handles this case on low level.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Wrote a test to check that StreamUtils.deserializeState doesn't fail when given a null state

## PR checklist

Before submitting this PR, please make sure:

- [X] I have tagged the relevant reviewers and interested parties
- [X] I have updated the READMEs of affected packages
- [X] I have made corresponding changes to the documentation

