### PR TITLE
Fixed the way the authorization header is created in RemoteAdminApi a…

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -681,7 +681,7 @@ export class CeramicDaemon {
       res.status(StatusCodes.UNAUTHORIZED).json({ error: 'Missing authorization header' })
       return
     }
-    const jwsString = req.headers.authorization.split("Authorization: Basic ")[1]
+    const jwsString = req.headers.authorization.split("Basic ")[1]
     if (!jwsString) {
       res.status(StatusCodes.BAD_REQUEST).json({ error: `Invalid authorization header format. It needs to be 'Authorization: Basic <JWS BLOCK>'` })
       return

--- a/packages/http-client/src/__tests__/remote-admin-api.test.ts
+++ b/packages/http-client/src/__tests__/remote-admin-api.test.ts
@@ -35,7 +35,7 @@ test('getIndexedModels()', async () => {
   const fauxFetch = jest.fn(async () => GET_RESPONSE) as typeof fetchJson
   (adminApi as any)._fetchJson = fauxFetch
   await adminApi.getIndexedModels(did)
-  expect(fauxFetch).toBeCalledWith(new URL(`https://example.com/admin/models`), {"headers": {"Authorization:": "Basic <FAKE JWS>"}})
+  expect(fauxFetch).toBeCalledWith(new URL(`https://example.com/admin/models`), {"headers": {"Authorization": "Basic <FAKE JWS>"}})
 })
 
 test('addModelsToIndex()', async () => {

--- a/packages/http-client/src/remote-admin-api.ts
+++ b/packages/http-client/src/remote-admin-api.ts
@@ -28,7 +28,7 @@ export class RemoteAdminApi implements AdminApi {
     const body = modelsIDs ? { models: modelsIDs.map(streamID => streamID.toString()) } : undefined
     const jws = await actingDid.createJWS({
       code: code,
-      requestPath: this._apiUrl.pathname,
+      requestPath: this.getModelsUrl().pathname,
       requestBody: body
     })
     return `${jws.signatures[0].protected}.${jws.payload}.${jws.signatures[0].signature}`
@@ -49,7 +49,7 @@ export class RemoteAdminApi implements AdminApi {
   async getIndexedModels(actingDid: DID): Promise<Array<StreamID>> {
     const code = await this.generateCode()
     const response= await this._fetchJson(this.getModelsUrl(), {
-      headers: { 'Authorization:': `Basic ${await this.buildJWS(actingDid, code)}` },
+      headers: { 'Authorization': `Basic ${await this.buildJWS(actingDid, code)}` },
     })
     return response.models.map((modelStreamIDString: string) => {
       return StreamID.fromString(modelStreamIDString)


### PR DESCRIPTION
Fixed the way the authorization header is created in RemoteAdminApi a…nd parsed in CeramicDaemon

## Description

There was a simple mistake in the way the authorization header was generated and parsed.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Updated tests

## PR checklist

Before submitting this PR, please make sure:

- [X] I have tagged the relevant reviewers and interested parties

