### PR TITLE
chore: Consolidate anchor commit application logic

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/caip10-link.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/caip10-link.test.ts.snap
@@ -175,6 +175,7 @@ Object {
         ],
         "version": 1,
       },
+      "timestamp": 1538352000,
       "type": 2,
     },
     Object {
@@ -261,6 +262,7 @@ Object {
         ],
         "version": 1,
       },
+      "timestamp": 1538352000,
       "type": 2,
     },
   ],
@@ -269,6 +271,7 @@ Object {
       "0x8fe2c4516e920425e177658aaac451ca0463ed69@eip155:1337",
     ],
     "family": "caip10-eip155:1337",
+    "lastUpdate": 1641461695,
   },
   "signature": 2,
   "type": 1,

--- a/packages/stream-caip10-link-handler/package.json
+++ b/packages/stream-caip10-link-handler/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "@ceramicnetwork/blockchain-utils-validation": "^2.2.0",
     "@ceramicnetwork/common": "^2.10.0",
-    "@ceramicnetwork/stream-caip10-link": "^2.5.0"
+    "@ceramicnetwork/stream-caip10-link": "^2.5.0",
+    "@ceramicnetwork/stream-handler-common": "^1.0.0"
   },
   "devDependencies": {
     "@stablelib/sha256": "^1.0.1",

--- a/packages/stream-caip10-link-handler/src/__tests__/__snapshots__/caip10-link-handler.test.ts.snap
+++ b/packages/stream-caip10-link-handler/src/__tests__/__snapshots__/caip10-link-handler.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Caip10LinkHandler applies anchor commit correctly 1`] = `
 Object {
   "anchorProof": Object {
     "blockNumber": 123456,
+    "blockTimestamp": 1666728832,
     "chainId": "fakechain:123",
   },
   "anchorStatus": 3,
@@ -136,6 +137,7 @@ Object {
         ],
         "version": 1,
       },
+      "timestamp": 1666728832,
       "type": 2,
     },
   ],
@@ -144,6 +146,7 @@ Object {
       "0x0544dcf4fce959c6c4f3b7530190cb5e1bd67cb8@eip155:1",
     ],
     "family": "caip10-eip155:1",
+    "lastUpdate": 1608116721,
   },
   "signature": 2,
   "type": 1,

