### PR TITLE
chore(streamid): Strict TS config

### DIFF
--- a/.changeset/orange-files-listen.md
+++ b/.changeset/orange-files-listen.md
@@ -1,0 +1,5 @@
+---
+"@ceramicnetwork/streamid": patch
+---
+
+chore(streamid): Stricter code. Also, now NoThrow functions really do not throw an error.

--- a/.changeset/orange-files-listen.md
+++ b/.changeset/orange-files-listen.md
@@ -1,5 +1,0 @@
----
-"@ceramicnetwork/streamid": patch
----
-
-chore(streamid): Stricter code. Also, now NoThrow functions really do not throw an error.

--- a/packages/streamid/src/__tests__/__snapshots__/stream-id.test.ts.snap
+++ b/packages/streamid/src/__tests__/__snapshots__/stream-id.test.ts.snap
@@ -49,10 +49,6 @@ exports[`.fromBytes create from bytes  1`] = `"kjzl6cwe1jw147dvq16zluojmraqvwdmb
 
 exports[`.fromString create from legacy string "/ceramic/" 1`] = `"kjzl6cwe1jw147dvq16zluojmraqvwdmbh61dx9e0c59i344lcrsgqfohexp60s"`;
 
-exports[`.fromString create from legacy string "/ceramic/" with commit param "?commit=" 1`] = `"kjzl6cwe1jw147dvq16zluojmraqvwdmbh61dx9e0c59i344lcrsgqfohexp60s"`;
-
-exports[`.fromString create from legacy string "/ceramic/" with commit param "?commit=0" 1`] = `"kjzl6cwe1jw147dvq16zluojmraqvwdmbh61dx9e0c59i344lcrsgqfohexp60s"`;
-
 exports[`.fromString create from string 1`] = `"kjzl6cwe1jw147dvq16zluojmraqvwdmbh61dx9e0c59i344lcrsgqfohexp60s"`;
 
 exports[`.fromString create from url string 1`] = `"kjzl6cwe1jw147dvq16zluojmraqvwdmbh61dx9e0c59i344lcrsgqfohexp60s"`;

--- a/packages/streamid/src/__tests__/stream-id.test.ts
+++ b/packages/streamid/src/__tests__/stream-id.test.ts
@@ -97,20 +97,12 @@ describe('.fromString', () => {
     expect(streamid.toString()).toMatchSnapshot()
   })
 
-  test('create from legacy string "/ceramic/" with commit param "?commit="', () => {
-    const streamid = StreamID.fromString(STREAM_ID_WITH_COMMIT_LEGACY)
-
-    expect(streamid.type).toEqual(0)
-    expect(streamid.cid.toString()).toEqual(CID_STRING)
-    expect(streamid.toString()).toMatchSnapshot()
+  test('create from legacy string "/ceramic/" with commit param "?commit=": fail', () => {
+    expect(() => StreamID.fromString(STREAM_ID_WITH_COMMIT_LEGACY)).toThrow()
   })
 
   test('create from legacy string "/ceramic/" with commit param "?commit=0"', () => {
-    const streamid = StreamID.fromString(STREAM_ID_WITH_0_COMMIT_LEGACY)
-
-    expect(streamid.type).toEqual(0)
-    expect(streamid.cid.toString()).toEqual(CID_STRING)
-    expect(streamid.toString()).toMatchSnapshot()
+    expect(() => StreamID.fromString(STREAM_ID_WITH_0_COMMIT_LEGACY)).toThrow()
   })
 
   test('roundtrip streamID string', () => {

--- a/packages/streamid/src/commit-id.ts
+++ b/packages/streamid/src/commit-id.ts
@@ -7,7 +7,7 @@ import { Memoize } from 'typescript-memoize'
 import { STREAMID_CODEC } from './constants.js'
 import { readCid, readVarint } from './reading-bytes.js'
 import { StreamID } from './stream-id.js'
-import { StreamRef } from './stream-ref.js'
+import type { StreamRef } from './stream-ref.js'
 import { tryCatch } from './try-catch.util.js'
 
 /**

--- a/packages/streamid/src/commit-id.ts
+++ b/packages/streamid/src/commit-id.ts
@@ -10,6 +10,22 @@ import type { StreamRef } from './stream-ref.js'
 import { tryCatch } from './try-catch.util.js'
 import * as parsing from './stream-ref-parsing.js'
 
+export class InvalidCommitIDBytesError extends Error {
+  constructor(bytes: Uint8Array) {
+    super(
+      `Error while parsing CommitID from bytes ${base36.encode(
+        bytes
+      )}: no commit information provided`
+    )
+  }
+}
+
+export class InvalidCommitIDStringError extends Error {
+  constructor(input: string) {
+    super(`Error while parsing CommitID from string ${input}: no commit information provided`)
+  }
+}
+
 /**
  * Parse CommitID from bytes representation.
  *
@@ -22,7 +38,7 @@ function fromBytes(bytes: Uint8Array): CommitID {
   if (parsed.kind === 'commit-id') {
     return new CommitID(parsed.type, parsed.genesis, parsed.commit)
   }
-  throw new Error(`No commit information provided`)
+  throw new InvalidCommitIDBytesError(bytes)
 }
 
 /**
@@ -48,7 +64,7 @@ function fromString(input: string): CommitID {
   if (parsed.kind === 'commit-id') {
     return new CommitID(parsed.type, parsed.genesis, parsed.commit)
   }
-  throw new Error(`No commit information provided`)
+  throw new InvalidCommitIDStringError(input)
 }
 
 /**

--- a/packages/streamid/src/reading-bytes.ts
+++ b/packages/streamid/src/reading-bytes.ts
@@ -14,17 +14,9 @@ function isCidVersion(input: number): input is 0 | 1 {
 }
 
 export function readCid(bytes: Uint8Array): [CID, Uint8Array] {
-  const result = readCidNoThrow(bytes)
-  if (result instanceof Error) {
-    throw result
-  }
-  return result
-}
-
-export function readCidNoThrow(bytes: Uint8Array): [CID, Uint8Array] | Error {
   const [cidVersion, cidVersionRemainder] = readVarint(bytes)
   if (!isCidVersion(cidVersion)) {
-    return new Error(`Unknown CID version ${cidVersion}`)
+    throw new Error(`Unknown CID version ${cidVersion}`)
   }
   const [codec, codecRemainder] = readVarint(cidVersionRemainder)
   const [, mhCodecRemainder, mhCodecLength] = readVarint(codecRemainder)

--- a/packages/streamid/src/reading-bytes.ts
+++ b/packages/streamid/src/reading-bytes.ts
@@ -5,7 +5,7 @@ import { decode as decodeMultiHash } from 'multiformats/hashes/digest'
 export function readVarint(bytes: Uint8Array): [number, Uint8Array, number] {
   const value = varint.decode(bytes)
   const readLength = varint.decode.bytes
-  const remainder = bytes.slice(readLength)
+  const remainder = bytes.subarray(readLength)
   return [value, remainder, readLength]
 }
 
@@ -21,7 +21,7 @@ export function readCid(bytes: Uint8Array): [CID, Uint8Array] {
   const [codec, codecRemainder] = readVarint(cidVersionRemainder)
   const [, mhCodecRemainder, mhCodecLength] = readVarint(codecRemainder)
   const [mhLength, , mhLengthLength] = readVarint(mhCodecRemainder)
-  const multihashBytes = codecRemainder.slice(0, mhCodecLength + mhLengthLength + mhLength)
-  const multihashBytesRemainder = codecRemainder.slice(mhCodecLength + mhLengthLength + mhLength)
+  const multihashBytes = codecRemainder.subarray(0, mhCodecLength + mhLengthLength + mhLength)
+  const multihashBytesRemainder = codecRemainder.subarray(mhCodecLength + mhLengthLength + mhLength)
   return [CID.create(cidVersion, codec, decodeMultiHash(multihashBytes)), multihashBytesRemainder]
 }

--- a/packages/streamid/src/stream-id.ts
+++ b/packages/streamid/src/stream-id.ts
@@ -74,6 +74,7 @@ function fromString(input: string): StreamID {
 function fromStringNoThrow(input: string): StreamID | Error {
   const protocolFree = input.replace('ceramic://', '').replace('/ceramic/', '')
   const commitFree = protocolFree.includes('commit') ? protocolFree.split('?')[0] : protocolFree
+  if (!commitFree) return new Error(`Malformed StreamID string: ${input}`)
   const bytes = base36.decode(commitFree)
   return fromBytesNoThrow(bytes)
 }
@@ -130,7 +131,6 @@ export class StreamID implements StreamRef {
   /**
    * Create a streamId from a genesis commit.
    *
-   * @param
    * @param {string|number}         type       the stream type
    * @param {Record<string, any>}   genesis    a genesis commit
    *

--- a/packages/streamid/src/stream-id.ts
+++ b/packages/streamid/src/stream-id.ts
@@ -8,7 +8,7 @@ import { concat as uint8ArrayConcat } from 'uint8arrays'
 import { STREAMID_CODEC } from './constants.js'
 import { readCid, readVarint } from './reading-bytes.js'
 import { Memoize } from 'typescript-memoize'
-import { StreamRef } from './stream-ref.js'
+import type { StreamRef } from './stream-ref.js'
 import { StreamType } from './stream-type.js'
 import { tryCatch } from './try-catch.util.js'
 

--- a/packages/streamid/src/stream-id.ts
+++ b/packages/streamid/src/stream-id.ts
@@ -12,6 +12,18 @@ import { StreamType } from './stream-type.js'
 import { tryCatch } from './try-catch.util.js'
 import * as parsing from './stream-ref-parsing.js'
 
+export class InvalidStreamIDBytesError extends Error {
+  constructor(bytes: Uint8Array) {
+    super(`Invalid StreamID bytes ${base36.encode(bytes)}: contains commit`)
+  }
+}
+
+export class InvalidStreamIDStringError extends Error {
+  constructor(input: string) {
+    super(`Invalid StreamID string ${input}: contains commit`)
+  }
+}
+
 /**
  * Parse StreamID from bytes representation.
  *
@@ -24,7 +36,7 @@ function fromBytes(bytes: Uint8Array): StreamID {
   if (parsed.kind === 'stream-id') {
     return new StreamID(parsed.type, parsed.genesis)
   }
-  throw new Error(`Invalid StreamID: contains commit`)
+  throw new InvalidStreamIDBytesError(bytes)
 }
 
 /**
@@ -50,7 +62,7 @@ function fromString(input: string): StreamID {
   if (parsed.kind === 'stream-id') {
     return new StreamID(parsed.type, parsed.genesis)
   }
-  throw new Error(`Invalid StreamID: contains commit`)
+  throw new InvalidStreamIDStringError(input)
 }
 
 /**
@@ -107,8 +119,8 @@ export class StreamID implements StreamRef {
    * ```
    */
   constructor(type: string | number, cid: CID | string) {
-    if (!(type || type === 0)) throw new Error('constructor: type required')
-    if (!cid) throw new Error('constructor: cid required')
+    if (!(type || type === 0)) throw new Error('StreamID constructor: type required')
+    if (!cid) throw new Error('StreamID constructor: cid required')
     this._type = typeof type === 'string' ? StreamType.codeByName(type) : type
     this._cid = typeof cid === 'string' ? CID.parse(cid) : cid
   }

