### PR TITLE
chore: Handle cookies in browser

### DIFF
--- a/packages/common/src/utils/http-utils.ts
+++ b/packages/common/src/utils/http-utils.ts
@@ -26,7 +26,7 @@ export async function fetchJson(url: URL | string, opts: FetchOpts = {}): Promis
     : timedAbortSignal.signal
 
   const res = await abortable(signal, (abortSignal) => {
-    return fetch(String(url), { ...opts, signal: abortSignal })
+    return fetch(String(url), { ...opts, signal: abortSignal, credentials: 'include' })
   }).finally(() => timedAbortSignal.clear())
 
   if (!res.ok) {


### PR DESCRIPTION
Cookies are remembered by browser.
Cookies do not work if a request is originated from Node.js

It would require a wrapper around one of the "native" fetch implementations. Due to sheer complexity of handling that in a cross-platform way, I better slightly postpone handling of cookies in Node.js. Expectation anyway is absolute most of the requests come from a browser.

So, treat this PR as a starter before moving to better more future-proof fetch based on undici.
