### PR TITLE
chore: use newer version of kubo in npm dependencies

### DIFF
--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -40,7 +40,7 @@
     "dag-jose": "^2.0.0",
     "express": "^4.17.2",
     "get-port": "^6.0.0",
-    "go-ipfs": "^0.12.0",
+    "go-ipfs": "^0.15.0",
     "ipfs-core": "~0.13.0",
     "ipfs-http-client": "^55.0.0",
     "ipfsd-ctl": "^10.0.5",


### PR DESCRIPTION
Going to leave this PR unmerged until we have clearance to take `kubo v0.15.0` to Clay/Prod.