--- a/packages/stream-caip10-link-handler/src/__tests__/caip10-link-handler.test.ts
+++ b/packages/stream-caip10-link-handler/src/__tests__/caip10-link-handler.test.ts
@@ -63,6 +63,7 @@ const COMMITS = {
   proof: {
     value: {
       blockNumber: 123456,
+      blockTimestamp: 1666728832,
       chainId: 'fakechain:123',
     },
   },

--- a/packages/stream-caip10-link-handler/src/caip10-link-handler.ts
+++ b/packages/stream-caip10-link-handler/src/caip10-link-handler.ts
@@ -12,6 +12,7 @@ import {
   StreamUtils,
   toLegacyAccountId,
 } from '@ceramicnetwork/common'
+import { applyAnchorCommit } from '@ceramicnetwork/stream-handler-common'
 
 export class Caip10LinkHandler implements StreamHandler<Caip10Link> {
   get type(): number {
@@ -42,7 +43,7 @@ export class Caip10LinkHandler implements StreamHandler<Caip10Link> {
     }
 
     if (StreamUtils.isAnchorCommitData(commitData)) {
-      return this._applyAnchor(context, commitData, state)
+      return this._applyAnchor(commitData, state)
     }
 
     return this._applySigned(commitData, state)
@@ -145,31 +146,11 @@ export class Caip10LinkHandler implements StreamHandler<Caip10Link> {
 
   /**
    * Applies anchor commit
-   * @param context - Ceramic context
    * @param commitData - Anchor commit
    * @param state - Stream state
    * @private
    */
-  async _applyAnchor(
-    context: Context,
-    commitData: CommitData,
-    state: StreamState
-  ): Promise<StreamState> {
-    StreamUtils.assertCommitLinksToState(state, commitData.commit)
-
-    state.log.push({ cid: commitData.cid, type: CommitType.ANCHOR })
-    let content = state.content
-    if (state.next?.content) {
-      content = state.next.content
-    }
-
-    delete state.next
-
-    return {
-      ...state,
-      content,
-      anchorStatus: AnchorStatus.ANCHORED,
-      anchorProof: commitData.proof,
-    }
+  async _applyAnchor(commitData: CommitData, state: StreamState): Promise<StreamState> {
+    return applyAnchorCommit(commitData, state)
   }
 }

--- a/packages/stream-handler-common/.eslintrc.json
+++ b/packages/stream-handler-common/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint", "import"],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/ban-ts-ignore": "off",
+    "@typescript-eslint/ban-ts-comment": "off",
+    "import/no-unresolved": "error",
+    "import/default": "off"
+  },
+  "settings": {
+    "import/parsers": {
+      "@typescript-eslint/parser": [".ts", ".tsx"]
+    },
+    "import/resolver": {
+      "typescript": {
+        "extensions": []
+      },
+      "node": true
+    }
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:import/typescript"
+  ]
+}

--- a/packages/stream-handler-common/.gitignore
+++ b/packages/stream-handler-common/.gitignore
@@ -1,0 +1,1 @@
+src/generated/

--- a/packages/stream-handler-common/LICENSE-APACHE
+++ b/packages/stream-handler-common/LICENSE-APACHE
@@ -1,0 +1,5 @@
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/packages/stream-handler-common/LICENSE-MIT
+++ b/packages/stream-handler-common/LICENSE-MIT
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/stream-handler-common/README.md
+++ b/packages/stream-handler-common/README.md
@@ -1,0 +1,21 @@
+# Ceramic Common Helpers for Stream Handlers
+![ceramicnetwork](https://circleci.com/gh/ceramicnetwork/js-ceramic.svg?style=shield)
+[![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://lbesson.mit-license.org/)
+[![](https://img.shields.io/badge/Chat%20on-Discord-orange.svg?style=flat)](https://discord.gg/6VRZpGP)
+[![Twitter](https://img.shields.io/twitter/follow/ceramicnetwork?label=Follow&style=social)](https://twitter.com/ceramicnetwork)
+
+> This package contains Ceramic types and utilities that are shared between implementations of Streamtype Handlers.
+
+## Installation
+```
+$ npm install @ceramicnetwork/strea-handler-common
+```
+
+## Usage
+
+See the [Ceramic developer site](https://developers.ceramic.network/) for more details about how to use this package.
+
+## Contributing
+We are happy to accept small and large contributions. Make sure to check out the [Ceramic specifications](https://github.com/ceramicnetwork/ceramic/blob/main/SPECIFICATION.md) for details of how the protocol works.
+
+## License

--- a/packages/stream-handler-common/README.md
+++ b/packages/stream-handler-common/README.md
@@ -8,7 +8,7 @@
 
 ## Installation
 ```
-$ npm install @ceramicnetwork/strea-handler-common
+$ npm install @ceramicnetwork/stream-handler-common
 ```
 
 ## Usage

--- a/packages/stream-handler-common/babel.config.json
+++ b/packages/stream-handler-common/babel.config.json
@@ -1,0 +1,17 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "16"
+        }
+      }
+    ],
+    "@babel/preset-typescript"
+  ],
+  "plugins": [
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-class-properties", { "legacy": true }]
+  ]
+}

--- a/packages/stream-handler-common/jest.config.json
+++ b/packages/stream-handler-common/jest.config.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "testEnvironment": "node",
+  "extensionsToTreatAsEsm": [".ts"],
+  "testRegex": "(/__tests__/.*(\\.|/)(test|spec))\\.tsx?$",
+  "moduleNameMapper": {
+    "^(\\.{1,2}/.*)\\.js$": "$1"
+  }
+}

--- a/packages/stream-handler-common/package.json
+++ b/packages/stream-handler-common/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@ceramicnetwork/stream-handler-common",
+  "version": "1.0.0",
+  "description": "Ceramic stream handler common types and utilities",
+  "keywords": [
+    "ceramic",
+    "types",
+    "utilities",
+    "stream",
+    "handlers"
+  ],
+  "author": "Spencer T Brody <spencer+npm@3box.io>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ceramicnetwork/js-ceramic.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ceramicnetwork/js-ceramic/issues"
+  },
+  "homepage": "https://github.com/ceramicnetwork/js-ceramic#readme",
+  "license": "(Apache-2.0 OR MIT)",
+  "directories": {
+    "lib": "./lib"
+  },
+  "main": "lib/index.js",
+  "type": "module",
+  "exports": {
+    ".": "./lib/index.js"
+  },
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --passWithNoTests",
+    "build": "npx tsc --project tsconfig.json",
+    "prepublishOnly": "npm run build",
+    "prebuild": "npm run clean",
+    "lint": "npx eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "clean": "npx rimraf ./lib"
+  },
+  "dependencies": {
+    "@ceramicnetwork/common": "^2.10.0",
+    "@ceramicnetwork/streamid": "^2.4.0",
+    "lodash.clonedeep": "^4.5.0"
+  }
+}

--- a/packages/stream-handler-common/src/anchor-commit-utils.ts
+++ b/packages/stream-handler-common/src/anchor-commit-utils.ts
@@ -1,0 +1,34 @@
+import {
+  AnchorStatus,
+  CommitData,
+  CommitType,
+  StreamState,
+  StreamUtils,
+} from '@ceramicnetwork/common'
+import cloneDeep from 'lodash.clonedeep'
+
+export async function applyAnchorCommit(
+  commitData: CommitData,
+  state: StreamState
+): Promise<StreamState> {
+  StreamUtils.assertCommitLinksToState(state, commitData.commit)
+  state = cloneDeep(state) // don't modify the source object
+
+  state.anchorStatus = AnchorStatus.ANCHORED
+  state.anchorProof = commitData.proof
+  state.log.push({
+    cid: commitData.cid,
+    type: CommitType.ANCHOR,
+    timestamp: commitData.proof.blockTimestamp,
+  })
+
+  if (state.next?.content) {
+    state.content = state.next.content
+  }
+  if (state.next?.metadata) {
+    state.metadata = state.next.metadata
+  }
+  delete state.next
+
+  return state
+}

--- a/packages/stream-handler-common/src/index.ts
+++ b/packages/stream-handler-common/src/index.ts
@@ -1,0 +1,1 @@
+export * from './anchor-commit-utils.js'

--- a/packages/stream-handler-common/tsconfig.json
+++ b/packages/stream-handler-common/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": [
+    "./src/**/*"
+  ]
+}

