### PR TITLE
feat(core,common,http-client): Standardize AdminAPI implementations to not take DID argument.

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -80,6 +80,7 @@
     "@types/stream-to-array": "^2.3.0",
     "cross-fetch": "^3.1.4",
     "get-port": "^6.0.0",
+    "lodash.merge": "^4.6.2",
     "mockdate": "^3.0.5",
     "rxjs": "^7.5.2",
     "tmp-promise": "^3.0.3"

--- a/packages/cli/src/__tests__/admin-api.test.ts
+++ b/packages/cli/src/__tests__/admin-api.test.ts
@@ -37,13 +37,15 @@ describe('admin api', () => {
 
     const did = new DID({
       provider: new Ed25519Provider(sha256.hash(uint8arrays.fromString(seed))),
-      resolver: KeyResolver.getResolver() })
+      resolver: KeyResolver.getResolver(),
+    })
     await did.authenticate()
     adminDid = did
 
     const anotherDid = new DID({
       provider: new Ed25519Provider(sha256.hash(uint8arrays.fromString('non-admin'))),
-      resolver: KeyResolver.getResolver() })
+      resolver: KeyResolver.getResolver(),
+    })
     await anotherDid.authenticate()
     nonAdminDid = anotherDid
 
@@ -57,7 +59,7 @@ describe('admin api', () => {
     await client.setDID(makeDID(client, seed))
 
     // @ts-ignore
-    const myModel1 = await  Model.create(core, MY_MODEL_1_CONTENT)
+    const myModel1 = await Model.create(core, MY_MODEL_1_CONTENT)
     exampleModelStreamId = myModel1.id.toString()
   })
 
@@ -75,7 +77,7 @@ describe('admin api', () => {
     const jws = await did.createJWS({
       code: code,
       requestPath: '/api/v0/admin/models',
-      requestBody: body
+      requestBody: body,
     })
     return `${jws.signatures[0].protected}.${jws.payload}.${jws.signatures[0].signature}`
   }
@@ -87,123 +89,119 @@ describe('admin api', () => {
       return (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
     }
 
-    const getResult = await fetchJson(adminURLString,
-      {
-        headers: {
-          authorization: `Authorization: Basic ${await buildJWS(adminDid, await fetchCode())}`
-        }
-      })
+    const getResult = await fetchJson(adminURLString, {
+      headers: {
+        authorization: `Authorization: Basic ${await buildJWS(adminDid, await fetchCode())}`,
+      },
+    })
     expect(getResult.models).toEqual([])
 
     const postResult = await fetchJson(adminURLString, {
-      method:'POST',
-      body: {  jws: await buildJWS(adminDid, await fetchCode(), [exampleModelStreamId]) }
+      method: 'POST',
+      body: { jws: await buildJWS(adminDid, await fetchCode(), [exampleModelStreamId]) },
     })
     expect(postResult.result).toEqual('success')
 
-    const newGetResult = await fetchJson(adminURLString,
-      {
-        headers: {
-          authorization: `Authorization: Basic ${await buildJWS(adminDid, await fetchCode())}`
-        }
-      })
+    const newGetResult = await fetchJson(adminURLString, {
+      headers: {
+        authorization: `Authorization: Basic ${await buildJWS(adminDid, await fetchCode())}`,
+      },
+    })
     expect(newGetResult.models).toEqual([exampleModelStreamId])
 
     const deleteResult = await fetchJson(adminURLString, {
-      method:'DELETE',
-      body: {  jws: await buildJWS(adminDid, await fetchCode(), [exampleModelStreamId]) }
+      method: 'DELETE',
+      body: { jws: await buildJWS(adminDid, await fetchCode(), [exampleModelStreamId]) },
     })
     expect(deleteResult.result).toEqual('success')
 
-    const getResultAfterDelete = await fetchJson(adminURLString,
-      {
-        headers: {
-          authorization: `Authorization: Basic ${await buildJWS(adminDid, await fetchCode())}`
-        }
-      })
+    const getResultAfterDelete = await fetchJson(adminURLString, {
+      headers: {
+        authorization: `Authorization: Basic ${await buildJWS(adminDid, await fetchCode())}`,
+      },
+    })
     expect(getResultAfterDelete.models).toEqual([])
   })
 
   describe('admin models API validation test', () => {
     it('No admin code for GET', async () => {
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           headers: {
-            authorization: `Authorization: Basic ${await buildJWS(adminDid, '')}`
-          }
-        }),
-      ).rejects.toThrow(
-        /Admin code is missing from the the jws block/
-      )
+            authorization: `Authorization: Basic ${await buildJWS(adminDid, '')}`,
+          },
+        })
+      ).rejects.toThrow(/Admin code is missing from the the jws block/)
     })
 
     it('No admin code for POST', async () => {
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
-          body: {  jws: await buildJWS(adminDid, '') }
-        }),
-      ).rejects.toThrow(
-        /Admin code is missing from the the jws block/
-      )
+          body: { jws: await buildJWS(adminDid, '') },
+        })
+      ).rejects.toThrow(/Admin code is missing from the the jws block/)
     })
 
     it('No admin code for DELETE', async () => {
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
-          body: {  jws: await buildJWS(adminDid, '') }
-        }),
-      ).rejects.toThrow(
-        /Admin code is missing from the the jws block/
-      )
+          body: { jws: await buildJWS(adminDid, '') },
+        })
+      ).rejects.toThrow(/Admin code is missing from the the jws block/)
     })
 
     it('Arbitrary admin code for GET', async () => {
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           headers: {
-            authorization: `Authorization: Basic ${await buildJWS(adminDid, '1B7F4C45-C0E8-4BF3-88E4-8F7C81AB3BEC')}`
-          }
-        }),
-      ).rejects.toThrow(
-        /Unauthorized access: invalid\/already used admin code/
-      )
+            authorization: `Authorization: Basic ${await buildJWS(
+              adminDid,
+              '1B7F4C45-C0E8-4BF3-88E4-8F7C81AB3BEC'
+            )}`,
+          },
+        })
+      ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
     })
 
     it('Arbitrary admin code for POST', async () => {
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
-          body: {  jws: await buildJWS(adminDid, '1B7F4C45-C0E8-4BF3-88E4-8F7C81AB3BEC', [exampleModelStreamId]) }
-        }),
-      ).rejects.toThrow(
-        /Unauthorized access: invalid\/already used admin code/
-      )
+          body: {
+            jws: await buildJWS(adminDid, '1B7F4C45-C0E8-4BF3-88E4-8F7C81AB3BEC', [
+              exampleModelStreamId,
+            ]),
+          },
+        })
+      ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
     })
 
     it('Arbitrary admin code for DELETE', async () => {
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
-          body: {  jws: await buildJWS(adminDid, '1B7F4C45-C0E8-4BF3-88E4-8F7C81AB3BEC', [exampleModelStreamId]) }
-        }),
-      ).rejects.toThrow(
-        /Unauthorized access: invalid\/already used admin code/
-      )
+          body: {
+            jws: await buildJWS(adminDid, '1B7F4C45-C0E8-4BF3-88E4-8F7C81AB3BEC', [
+              exampleModelStreamId,
+            ]),
+          },
+        })
+      ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
     })
 
     it('Old code used with GET', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
-      const now = (new Date()).getTime()
+      const now = new Date().getTime()
       MockDate.set(now + (1000 * 60 * 1 + 1000)) // One minute one second in the future
       expect(true).toBeTruthy()
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           headers: {
-            authorization: `Authorization: Basic ${await buildJWS(adminDid, code)}`
-          }
-        }),
+            authorization: `Authorization: Basic ${await buildJWS(adminDid, code)}`,
+          },
+        })
       ).rejects.toThrow(
         /Unauthorized access: expired admin code - admin codes are only valid for 60 seconds/
       )