--- a/packages/streamid/src/stream-ref-parsing.ts
+++ b/packages/streamid/src/stream-ref-parsing.ts
@@ -101,7 +101,8 @@ export function parseCID(input: any): CID | null {
  * @param commit - representation of commit, be it CID, 0, `'0'`, `null`
  */
 export function parseCommit(genesis: CID, commit: CID | string | number | null = null): CID | null {
-  if (!commit) return null
+  if (!commit) return null // Handle number 0, null and undefined
+  if (commit === '0') return null // Handle string 0
 
   const commitCID = parseCID(commit)
   if (commitCID) {
@@ -111,9 +112,6 @@ export function parseCommit(genesis: CID, commit: CID | string | number | null =
     } else {
       return commitCID
     }
-  } else if (String(commit) === '0') {
-    // Zero as number or string
-    return null
   } else {
     throw new Error(
       'Cannot specify commit as a number except to request commit 0 (the genesis commit)'

--- a/packages/streamid/src/stream-ref-parsing.ts
+++ b/packages/streamid/src/stream-ref-parsing.ts
@@ -1,0 +1,122 @@
+import { readCid, readVarint } from './reading-bytes.js'
+import { STREAMID_CODEC } from './constants.js'
+import { CID } from 'multiformats/cid'
+import { base36 } from 'multiformats/bases/base36'
+
+export type StreamIDComponents = {
+  kind: 'stream-id'
+  type: number
+  genesis: CID
+}
+
+export type CommitIDComponents = {
+  kind: 'commit-id'
+  type: number
+  genesis: CID
+  commit: CID | null
+}
+
+export type StreamRefComponents = StreamIDComponents | CommitIDComponents
+
+/**
+ * Parse StreamID or CommitID from bytes.
+ */
+export function fromBytes(input: Uint8Array, title = 'StreamRef'): StreamRefComponents {
+  const [streamCodec, streamCodecRemainder] = readVarint(input)
+  if (streamCodec !== STREAMID_CODEC)
+    throw new Error(`Invalid ${title}, does not include streamid codec`)
+  const [type, streamtypeRemainder] = readVarint(streamCodecRemainder)
+  const cidResult = readCid(streamtypeRemainder)
+  const [genesis, gnesisRemainder] = cidResult
+  if (gnesisRemainder.length === 0) {
+    return {
+      kind: 'stream-id',
+      type: type,
+      genesis: genesis,
+    }
+  } else if (gnesisRemainder.length === 1) {
+    // Zero commit
+    return {
+      kind: 'commit-id',
+      type: type,
+      genesis: genesis,
+      commit: null,
+    }
+  } else {
+    // Commit
+    const [commit] = readCid(gnesisRemainder)
+    return {
+      kind: 'commit-id',
+      type: type,
+      genesis: genesis,
+      commit: commit,
+    }
+  }
+}
+
+/**
+ * RegExp to match against URL representation of StreamID or CommitID.
+ */
+const URL_PATTERN = /(ceramic:\/\/|\/ceramic\/)?([a-zA-Z0-9]+)(\?commit=([a-zA-Z0-9]+))?/
+
+export function fromString(input: string, title = 'StreamRef'): StreamRefComponents {
+  const protocolMatch = URL_PATTERN.exec(input) || []
+  const base = protocolMatch[2]
+  if (!base) throw new Error(`Malformed ${title} string: ${input}`)
+  const bytes = base36.decode(base)
+  const streamRef = fromBytes(bytes)
+  const commit = protocolMatch[4]
+  if (commit) {
+    return {
+      kind: 'commit-id',
+      type: streamRef.type,
+      genesis: streamRef.genesis,
+      commit: parseCommit(streamRef.genesis, commit),
+    }
+  }
+  return streamRef
+}
+
+/**
+ * Safely parse CID, be it CID instance or a string representation.
+ * Return `undefined` if not CID.
+ *
+ * @param input - CID or string.
+ */
+export function parseCID(input: any): CID | null {
+  try {
+    return typeof input === 'string' ? CID.parse(input) : CID.asCID(input)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Parse commit CID from string or number.
+ * `null` result indicates genesis commit.
+ * If `commit` is 0, `'0'`, `null` or is equal to `genesis` CID, result is `null`.
+ * Otherwise, return commit as proper CID.
+ *
+ * @param genesis - genesis CID for stream
+ * @param commit - representation of commit, be it CID, 0, `'0'`, `null`
+ */
+export function parseCommit(genesis: CID, commit: CID | string | number | null = null): CID | null {
+  if (!commit) return null
+
+  const commitCID = parseCID(commit)
+  if (commitCID) {
+    // CID-like
+    if (genesis.equals(commitCID)) {
+      return null
+    } else {
+      return commitCID
+    }
+  } else if (String(commit) === '0') {
+    // Zero as number or string
+    return null
+  } else {
+    throw new Error(
+      'Cannot specify commit as a number except to request commit 0 (the genesis commit)'
+    )
+  }
+}

--- a/packages/streamid/src/stream-ref-parsing.ts
+++ b/packages/streamid/src/stream-ref-parsing.ts
@@ -27,14 +27,14 @@ export function fromBytes(input: Uint8Array, title = 'StreamRef'): StreamRefComp
     throw new Error(`Invalid ${title}, does not include streamid codec`)
   const [type, streamtypeRemainder] = readVarint(streamCodecRemainder)
   const cidResult = readCid(streamtypeRemainder)
-  const [genesis, gnesisRemainder] = cidResult
-  if (gnesisRemainder.length === 0) {
+  const [genesis, genesisRemainder] = cidResult
+  if (genesisRemainder.length === 0) {
     return {
       kind: 'stream-id',
       type: type,
       genesis: genesis,
     }
-  } else if (gnesisRemainder.length === 1) {
+  } else if (genesisRemainder.length === 1 && genesisRemainder[0] === 0) {
     // Zero commit
     return {
       kind: 'commit-id',
@@ -44,7 +44,7 @@ export function fromBytes(input: Uint8Array, title = 'StreamRef'): StreamRefComp
     }
   } else {
     // Commit
-    const [commit] = readCid(gnesisRemainder)
+    const [commit] = readCid(genesisRemainder)
     return {
       kind: 'commit-id',
       type: type,

--- a/packages/streamid/src/stream-ref.ts
+++ b/packages/streamid/src/stream-ref.ts
@@ -16,17 +16,6 @@ export interface StreamRef {
   toUrl(): string
 }
 
-/**
- * Return result of `f` or null if it fails.
- */
-function tryCatch<A>(f: () => A): A {
-  try {
-    return f()
-  } catch {
-    return null
-  }
-}
-
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace StreamRef {
   /**

--- a/packages/streamid/src/stream-ref.ts
+++ b/packages/streamid/src/stream-ref.ts
@@ -1,6 +1,9 @@
 import type { CID } from 'multiformats/cid'
 import { StreamID } from './stream-id.js'
 import { CommitID } from './commit-id.js'
+import { readCid, readVarint } from './reading-bytes.js'
+import { STREAMID_CODEC } from './constants.js'
+import { base36 } from 'multiformats/bases/base36'
 
 /**
  * Ensure there is some resemblance in CommitID and StreamID APIs.
@@ -18,31 +21,60 @@ export interface StreamRef {
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace StreamRef {
+  export function fromBytes(input: Uint8Array): StreamID | CommitID {
+    const [streamCodec, streamCodecRemainder] = readVarint(input)
+    if (streamCodec !== STREAMID_CODEC)
+      throw new Error('fromBytes: invalid streamid, does not include streamid codec')
+    const [type, streamtypeRemainder] = readVarint(streamCodecRemainder)
+    const cidResult = readCid(streamtypeRemainder)
+    const [base, baseRemainder] = cidResult
+    if (baseRemainder.length === 0) {
+      return new StreamID(type, base)
+    } else if (baseRemainder.length === 1) {
+      // Zero commit
+      return new CommitID(type, base, baseRemainder[0])
+    } else {
+      // Commit
+      const [commit] = readCid(baseRemainder)
+      return new CommitID(type, base, commit)
+    }
+  }
+
+  export function fromString(input: string): CommitID | StreamID {
+    const protocolFree = input.replace('ceramic://', '').replace('/ceramic/', '')
+    const commit = protocolFree.split('?')[1]?.split('=')[1]
+    const base = protocolFree.split('?')[0]
+    if (!base) throw new Error(`Malformed commit string: ${input}`)
+    if (commit) {
+      const streamId = StreamID.fromString(base)
+      return new CommitID(streamId.type, streamId.cid, commit)
+    } else {
+      const bytes = base36.decode(base)
+      return fromBytes(bytes)
+    }
+  }
+
   /**
    * Try to parse `input` into CommitID or StreamID.
    */
-  // eslint-disable-next-line no-inner-declarations
-  export function from(input: StreamID | CommitID | string | Uint8Array): StreamID | CommitID {
+  export function from(input: StreamID): StreamID
+  export function from(input: CommitID): CommitID
+  export function from(input: string | Uint8Array | unknown): StreamID | CommitID
+  export function from(
+    input: StreamID | CommitID | string | Uint8Array | unknown
+  ): StreamID | CommitID {
     if (StreamID.isInstance(input)) {
       return input
-    } else if (CommitID.isInstance(input)) {
-      return input
-    } else if (input instanceof Uint8Array) {
-      // Lazy computation: try CommitID, then StreamID
-      const commitId = CommitID.fromBytesNoThrow(input)
-      if (commitId instanceof Error) {
-        return StreamID.fromBytes(input)
-      }
-      return commitId
-    } else if (typeof input === 'string') {
-      // Lazy computation: try CommitID, then StreamID
-      const commitId = CommitID.fromStringNoThrow(input)
-      if (commitId instanceof Error) {
-        return StreamID.fromString(input)
-      }
-      return commitId
-    } else {
-      throw new Error(`Can not build CommitID or StreamID from ${JSON.stringify(input)}`)
     }
+    if (CommitID.isInstance(input)) {
+      return input
+    }
+    if (input instanceof Uint8Array) {
+      return fromBytes(input)
+    }
+    if (typeof input === 'string') {
+      return fromString(input)
+    }
+    throw new Error(`Can not build CommitID or StreamID from ${JSON.stringify(input)}`)
   }
 }

--- a/packages/streamid/src/try-catch.util.ts
+++ b/packages/streamid/src/try-catch.util.ts
@@ -1,0 +1,10 @@
+/**
+ * Return result of `fn`. If it throws, return an Error.
+ */
+export function tryCatch<A>(fn: () => A): A | Error {
+  try {
+    return fn()
+  } catch (e) {
+    return e as Error
+  }
+}

--- a/packages/streamid/tsconfig.json
+++ b/packages/streamid/tsconfig.json
@@ -2,7 +2,15 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
- Throw/no-throw functions: throw by default, `NoThrow` function wraps a throwing one in a try-catch.
- `StreamRef.fromBytes` and `StreamRef.fromString` along with respective `StreamID` and `CommitID` parsing functions reuse same parsing logic. Control flow does not rely on errors. @stbrody Your precious debugging should be all right.

It is now slightly faster: https://github.com/ceramicnetwork/js-ceramic/blob/feature/cdb-1945-streamid-bench/packages/streamid/src/old-new.bench.ts


<img width="382" alt="Screenshot 2022-10-24 at 16 49 48" src="https://user-images.githubusercontent.com/193527/197543028-9e58aecc-c076-49a1-a1d5-59d9f2335d5e.png">

One caveat. For some reason we allowed parsing StreamID from `/ceramic/<stream-id>?commit=<commit-id>` string. This is a drastic inconsistency with other formats, where presence of CommitID information leads to an error. I changed parsing here, so that we throw an error if commit is present in a string formatted like that.

Git blame leads to an obscure commit https://github.com/ceramicnetwork/js-ceramic/commit/e2dce7e30ed15f95eae0a96444b5800f56c4b812 which effectively made previous history opaque.