### PR TITLE
feat: Use StaticJsonRpcProvider in EthereumAnchorValidator

### DIFF
--- a/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-validator.test.ts
+++ b/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-validator.test.ts
@@ -50,7 +50,7 @@ jest.unstable_mockModule('@ethersproject/providers', () => {
 
   return {
     ...originalModule,
-    JsonRpcProvider: class {
+    StaticJsonRpcProvider: class {
       constructor() {
         MockJsonRpcProvider.reset()
         return MockJsonRpcProvider

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
@@ -275,7 +275,7 @@ export class EthereumAnchorValidator implements AnchorValidator {
     const endpoint = this.ethereumRpcEndpoint || ethNetwork?.endpoint
 
     if (endpoint) {
-      const provider = new providers.JsonRpcProvider(endpoint)
+      const provider = new providers.StaticJsonRpcProvider(endpoint)
       this.providersCache.set(chain, provider)
       return provider
     }


### PR DESCRIPTION
We use INFURA in EthereumAnchorValidator.

There we have three calls to a provider:

`provider.getNetwork` - in `init` function, definitely a one-time operation

`provider.getTransaction` - per anchor proof

`provider.getBlock` - per anchor proof, same as `getTransaction`.



Let's start with `getTransaction`. We use JsonRPCPRovider. `getTransaction` is inherited from `BaseProvider`. https://github.com/ethers-io/ethers.js/blob/master/packages/providers/src.ts/base-provider.ts#L1849

The first thing it does is `getNetwork`. Then inside it calls `detectNetwork`, which is defined in JSONRPCProvider: https://github.com/ethers-io/ethers.js/blob/44cbc7fa4e199c1d6113ceec3c5162f53def5bb8/packages/providers/src.ts/base-provider.ts#L1148

https://github.com/ethers-io/ethers.js/blob/44cbc7fa4e199c1d6113ceec3c5162f53def5bb8/packages/providers/src.ts/json-rpc-provider.ts#L446

There, it sends chain id request: https://github.com/ethers-io/ethers.js/blob/44cbc7fa4e199c1d6113ceec3c5162f53def5bb8/packages/providers/src.ts/json-rpc-provider.ts#L463 

As surprising as it is, it clears the network at the beginning of the next event loop. So, every `getTransaction` results in one call to chain_id.

The same is true for `getBlock`: https://github.com/ethers-io/ethers.js/blob/44cbc7fa4e199c1d6113ceec3c5162f53def5bb8/packages/providers/src.ts/base-provider.ts#L1765



Apparently, the issue is acknowledged in https://github.com/ethers-io/ethers.js/issues/901

Solution is to use `StaticJsonRpcProvider`.