@@ -211,14 +209,14 @@ describe('admin api', () => {
 
     it('Old code used with POST', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
-      const now = (new Date()).getTime()
+      const now = new Date().getTime()
       MockDate.set(now + (1000 * 60 * 1 + 1000)) // One minute one second in the future
       expect(true).toBeTruthy()
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
-          body: {  jws: await buildJWS(adminDid, code, [exampleModelStreamId]) }
-        }),
+          body: { jws: await buildJWS(adminDid, code, [exampleModelStreamId]) },
+        })
       ).rejects.toThrow(
         /Unauthorized access: expired admin code - admin codes are only valid for 60 seconds/
       )
@@ -226,14 +224,14 @@ describe('admin api', () => {
 
     it('Old code used with DELETE', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
-      const now = (new Date()).getTime()
+      const now = new Date().getTime()
       MockDate.set(now + (1000 * 60 * 1 + 1000)) // One minute one second in the future
       expect(true).toBeTruthy()
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'DELETE',
-          body: {  jws: await buildJWS(adminDid, code, [exampleModelStreamId]) }
-        }),
+          body: { jws: await buildJWS(adminDid, code, [exampleModelStreamId]) },
+        })
       ).rejects.toThrow(
         /Unauthorized access: expired admin code - admin codes are only valid for 60 seconds/
       )