--- a/packages/stream-model-handler/package.json
+++ b/packages/stream-model-handler/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@ceramicnetwork/common": "^2.10.0",
+    "@ceramicnetwork/stream-handler-common": "^1.0.0",
     "@ceramicnetwork/stream-model": "^0.8.0",
     "@ceramicnetwork/streamid": "^2.4.0",
     "ajv": "^8.8.2",

--- a/packages/stream-model-instance-handler/package.json
+++ b/packages/stream-model-instance-handler/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@ceramicnetwork/common": "^2.10.0",
+    "@ceramicnetwork/stream-handler-common": "^1.0.0",
     "@ceramicnetwork/stream-model-instance": "^0.6.0",
     "@ceramicnetwork/streamid": "^2.4.0",
     "ajv": "^8.8.2",

--- a/packages/stream-tile-handler/package.json
+++ b/packages/stream-tile-handler/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@ceramicnetwork/common": "^2.10.0",
+    "@ceramicnetwork/stream-handler-common": "^1.0.0",
     "@ceramicnetwork/stream-tile": "^2.6.0",
     "ajv": "^8.8.2",
     "ajv-formats": "^2.1.1",


### PR DESCRIPTION
Also introduce @ceramicnetwork/stream-handler-common package to house code shared between the various streamtype handlers.