### PR TITLE
chore: Depend on actual metrics package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
     "@ceramicnetwork/http-client": "^2.7.0",
     "@ceramicnetwork/ipfs-daemon": "^2.3.0",
     "@ceramicnetwork/logger": "^2.2.0",
-    "@ceramicnetwork/metrics": "^0.0.3",
+    "@ceramicnetwork/metrics": "^0.2.0",
     "@ceramicnetwork/stream-tile": "^2.6.0",
     "@ceramicnetwork/streamid": "^2.4.0",
     "@stablelib/random": "^1.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@ceramicnetwork/common": "^2.10.0",
     "@ceramicnetwork/ipfs-topology": "^2.4.0",
-    "@ceramicnetwork/metrics": "^0.0.3",
+    "@ceramicnetwork/metrics": "^0.2.0",
     "@ceramicnetwork/pinning-aggregation": "^2.2.0",
     "@ceramicnetwork/pinning-ipfs-backend": "^2.2.0",
     "@ceramicnetwork/stream-caip10-link": "^2.5.0",


### PR DESCRIPTION
In semver "^0.x" effectively disregards caret.