### PR TITLE
fix(cli): Don't return UNAUTHORIZED for non-auth failure of AdminAPI getIndexedModels()

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -720,13 +720,13 @@ export class CeramicDaemon {
       try {
         this._verifyAndDiscardAdminCode(jwsValidation.code)
         this._verifyActingDid(jwsValidation.kid)
-        const indexedModelStreamIDs = await this.ceramic.admin.getIndexedModels()
-        res.json({
-          models: indexedModelStreamIDs.map((modelStreamID) => modelStreamID.toString()),
-        })
       } catch (e) {
         res.status(StatusCodes.UNAUTHORIZED).json({ error: e.message })
       }
+      const indexedModelStreamIDs = await this.ceramic.admin.getIndexedModels()
+      res.json({
+        models: indexedModelStreamIDs.map((modelStreamID) => modelStreamID.toString()),
+      })
     }
   }
 


### PR DESCRIPTION
Don't return UNAUTHORIZED from admin api's getIndexedModels, if it's not authorization that fails. Return a higher-level error in that case instead.