### PR TITLE
Cdb 1784 remove models from config file

### DIFF
--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -221,10 +221,13 @@ export class IndexingConfig {
   allowQueriesBeforeHistoricalSync = false
 
   /**
+   * @deprecated
+   * 
    * Models to index.
    */
+    // TODO: Remove when Admin API is implemented
   @jsonArrayMember(StreamID, {
-    emitDefaultValue: true,
+    emitDefaultValue: false,
     deserializer: (arr?: Array<string>) => {
       if (!arr) return arr
       return arr.map(StreamID.fromString)
@@ -234,7 +237,7 @@ export class IndexingConfig {
       return arr.map((s) => s.toString())
     },
   })
-  models: StreamID[]
+  models?: StreamID[]
 }
 
 @jsonObject

--- a/packages/core/src/indexing/build-indexing.ts
+++ b/packages/core/src/indexing/build-indexing.ts
@@ -12,11 +12,15 @@ export type IndexingConfig = {
   db: string
 
   /**
+   * @deprecated
+   *
    * List of models to index.
    */
-  models: Array<StreamID>
+  // TODO: Remove this key when Admin API is implemented
+  models?: Array<StreamID>
 
   /**
+   *
    * Allow a query only if historical sync is over.
    */
   allowQueriesBeforeHistoricalSync: boolean

--- a/packages/core/src/indexing/local-index-api.ts
+++ b/packages/core/src/indexing/local-index-api.ts
@@ -26,6 +26,14 @@ export class LocalIndexApi implements IndexApi {
     private readonly logger: DiagnosticsLogger,
     networkName: Networks
   ) {
+    // the '?' is here, because we're passing `unknown` as the indexingConfig in tests. refactor the tests maybe?
+    if (indexingConfig?.models !== undefined) {
+      // TODO: Update the log once admin API is implemented
+      logger.warn(`
+      Passing stream IDs to be indexed via indexing config is deprecated and will soon be removed as an option.
+      Instead, you will be configuring your index via the @composedb/cli commands (see documentation at https://composedb.js.org).
+      `)
+    }
     this.databaseIndexApi = makeIndexApi(indexingConfig, networkName, logger)
   }
 
@@ -107,7 +115,10 @@ export class LocalIndexApi implements IndexApi {
   }
 
   async init(): Promise<void> {
-    return this.indexModels(this.indexingConfig.models)
+    if (this.indexingConfig.models) {
+      return this.indexModels(this.indexingConfig.models)
+    }
+    return
   }
 
   async close(): Promise<void> {

--- a/packages/core/src/indexing/local-index-api.ts
+++ b/packages/core/src/indexing/local-index-api.ts
@@ -30,7 +30,7 @@ export class LocalIndexApi implements IndexApi {
     if (indexingConfig?.models !== undefined) {
       // TODO: Update the log once admin API is implemented
       logger.warn(`
-      Passing stream IDs to be indexed via indexing config is deprecated and will soon be removed as an option.
+      Passing the list of Model StreamIDs to be indexed the config file's 'indexing.models' field is deprecated and will soon be removed as an option.
       Instead, you will be configuring your index via the @composedb/cli commands (see documentation at https://composedb.js.org).
       `)
     }


### PR DESCRIPTION
## Description

This PR doesn't remove the `models` config key yet, just deprecates, adds TODOs to remove them it and a logger warning when they're present. It will be removed in a future PR.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Started a local daemon with models array in the config and queried `model:list` against it:
1. Set `indexing.models` to `["kh4q0ozorrgaq2mezktnrmdwleo1d"]` in my local daemon config file
2. Started the daemon and got the new warning log:
```
☁  js-ceramic [CDB-1784-remove-models-from-config-file] CERAMIC_ENABLE_EXPERIMENTAL_COMPOSE_DB=true  node packages/cli/bin/ceramic.js daemon --network=inmemory
[2022-09-19T13:12:35.475Z] IMPORTANT: Starting Ceramic Daemon at version 2.7.0-rc.2 with config: 
{
  "anchor": {},
  "http-api": {
    "cors-allowed-origins": [
      ".*"
    ]
  },
  "ipfs": {
    "mode": "bundled"
  },
  "logger": {
    "log-level": 2,
    "log-to-files": false
  },
  "metrics": {
    "metrics-exporter-enabled": false,
    "metrics-port": 9090
  },
  "network": {
    "name": "inmemory"
  },
  "node": {},
  "state-store": {
    "mode": "fs",
    "local-directory": "/Users/arturwdowiarski/.ceramic/statestore/"
  },
  "indexing": {
    "db": "sqlite:///Users/arturwdowiarski/.ceramic/indexing.sqlite",
    "allow-queries-before-historical-sync": true,
    "models": [
      "kh4q0ozorrgaq2mezktnrmdwleo1d"
    ]
  }
}
[2022-09-19T13:12:35.498Z] WARNING: 
      Passing stream IDs to be indexed via indexing config is deprecated and will soon be removed as an option.
      Instead, you will be configuring your index via the @composedb/cli commands (see documentation at https://composedb.js.org).
      
[2022-09-19T13:12:35.498Z] IMPORTANT: Initializing SQLite connection
[2022-09-19T13:12:35.535Z] IMPORTANT: Connecting to ceramic network 'inmemory' using pubsub topic '/ceramic/inmemory-245556270'
[2022-09-19T13:12:35.535Z] WARNING: Warning: indexing and query APIs are experimental and still under active development.  Please do not create Composites, Models, or ModelInstanceDocument streams, or use any of the new GraphQL query APIs on mainnet until they are officially released
[2022-09-19T13:12:35.539Z] IMPORTANT: Connected to anchor service '<inmemory>' with supported anchor chains ['inmemory:12345']
[2022-09-19T13:12:35.548Z] WARNING: No pinned streams detected. This is expected if this is the first time this node has been run, but may indicate a problem with the node's persistence setup if it should have pinned streams
[2022-09-19T13:12:35.552Z] IMPORTANT: Ceramic API running on 0.0.0.0:7007'
^C[2022-09-19T13:12:45.024Z] IMPORTANT: Closing Ceramic instance
[2022-09-19T13:12:45.031Z] IMPORTANT: Ceramic instance closed successfully
```
3. Queried the model index and got an empty list:
```
js-ceramic [CDB-1784-remove-models-from-config-file] composedb model:list --indexer-url=http://localhost:7007
✔ Loading models... Done
```
- [X] Started a local daemon without models array in the config and queried `model:list` against it:
1. Set `indexing.models` from my local daemon config file
2. Started the daemon (and didn't get any new warning logs):
```
☁  js-ceramic [CDB-1784-remove-models-from-config-file] node packages/cli/bin/ceramic.js daemon --network=inmemory
[2022-09-19T13:13:28.132Z] IMPORTANT: Starting Ceramic Daemon at version 2.7.0-rc.2 with config: 
{
  "anchor": {},
  "http-api": {
    "cors-allowed-origins": [
      ".*"
    ]
  },
  "ipfs": {
    "mode": "bundled"
  },
  "logger": {
    "log-level": 2,
    "log-to-files": false
  },
  "metrics": {
    "metrics-exporter-enabled": false,
    "metrics-port": 9090
  },
  "network": {
    "name": "inmemory"
  },
  "node": {},
  "state-store": {
    "mode": "fs",
    "local-directory": "/Users/arturwdowiarski/.ceramic/statestore/"
  },
  "indexing": {
    "db": "sqlite:///Users/arturwdowiarski/.ceramic/indexing.sqlite",
    "allow-queries-before-historical-sync": true
  }
}
[2022-09-19T13:13:28.156Z] IMPORTANT: Initializing SQLite connection
[2022-09-19T13:13:28.176Z] IMPORTANT: Connecting to ceramic network 'inmemory' using pubsub topic '/ceramic/inmemory-2810309002'
[2022-09-19T13:13:28.176Z] WARNING: Warning: indexing and query APIs are experimental and still under active development.  Please do not create Composites, Models, or ModelInstanceDocument streams, or use any of the new GraphQL query APIs on mainnet until they are officially released
[2022-09-19T13:13:28.181Z] IMPORTANT: Connected to anchor service '<inmemory>' with supported anchor chains ['inmemory:12345']
[2022-09-19T13:13:28.183Z] WARNING: No pinned streams detected. This is expected if this is the first time this node has been run, but may indicate a problem with the node's persistence setup if it should have pinned streams
[2022-09-19T13:13:28.186Z] IMPORTANT: Ceramic API running on 0.0.0.0:7007'
^C[2022-09-19T13:13:55.091Z] IMPORTANT: Closing Ceramic instance
[2022-09-19T13:13:55.102Z] IMPORTANT: Ceramic instance closed successfully
```
3. Queried the model index and got an empty list:
```
js-ceramic [CDB-1784-remove-models-from-config-file] composedb model:list --indexer-url=http://localhost:7007
✔ Loading models... Done
```

## PR checklist

Before submitting this PR, please make sure:

- [X] I have tagged the relevant reviewers and interested parties
- [X] I have made corresponding changes to the documentation

