### PR TITLE
fix(core, http-client, common): Remove AdminApi from CeramicAPI since the implementations are different

### DIFF
--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -92,8 +92,6 @@ export interface CeramicApi extends CeramicSigner {
 
   readonly index: IndexApi
 
-  readonly admin: AdminApi
-
   /**
    * Register Stream handler
    * @param streamHandler - StreamHandler instance

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -23,8 +23,6 @@ import {
   AnchorValidator,
   AnchorStatus,
   StreamState,
-  AdminApi,
-
 } from '@ceramicnetwork/common'
 
 import { DID } from 'dids'
@@ -180,7 +178,7 @@ export class Ceramic implements CeramicApi {
   public readonly dispatcher: Dispatcher
   public readonly loggerProvider: LoggerProvider
   public readonly pin: PinApi
-  public readonly admin: AdminApi
+  public readonly admin: LocalAdminApi
   readonly repository: Repository
 
   readonly _streamHandlers: HandlersMap

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -20,7 +20,6 @@ import {
   AnchorStatus,
   IndexApi,
   StreamState,
-  AdminApi,
 } from '@ceramicnetwork/common'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { Caip10Link } from '@ceramicnetwork/stream-caip10-link'
@@ -75,7 +74,7 @@ export class CeramicClient implements CeramicApi {
   private _supportedChains: Array<string>
 
   public readonly pin: PinApi
-  public readonly admin: AdminApi
+  public readonly admin: RemoteAdminApi
   public readonly index: IndexApi
   public readonly context: Context
 


### PR DESCRIPTION
for now I left the AdminApi interface around, but it might make sense to delete the interface entirely and just let LocalAdminApi and RemoteAdminApi exist as totally independent types.  Would love input here.