### PR TITLE
chore(stream-tile): Make TS compiler strict

### DIFF
--- a/.changeset/tidy-eagles-try.md
+++ b/.changeset/tidy-eagles-try.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+chore(stream-tile): Make TS compiler strict

--- a/.changeset/tidy-eagles-try.md
+++ b/.changeset/tidy-eagles-try.md
@@ -1,5 +1,0 @@
----
-"@fake-scope/fake-pkg": patch
----
-
-chore(stream-tile): Make TS compiler strict

--- a/packages/common/src/context.ts
+++ b/packages/common/src/context.ts
@@ -12,5 +12,5 @@ export interface Context {
   anchorService?: AnchorService
   loggerProvider?: LoggerProvider
 
-  api?: CeramicApi // the self reference to the Ceramic API
+  api: CeramicApi // the self reference to the Ceramic API
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -21,6 +21,7 @@ export * from './running-state-like.js'
 export * from './stream-state-subject.js'
 export * from './subscription-set.js'
 export * from './index-api.js'
+export * from './non-empty-array.js'
 
 import type { IPFS } from 'ipfs-core-types'
 export type IpfsApi = IPFS

--- a/packages/common/src/non-empty-array.ts
+++ b/packages/common/src/non-empty-array.ts
@@ -1,0 +1,4 @@
+/**
+ * This array contains at least one item.
+ */
+export type NonEmptyArray<T> = [T, ...T[]]

--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -9,6 +9,7 @@ import type { RunningStateLike } from './running-state-like.js'
 import type { CeramicApi } from './ceramic-api.js'
 import { LoadOpts, SyncOptions } from './streamopts.js'
 import type { Cacao } from '@didtools/cacao'
+import { NonEmptyArray } from './non-empty-array.js'
 
 /**
  * Describes signature status
@@ -142,7 +143,7 @@ export interface StreamState {
   signature: SignatureStatus
   anchorStatus: AnchorStatus
   anchorProof?: AnchorProof // the anchor proof of the latest anchor, only present when anchor status is anchored
-  log: Array<LogEntry>
+  log: NonEmptyArray<LogEntry>
 }
 
 /**

--- a/packages/stream-caip10-link-handler/src/caip10-link-handler.ts
+++ b/packages/stream-caip10-link-handler/src/caip10-link-handler.ts
@@ -66,7 +66,7 @@ export class Caip10LinkHandler implements StreamHandler<Caip10Link> {
     }
 
     // TODO - verify genesis commit
-    const state = {
+    const state: StreamState = {
       type: Caip10Link.STREAM_TYPE_ID,
       content: null,
       next: {

--- a/packages/stream-model-handler/src/model-handler.ts
+++ b/packages/stream-model-handler/src/model-handler.ts
@@ -135,7 +135,7 @@ export class ModelHandler implements StreamHandler<Model> {
     }
 
     const metadata = { controllers: [controller], model: modelStreamId }
-    const state = {
+    const state: StreamState = {
       type: Model.STREAM_TYPE_ID,
       content: payload.data,
       metadata,

--- a/packages/stream-tile-handler/package.json
+++ b/packages/stream-tile-handler/package.json
@@ -45,6 +45,7 @@
     "ajv-formats": "^2.1.1",
     "fast-json-patch": "^3.1.0",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.isplainobject": "^4.0.6",
     "lru_map": "^0.4.1",
     "uint8arrays": "^3.0.0"
   },
@@ -54,6 +55,7 @@
     "@ipld/dag-cbor": "^7.0.0",
     "@stablelib/sha256": "^1.0.1",
     "@types/lodash.clonedeep": "^4.5.6",
+    "@types/lodash.isplainobject": "^4.0.7",
     "did-resolver": "^3.1.5",
     "dids": "^3.4.0",
     "key-did-resolver": "^2.3.0",

--- a/packages/stream-tile-handler/package.json
+++ b/packages/stream-tile-handler/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@ceramicnetwork/common": "^2.10.0",
+    "@ceramicnetwork/streamid": "^2.4.0",
     "@ceramicnetwork/stream-handler-common": "^1.0.0",
     "@ceramicnetwork/stream-tile": "^2.6.0",
     "ajv": "^8.8.2",

--- a/packages/stream-tile-handler/package.json
+++ b/packages/stream-tile-handler/package.json
@@ -46,7 +46,6 @@
     "ajv-formats": "^2.1.1",
     "fast-json-patch": "^3.1.0",
     "lodash.clonedeep": "^4.5.0",
-    "lodash.isplainobject": "^4.0.6",
     "lru_map": "^0.4.1",
     "uint8arrays": "^3.0.0"
   },
@@ -56,7 +55,6 @@
     "@ipld/dag-cbor": "^7.0.0",
     "@stablelib/sha256": "^1.0.1",
     "@types/lodash.clonedeep": "^4.5.6",
-    "@types/lodash.isplainobject": "^4.0.7",
     "did-resolver": "^3.1.5",
     "dids": "^3.4.0",
     "key-did-resolver": "^2.3.0",

--- a/packages/stream-tile-handler/src/__tests__/tile-document-handler.test.ts
+++ b/packages/stream-tile-handler/src/__tests__/tile-document-handler.test.ts
@@ -20,6 +20,7 @@ import {
   IpfsApi,
   GenesisCommit,
   CeramicSigner,
+  CommitData,
 } from '@ceramicnetwork/common'
 import { parse as parseDidUrl } from 'did-resolver'
 
@@ -608,7 +609,7 @@ describe('TileDocumentHandler', () => {
       envelope: genesisCommit.jws,
     }
     const state = await tileDocumentHandler.applyCommit(genesisCommitData, context)
-    const doc = new TileDocument(state, context)
+    const doc = new TileDocument(TestUtils.runningState(state), context)
     const makeCommit = doc.makeCommit(context.api, COMMITS.r1.desiredContent, {
       controllers: [did.id, did.id],
     })
@@ -639,13 +640,13 @@ describe('TileDocumentHandler', () => {
     for (let i = 0; i < invalidControllerValues.length; i++) {
       const state$ = TestUtils.runningState(genesisState)
       const doc = new TileDocument(state$, context)
-      const rawCommit = await doc._makeRawCommit({
+      const rawCommit = await (doc as any)._makeRawCommit({
         other: { obj2: 'fefe' },
       })
 
       // update unsigned metadata
       rawCommit.header.controllers = [invalidControllerValues[i]]
-      const signedCommit = await TileDocument._signDagJWS(context.api, rawCommit)
+      const signedCommit = await (TileDocument as any)._signDagJWS(context.api, rawCommit)
       await context.ipfs.dag.put(signedCommit, FAKE_CID_2)
       const sPayload = dagCBOR.decode(signedCommit.linkedBlock)
       await context.ipfs.dag.put(sPayload, signedCommit.jws.link)
@@ -687,13 +688,13 @@ describe('TileDocumentHandler', () => {
     for (let i = 0; i < invalidControllerValues.length; i++) {
       const state$ = TestUtils.runningState(genesisState)
       const doc = new TileDocument(state$, context)
-      const rawCommit = await doc._makeRawCommit({
+      const rawCommit = await (doc as any)._makeRawCommit({
         other: { obj2: 'fefe' },
       })
 
       // update unsigned metadata
       rawCommit.prev = FAKE_CID_3
-      const signedCommit = await TileDocument._signDagJWS(context.api, rawCommit)
+      const signedCommit = await (TileDocument as any)._signDagJWS(context.api, rawCommit)
       await context.ipfs.dag.put(signedCommit, FAKE_CID_2)
       const sPayload = dagCBOR.decode(signedCommit.linkedBlock)
       await context.ipfs.dag.put(sPayload, signedCommit.jws.link)
@@ -735,13 +736,13 @@ describe('TileDocumentHandler', () => {
     for (let i = 0; i < invalidControllerValues.length; i++) {
       const state$ = TestUtils.runningState(genesisState)
       const doc = new TileDocument(state$, context)
-      const rawCommit = await doc._makeRawCommit({
+      const rawCommit = await (doc as any)._makeRawCommit({
         other: { obj2: 'fefe' },
       })
 
       // update unsigned metadata
       rawCommit.id = FAKE_CID_3
-      const signedCommit = await TileDocument._signDagJWS(context.api, rawCommit)
+      const signedCommit = await (TileDocument as any)._signDagJWS(context.api, rawCommit)
       await context.ipfs.dag.put(signedCommit, FAKE_CID_2)
       const sPayload = dagCBOR.decode(signedCommit.linkedBlock)
       await context.ipfs.dag.put(sPayload, signedCommit.jws.link)
@@ -808,7 +809,7 @@ describe('TileDocumentHandler', () => {
       type: CommitType.ANCHOR,
       commit: COMMITS.r2.commit,
       proof: COMMITS.proof,
-    }
+    } as CommitData
     state = await tileDocumentHandler.applyCommit(anchorCommitData, context, state)
     delete state.metadata.unique
     expect(state).toMatchSnapshot()

--- a/packages/stream-tile-handler/src/__tests__/tile-document-handler.test.ts
+++ b/packages/stream-tile-handler/src/__tests__/tile-document-handler.test.ts
@@ -639,7 +639,7 @@ describe('TileDocumentHandler', () => {
     for (let i = 0; i < invalidControllerValues.length; i++) {
       const state$ = TestUtils.runningState(genesisState)
       const doc = new TileDocument(state$, context)
-      const rawCommit = await doc._makeRawCommit(context.api, {
+      const rawCommit = await doc._makeRawCommit({
         other: { obj2: 'fefe' },
       })
 
@@ -687,7 +687,7 @@ describe('TileDocumentHandler', () => {
     for (let i = 0; i < invalidControllerValues.length; i++) {
       const state$ = TestUtils.runningState(genesisState)
       const doc = new TileDocument(state$, context)
-      const rawCommit = await doc._makeRawCommit(context.api, {
+      const rawCommit = await doc._makeRawCommit({
         other: { obj2: 'fefe' },
       })
 
@@ -735,7 +735,7 @@ describe('TileDocumentHandler', () => {
     for (let i = 0; i < invalidControllerValues.length; i++) {
       const state$ = TestUtils.runningState(genesisState)
       const doc = new TileDocument(state$, context)
-      const rawCommit = await doc._makeRawCommit(context.api, {
+      const rawCommit = await doc._makeRawCommit({
         other: { obj2: 'fefe' },
       })
 

--- a/packages/stream-tile-handler/src/schema-utils.ts
+++ b/packages/stream-tile-handler/src/schema-utils.ts
@@ -35,7 +35,7 @@ export class SchemaValidation {
     schemaStreamId: string
   ): Promise<void> {
     const schema = await this._loadSchemaById(ceramic, schemaStreamId)
-    if (!isRecord(schema)) throw new Error(`Invalid schema ${schemaStreamId}: Not object`)
+    if (!isRecord(schema)) throw new Error(`Invalid schema in stream ${schemaStreamId}: The contents of the schema stream are not an object`)
     this._validate(content, schema, schemaStreamId)
   }
 

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -81,18 +81,14 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
    * @private
    */
   async _applyGenesis(commitData: CommitData, context: Context): Promise<StreamState> {
+    const did = context.did
+    if (!did) throw new Error(`DID is not set`)
     const payload = commitData.commit
     const isSigned = StreamUtils.isSignedCommitData(commitData)
     if (isSigned) {
       const streamId = await StreamID.fromGenesis('tile', commitData.commit)
       const { controllers } = payload.header
-      await SignatureUtils.verifyCommitSignature(
-        commitData,
-        context.did,
-        controllers[0],
-        null,
-        streamId
-      )
+      await SignatureUtils.verifyCommitSignature(commitData, did, controllers[0], null, streamId)
     } else if (payload.data) {
       throw Error('Genesis commit with contents should always be signed')
     }
@@ -129,14 +125,17 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
     state: StreamState,
     context: Context
   ): Promise<StreamState> {
+    const did = context.did
+    if (!did) throw new Error(`DID is not set`)
     // Retrieve the payload
     const payload = commitData.commit
     StreamUtils.assertCommitLinksToState(state, payload)
 
     // Verify the signature
     const controller = state.next?.metadata?.controllers?.[0] || state.metadata.controllers[0]
+    if (!controller) throw new Error(`Controller is not set`)
     const streamId = StreamUtils.streamIdFromState(state)
-    await SignatureUtils.verifyCommitSignature(commitData, context.did, controller, null, streamId)
+    await SignatureUtils.verifyCommitSignature(commitData, did, controller, null, streamId)
 
     if (payload.header.controllers) {
       if (payload.header.controllers.length !== 1) {
@@ -152,7 +151,8 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
       payload.header.controllers &&
       !stringArraysEqual(payload.header.controllers, state.metadata.controllers)
     ) {
-      const streamId = new StreamID(TileDocument.STREAM_TYPE_ID, state.log[0].cid)
+      const genesisLogEntry = state.log[0]
+      const streamId = new StreamID(TileDocument.STREAM_TYPE_ID, genesisLogEntry.cid)
       throw new Error(
         `Cannot change controllers since 'forbidControllerChange' is set. Tried to change controllers for Stream ${streamId} from ${JSON.stringify(
           state.metadata.controllers

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -97,7 +97,7 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
       throw new Error('Exactly one controller must be specified')
     }
 
-    const state = {
+    const state: StreamState = {
       type: TileDocument.STREAM_TYPE_ID,
       content: payload.data || {},
       metadata: payload.header,

--- a/packages/stream-tile-handler/tsconfig.json
+++ b/packages/stream-tile-handler/tsconfig.json
@@ -2,7 +2,15 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "include": [
     "./src/**/*"

--- a/packages/stream-tile/package.json
+++ b/packages/stream-tile/package.json
@@ -42,6 +42,7 @@
     "@ceramicnetwork/streamid": "^2.4.0",
     "@ipld/dag-cbor": "^7.0.0",
     "@stablelib/random": "^1.0.1",
+    "dids": "^3.4.0",
     "fast-json-patch": "^3.1.0",
     "lodash.clonedeep": "^4.5.0",
     "uint8arrays": "^3.0.0"

--- a/packages/stream-tile/src/tile-document.ts
+++ b/packages/stream-tile/src/tile-document.ts
@@ -354,8 +354,9 @@ export class TileDocument<T = Record<string, any>> extends Stream {
    */
   private async _makeRawCommit(
     newContent: T | null | undefined,
-    newMetadata: TileMetadataArgs = {}
+    newMetadata?: TileMetadataArgs | undefined | null
   ): Promise<RawCommit> {
+    newMetadata ||= {}
     const header = headerFromMetadata(newMetadata, false)
 
     if (newContent == null) {
@@ -391,8 +392,9 @@ export class TileDocument<T = Record<string, any>> extends Stream {
   static async makeGenesis<T>(
     signer: CeramicSigner,
     content: T | null | undefined,
-    metadata: TileMetadataArgs = {}
+    metadata: TileMetadataArgs | undefined | null
   ): Promise<CeramicCommit> {
+    metadata ||= {}
     if (!metadata.controllers || metadata.controllers.length === 0) {
       if (signer.did) {
         const did = await getAuthenticatedDID(signer)

--- a/packages/stream-tile/src/tile-document.ts
+++ b/packages/stream-tile/src/tile-document.ts
@@ -374,7 +374,6 @@ export class TileDocument<T = Record<string, any>> extends Stream {
 
     const patch = jsonpatch.compare(this.content, newContent)
     const genesisLogEntry = this.state.log[0]
-    if (!genesisLogEntry) throw new Error(`No genesis log entry`)
     return {
       header,
       data: patch,

--- a/packages/stream-tile/tsconfig.json
+++ b/packages/stream-tile/tsconfig.json
@@ -2,7 +2,15 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
Note: `context.api` is mandatory now.

One more change: `StreamState#log` is `NonEmptyArray` now, which on type level gives assurance that `log[0]` is present. No run-time guarantees though, but it seems fine for now.