### PR TITLE
fix: Wrap AJV instances in LRU cache

### DIFF
--- a/packages/core/src/state-management/__tests__/repository.test.ts
+++ b/packages/core/src/state-management/__tests__/repository.test.ts
@@ -223,37 +223,6 @@ describe('#load', () => {
 })
 
 describe('validation', () => {
-  test('json schema fuckery', async () => {
-    function dropResidue(name: string, prevKeys: any[] = []) {
-      const residue =
-        ((ceramic._streamHandlers.get('tile') as any)._schemaValidator._validator.scope._values
-          .schema as Map<any, any>) || new Map()
-      const diff = new Map<any, any>()
-      for (const [k, v] of residue) {
-        if (!prevKeys.includes(k)) {
-          diff.set(k, v)
-        }
-      }
-      console.log(`residue:${name}: total: ${residue.size}, added: ${diff.size}`, diff)
-      return Array.from(residue.keys())
-    }
-    const stringMapSchema = await TileDocument.create(ceramic, STRING_MAP_SCHEMA)
-    const d0 = dropResidue(`0`)
-    await TileDocument.create(ceramic, { stuff: 'stuff' }, { schema: stringMapSchema.commitId })
-    const d1 = dropResidue(`1`, d0)
-    const stringLenSchema = await TileDocument.create(ceramic, STRLEN_MAP_SCHEMA)
-    const d2 = dropResidue(`2`, d1)
-    await TileDocument.create(ceramic, { stuff: 'stf' }, { schema: stringLenSchema.commitId })
-    const d3 = dropResidue(`3`, d2)
-    const numSchema = await TileDocument.create(ceramic, NUMBER_MAP_SCHEMA)
-    await TileDocument.create(ceramic, { stuff: 3 }, { schema: numSchema.commitId })
-    const d4 = dropResidue(`4`, d3)
-    await TileDocument.create(ceramic, { stuff: 4 }, { schema: numSchema.commitId })
-    const d5 = dropResidue(`5`, d4)
-    await TileDocument.create(ceramic, { stuff: 5 }, { schema: numSchema.commitId })
-    dropResidue(`6`, d5)
-  }, 10000)
-
   test('when loading genesis ', async () => {
     // Create schema
     const schema = await TileDocument.create(ceramic, STRING_MAP_SCHEMA)

--- a/packages/core/src/state-management/__tests__/repository.test.ts
+++ b/packages/core/src/state-management/__tests__/repository.test.ts
@@ -25,6 +25,26 @@ const STRING_MAP_SCHEMA = {
   },
 }
 
+const NUMBER_MAP_SCHEMA = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'StringMap',
+  type: 'object',
+  additionalProperties: {
+    type: 'number',
+  },
+}
+
+const STRLEN_MAP_SCHEMA = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'StringMap',
+  type: 'object',
+  additionalProperties: {
+    type: 'string',
+    minLength: 2,
+    maxLength: 3,
+  },
+}
+
 let ipfs: IpfsApi
 let ceramic: Ceramic
 let repository: Repository
@@ -203,6 +223,37 @@ describe('#load', () => {
 })
 
 describe('validation', () => {
+  test('json schema fuckery', async () => {
+    function dropResidue(name: string, prevKeys: any[] = []) {
+      const residue =
+        ((ceramic._streamHandlers.get('tile') as any)._schemaValidator._validator.scope._values
+          .schema as Map<any, any>) || new Map()
+      const diff = new Map<any, any>()
+      for (const [k, v] of residue) {
+        if (!prevKeys.includes(k)) {
+          diff.set(k, v)
+        }
+      }
+      console.log(`residue:${name}: total: ${residue.size}, added: ${diff.size}`, diff)
+      return Array.from(residue.keys())
+    }
+    const stringMapSchema = await TileDocument.create(ceramic, STRING_MAP_SCHEMA)
+    const d0 = dropResidue(`0`)
+    await TileDocument.create(ceramic, { stuff: 'stuff' }, { schema: stringMapSchema.commitId })
+    const d1 = dropResidue(`1`, d0)
+    const stringLenSchema = await TileDocument.create(ceramic, STRLEN_MAP_SCHEMA)
+    const d2 = dropResidue(`2`, d1)
+    await TileDocument.create(ceramic, { stuff: 'stf' }, { schema: stringLenSchema.commitId })
+    const d3 = dropResidue(`3`, d2)
+    const numSchema = await TileDocument.create(ceramic, NUMBER_MAP_SCHEMA)
+    await TileDocument.create(ceramic, { stuff: 3 }, { schema: numSchema.commitId })
+    const d4 = dropResidue(`4`, d3)
+    await TileDocument.create(ceramic, { stuff: 4 }, { schema: numSchema.commitId })
+    const d5 = dropResidue(`5`, d4)
+    await TileDocument.create(ceramic, { stuff: 5 }, { schema: numSchema.commitId })
+    dropResidue(`6`, d5)
+  }, 10000)
+
   test('when loading genesis ', async () => {
     // Create schema
     const schema = await TileDocument.create(ceramic, STRING_MAP_SCHEMA)

--- a/packages/core/src/state-management/__tests__/repository.test.ts
+++ b/packages/core/src/state-management/__tests__/repository.test.ts
@@ -25,26 +25,6 @@ const STRING_MAP_SCHEMA = {
   },
 }
 
-const NUMBER_MAP_SCHEMA = {
-  $schema: 'http://json-schema.org/draft-07/schema#',
-  title: 'StringMap',
-  type: 'object',
-  additionalProperties: {
-    type: 'number',
-  },
-}
-
-const STRLEN_MAP_SCHEMA = {
-  $schema: 'http://json-schema.org/draft-07/schema#',
-  title: 'StringMap',
-  type: 'object',
-  additionalProperties: {
-    type: 'string',
-    minLength: 2,
-    maxLength: 3,
-  },
-}
-
 let ipfs: IpfsApi
 let ceramic: Ceramic
 let repository: Repository

--- a/packages/stream-model-instance-handler/package.json
+++ b/packages/stream-model-instance-handler/package.json
@@ -38,6 +38,7 @@
     "ajv-formats": "^2.1.1",
     "fast-json-patch": "^3.1.0",
     "lodash.clonedeep": "^4.5.0",
+    "lru_map": "^0.4.1",
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -273,10 +273,12 @@ describe('ModelInstanceDocumentHandler', () => {
         if (streamId.toString() === FAKE_MODEL_ID.toString()) {
           return {
             content: MODEL_DEFINITION,
+            commitId: FAKE_MODEL_ID,
           }
         } else if (streamId.toString() === FAKE_MODEL_ID2.toString()) {
           return {
             content: MODEL_DEFINITION_SINGLE,
+            commitId: FAKE_MODEL_ID2,
           }
         } else {
           throw new Error(

--- a/packages/stream-model-instance-handler/src/__tests__/schema-utils.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/schema-utils.test.ts
@@ -1,6 +1,8 @@
 import { SchemaValidation } from '../schema-utils.js'
 import { ModelDefinition } from '@ceramicnetwork/stream-model'
 
+const SCHEMA_COMMIT_ID = 'k3y52l7mkcvtg023bt9txegccxe1bah8os3naw5asin3baf3l3t54atn0cuy98yws'
+
 const MODEL_DEFINITION: ModelDefinition = {
   name: 'MyModel',
   accountRelation: { type: 'list' },
@@ -95,13 +97,17 @@ describe('SchemaValidation', () => {
 
   it('validates content that conforms to schema', () => {
     expect(() => {
-      schemaValidator.validateSchema(CONTENT_VALID, MODEL_DEFINITION.schema)
+      schemaValidator.validateSchema(CONTENT_VALID, MODEL_DEFINITION.schema, SCHEMA_COMMIT_ID)
     }).not.toThrow()
   })
 
   it('throws when required properties are missing', () => {
     expect(() => {
-      schemaValidator.validateSchema(CONTENT_NO_REQ_PROPS, MODEL_DEFINITION.schema)
+      schemaValidator.validateSchema(
+        CONTENT_NO_REQ_PROPS,
+        MODEL_DEFINITION.schema,
+        SCHEMA_COMMIT_ID
+      )
     }).toThrow(
       /data must have required property 'arrayProperty', data must have required property 'stringArrayProperty', data must have required property 'stringProperty', data must have required property 'intProperty', data must have required property 'floatProperty'/
     )
@@ -109,7 +115,11 @@ describe('SchemaValidation', () => {
 
   it('throws when min values requirements are not respected', () => {
     expect(() => {
-      schemaValidator.validateSchema(CONTENT_MINS_NOT_RESPECTED, MODEL_DEFINITION.schema)
+      schemaValidator.validateSchema(
+        CONTENT_MINS_NOT_RESPECTED,
+        MODEL_DEFINITION.schema,
+        SCHEMA_COMMIT_ID
+      )
     }).toThrow(
       /data\/arrayProperty must NOT have fewer than 2 items, data\/stringArrayProperty\/0 must NOT have fewer than 2 characters, data\/stringProperty must NOT have fewer than 3 characters, data\/intProperty must be >= 2, data\/floatProperty must be >= 3/
     )
@@ -117,7 +127,11 @@ describe('SchemaValidation', () => {
 
   it('throws when max values requirements are not respected', () => {
     expect(() => {
-      schemaValidator.validateSchema(CONTENT_MAXS_NOT_RESPECTED, MODEL_DEFINITION.schema)
+      schemaValidator.validateSchema(
+        CONTENT_MAXS_NOT_RESPECTED,
+        MODEL_DEFINITION.schema,
+        SCHEMA_COMMIT_ID
+      )
     }).toThrow(
       /data\/arrayProperty must NOT have more than 4 items, data\/stringArrayProperty\/0 must NOT have more than 6 characters, data\/stringProperty must NOT have more than 8 characters, data\/intProperty must be <= 100, data\/floatProperty must be <= 110/
     )
@@ -125,7 +139,11 @@ describe('SchemaValidation', () => {
 
   it('throws when additional values are given', () => {
     expect(() => {
-      schemaValidator.validateSchema(CONTENT_WITH_ADDITIONAL_PROPERTY, MODEL_DEFINITION.schema)
+      schemaValidator.validateSchema(
+        CONTENT_WITH_ADDITIONAL_PROPERTY,
+        MODEL_DEFINITION.schema,
+        SCHEMA_COMMIT_ID
+      )
     }).toThrow(/data must NOT have additional properties/)
   })
 })

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -19,6 +19,7 @@ import {
 import { StreamID } from '@ceramicnetwork/streamid'
 import { SchemaValidation } from './schema-utils.js'
 import { Model } from '@ceramicnetwork/stream-model'
+import lru from 'lru_map'
 
 // Hardcoding the model streamtype id to avoid introducing a dependency on the stream-model package
 const MODEL_STREAM_TYPE_ID = 2
@@ -218,7 +219,11 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
         )
       }
     } else {
-      await this._schemaValidator.validateSchema(content, model.content.schema)
+      await this._schemaValidator.validateSchema(
+        content,
+        model.content.schema,
+        model.commitId.toString()
+      )
     }
   }
 

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -19,7 +19,6 @@ import {
 import { StreamID } from '@ceramicnetwork/streamid'
 import { SchemaValidation } from './schema-utils.js'
 import { Model } from '@ceramicnetwork/stream-model'
-import lru from 'lru_map'
 
 // Hardcoding the model streamtype id to avoid introducing a dependency on the stream-model package
 const MODEL_STREAM_TYPE_ID = 2

--- a/packages/stream-model-instance-handler/src/schema-utils.ts
+++ b/packages/stream-model-instance-handler/src/schema-utils.ts
@@ -1,12 +1,11 @@
-import ajv, { SchemaObject } from 'ajv/dist/2020.js'
+import Ajv, { SchemaObject } from 'ajv/dist/2020.js'
 import addFormats from 'ajv-formats'
 import lru from 'lru_map'
-import Ajv from 'ajv'
 
 const AJV_CACHE_SIZE = 500
 
 function buildAjv(): Ajv {
-  const validator = new ajv({
+  const validator = new Ajv({
     strict: true,
     allErrors: true,
     allowMatchingProperties: false,

--- a/packages/stream-tile-handler/package.json
+++ b/packages/stream-tile-handler/package.json
@@ -37,6 +37,7 @@
     "ajv-formats": "^2.1.1",
     "fast-json-patch": "^3.1.0",
     "lodash.clonedeep": "^4.5.0",
+    "lru_map": "^0.4.1",
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Apparently, AJV instance is just a huge source of memory leaks when applied to on-demand schema validation. Better put AJV instances in LRU cache to isolate garbage.