### PR TITLE
Start populating the `ceramic_models` table and add stopIndexingModels(...) to `DatabaseIndexApi`

### DIFF
--- a/packages/core/src/indexing/database-index-api.ts
+++ b/packages/core/src/indexing/database-index-api.ts
@@ -36,6 +36,13 @@ export interface DatabaseIndexApi {
   indexModels(models: Array<IndexModelArgs>): Promise<void>
 
   /**
+   * Update the database to mark a list of models as no longer indexed.
+   *
+   * @param models
+   */
+  stopIndexingModels(models: Array<StreamID>): Promise<void>
+
+  /**
    * This method inserts the stream if it is not present in the index, or updates
    * the 'content' if the stream already exists in the index.
    * @param args

--- a/packages/core/src/indexing/database-index-api.ts
+++ b/packages/core/src/indexing/database-index-api.ts
@@ -3,6 +3,8 @@ import type { BaseQuery, Pagination, Page } from '@ceramicnetwork/common'
 import type { CID } from 'multiformats/cid'
 import { ModelRelationsDefinition } from '@ceramicnetwork/stream-model'
 
+export const INDEXED_MODEL_CONFIG_TABLE_NAME = 'ceramic_models'
+
 export interface IndexStreamArgs {
   readonly streamID: StreamID
   readonly model: StreamID

--- a/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
+++ b/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
@@ -70,6 +70,7 @@ afterEach(async () => {
 })
 
 export async function dropTables() {
+  await dbConnection.schema.dropTableIfExists(INDEXED_MODEL_CONFIG_TABLE_NAME)
   await dbConnection.schema.dropTableIfExists(Model.MODEL.toString())
   await dbConnection.schema.dropTableIfExists(STREAM_ID_A)
   await dbConnection.schema.dropTableIfExists(STREAM_ID_B)
@@ -296,11 +297,11 @@ describe('indexModels', () => {
     ).toEqual([
       {
         "model": "kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-        "is_indexed": 1
+        "is_indexed": true
       },
       {
         "model": "kh4q0ozorrgaq2mezktnrmdwleo1d",
-        "is_indexed": 1
+        "is_indexed": true
       }
     ])
   })
@@ -318,11 +319,11 @@ describe('indexModels', () => {
     ).toEqual([
       {
         "model": "kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-        "is_indexed": 0
+        "is_indexed": false
       },
       {
         "model": "kh4q0ozorrgaq2mezktnrmdwleo1d",
-        "is_indexed": 1
+        "is_indexed": true
       }
     ])
   })
@@ -339,11 +340,11 @@ describe('indexModels', () => {
     ).toEqual([
       {
         "model": "kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-        "is_indexed": 1
+        "is_indexed": true
       },
       {
         "model": "kh4q0ozorrgaq2mezktnrmdwleo1d",
-        "is_indexed": 1
+        "is_indexed": true
       }
     ])
 
@@ -355,11 +356,11 @@ describe('indexModels', () => {
     ).toEqual([
       {
         "model": "kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-        "is_indexed": 0
+        "is_indexed": false
       },
       {
         "model": "kh4q0ozorrgaq2mezktnrmdwleo1d",
-        "is_indexed": 1
+        "is_indexed": true
       }
     ])
 
@@ -370,11 +371,11 @@ describe('indexModels', () => {
     ).toEqual([
       {
         "model": "kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-        "is_indexed": 1
+        "is_indexed": true
       },
       {
         "model": "kh4q0ozorrgaq2mezktnrmdwleo1d",
-        "is_indexed": 1
+        "is_indexed": true
       }
     ])
   })

--- a/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
+++ b/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
@@ -177,6 +177,7 @@ describe('init', () => {
       const modelToIndex = StreamID.fromString(STREAM_ID_A)
       const tableName = asTableName(modelToIndex)
       const indexApi = new PostgresIndexApi(dbConnection, true, logger)
+      indexApi.init()
 
       // Create the table in the database with all expected fields but one (leaving off 'updated_at')
       await dbConnection.schema.createTable(tableName, (table) => {
@@ -204,6 +205,7 @@ describe('init', () => {
       const tableName = asTableName(modelToIndex)
 
       const indexApi = new PostgresIndexApi(dbConnection, true, logger)
+      indexApi.init()
 
       // Create the table in the database with all expected fields but one (leaving off 'updated_at')
       await dbConnection.schema.createTable(tableName, (table) => {
@@ -238,6 +240,7 @@ describe('init', () => {
       ]
 
       const indexApi = new PostgresIndexApi(dbConnection, true, logger)
+      indexApi.init()
 
       // Create the table in the database with all expected fields but one (leaving off 'updated_at')
       await dbConnection.schema.createTable(tableName, (table) => {

--- a/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
+++ b/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
@@ -408,7 +408,6 @@ describe('indexModels', () => {
     ])
   })
 
-  
   test('modelsToIndex is properly updated after stopIndexingModels()', async () => {
     const modelsToIndex = [StreamID.fromString(STREAM_ID_A), Model.MODEL]
     const indexApi = new PostgresIndexApi(dbConnection, true, logger)

--- a/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
+++ b/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
@@ -283,6 +283,52 @@ function closeDates(a: Date, b: Date, deltaS = 1) {
   return Math.abs(aSeconds - bSeconds) <= deltaS
 }
 
+describe('indexModels', () => {
+  test('populates the INDEXED_MODEL_CONFIG_TABLE_NAME table on indexModels()', async () => {
+    const modelsToIndex = [StreamID.fromString(STREAM_ID_A), Model.MODEL]
+    const indexApi = new PostgresIndexApi(dbConnection, true, logger)
+    await indexApi.init()
+    await indexApi.indexModels(modelsToIndexArgs(modelsToIndex))
+
+    expect(await dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)
+      .select('model', 'is_indexed')
+      .orderBy('model', 'desc')
+    ).toEqual([
+      {
+        "model": "kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
+        "is_indexed": 1
+      },
+      {
+        "model": "kh4q0ozorrgaq2mezktnrmdwleo1d",
+        "is_indexed": 1
+      }
+    ])
+  })
+
+  test('updates the INDEXED_MODEL_CONFIG_TABLE_NAME table on stopIndexingModels()', async () => {
+    const modelsToIndex = [StreamID.fromString(STREAM_ID_A), Model.MODEL]
+    const indexApi = new PostgresIndexApi
+    (dbConnection, true, logger)
+    await indexApi.init()
+    await indexApi.indexModels(modelsToIndexArgs(modelsToIndex))
+    await indexApi.stopIndexingModels([StreamID.fromString(STREAM_ID_A)])
+
+    expect(await dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)
+      .select('model', 'is_indexed')
+      .orderBy('model', 'desc')
+    ).toEqual([
+      {
+        "model": "kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
+        "is_indexed": 0
+      },
+      {
+        "model": "kh4q0ozorrgaq2mezktnrmdwleo1d",
+        "is_indexed": 1
+      }
+    ])
+  })
+})
+
 describe('indexStream', () => {
   const MODELS_TO_INDEX = [STREAM_ID_A, STREAM_ID_B].map(StreamID.fromString)
   const STREAM_CONTENT_A = {

--- a/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
+++ b/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
@@ -327,6 +327,57 @@ describe('indexModels', () => {
     ])
   })
 
+  test('re-indexing models', async () => {
+    const modelsToIndex = [StreamID.fromString(STREAM_ID_A), Model.MODEL]
+    const indexApi = new PostgresIndexApi(dbConnection, true, logger)
+    await indexApi.init()
+
+    await indexApi.indexModels(modelsToIndexArgs(modelsToIndex))
+    expect(await dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)
+      .select('model', 'is_indexed')
+      .orderBy('model', 'desc')
+    ).toEqual([
+      {
+        "model": "kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
+        "is_indexed": 1
+      },
+      {
+        "model": "kh4q0ozorrgaq2mezktnrmdwleo1d",
+        "is_indexed": 1
+      }
+    ])
+
+
+    await indexApi.stopIndexingModels([StreamID.fromString(STREAM_ID_A)])
+    expect(await dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)
+      .select('model', 'is_indexed')
+      .orderBy('model', 'desc')
+    ).toEqual([
+      {
+        "model": "kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
+        "is_indexed": 0
+      },
+      {
+        "model": "kh4q0ozorrgaq2mezktnrmdwleo1d",
+        "is_indexed": 1
+      }
+    ])
+
+    await indexApi.indexModels(modelsToIndexArgs([StreamID.fromString(STREAM_ID_A)]))
+    expect(await dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)
+      .select('model', 'is_indexed')
+      .orderBy('model', 'desc')
+    ).toEqual([
+      {
+        "model": "kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
+        "is_indexed": 1
+      },
+      {
+        "model": "kh4q0ozorrgaq2mezktnrmdwleo1d",
+        "is_indexed": 1
+      }
+    ])
+  })
 
   test('modelsToIndex is properly populated after init()', async () => {
     const modelsToIndex = [StreamID.fromString(STREAM_ID_A), Model.MODEL]
@@ -338,13 +389,40 @@ describe('indexModels', () => {
     console.log('CREATING ANOTHER API')
     await anotherIndexApi.init()
 
-    expect(anotherIndexApi.getActiveModelsToIndex().sort())
+    expect(anotherIndexApi.getActiveModelsToIndex().map(streamID => streamID.toString()).sort())
       .toEqual([
-        StreamID.fromString("kh4q0ozorrgaq2mezktnrmdwleo1d"),
-        StreamID.fromString("kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd")
+        "kh4q0ozorrgaq2mezktnrmdwleo1d",
+        "kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd"
       ])
   })
 
+  test('modelsToIndex is properly updated after indexModels()', async () => {
+    const modelsToIndex = [StreamID.fromString(STREAM_ID_A), Model.MODEL]
+    const indexApi = new PostgresIndexApi(dbConnection, true, logger)
+    await indexApi.init()
+    expect(indexApi.getActiveModelsToIndex()).toEqual([])
+    await indexApi.indexModels(modelsToIndexArgs(modelsToIndex))
+    expect(indexApi.getActiveModelsToIndex().map(streamID => streamID.toString()).sort()).toEqual([
+      "kh4q0ozorrgaq2mezktnrmdwleo1d",
+      "kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd"
+    ])
+  })
+
+  
+  test('modelsToIndex is properly updated after stopIndexingModels()', async () => {
+    const modelsToIndex = [StreamID.fromString(STREAM_ID_A), Model.MODEL]
+    const indexApi = new PostgresIndexApi(dbConnection, true, logger)
+    await indexApi.init()
+    await indexApi.indexModels(modelsToIndexArgs(modelsToIndex))
+    expect(indexApi.getActiveModelsToIndex().map(streamID => streamID.toString()).sort()).toEqual([
+      "kh4q0ozorrgaq2mezktnrmdwleo1d",
+      "kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd"
+    ])
+    await indexApi.stopIndexingModels([StreamID.fromString("kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd")])
+    expect(indexApi.getActiveModelsToIndex().map(streamID => streamID.toString())).toEqual([
+      "kh4q0ozorrgaq2mezktnrmdwleo1d"
+    ])
+  })
 })
 
 describe('indexStream', () => {

--- a/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
+++ b/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
@@ -10,7 +10,7 @@ import { listMidTables } from '../init-tables.js'
 import { Model } from '@ceramicnetwork/stream-model'
 import { LoggerProvider } from '@ceramicnetwork/common'
 import { CID } from 'multiformats/cid'
-import { IndexModelArgs } from '../../database-index-api.js'
+import { INDEXED_MODEL_CONFIG_TABLE_NAME, IndexModelArgs } from '../../database-index-api.js'
 import {
   COMMON_TABLE_STRUCTURE,
   RELATION_COLUMN_STRUCTURE,
@@ -99,7 +99,7 @@ describe('init', () => {
       expect(JSON.stringify(columns)).toEqual(JSON.stringify(COMMON_TABLE_STRUCTURE))
 
       // Also manually check config table structure
-      columns = await dbConnection.table(asTableName('ceramic_models')).columnInfo()
+      columns = await dbConnection.table(asTableName(INDEXED_MODEL_CONFIG_TABLE_NAME)).columnInfo()
       expect(JSON.stringify(columns)).toEqual(JSON.stringify(CONFIG_TABLE_MODEL_INDEX_STRUCTURE))
     })
 

--- a/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
+++ b/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
@@ -307,8 +307,7 @@ describe('indexModels', () => {
 
   test('updates the INDEXED_MODEL_CONFIG_TABLE_NAME table on stopIndexingModels()', async () => {
     const modelsToIndex = [StreamID.fromString(STREAM_ID_A), Model.MODEL]
-    const indexApi = new PostgresIndexApi
-    (dbConnection, true, logger)
+    const indexApi = new PostgresIndexApi(dbConnection, true, logger)
     await indexApi.init()
     await indexApi.indexModels(modelsToIndexArgs(modelsToIndex))
     await indexApi.stopIndexingModels([StreamID.fromString(STREAM_ID_A)])
@@ -327,6 +326,25 @@ describe('indexModels', () => {
       }
     ])
   })
+
+
+  test('modelsToIndex is properly populated after init()', async () => {
+    const modelsToIndex = [StreamID.fromString(STREAM_ID_A), Model.MODEL]
+    const indexApi = new PostgresIndexApi(dbConnection, true, logger)
+    await indexApi.init()
+    await indexApi.indexModels(modelsToIndexArgs(modelsToIndex))
+
+    const anotherIndexApi = new PostgresIndexApi(dbConnection, true, logger)
+    console.log('CREATING ANOTHER API')
+    await anotherIndexApi.init()
+
+    expect(anotherIndexApi.getActiveModelsToIndex().sort())
+      .toEqual([
+        StreamID.fromString("kh4q0ozorrgaq2mezktnrmdwleo1d"),
+        StreamID.fromString("kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd")
+      ])
+  })
+
 })
 
 describe('indexStream', () => {

--- a/packages/core/src/indexing/postgres/init-tables.ts
+++ b/packages/core/src/indexing/postgres/init-tables.ts
@@ -111,7 +111,7 @@ export async function verifyTables(dataSource: Knex, modelsToIndex: Array<IndexM
   for (const tableName of tables) {
     const modelIndexArgs = modelsToIndex.find((model) => tableName == asTableName(model.model))
     if (!modelIndexArgs) {
-      // FIXME: This means that there's is a table for a model that is no longer indexed. Should this table have been deleted?
+      // TODO: CDB-1869 - This means that there's is a table for a model that is no longer indexed. Should this table have been deleted?
       continue
     }
 

--- a/packages/core/src/indexing/postgres/init-tables.ts
+++ b/packages/core/src/indexing/postgres/init-tables.ts
@@ -8,7 +8,7 @@ import { asTableName } from '../as-table-name.util.js'
 import { Knex } from 'knex'
 import { Model, ModelRelationsDefinition } from '@ceramicnetwork/stream-model'
 import { DiagnosticsLogger } from '@ceramicnetwork/common'
-import { IndexModelArgs } from '../database-index-api.js'
+import { INDEXED_MODEL_CONFIG_TABLE_NAME, IndexModelArgs } from '../database-index-api.js'
 import {
   COMMON_TABLE_STRUCTURE,
   CONFIG_TABLE_MODEL_INDEX_STRUCTURE,
@@ -33,7 +33,7 @@ export async function listMidTables(dataSource: Knex): Promise<Array<string>> {
 
 export async function listConfigTables(): Promise<Array<any>> {
   // TODO (CDB-1852): extend with ceramic_auth
-  return [{ tableName: 'ceramic_models', validSchema: CONFIG_TABLE_MODEL_INDEX_STRUCTURE }]
+  return [{ tableName: INDEXED_MODEL_CONFIG_TABLE_NAME, validSchema: CONFIG_TABLE_MODEL_INDEX_STRUCTURE }]
 }
 
 function relationsDefinitionsToColumnInfo(relations?: ModelRelationsDefinition): Array<ColumnInfo> {

--- a/packages/core/src/indexing/postgres/init-tables.ts
+++ b/packages/core/src/indexing/postgres/init-tables.ts
@@ -110,6 +110,10 @@ export async function verifyTables(dataSource: Knex, modelsToIndex: Array<IndexM
 
   for (const tableName of tables) {
     const modelIndexArgs = modelsToIndex.find((model) => tableName == asTableName(model.model))
+    if (!modelIndexArgs) {
+      // FIXME: This means that there's is a table for a model that is no longer indexed. Should this table have been deleted?
+      continue
+    }
 
     // Clone the COMMON_TABLE_STRUCTURE object that has the fields expected for all tables so we can
     // extend it with the model-specific fields expected

--- a/packages/core/src/indexing/postgres/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/postgres/migrations/1-create-model-table.ts
@@ -81,7 +81,7 @@ export async function createConfigTable(dataSource: Knex, tableName: string) {
       await dataSource.schema.createTable(tableName, function (table) {
         // create model indexing configuration table
         table.bigIncrements('index_id')
-        table.string('model', 1024).notNullable()
+        table.string('model', 1024).unique().notNullable()
         table.boolean('is_indexed').notNullable().defaultTo(true)
         table.dateTime('created_at').notNullable().defaultTo(dataSource.fn.now())
         table.dateTime('updated_at').notNullable().defaultTo(dataSource.fn.now())

--- a/packages/core/src/indexing/postgres/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/postgres/migrations/1-create-model-table.ts
@@ -1,5 +1,7 @@
 import type { Knex } from 'knex'
 import { UnreachableCaseError } from '@ceramicnetwork/common'
+import { INDEXED_MODEL_CONFIG_TABLE_NAME } from '../../database-index-api.js'
+
 
 /**
  * The expected type for the data in the column.  For now only supports STRING as the only extra
@@ -75,7 +77,7 @@ export async function createModelTable(
 
 export async function createConfigTable(dataSource: Knex, tableName: string) {
   switch (tableName) {
-    case 'ceramic_models':
+    case INDEXED_MODEL_CONFIG_TABLE_NAME:
       await dataSource.schema.createTable(tableName, function (table) {
         // create model indexing configuration table
         table.bigIncrements('index_id')

--- a/packages/core/src/indexing/postgres/migrations/cdb-schema-verification.ts
+++ b/packages/core/src/indexing/postgres/migrations/cdb-schema-verification.ts
@@ -73,36 +73,36 @@ export const CONFIG_TABLE_MODEL_INDEX_STRUCTURE = {
     type: 'bigint',
     maxLength: null,
     nullable: false,
-    defaultValue: "nextval('ceramic_models_index_id_seq'::regclass)"
+    defaultValue: "nextval('ceramic_models_index_id_seq'::regclass)",
   },
   model: {
     type: 'character varying',
     maxLength: 1024,
     nullable: false,
-    defaultValue: null
+    defaultValue: null,
   },
   is_indexed: {
     type: 'boolean',
     maxLength: null,
     nullable: false,
-    defaultValue: 'true'
+    defaultValue: 'true',
   },
   created_at: {
     type: 'timestamp with time zone',
     maxLength: null,
     nullable: false,
-    defaultValue: 'CURRENT_TIMESTAMP'
+    defaultValue: 'CURRENT_TIMESTAMP',
   },
   updated_at: {
     type: 'timestamp with time zone',
     maxLength: null,
     nullable: false,
-    defaultValue: 'CURRENT_TIMESTAMP'
+    defaultValue: 'CURRENT_TIMESTAMP',
   },
   updated_by: {
     type: 'character varying',
     maxLength: 1024,
     nullable: false,
-    defaultValue: null
-  }
+    defaultValue: null,
+  },
 }

--- a/packages/core/src/indexing/postgres/postgres-index-api.ts
+++ b/packages/core/src/indexing/postgres/postgres-index-api.ts
@@ -100,12 +100,14 @@ export class PostgresIndexApi implements DatabaseIndexApi {
         }
       }))
       .onConflict('model')
+      
       .merge({
         updated_at: this.dbConnection.fn.now(),
         is_indexed: false,
         updated_by: "<FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>"
       })
-    this.modelsToIndex = this.modelsToIndex.filter(modelStreamID => !models.includes(modelStreamID))
+    const modelsAsStrings = models.map(streamID => streamID.toString())
+    this.modelsToIndex = this.modelsToIndex.filter(modelStreamID => !modelsAsStrings.includes(modelStreamID.toString()))
   }
 
   async init(): Promise<void> {

--- a/packages/core/src/indexing/postgres/postgres-index-api.ts
+++ b/packages/core/src/indexing/postgres/postgres-index-api.ts
@@ -64,6 +64,8 @@ export class PostgresIndexApi implements DatabaseIndexApi {
   }
 
   async indexModels(models: Array<IndexModelArgs>): Promise<void> {
+    if (models.length === 0) return
+
     await initMidTables(this.dbConnection, models, this.logger)
     await this.verifyTables(models)
     // FIXME: populate the updated_by field properly when auth is implemented
@@ -86,6 +88,8 @@ export class PostgresIndexApi implements DatabaseIndexApi {
   }
 
   async stopIndexingModels(models: Array<StreamID>): Promise<void> {
+    if (models.length === 0) return
+
     // FIXME: populate the updated_by field properly when auth is implemented
     await this.dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)
       .insert(models.map(model => {

--- a/packages/core/src/indexing/postgres/postgres-index-api.ts
+++ b/packages/core/src/indexing/postgres/postgres-index-api.ts
@@ -70,7 +70,7 @@ export class PostgresIndexApi implements DatabaseIndexApi {
     await this.dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)
       .insert(models.map(indexModelArgs => {
         return {
-          model: indexModelArgs.model,
+          model: indexModelArgs.model.toString(),
           updated_by: "<FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>"
         }
       }))

--- a/packages/core/src/indexing/postgres/postgres-index-api.ts
+++ b/packages/core/src/indexing/postgres/postgres-index-api.ts
@@ -69,6 +69,16 @@ export class PostgresIndexApi implements DatabaseIndexApi {
     this.modelsToIndex.push(...modelStreamIDs)
   }
 
+  async stopIndexingModels(models: Array<StreamID>): Promise<void> {
+    // TODO: update mid tables to set is_indexed=false for models
+    // TODO: this.verifyTables(??) ??
+    for (let i = this.modelsToIndex.length - 1; i >= 0; i--) {
+      if (models.includes(this.modelsToIndex[i])) {
+        this.modelsToIndex.splice(i, 1)
+      }
+    }
+  }
+
   async init(): Promise<void> {
     await initConfigTables(this.dbConnection, this.logger)
   }

--- a/packages/core/src/indexing/postgres/postgres-index-api.ts
+++ b/packages/core/src/indexing/postgres/postgres-index-api.ts
@@ -77,7 +77,10 @@ export class PostgresIndexApi implements DatabaseIndexApi {
       .onConflict('model')
       .merge({
         updated_at: this.dbConnection.fn.now(),
+        is_indexed: true,
+        updated_by: "<FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>"
       })
+
     const modelStreamIDs = models.map((args) => args.model)
     this.modelsToIndex.push(...modelStreamIDs)
   }

--- a/packages/core/src/indexing/sqlite/__tests__/sqlite-index-api.test.ts
+++ b/packages/core/src/indexing/sqlite/__tests__/sqlite-index-api.test.ts
@@ -284,6 +284,23 @@ describe('indexModels', () => {
       }
     ])
   })
+
+  test('modelsToIndex is properly populated after init()', async () => {
+    const modelsToIndex = [StreamID.fromString(STREAM_ID_A), Model.MODEL]
+    const indexApi = new SqliteIndexApi(dbConnection, true, logger)
+    await indexApi.init()
+    await indexApi.indexModels(modelsToIndexArgs(modelsToIndex))
+
+    const anotherIndexApi = new SqliteIndexApi(dbConnection, true, logger)
+    console.log('CREATING ANOTHER API')
+    await anotherIndexApi.init()
+
+    expect(anotherIndexApi.getActiveModelsToIndex().sort())
+      .toEqual([
+        StreamID.fromString("kh4q0ozorrgaq2mezktnrmdwleo1d"),
+        StreamID.fromString("kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd")
+      ])
+  })
 })
 
 describe('indexStream', () => {

--- a/packages/core/src/indexing/sqlite/init-tables.ts
+++ b/packages/core/src/indexing/sqlite/init-tables.ts
@@ -102,7 +102,7 @@ export async function verifyTables(dataSource: Knex, modelsToIndex: Array<IndexM
   for (const tableName of tables) {
     const modelIndexArgs = modelsToIndex.find((model) => tableName == asTableName(model.model))
     if (!modelIndexArgs) {
-      // FIXME: This means that there's is a table for a model that is no longer indexed. Should this table have been deleted?
+      // TODO: CDB-1869 - This means that there's is a table for a model that is no longer indexed. Should this table have been deleted?
       continue
     }
 

--- a/packages/core/src/indexing/sqlite/init-tables.ts
+++ b/packages/core/src/indexing/sqlite/init-tables.ts
@@ -101,6 +101,10 @@ export async function verifyTables(dataSource: Knex, modelsToIndex: Array<IndexM
 
   for (const tableName of tables) {
     const modelIndexArgs = modelsToIndex.find((model) => tableName == asTableName(model.model))
+    if (!modelIndexArgs) {
+      // FIXME: This means that there's is a table for a model that is no longer indexed. Should this table have been deleted?
+      continue
+    }
 
     // Clone the COMMON_TABLE_STRUCTURE object that has the fields expected for all tables so we can
     // extend it with the model-specific fields expected

--- a/packages/core/src/indexing/sqlite/init-tables.ts
+++ b/packages/core/src/indexing/sqlite/init-tables.ts
@@ -8,7 +8,7 @@ import {
 import { asTableName } from '../as-table-name.util.js'
 import { Model, ModelRelationsDefinition } from '@ceramicnetwork/stream-model'
 import { DiagnosticsLogger } from '@ceramicnetwork/common'
-import { IndexModelArgs } from '../database-index-api.js'
+import { INDEXED_MODEL_CONFIG_TABLE_NAME, IndexModelArgs } from '../database-index-api.js'
 import {
   COMMON_TABLE_STRUCTURE,
   RELATION_COLUMN_STRUCTURE,
@@ -29,7 +29,7 @@ export async function listMidTables(dbConnection: Knex): Promise<Array<string>> 
 
 export async function listConfigTables(): Promise<Array<any>> {
   // TODO (CDB-1852): extend with ceramic_auth
-  return [{ tableName: 'ceramic_models', validSchema: CONFIG_TABLE_MODEL_INDEX_STRUCTURE }]
+  return [{ tableName: INDEXED_MODEL_CONFIG_TABLE_NAME, validSchema: CONFIG_TABLE_MODEL_INDEX_STRUCTURE }]
 }
 
 function relationsDefinitionsToColumnInfo(relations?: ModelRelationsDefinition): Array<ColumnInfo> {

--- a/packages/core/src/indexing/sqlite/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/sqlite/migrations/1-create-model-table.ts
@@ -1,5 +1,6 @@
 import type { Knex } from 'knex'
 import { UnreachableCaseError } from '@ceramicnetwork/common'
+import { INDEXED_MODEL_CONFIG_TABLE_NAME } from '../../database-index-api.js'
 
 /**
  * The expected type for the data in the column.  For now only supports STRING as the only extra
@@ -59,7 +60,7 @@ export async function createModelTable(
 
 export async function createConfigTable(dataSource: Knex, tableName: string) {
   switch (tableName) {
-    case 'ceramic_models':
+    case INDEXED_MODEL_CONFIG_TABLE_NAME:
       await dataSource.schema.createTable(tableName, function (table) {
         // create model indexing configuration table
         table.bigIncrements('index_id')

--- a/packages/core/src/indexing/sqlite/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/sqlite/migrations/1-create-model-table.ts
@@ -64,7 +64,7 @@ export async function createConfigTable(dataSource: Knex, tableName: string) {
       await dataSource.schema.createTable(tableName, function (table) {
         // create model indexing configuration table
         table.bigIncrements('index_id')
-        table.string('model', 1024).notNullable()
+        table.string('model', 1024).unique().notNullable()
         table.boolean('is_indexed').notNullable().defaultTo(true)
         table.dateTime('created_at').notNullable().defaultTo(dataSource.fn.now())
         table.dateTime('updated_at').notNullable().defaultTo(dataSource.fn.now())

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -6,6 +6,7 @@ import { initConfigTables, initMidTables, verifyTables } from './init-tables.js'
 import { asTableName } from '../as-table-name.util.js'
 import { InsertionOrder } from './insertion-order.js'
 import { IndexQueryNotAvailableError } from '../index-query-not-available.error.js'
+import { INDEXED_MODEL_CONFIG_TABLE_NAME } from '../database-index-api.js'
 
 /**
  * Convert `Date` to SQLite `INTEGER`.

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -101,7 +101,7 @@ export class SqliteIndexApi implements DatabaseIndexApi {
 
   async stopIndexingModels(models: Array<StreamID>): Promise<void> {
     if (models.length === 0) return
-    
+
     const now = asTimestamp(new Date())
     // FIXME: populate the updated_by field properly when auth is implemented
     await this.dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -81,7 +81,7 @@ export class SqliteIndexApi implements DatabaseIndexApi {
   }
 
   async stopIndexingModels(models: Array<StreamID>): Promise<void> {
-    // TODO: update mid tables to set is_indexed=false for models
+    // TODO: update config tables to set is_indexed=false for models
     // TODO: this.verifyTables(??) ??
     for (let i = this.modelsToIndex.length - 1; i >= 0; i--) {
       if (models.includes(this.modelsToIndex[i])) {

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -90,6 +90,8 @@ export class SqliteIndexApi implements DatabaseIndexApi {
       .onConflict('model')
       .merge({
         updated_at: now,
+        is_indexed: true,
+        updated_by: "<FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>"
       })
     const modelStreamIDs = models.map((args) => args.model)
     this.modelsToIndex.push(...modelStreamIDs)
@@ -112,7 +114,9 @@ export class SqliteIndexApi implements DatabaseIndexApi {
         is_indexed: false,
         updated_by: "<FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>"
       })
-    this.modelsToIndex = this.modelsToIndex.filter(modelStreamID => !models.includes(modelStreamID))
+
+    const modelsAsStrings = models.map(streamID => streamID.toString())
+    this.modelsToIndex = this.modelsToIndex.filter(modelStreamID => !modelsAsStrings.includes(modelStreamID.toString()))
   }
 
   async init(): Promise<void> {

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -79,7 +79,7 @@ export class SqliteIndexApi implements DatabaseIndexApi {
     await this.verifyTables(models)
     const now = asTimestamp(new Date())
     // FIXME: populate the updated_by field properly when auth is implemented
-    this.dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)
+    await this.dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)
       .insert(models.map(indexModelArgs => {
         return {
           model: indexModelArgs.model,
@@ -97,7 +97,7 @@ export class SqliteIndexApi implements DatabaseIndexApi {
   async stopIndexingModels(models: Array<StreamID>): Promise<void> {
     const now = asTimestamp(new Date())
     // FIXME: populate the updated_by field properly when auth is implemented
-    this.dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)
+    await this.dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)
       .insert(models.map(model => {
         return {
           model: model.toString(),
@@ -108,6 +108,7 @@ export class SqliteIndexApi implements DatabaseIndexApi {
       .onConflict('model')
       .merge({
         updated_at: now,
+        is_indexed: false,
         updated_by: "<FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>"
       })
     for (let i = this.modelsToIndex.length - 1; i >= 0; i--) {
@@ -124,8 +125,8 @@ export class SqliteIndexApi implements DatabaseIndexApi {
         .select('model')
         .where({
           is_indexed: true
-        }) as Array<string>
-      ).map(modelIDString => { return StreamID.fromString(modelIDString) })
+        })
+      ).map(result => { return StreamID.fromString(result.model) })
     )
   }
 

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -76,6 +76,8 @@ export class SqliteIndexApi implements DatabaseIndexApi {
   }
 
   async indexModels(models: Array<IndexModelArgs>): Promise<void> {
+    if (models.length === 0) return
+
     await initMidTables(this.dbConnection, models, this.logger)
     await this.verifyTables(models)
     const now = asTimestamp(new Date())
@@ -98,6 +100,8 @@ export class SqliteIndexApi implements DatabaseIndexApi {
   }
 
   async stopIndexingModels(models: Array<StreamID>): Promise<void> {
+    if (models.length === 0) return
+    
     const now = asTimestamp(new Date())
     // FIXME: populate the updated_by field properly when auth is implemented
     await this.dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -19,6 +19,7 @@ export function asTimestamp(input: Date | null | undefined): number | null {
   }
 }
 
+
 export class SqliteIndexApi implements DatabaseIndexApi {
   readonly insertionOrder: InsertionOrder
   readonly modelsToIndex: Array<StreamID> = []

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -83,7 +83,7 @@ export class SqliteIndexApi implements DatabaseIndexApi {
     await this.dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)
       .insert(models.map(indexModelArgs => {
         return {
-          model: indexModelArgs.model,
+          model: indexModelArgs.model.toString(),
           updated_by: "<FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>"
         }
       }))

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -80,6 +80,16 @@ export class SqliteIndexApi implements DatabaseIndexApi {
     this.modelsToIndex.push(...modelStreamIDs)
   }
 
+  async stopIndexingModels(models: Array<StreamID>): Promise<void> {
+    // TODO: update mid tables to set is_indexed=false for models
+    // TODO: this.verifyTables(??) ??
+    for (let i = this.modelsToIndex.length - 1; i >= 0; i--) {
+      if (models.includes(this.modelsToIndex[i])) {
+        this.modelsToIndex.splice(i, 1)
+      }
+    }
+  }
+
   async init(): Promise<void> {
     await initConfigTables(this.dbConnection, this.logger)
   }


### PR DESCRIPTION
## Description

* made the `model` column unique in `ceramic_models` table
* started adding entries to `ceramic_models` table in `indexModels(...)`
* added `stopIndexingModels(...)` to `DatabaseIndexApi` and implemented it in postres and sqlite db apis
* **did not(!!!!)** implement deletion of model index tables on `stopIndexingModels(...)`
* update entries in `ceramic_models` table in `stopIndexingModels(...)`
* load the list of models to index in `init()` in `DatabaseIndexApi`

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Added tests for postgres
- [X] Added tests for sqlite

## PR checklist

Before submitting this PR, please make sure:

- [X] I have tagged the relevant reviewers and interested parties

