### PR TITLE
chore(core): Make pinStore initialization async

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -290,7 +290,10 @@ export class CeramicDaemon {
       )
 
     if (opts.stateStore?.mode == StateStoreMode.S3) {
-      const s3StateStore = new S3StateStore(opts.stateStore?.s3Bucket)
+      const s3StateStore = new S3StateStore(
+        opts.stateStore?.s3Bucket,
+        modules.loggerProvider.getDiagnosticsLogger()
+      )
       modules.pinStoreFactory.setStateStore(s3StateStore)
     }
 

--- a/packages/cli/src/s3-state-store.ts
+++ b/packages/cli/src/s3-state-store.ts
@@ -1,4 +1,4 @@
-import { StreamState, Stream, StreamUtils } from '@ceramicnetwork/common'
+import { StreamState, Stream, StreamUtils, DiagnosticsLogger } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { StateStore } from '@ceramicnetwork/core'
 import LevelUp from 'levelup'
@@ -16,6 +16,7 @@ const MAX_LOAD_RPS = 4000
  */
 export class S3StateStore implements StateStore {
   readonly #bucketName: string
+  readonly #logger: DiagnosticsLogger
   /**
    * Limit reading to +MAX_CONCURRENT_READS+ requests per second
    */
@@ -26,14 +27,15 @@ export class S3StateStore implements StateStore {
   })
   #store
 
-  constructor(bucketName: string) {
+  constructor(bucketName: string, logger: DiagnosticsLogger) {
     this.#bucketName = bucketName
+    this.#logger = logger
   }
 
   /**
    * Open pinning service
    */
-  open(networkName: string): void {
+  async open(networkName: string): Promise<void> {
     const location = this.#bucketName + '/ceramic/' + networkName + '/state-store'
     // @ts-ignore
     this.#store = new LevelUp(new S3LevelDOWN(location))

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -444,7 +444,7 @@ export class Ceramic implements CeramicApi {
 
     const ipfsTopology = new IpfsTopology(ipfs, networkOptions.name, logger)
     const repository = new Repository(streamCacheLimit, concurrentRequestsLimit, logger)
-    const pinStoreFactory = new PinStoreFactory(ipfs, repository, pinStoreOptions)
+    const pinStoreFactory = new PinStoreFactory(ipfs, repository, pinStoreOptions, logger)
     const shutdownSignal = new ShutdownSignal()
     const dispatcher = new Dispatcher(
       ipfs,
@@ -530,7 +530,7 @@ export class Ceramic implements CeramicApi {
       }
 
       await this._anchorValidator.init(this._supportedChains ? this._supportedChains[0] : null)
-      await this.index.init()
+      await this.repository.init(this._networkOptions.name)
 
       await this._startupChecks()
     } catch (err) {

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -6,6 +6,7 @@ import {
   Context,
   CreateOpts,
   LoadOpts,
+  Networks,
   PinningOpts,
   PublishOpts,
   StreamState,
@@ -93,6 +94,11 @@ export class Repository {
       state$.complete()
     })
     this.updates$ = this.updates$.bind(this)
+  }
+
+  async init(networkName: string): Promise<void> {
+    await this.pinStore.open(networkName)
+    await this.index.init()
   }
 
   get pinStore(): PinStore {

--- a/packages/core/src/store/__tests__/level-state-store.test.ts
+++ b/packages/core/src/store/__tests__/level-state-store.test.ts
@@ -9,6 +9,7 @@ import {
   StreamUtils,
   TestUtils,
   StreamState,
+  LoggerProvider,
 } from '@ceramicnetwork/common'
 
 class FakeType extends Stream {
@@ -47,7 +48,7 @@ describe('LevelDB state store', () => {
 
   beforeEach(async () => {
     tmpFolder = await tmp.dir({ unsafeCleanup: true })
-    stateStore = new LevelStateStore(tmpFolder.path)
+    stateStore = new LevelStateStore(tmpFolder.path, new LoggerProvider().getDiagnosticsLogger())
     stateStore.open('fakeNetwork')
 
     // add a small delay after creating the leveldb instance before trying to use it.

--- a/packages/core/src/store/__tests__/pin-store.test.ts
+++ b/packages/core/src/store/__tests__/pin-store.test.ts
@@ -67,7 +67,7 @@ class FakeType extends Stream {
 
 test('#open', async () => {
   const pinStore = new PinStore(stateStore, pinning, jest.fn(), jest.fn(), jest.fn())
-  pinStore.open(NETWORK)
+  await pinStore.open(NETWORK)
   expect(stateStore.open).toBeCalledWith(NETWORK)
   expect(pinning.open).toBeCalled()
 })

--- a/packages/core/src/store/level-state-store.ts
+++ b/packages/core/src/store/level-state-store.ts
@@ -1,6 +1,11 @@
 import levelTs from 'level-ts'
 import type Level from 'level-ts'
-import { StreamState, StreamStateHolder, StreamUtils } from '@ceramicnetwork/common'
+import {
+  DiagnosticsLogger,
+  StreamState,
+  StreamStateHolder,
+  StreamUtils,
+} from '@ceramicnetwork/common'
 import { StateStore } from './state-store.js'
 import { StreamID } from '@ceramicnetwork/streamid'
 import * as fs from 'fs'
@@ -23,8 +28,11 @@ const LevelC = (levelTs as any).default as unknown as typeof Level
  */
 export class LevelStateStore implements StateStore {
   #store: Level
+  #logger: DiagnosticsLogger
 
-  constructor(private storeRoot: string) {}
+  constructor(private storeRoot: string, logger: DiagnosticsLogger) {
+    this.#logger = logger
+  }
 
   /**
    * Gets internal db
@@ -36,7 +44,7 @@ export class LevelStateStore implements StateStore {
   /**
    * Open pinning service
    */
-  open(networkName: string): void {
+  async open(networkName: string): Promise<void> {
     // Always store the pinning state in a network-specific directory
     const storePath = path.join(this.storeRoot, networkName)
     if (fs) {

--- a/packages/core/src/store/pin-store.ts
+++ b/packages/core/src/store/pin-store.ts
@@ -17,8 +17,8 @@ export class PinStore {
     readonly loadStream: (streamID: StreamID) => Promise<RunningState>
   ) {}
 
-  open(networkName: string): void {
-    this.stateStore.open(networkName)
+  async open(networkName: string): Promise<void> {
+    await this.stateStore.open(networkName)
     this.pinning.open()
   }
 

--- a/packages/core/src/store/state-store.ts
+++ b/packages/core/src/store/state-store.ts
@@ -2,7 +2,7 @@ import type { StreamState, StreamStateHolder } from '@ceramicnetwork/common'
 import type { StreamID } from '@ceramicnetwork/streamid'
 
 export interface StateStore {
-  open(networkName: string): void
+  open(networkName: string): Promise<void>
   close(): Promise<void>
   save(streamStateHolder: StreamStateHolder): Promise<void>
   load(streamId: StreamID): Promise<StreamState | null>


### PR DESCRIPTION
A small cleanup to prepare for https://linear.app/3boxlabs/issue/CDB-1837/allow-network=mainnet, which will require querying the state store during initialization to detect if there is existing data under an `elp` directory or not