### PR TITLE
test: Make pubsub-ratelimit test less flaky

### DIFF
--- a/packages/core/src/pubsub/__tests__/pubsub-ratelimit.test.ts
+++ b/packages/core/src/pubsub/__tests__/pubsub-ratelimit.test.ts
@@ -38,6 +38,13 @@ async function startOfASecond() {
   await new Promise((resolve) => setTimeout(resolve, start - now))
 }
 
+/**
+ * Round timestamp to the closest lowest second.
+ */
+function floorSecond(timestamp: Date): number {
+  return Math.floor(timestamp.valueOf() / 1000) * 1000
+}
+
 describe('pubsub with queries rate limited', () => {
   jest.setTimeout(ONE_SECOND * 30)
 
@@ -98,6 +105,7 @@ describe('pubsub with queries rate limited', () => {
       return empty().subscribe()
     })
     const messages = Array.from({ length: QUERIES_PER_SECOND * batches }).map(randomQueryMessage)
+
     await Promise.all(messages.map((message) => whenSubscriptionDone(pubsub.next(message))))
     // Send all the messages using `this.pubsub.next`
     expect(times.length).toEqual(messages.length)
@@ -111,7 +119,7 @@ describe('pubsub with queries rate limited', () => {
     for (let i = 1; i < firstElements.length; i++) {
       const current = firstElements[i]
       const previous = firstElements[i - 1]
-      const difference = current.valueOf() - previous.valueOf()
+      const difference = floorSecond(current) - floorSecond(previous)
       expect(difference >= ONE_SECOND).toBeTruthy()
     }
     for (const chunk of perSecondChunks) {


### PR DESCRIPTION
The source of the flakiness is not-really precise timer it seems. Our expectation is that `setTimeout(fn, N)` would trigger a function at `currentTime+N+ɛ`, `ɛ ≥ 0`. In the test, we expect functions to be called every second. Apparently, and obviously in retrospect, `ɛ` varies second to second. For second `N` `ɛ = 10`, while for the next second `N+1` `ɛ = 5`.  This means two invocations are `<1 second` apart, which triggers an error.

Here is how it looks for real. Every timestamp below is when a function is called. Notice the difference between start of the 3rd and the 2nd second is 999ms.
```
times [
      2022-09-29T13:52:44.702Z,
      2022-09-29T13:52:44.703Z,
      2022-09-29T13:52:44.703Z,
      2022-09-29T13:52:44.703Z,
      2022-09-29T13:52:44.703Z,
      2022-09-29T13:52:45.702Z, // <= start of the 2nd second
      2022-09-29T13:52:45.702Z,
      2022-09-29T13:52:45.702Z,
      2022-09-29T13:52:45.703Z,
      2022-09-29T13:52:45.703Z,
      2022-09-29T13:52:46.701Z, // <= start of the 3rd second
      2022-09-29T13:52:46.701Z,
      2022-09-29T13:52:46.702Z,
      2022-09-29T13:52:46.702Z,
      2022-09-29T13:52:46.702Z
    ]
```

Modified the test, so that we compare timestamps rounded to the lowest second.