@@ -244,126 +242,107 @@ describe('admin api', () => {
       expect(true).toBeTruthy()
       await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
         headers: {
-          authorization: `Authorization: Basic ${await buildJWS(adminDid, code)}`
-        }
+          authorization: `Authorization: Basic ${await buildJWS(adminDid, code)}`,
+        },
       })
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           headers: {
-            authorization: `Authorization: Basic ${await buildJWS(adminDid, code)}`
-          }
-        }),
-      ).rejects.toThrow(
-        /Unauthorized access: invalid\/already used admin code/
-      )
+            authorization: `Authorization: Basic ${await buildJWS(adminDid, code)}`,
+          },
+        })
+      ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
     })
 
     it('Same code used again for POST', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       expect(true).toBeTruthy()
-      await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
-          method: 'POST',
-          body: {  jws: await buildJWS(adminDid, code, [exampleModelStreamId]), }
+      await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+        method: 'POST',
+        body: { jws: await buildJWS(adminDid, code, [exampleModelStreamId]) },
       })
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
-          body: {  jws: await buildJWS(adminDid, code, [exampleModelStreamId]) }
-        }),
-      ).rejects.toThrow(
-        /Unauthorized access: invalid\/already used admin code/
-      )
+          body: { jws: await buildJWS(adminDid, code, [exampleModelStreamId]) },
+        })
+      ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
     })
 
     it('Same code used again for DELETE', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       expect(true).toBeTruthy()
-      await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+        method: 'DELETE',
+        body: { jws: await buildJWS(adminDid, code, [exampleModelStreamId]) },
+      })
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'DELETE',
-          body: {  jws: await buildJWS(adminDid, code, [exampleModelStreamId]), }
+          body: { jws: await buildJWS(adminDid, code, [exampleModelStreamId]) },
         })
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
-          method: 'DELETE',
-          body: {  jws: await buildJWS(adminDid, code, [exampleModelStreamId]) }
-        }),
-      ).rejects.toThrow(
-        /Unauthorized access: invalid\/already used admin code/
-      )
+      ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
     })
 
     it('Unauthorised DID for GET', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           headers: {
-            authorization: `Authorization: Basic ${await buildJWS(nonAdminDid, code)}`
-          }
-        }),
-      ).rejects.toThrow(
-        /Unauthorized access/
-      )
+            authorization: `Authorization: Basic ${await buildJWS(nonAdminDid, code)}`,
+          },
+        })
+      ).rejects.toThrow(/Unauthorized access/)
     })
 
     it('Unauthorised DID for POST', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
-          body: {  jws: await buildJWS(nonAdminDid, code, [exampleModelStreamId]) }
-        }),
-      ).rejects.toThrow(
-        /Unauthorized access/
-      )
+          body: { jws: await buildJWS(nonAdminDid, code, [exampleModelStreamId]) },
+        })
+      ).rejects.toThrow(/Unauthorized access/)
     })
 
     it('Unauthorised DID for DELETE', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'DELETE',
-          body: {  jws: await buildJWS(nonAdminDid, code, [exampleModelStreamId]) }
-        }),
-      ).rejects.toThrow(
-        /Unauthorized access/
-      )
+          body: { jws: await buildJWS(nonAdminDid, code, [exampleModelStreamId]) },
+        })
+      ).rejects.toThrow(/Unauthorized access/)
     })
 
     it('No authorization for GET', async () => {
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`)
-      ).rejects.toThrow(
-        /Missing authorization header/
-      )
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`)
+      ).rejects.toThrow(/Missing authorization header/)
     })
 
     it('No authorization for POST', async () => {
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
-          method: 'POST'
-        }),
-      ).rejects.toThrow(
-        /Missing authorization jws/
-      )
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+          method: 'POST',
+        })
+      ).rejects.toThrow(/Missing authorization jws/)
     })
 
     it('No authorization for DELETE', async () => {
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
-          method: 'DELETE'
-        }),
-      ).rejects.toThrow(
-        /Missing authorization jws/
-      )
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+          method: 'DELETE',
+        })
+      ).rejects.toThrow(/Missing authorization jws/)
     })
 
     it('No models for POST', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
-          method:'POST',
-          body: { jws: await buildJWS(adminDid, code) }
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+          method: 'POST',
+          body: { jws: await buildJWS(adminDid, code) },
         })
       ).rejects.toThrow(
         /The 'models' parameter is required and it has to be an array containing at least one model stream id/
@@ -372,10 +351,10 @@ describe('admin api', () => {
 
     it('Empty models for POST', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
-          method:'POST',
-          body: { jws: await buildJWS(adminDid, code, []) }
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+          method: 'POST',
+          body: { jws: await buildJWS(adminDid, code, []) },
         })
       ).rejects.toThrow(
         /The 'models' parameter is required and it has to be an array containing at least one model stream id/
@@ -384,10 +363,10 @@ describe('admin api', () => {
 
     it('No models for DELETE', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
-          method:'DELETE',
-          body: { jws: await buildJWS(adminDid, code) }
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+          method: 'DELETE',
+          body: { jws: await buildJWS(adminDid, code) },
         })
       ).rejects.toThrow(
         /The 'models' parameter is required and it has to be an array containing at least one model stream id/
@@ -396,10 +375,10 @@ describe('admin api', () => {
 
     it('Empty models for DELETE', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
-      await expect(fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`,
-        {
-          method:'DELETE',
-          body: { jws: await buildJWS(adminDid, code, []) }
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+          method: 'DELETE',
+          body: { jws: await buildJWS(adminDid, code, []) },
         })
       ).rejects.toThrow(
         /The 'models' parameter is required and it has to be an array containing at least one model stream id/

--- a/packages/cli/src/__tests__/admin-api.test.ts
+++ b/packages/cli/src/__tests__/admin-api.test.ts
@@ -51,12 +51,14 @@ describe('admin api', () => {
 
     tmpFolder = await tmp.dir({ unsafeCleanup: true })
     core = await makeCeramicCore(ipfs, tmpFolder.path)
-    daemon = await makeCeramicDaemon(core)
+    daemon = await makeCeramicDaemon(core, {
+      'http-api': { 'admin-dids': [adminDid.id.toString()] },
+    })
     const apiUrl = `http://localhost:${daemon.port}`
     client = new CeramicClient(apiUrl, { syncInterval: 500 })
 
-    await core.setDID(makeDID(core, seed))
-    await client.setDID(makeDID(client, seed))
+    core.did = makeDID(core, seed)
+    client.did = makeDID(client, seed)
 
     // @ts-ignore
     const myModel1 = await Model.create(core, MY_MODEL_1_CONTENT)

--- a/packages/cli/src/__tests__/make-ceramic-core.ts
+++ b/packages/cli/src/__tests__/make-ceramic-core.ts
@@ -7,7 +7,6 @@ export async function makeCeramicCore(
   stateStoreDirectory: string
 ): Promise<Ceramic> {
   const core = await Ceramic.create(ipfs, {
-    adminDids: ['did:key:z6MkgwMzPmLuvUiWsQfyQeGpNRRNkLyCB5cL96fPshy1DKJd'],
     pubsubTopic: '/ceramic',
     stateStoreDirectory,
     anchorOnRequest: false,

--- a/packages/cli/src/__tests__/make-ceramic-daemon.ts
+++ b/packages/cli/src/__tests__/make-ceramic-daemon.ts
@@ -2,18 +2,25 @@ import { Ceramic } from '@ceramicnetwork/core'
 import getPort from 'get-port'
 import { CeramicDaemon } from '../ceramic-daemon.js'
 import { DaemonConfig } from '../daemon-config.js'
+import merge from 'lodash.merge'
 
-export async function makeCeramicDaemon(core: Ceramic): Promise<CeramicDaemon> {
+export async function makeCeramicDaemon(
+  core: Ceramic,
+  opts: Record<string, any> = {}
+): Promise<CeramicDaemon> {
   const port = await getPort()
-  const daemon = new CeramicDaemon(
-    core,
-    DaemonConfig.fromObject({
+
+  const configObj = merge(
+    {
       'http-api': { port },
       indexing: {
         'allow-queries-before-historical-sync': true,
       },
-    })
+    },
+    opts
   )
+
+  const daemon = new CeramicDaemon(core, DaemonConfig.fromObject(configObj))
   await daemon.listen()
   return daemon
 }

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -33,7 +33,7 @@ const DEFAULT_METRICS_EXPORTER_PORT = 9090
 
 const DEFAULT_DAEMON_CONFIG = DaemonConfig.fromObject({
   anchor: {},
-  'http-api': { 'cors-allowed-origins': [new RegExp('.*')] },
+  'http-api': { 'cors-allowed-origins': [new RegExp('.*')], 'admin-dids': [] },
   ipfs: { mode: IpfsMode.BUNDLED },
   logger: { 'log-level': LogLevel.important, 'log-to-files': false },
   metrics: {

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -153,6 +153,12 @@ export class DaemonHTTPApiConfig {
     },
   })
   corsAllowedOrigins?: RegExp[]
+
+  /**
+   * An array of DIDs with access to Admin API (represented as strings)
+   */
+  @jsonArrayMember(String, { name: 'admin-dids' })
+  adminDids?: Array<string>
 }
 
 /**
@@ -271,12 +277,6 @@ export class DaemonDidResolversConfig {
 @jsonObject
 @toJson
 export class DaemonCeramicNodeConfig {
-  /**
-   * An array of DIDs with access to Admin API (represented as strings)
-   */
-  @jsonArrayMember(String, { name: 'admin-dids' })
-  adminDids: Array<string>
-
   /**
    * Whether to run the Ceramic node in read-only gateway mode.
    */

--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -92,8 +92,6 @@ export interface CeramicApi extends CeramicSigner {
 
   readonly index: IndexApi
 
-  readonly admin: AdminApi
-
   /**
    * Register Stream handler
    * @param streamHandler - StreamHandler instance

--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -60,27 +60,23 @@ export interface CeramicSigner extends CeramicCommon {
 export interface AdminApi {
   /**
    * List indexed model streams
-   *
-   * @param actingDid - did that performs the operation
    */
-  getIndexedModels(actingDid: DID | string): Promise<Array<StreamID>>
+  getIndexedModels(): Promise<Array<StreamID>>
 
   /**
    * Adds model streams to index
    *
-   * @param actingDid - did that performs the operation
    * @param modelsIDs - array of model stream IDs to add to index
    */
-  startIndexingModels(actingDid: DID | string, modelsIDs: Array<StreamID>): Promise<void>
+  startIndexingModels(modelsIDs: Array<StreamID>): Promise<void>
 
   /**
    * Removes model streams from index
    *
-   * @param actingDid - did that performs the operation
    * @param modelsIDs - array of model stream IDs to remove from index
    */
 
-  stopIndexingModels(actingDid: DID | string, modelsIDs: Array<StreamID>): Promise<void>
+  stopIndexingModels(modelsIDs: Array<StreamID>): Promise<void>
 }
 
 /**
@@ -91,6 +87,8 @@ export interface CeramicApi extends CeramicSigner {
   // loggerProvider: LoggerProvider; // TODO uncomment once logger is available on http-client
 
   readonly index: IndexApi
+
+  readonly admin: AdminApi
 
   /**
    * Register Stream handler

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -23,6 +23,7 @@ import {
   AnchorValidator,
   AnchorStatus,
   StreamState,
+  AdminApi,
 } from '@ceramicnetwork/common'
 
 import { DID } from 'dids'
@@ -85,7 +86,6 @@ const DEFAULT_LOAD_OPTS = { sync: SyncOptions.PREFER_CACHE }
  * Ceramic configuration
  */
 export interface CeramicConfig {
-  adminDids?: Array<string>
   ethereumRpcUrl?: string
   anchorServiceUrl?: string
   stateStoreDirectory?: string
@@ -133,7 +133,6 @@ export interface CeramicModules {
  * `CeramicConfig` via `Ceramic.create()`.
  */
 export interface CeramicParameters {
-  adminDids?: Array<string>
   gateway: boolean
   indexingConfig: IndexingConfig
   networkOptions: CeramicNetworkOptions
@@ -178,7 +177,7 @@ export class Ceramic implements CeramicApi {
   public readonly dispatcher: Dispatcher
   public readonly loggerProvider: LoggerProvider
   public readonly pin: PinApi
-  public readonly admin: LocalAdminApi
+  public readonly admin: AdminApi
   readonly repository: Repository
 
   readonly _streamHandlers: HandlersMap
@@ -232,7 +231,7 @@ export class Ceramic implements CeramicApi {
       this._logger,
       params.networkOptions.name
     )
-    this.admin = new LocalAdminApi(params.adminDids, localIndex, this._logger)
+    this.admin = new LocalAdminApi(localIndex, this._logger)
     this.repository.setDeps({
       dispatcher: this.dispatcher,
       pinStore: pinStore,
@@ -458,7 +457,6 @@ export class Ceramic implements CeramicApi {
     )
 
     const params: CeramicParameters = {
-      adminDids: config.adminDids,
       gateway: config.gateway,
       indexingConfig: config.indexing,
       networkOptions,

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -23,8 +23,6 @@ import {
   AnchorValidator,
   AnchorStatus,
   StreamState,
-  AdminApi,
-
 } from '@ceramicnetwork/common'
 
 import { DID } from 'dids'
@@ -180,7 +178,7 @@ export class Ceramic implements CeramicApi {
   public readonly dispatcher: Dispatcher
   public readonly loggerProvider: LoggerProvider
   public readonly pin: PinApi
-  public readonly admin: AdminApi
+  public readonly admin: LocalAdminApi
   readonly repository: Repository
 
   readonly _streamHandlers: HandlersMap

--- a/packages/core/src/indexing/local-index-api.ts
+++ b/packages/core/src/indexing/local-index-api.ts
@@ -143,6 +143,7 @@ export class LocalIndexApi implements IndexApi {
   }
 
   async stopIndexingModels(models: Array<StreamID>): Promise<void> {
+    this.logger.imp(`Stopping indexing for Models: ${models.map(String).join(',')}`)
     await this.databaseIndexApi?.stopIndexingModels(models)
   }
 

--- a/packages/core/src/local-admin-api.ts
+++ b/packages/core/src/local-admin-api.ts
@@ -1,4 +1,4 @@
-import { AdminApi, DiagnosticsLogger, LogStyle } from '@ceramicnetwork/common'
+import { AdminApi, DiagnosticsLogger } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { LocalIndexApi } from './indexing/local-index-api.js'
 
@@ -7,38 +7,19 @@ import { LocalIndexApi } from './indexing/local-index-api.js'
  */
 export class LocalAdminApi implements AdminApi {
   constructor(
-    private readonly adminDids: Array<string> | undefined,
     private readonly indexApi: LocalIndexApi,
     private readonly logger: DiagnosticsLogger
   ) {}
 
-  private verifyActingDid(actingDid: string) {
-    // TODO: CDB-1887 - Consider moving admin did verification out of this class
-    if (!this.adminDids || !this.adminDids.some((adminDid) => actingDid.startsWith(adminDid))) {
-      this.logger.log(
-        LogStyle.warn,
-        `Unauthorized access attempt to Admin Api from did: ${actingDid}`
-      )
-      throw Error(
-        `Unauthorized access: DID '${actingDid}' does not have admin access permission to this node`
-      )
-    }
-  }
-
-  async startIndexingModels(actingDid: string, modelsIDs: Array<StreamID>): Promise<void> {
-    this.verifyActingDid(actingDid)
-    this.logger.log(LogStyle.info, `Adding models to index: ${modelsIDs}`)
+  async startIndexingModels(modelsIDs: Array<StreamID>): Promise<void> {
     await this.indexApi.indexModels(modelsIDs)
   }
 
-  getIndexedModels(actingDid: string): Promise<Array<StreamID>> {
-    this.verifyActingDid(actingDid)
+  getIndexedModels(): Promise<Array<StreamID>> {
     return Promise.resolve(this.indexApi.indexedModels() ?? [])
   }
 
-  async stopIndexingModels(actingDid: string, modelsIDs: Array<StreamID>): Promise<void> {
-    this.verifyActingDid(actingDid)
-    this.logger.log(LogStyle.info, `Removing models from index: ${modelsIDs}`)
+  async stopIndexingModels(modelsIDs: Array<StreamID>): Promise<void> {
     await this.indexApi.stopIndexingModels(modelsIDs)
   }
 }

--- a/packages/core/src/local-admin-api.ts
+++ b/packages/core/src/local-admin-api.ts
@@ -14,9 +14,14 @@ export class LocalAdminApi implements AdminApi {
 
   private verifyActingDid(actingDid: string) {
     // TODO: CDB-1887 - Consider moving admin did verification out of this class
-    if (!this.adminDids || !this.adminDids.some( adminDid => actingDid.startsWith(adminDid) )) {
-      this.logger.log(LogStyle.warn, `Unauthorized access attempt to Admin Api from did: ${actingDid}`)
-      throw Error(`Unauthorized access: DID '${actingDid}' does not have admin access permission to this node`)
+    if (!this.adminDids || !this.adminDids.some((adminDid) => actingDid.startsWith(adminDid))) {
+      this.logger.log(
+        LogStyle.warn,
+        `Unauthorized access attempt to Admin Api from did: ${actingDid}`
+      )
+      throw Error(
+        `Unauthorized access: DID '${actingDid}' does not have admin access permission to this node`
+      )
     }
   }
 

--- a/packages/http-client/src/__tests__/remote-admin-api.test.ts
+++ b/packages/http-client/src/__tests__/remote-admin-api.test.ts
@@ -10,13 +10,14 @@ import { randomBytes } from '@stablelib/random'
 const FAUX_ENDPOINT = new URL('https://example.com')
 const MODEL = new StreamID(1, TestUtils.randomCID())
 const SUCCESS_RESPONSE = {
-  result: 'success'
+  result: 'success',
 }
 const GET_RESPONSE = {
-  models: [MODEL.toString()]
+  models: [MODEL.toString()],
 }
 
 let did: DID
+let getDidFn
 
 beforeAll(async () => {
   const seed = randomBytes(32)
@@ -24,52 +25,51 @@ beforeAll(async () => {
   const actingDid = new DID({ provider, resolver: KeyResolver.getResolver() })
   await actingDid.authenticate()
   did = actingDid
+  getDidFn = () => {
+    return did
+  }
 })
 
 test('getIndexedModels()', async () => {
-  const adminApi = new RemoteAdminApi(FAUX_ENDPOINT)
+  const adminApi = new RemoteAdminApi(FAUX_ENDPOINT, getDidFn)
   // @ts-ignore
   adminApi.buildJWS = (): string => {
     return '<FAKE JWS>'
   }
   const fauxFetch = jest.fn(async () => GET_RESPONSE) as typeof fetchJson
-  (adminApi as any)._fetchJson = fauxFetch
-  await adminApi.getIndexedModels(did)
-  expect(fauxFetch).toBeCalledWith(new URL(`https://example.com/admin/models`), {"headers": {"Authorization": "Basic <FAKE JWS>"}})
+  ;(adminApi as any)._fetchJson = fauxFetch
+  await adminApi.getIndexedModels()
+  expect(fauxFetch).toBeCalledWith(new URL(`https://example.com/admin/models`), {
+    headers: { Authorization: 'Basic <FAKE JWS>' },
+  })
 })
 
 test('addModelsToIndex()', async () => {
-  const adminApi = new RemoteAdminApi(FAUX_ENDPOINT)
+  const adminApi = new RemoteAdminApi(FAUX_ENDPOINT, getDidFn)
   // @ts-ignore
   adminApi.buildJWS = (): string => {
     return '<FAKE JWS>'
   }
   const fauxFetch = jest.fn(async () => SUCCESS_RESPONSE) as typeof fetchJson
-  (adminApi as any)._fetchJson = fauxFetch
-  await adminApi.startIndexingModels(did, [MODEL])
-  expect(fauxFetch).toBeCalledWith(
-    new URL(`https://example.com/admin/models`),
-    {
-      method: 'post',
-      body: { jws: "<FAKE JWS>" },
-    }
-  )
+  ;(adminApi as any)._fetchJson = fauxFetch
+  await adminApi.startIndexingModels([MODEL])
+  expect(fauxFetch).toBeCalledWith(new URL(`https://example.com/admin/models`), {
+    method: 'post',
+    body: { jws: '<FAKE JWS>' },
+  })
 })
 
 test('removeModelsFromIndex()', async () => {
-  const adminApi = new RemoteAdminApi(FAUX_ENDPOINT)
+  const adminApi = new RemoteAdminApi(FAUX_ENDPOINT, getDidFn)
   // @ts-ignore
   adminApi.buildJWS = (): string => {
     return '<FAKE JWS>'
   }
   const fauxFetch = jest.fn(async () => SUCCESS_RESPONSE) as typeof fetchJson
-  (adminApi as any)._fetchJson = fauxFetch
-  await adminApi.stopIndexingModels(did, [MODEL])
-  expect(fauxFetch).toBeCalledWith(
-    new URL(`https://example.com/admin/models`),
-    {
-      method: 'delete',
-      body: { jws: "<FAKE JWS>" },
-    }
-  )
+  ;(adminApi as any)._fetchJson = fauxFetch
+  await adminApi.stopIndexingModels([MODEL])
+  expect(fauxFetch).toBeCalledWith(new URL(`https://example.com/admin/models`), {
+    method: 'delete',
+    body: { jws: '<FAKE JWS>' },
+  })
 })

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -93,9 +93,10 @@ export class CeramicClient implements CeramicApi {
 
     this.pin = new RemotePinApi(this._apiUrl)
     this.index = new RemoteIndexApi(this._apiUrl)
-    this.admin = new RemoteAdminApi(this._apiUrl, () => {
+    const getDidFn = (() => {
       return this.did
-    })
+    }).bind(this)
+    this.admin = new RemoteAdminApi(this._apiUrl, getDidFn)
 
     this._streamConstructors = {
       [Caip10Link.STREAM_TYPE_ID]: Caip10Link,

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -20,6 +20,7 @@ import {
   AnchorStatus,
   IndexApi,
   StreamState,
+  AdminApi,
 } from '@ceramicnetwork/common'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { Caip10Link } from '@ceramicnetwork/stream-caip10-link'
@@ -74,7 +75,7 @@ export class CeramicClient implements CeramicApi {
   private _supportedChains: Array<string>
 
   public readonly pin: PinApi
-  public readonly admin: RemoteAdminApi
+  public readonly admin: AdminApi
   public readonly index: IndexApi
   public readonly context: Context
 
@@ -92,7 +93,9 @@ export class CeramicClient implements CeramicApi {
 
     this.pin = new RemotePinApi(this._apiUrl)
     this.index = new RemoteIndexApi(this._apiUrl)
-    this.admin = new RemoteAdminApi(this._apiUrl)
+    this.admin = new RemoteAdminApi(this._apiUrl, () => {
+      return this.did
+    })
 
     this._streamConstructors = {
       [Caip10Link.STREAM_TYPE_ID]: Caip10Link,

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -20,7 +20,6 @@ import {
   AnchorStatus,
   IndexApi,
   StreamState,
-  AdminApi,
 } from '@ceramicnetwork/common'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { Caip10Link } from '@ceramicnetwork/stream-caip10-link'
@@ -75,7 +74,7 @@ export class CeramicClient implements CeramicApi {
   private _supportedChains: Array<string>
 
   public readonly pin: PinApi
-  public readonly admin: AdminApi
+  public readonly admin: RemoteAdminApi
   public readonly index: IndexApi
   public readonly context: Context
 

--- a/packages/http-client/src/remote-admin-api.ts
+++ b/packages/http-client/src/remote-admin-api.ts
@@ -12,9 +12,7 @@ export class RemoteAdminApi implements AdminApi {
   readonly modelsPath = './admin/models'
   readonly getCodePath = './admin/getCode'
 
-  constructor(
-    private readonly _apiUrl: URL
-  ) {}
+  constructor(private readonly _apiUrl: URL) {}
 
   private getCodeUrl(): URL {
     return new URL(this.getCodePath, this._apiUrl)
@@ -24,12 +22,18 @@ export class RemoteAdminApi implements AdminApi {
     return new URL(this.modelsPath, this._apiUrl)
   }
 
-  private async buildJWS(actingDid: DID, code: string, modelsIDs?: Array<StreamID>): Promise<string> {
-    const body = modelsIDs ? { models: modelsIDs.map(streamID => streamID.toString()) } : undefined
+  private async buildJWS(
+    actingDid: DID,
+    code: string,
+    modelsIDs?: Array<StreamID>
+  ): Promise<string> {
+    const body = modelsIDs
+      ? { models: modelsIDs.map((streamID) => streamID.toString()) }
+      : undefined
     const jws = await actingDid.createJWS({
       code: code,
       requestPath: this.getModelsUrl().pathname,
-      requestBody: body
+      requestBody: body,
     })
     return `${jws.signatures[0].protected}.${jws.payload}.${jws.signatures[0].signature}`
   }
@@ -42,14 +46,14 @@ export class RemoteAdminApi implements AdminApi {
     const code = await this.generateCode()
     await this._fetchJson(this.getModelsUrl(), {
       method: 'post',
-      body: { jws: await this.buildJWS(actingDid, code, modelsIDs)},
+      body: { jws: await this.buildJWS(actingDid, code, modelsIDs) },
     })
   }
 
   async getIndexedModels(actingDid: DID): Promise<Array<StreamID>> {
     const code = await this.generateCode()
-    const response= await this._fetchJson(this.getModelsUrl(), {
-      headers: { 'Authorization': `Basic ${await this.buildJWS(actingDid, code)}` },
+    const response = await this._fetchJson(this.getModelsUrl(), {
+      headers: { Authorization: `Basic ${await this.buildJWS(actingDid, code)}` },
     })
     return response.models.map((modelStreamIDString: string) => {
       return StreamID.fromString(modelStreamIDString)
@@ -60,7 +64,7 @@ export class RemoteAdminApi implements AdminApi {
     const code = await this.generateCode()
     await this._fetchJson(this.getModelsUrl(), {
       method: 'delete',
-      body: { jws: await this.buildJWS(actingDid, code, modelsIDs)},
+      body: { jws: await this.buildJWS(actingDid, code, modelsIDs) },
     })
   }
 }

--- a/packages/stream-tests/src/__tests__/admin-api.test.ts
+++ b/packages/stream-tests/src/__tests__/admin-api.test.ts
@@ -1,0 +1,141 @@
+import { jest } from '@jest/globals'
+import getPort from 'get-port'
+import { IpfsApi, Page, StreamState, TestUtils } from '@ceramicnetwork/common'
+import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
+import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
+import { createCeramic } from '../create-ceramic.js'
+import { Ceramic } from '@ceramicnetwork/core'
+import { CeramicDaemon, DaemonConfig } from '@ceramicnetwork/cli'
+import { CeramicClient } from '@ceramicnetwork/http-client'
+import { Model, ModelDefinition } from '@ceramicnetwork/stream-model'
+import tmp from 'tmp-promise'
+import * as fs from 'fs/promises'
+import { DID } from 'dids'
+import { makeDID } from '@ceramicnetwork/cli/lib/__tests__/make-did.js'
+
+const CONTENT0 = { myData: 0 }
+const CONTENT1 = { myData: 1 }
+
+const MODEL_DEFINITION: ModelDefinition = {
+  name: 'MyModel1',
+  accountRelation: { type: 'list' },
+  schema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      myData: {
+        type: 'integer',
+        maximum: 10000,
+        minimum: 0,
+      },
+    },
+    required: ['myData'],
+  },
+}
+
+describe('Admin API tests', () => {
+  jest.setTimeout(1000 * 30)
+
+  let ipfs: IpfsApi
+  let port: number
+  let core: Ceramic
+  let daemon: CeramicDaemon
+  let ceramic: CeramicClient
+  let adminDid: DID
+  let nonAdminDid: DID
+
+  beforeAll(async () => {
+    ipfs = await createIPFS()
+  })
+
+  afterAll(async () => {
+    await ipfs.stop()
+  })
+
+  beforeEach(async () => {
+    process.env.CERAMIC_ENABLE_EXPERIMENTAL_COMPOSE_DB = 'true'
+
+    const indexingDirectory = await tmp.tmpName()
+    await fs.mkdir(indexingDirectory)
+    core = await createCeramic(ipfs, {
+      indexing: {
+        db: `sqlite://${indexingDirectory}/ceramic.sqlite`,
+        models: [],
+        allowQueriesBeforeHistoricalSync: true,
+      },
+    })
+
+    adminDid = makeDID(core, 'ADMIN SEED')
+    await adminDid.authenticate()
+    nonAdminDid = makeDID(core, 'NON ADMIN SEED')
+    await nonAdminDid.authenticate()
+
+    port = await getPort()
+    const apiUrl = 'http://localhost:' + port
+    daemon = new CeramicDaemon(
+      core,
+      DaemonConfig.fromObject({ 'http-api': { port, 'admin-dids': [adminDid.id.toString()] } })
+    )
+    await daemon.listen()
+    ceramic = new CeramicClient(apiUrl)
+    ceramic.did = nonAdminDid
+  }, 30 * 1000)
+
+  afterEach(async () => {
+    await ceramic.close()
+    await daemon.close()
+    await core.close()
+  })
+
+  describe('Indexing config tests', () => {
+    test('Fails with non-admin DID', async () => {
+      const model = await Model.create(ceramic, MODEL_DEFINITION)
+
+      await expect(ceramic.admin.getIndexedModels()).rejects.toThrow(/Unauthorized access/)
+      await expect(ceramic.admin.startIndexingModels([model.id])).rejects.toThrow(
+        /Unauthorized access/
+      )
+      await expect(ceramic.admin.stopIndexingModels([model.id])).rejects.toThrow(
+        /Unauthorized access/
+      )
+    })
+
+    test('Dynamic indexing', async () => {
+      const model = await Model.create(ceramic, MODEL_DEFINITION)
+
+      const doc1 = await ModelInstanceDocument.create(ceramic, CONTENT0, { model: model.id })
+
+      ceramic.did = adminDid
+
+      let indexedModels = await ceramic.admin.getIndexedModels()
+      expect(indexedModels.length).toEqual(0)
+
+      await expect(ceramic.index.count({ model: model.id })).rejects.toThrow(
+        /is not indexed on this node/
+      )
+
+      // Now start indexing the first model
+      await ceramic.admin.startIndexingModels([model.id])
+      indexedModels = await ceramic.admin.getIndexedModels()
+      expect(indexedModels.length).toEqual(1)
+
+      // Doesn't know about the doc created before the model was indexed
+      await expect(ceramic.index.count({ model: model.id })).resolves.toEqual(0)
+      await ModelInstanceDocument.create(ceramic, CONTENT0, { model: model.id })
+      await expect(ceramic.index.count({ model: model.id })).resolves.toEqual(1)
+      // Discovers the first doc when it is updated
+      ceramic.did = nonAdminDid // Set did back to the stream controller so it can be updated
+      await doc1.replace(CONTENT1)
+      await expect(ceramic.index.count({ model: model.id })).resolves.toEqual(2)
+
+      // Now stop indexing the model
+      ceramic.did = adminDid
+      await ceramic.admin.stopIndexingModels([model.id])
+
+      await expect(ceramic.index.count({ model: model.id })).rejects.toThrow(
+        /is not indexed on this node/
+      )
+    })
+  })
+})


### PR DESCRIPTION
puts the `admin: AdminAPI` back into the common `CeramicApi` interface (effectively reverting https://github.com/ceramicnetwork/js-ceramic/commit/d83c739ef6e5679da485363db8bc477ec1d39540) and unifies the `LocalAdminApi` and `RemoteAdminApi` to have the same signatures by removing the DID arguments from both and taking the DID from the `CeramicClient` handle in the http-client implementation