### PR TITLE
feat: Parallelise table operations in database apis

### DIFF
--- a/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
+++ b/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
@@ -117,7 +117,7 @@ describe('init', () => {
       await indexApi.indexModels(indexModelsArgs)
       const created = await listMidTables(dbConnection)
       const tableNames = indexModelsArgs.map((args) => `${asTableName(args.model)}`)
-      expect(created).toEqual(tableNames)
+      expect(created.sort()).toEqual(tableNames.sort())
 
       await expect(indexApi.verifyTables(indexModelsArgs)).resolves.not.toThrow()
 
@@ -138,7 +138,7 @@ describe('init', () => {
       await indexApi.indexModels(modelsToIndexArgs(modelsToIndex))
       const created = await listMidTables(dbConnection)
       const tableNames = modelsToIndex.map(asTableName)
-      expect(created).toEqual(tableNames)
+      expect(created.sort()).toEqual(tableNames.sort())
     })
 
     test('create new table with existing ones', async () => {
@@ -149,7 +149,7 @@ describe('init', () => {
       await indexApiA.indexModels(modelsToIndexArgs(modelsA))
       const createdA = await listMidTables(dbConnection)
       const tableNamesA = modelsA.map(asTableName)
-      expect(createdA).toEqual(tableNamesA)
+      expect(createdA.sort()).toEqual(tableNamesA.sort())
 
       // Next add another one
       const modelsB = [...modelsA, StreamID.fromString(STREAM_ID_B)]
@@ -157,9 +157,7 @@ describe('init', () => {
       await indexApiB.indexModels(modelsToIndexArgs(modelsB))
       const createdB = await listMidTables(dbConnection)
       const tableNamesB = modelsB.map(asTableName)
-      createdB.sort()
-      tableNamesB.sort()
-      expect(createdB).toEqual(tableNamesB)
+      expect(createdB.sort()).toEqual(tableNamesB.sort())
     })
   })
 

--- a/packages/core/src/indexing/postgres/init-tables.ts
+++ b/packages/core/src/indexing/postgres/init-tables.ts
@@ -39,8 +39,8 @@ export async function listMidTables(dataSource: Knex): Promise<Array<string>> {
   return midTables
 }
 
-export async function listConfigTables(): Promise<Array<ConfigTable>> {
-  // TODO (CDB-1852): extend with ceramic_auth
+export function listConfigTables(): Array<ConfigTable> {
+  // TODO (CDB-1852): extend with ceramic_auth; If it will need to be async, see if it can be parallelised within initConfigTables(...)
   return [{ tableName: INDEXED_MODEL_CONFIG_TABLE_NAME, validSchema: CONFIG_TABLE_MODEL_INDEX_STRUCTURE }]
 }
 
@@ -57,13 +57,17 @@ function relationsDefinitionsToColumnInfo(relations?: ModelRelationsDefinition):
  * Create Compose DB config tables
  */
 export async function initConfigTables(dataSource: Knex, logger: DiagnosticsLogger) {
-  const configTables = await listConfigTables()
-  for (const table of configTables) {
-    const exists = await dataSource.schema.hasTable(table.tableName)
-    if (!exists) {
-      logger.imp(`Creating Compose DB config table: ${table.tableName}`)
-      await createConfigTable(dataSource, table.tableName)
-    }
+  const configTables = listConfigTables()
+  await Promise.all(configTables.map( table => {
+    return initConfigTable(table, dataSource, logger)
+  }))
+}
+
+async function initConfigTable(table: ConfigTable, dataSource: Knex, logger: DiagnosticsLogger) {
+  const exists = await dataSource.schema.hasTable(table.tableName)
+  if (!exists) {
+    logger.imp(`Creating Compose DB config table: ${table.tableName}`)
+    await createConfigTable(dataSource, table.tableName)
   }
 }
 
@@ -75,20 +79,24 @@ export async function initMidTables(
   modelsToIndex: Array<IndexModelArgs>,
   logger: DiagnosticsLogger
 ) {
-  for (const modelIndexArgs of modelsToIndex) {
-    const tableName = asTableName(modelIndexArgs.model)
-    if (tableName.length > 63) {
-      const errStr = `Cannot index model ${modelIndexArgs.model.toString()}.  Table name is too long: ${tableName}`
-      logger.err(errStr)
-      throw new Error(errStr)
-    }
+  await Promise.all(modelsToIndex.map( modelIndexArgs => {
+    return initMidTable(modelIndexArgs, dataSource, logger)
+  }))
+}
 
-    const exists = await dataSource.schema.hasTable(tableName)
-    if (!exists) {
-      logger.imp(`Creating Compose DB Indexing table for model: ${tableName}`)
-      const relationColumns = relationsDefinitionsToColumnInfo(modelIndexArgs.relations)
-      await createModelTable(dataSource, tableName, relationColumns)
-    }
+async function initMidTable(modelIndexArgs: IndexModelArgs, dataSource: Knex, logger: DiagnosticsLogger) {
+  const tableName = asTableName(modelIndexArgs.model)
+  if (tableName.length > 63) {
+    const errStr = `Cannot index model ${modelIndexArgs.model.toString()}.  Table name is too long: ${tableName}`
+    logger.err(errStr)
+    throw new Error(errStr)
+  }
+
+  const exists = await dataSource.schema.hasTable(tableName)
+  if (!exists) {
+    logger.imp(`Creating Compose DB Indexing table for model: ${tableName}`)
+    const relationColumns = relationsDefinitionsToColumnInfo(modelIndexArgs.relations)
+    await createModelTable(dataSource, tableName, relationColumns)
   }
 }
 
@@ -97,18 +105,22 @@ export async function initMidTables(
  * @param dataSource
  * @param modelsToIndex
  */
-async function _verifyConfigTables(dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {
-  const configTables = await listConfigTables()
-  for (const table of configTables) {
-    const columns = await dataSource.table(table.tableName).columnInfo()
-    const validSchema = JSON.stringify(table.validSchema)
+async function _verifyConfigTables(dataSource: Knex) {
+  const configTables = listConfigTables()
+  await Promise.all(configTables.map( table => {
+    return _verifyConfigTable(table, dataSource)
+  }))
+}
 
-    if (validSchema != JSON.stringify(columns)) {
-      throw new Error(
-        `Schema verification failed for config table: ${table.tableName}. Please make sure node has been setup correctly.`
-      )
-      process.exit(-1)
-    }
+async function _verifyConfigTable(table: ConfigTable, dataSource: Knex) {
+  const columns = await dataSource.table(table.tableName).columnInfo()
+  const validSchema = JSON.stringify(table.validSchema)
+
+  if (validSchema != JSON.stringify(columns)) {
+    throw new Error(
+      `Schema verification failed for config table: ${table.tableName}. Please make sure node has been setup correctly.`
+    )
+    process.exit(-1)
   }
 }
 
@@ -118,31 +130,34 @@ async function _verifyConfigTables(dataSource: Knex, modelsToIndex: Array<IndexM
  * @param modelsToIndex
  */
 async function _verifyMidTables(dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {
-  const tables = await listMidTables(dataSource)
+  const tableNames = await listMidTables(dataSource)
+  await Promise.all(tableNames.map( tableName => {
+    return _verifyMidTable(tableName, dataSource, modelsToIndex)
+  }))
+}
 
-  for (const tableName of tables) {
-    const modelIndexArgs = modelsToIndex.find((model) => tableName == asTableName(model.model))
-    if (!modelIndexArgs) {
-      // TODO: CDB-1869 - This means that there's is a table for a model that is no longer indexed. Should this table have been deleted?
-      continue
-    }
+async function _verifyMidTable(tableName: string, dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {
+  const modelIndexArgs = modelsToIndex.find((model) => tableName == asTableName(model.model))
+  if (!modelIndexArgs) {
+    // TODO: CDB-1869 - This means that there's is a table for a model that is no longer indexed. Should this table have been deleted?
+    return
+  }
 
-    // Clone the COMMON_TABLE_STRUCTURE object that has the fields expected for all tables so we can
-    // extend it with the model-specific fields expected
-    const expectedTableStructure = Object.assign({}, COMMON_TABLE_STRUCTURE)
-    if (modelIndexArgs.relations) {
-      for (const relation of Object.keys(modelIndexArgs.relations)) {
-        expectedTableStructure[relation] = RELATION_COLUMN_STRUCTURE
-      }
+  // Clone the COMMON_TABLE_STRUCTURE object that has the fields expected for all tables so we can
+  // extend it with the model-specific fields expected
+  const expectedTableStructure = Object.assign({}, COMMON_TABLE_STRUCTURE)
+  if (modelIndexArgs.relations) {
+    for (const relation of Object.keys(modelIndexArgs.relations)) {
+      expectedTableStructure[relation] = RELATION_COLUMN_STRUCTURE
     }
-    const validSchema = JSON.stringify(expectedTableStructure)
+  }
+  const validSchema = JSON.stringify(expectedTableStructure)
 
-    const columns = await dataSource.table(tableName).columnInfo()
-    if (validSchema != JSON.stringify(columns)) {
-      throw new Error(
-        `Schema verification failed for index: ${tableName}. Please make sure latest migrations have been applied.`
-      )
-    }
+  const columns = await dataSource.table(tableName).columnInfo()
+  if (validSchema != JSON.stringify(columns)) {
+    throw new Error(
+      `Schema verification failed for index: ${tableName}. Please make sure latest migrations have been applied.`
+    )
   }
 }
 
@@ -153,6 +168,8 @@ async function _verifyMidTables(dataSource: Knex, modelsToIndex: Array<IndexMode
  */
 // TODO (NET-1635): unify logic between postgres & sqlite
 export async function verifyTables(dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {
-  await _verifyConfigTables(dataSource, modelsToIndex)
-  await _verifyMidTables(dataSource, modelsToIndex)
+  await Promise.all([
+    _verifyConfigTables(dataSource),
+    _verifyMidTables(dataSource, modelsToIndex)
+  ])
 }

--- a/packages/core/src/indexing/postgres/init-tables.ts
+++ b/packages/core/src/indexing/postgres/init-tables.ts
@@ -39,11 +39,17 @@ export async function listMidTables(dataSource: Knex): Promise<Array<string>> {
   return midTables
 }
 
+/**
+ * List existing config tables.
+ */
 export function listConfigTables(): Array<ConfigTable> {
   // TODO (CDB-1852): extend with ceramic_auth; If it will need to be async, see if it can be parallelised within initConfigTables(...)
   return [{ tableName: INDEXED_MODEL_CONFIG_TABLE_NAME, validSchema: CONFIG_TABLE_MODEL_INDEX_STRUCTURE }]
 }
 
+/**
+ * Create a list of db column info for relations in a given model
+ */
 function relationsDefinitionsToColumnInfo(relations?: ModelRelationsDefinition): Array<ColumnInfo> {
   if (!relations) {
     return []
@@ -63,6 +69,9 @@ export async function initConfigTables(dataSource: Knex, logger: DiagnosticsLogg
   }))
 }
 
+/**
+ * Create a single DB config table
+ */
 async function initConfigTable(table: ConfigTable, dataSource: Knex, logger: DiagnosticsLogger) {
   const exists = await dataSource.schema.hasTable(table.tableName)
   if (!exists) {
@@ -84,6 +93,9 @@ export async function initMidTables(
   }))
 }
 
+/**
+ * Create a single mid table for a given model
+ */
 async function initMidTable(modelIndexArgs: IndexModelArgs, dataSource: Knex, logger: DiagnosticsLogger) {
   const tableName = asTableName(modelIndexArgs.model)
   if (tableName.length > 63) {
@@ -102,8 +114,6 @@ async function initMidTable(modelIndexArgs: IndexModelArgs, dataSource: Knex, lo
 
 /**
  * Compose DB configuration table schema verification
- * @param dataSource
- * @param modelsToIndex
  */
 async function _verifyConfigTables(dataSource: Knex) {
   const configTables = listConfigTables()
@@ -112,6 +122,9 @@ async function _verifyConfigTables(dataSource: Knex) {
   }))
 }
 
+/**
+ * Verify a single config table schema
+ */
 async function _verifyConfigTable(table: ConfigTable, dataSource: Knex) {
   const columns = await dataSource.table(table.tableName).columnInfo()
   const validSchema = JSON.stringify(table.validSchema)
@@ -126,8 +139,6 @@ async function _verifyConfigTable(table: ConfigTable, dataSource: Knex) {
 
 /**
  * Compose DB Model Instance Document table schema verification
- * @param dataSource
- * @param modelsToIndex
  */
 async function _verifyMidTables(dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {
   const tableNames = await listMidTables(dataSource)
@@ -136,6 +147,9 @@ async function _verifyMidTables(dataSource: Knex, modelsToIndex: Array<IndexMode
   }))
 }
 
+/**
+ * Verify a single mid table schema
+ */
 async function _verifyMidTable(tableName: string, dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {
   const modelIndexArgs = modelsToIndex.find((model) => tableName == asTableName(model.model))
   if (!modelIndexArgs) {
@@ -163,8 +177,6 @@ async function _verifyMidTable(tableName: string, dataSource: Knex, modelsToInde
 
 /**
  * Public function to run table schema verification helpers
- * @param dataSource
- * @param modelsToIndex
  */
 // TODO (NET-1635): unify logic between postgres & sqlite
 export async function verifyTables(dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {

--- a/packages/core/src/indexing/sqlite/__tests__/sqlite-index-api.test.ts
+++ b/packages/core/src/indexing/sqlite/__tests__/sqlite-index-api.test.ts
@@ -99,7 +99,7 @@ describe('init', () => {
       await indexApi.indexModels(indexModelsArgs)
       const created = await listMidTables(dbConnection)
       const tableNames = indexModelsArgs.map((args) => `${asTableName(args.model)}`)
-      expect(created).toEqual(tableNames)
+      expect(created.sort()).toEqual(tableNames.sort())
 
       await expect(indexApi.verifyTables(indexModelsArgs)).resolves.not.toThrow()
 
@@ -120,7 +120,7 @@ describe('init', () => {
       await indexApi.indexModels(modelsToIndexArgs(modelsToIndex))
       const created = await listMidTables(dbConnection)
       const tableNames = modelsToIndex.map((m) => `${m.toString()}`)
-      expect(created).toEqual(tableNames)
+      expect(created.sort()).toEqual(tableNames.sort())
     })
 
     test('create new table with existing ones', async () => {
@@ -131,7 +131,7 @@ describe('init', () => {
       await indexApiA.indexModels(modelsToIndexArgs(modelsA))
       const createdA = await listMidTables(dbConnection)
       const tableNamesA = modelsA.map((m) => `${m.toString()}`)
-      expect(createdA).toEqual(tableNamesA)
+      expect(createdA.sort()).toEqual(tableNamesA.sort())
 
       // Next add another one
       const modelsB = [...modelsA, StreamID.fromString(STREAM_ID_B)]
@@ -139,7 +139,7 @@ describe('init', () => {
       await indexApiB.indexModels(modelsToIndexArgs(modelsB))
       const createdB = await listMidTables(dbConnection)
       const tableNamesB = modelsB.map((m) => `${m.toString()}`)
-      expect(createdB).toEqual(tableNamesB)
+      expect(createdB.sort()).toEqual(tableNamesB.sort())
     })
   })
 

--- a/packages/core/src/indexing/sqlite/init-tables.ts
+++ b/packages/core/src/indexing/sqlite/init-tables.ts
@@ -35,8 +35,8 @@ export async function listMidTables(dbConnection: Knex): Promise<Array<string>> 
   return result.map((r) => r.name)
 }
 
-export async function listConfigTables(): Promise<Array<ConfigTable>> {
-  // TODO (CDB-1852): extend with ceramic_auth
+export function listConfigTables(): Array<ConfigTable> {
+  // TODO (CDB-1852): extend with ceramic_auth; If it will need to be async, see if it can be parallelised within initConfigTables(...)
   return [{ tableName: INDEXED_MODEL_CONFIG_TABLE_NAME, validSchema: CONFIG_TABLE_MODEL_INDEX_STRUCTURE }]
 }
 
@@ -54,17 +54,19 @@ function relationsDefinitionsToColumnInfo(relations?: ModelRelationsDefinition):
  */
 export async function initConfigTables(dataSource: Knex, logger: DiagnosticsLogger) {
   const configTables = await listConfigTables()
-  for (const table of configTables) {
-    const exists = await dataSource.schema.hasTable(table.tableName)
-    if (!exists) {
-      logger.imp(`Creating Compose DB config table: ${table.tableName}`)
-      await createConfigTable(dataSource, table.tableName)
-    }
+  await Promise.all(configTables.map( table => { return initConfigTable(table, dataSource, logger) } ))
+}
+
+async function initConfigTable(table: ConfigTable, dataSource: Knex, logger: DiagnosticsLogger) {
+  const exists = await dataSource.schema.hasTable(table.tableName)
+  if (!exists) {
+    logger.imp(`Creating Compose DB config table: ${table.tableName}`)
+    await createConfigTable(dataSource, table.tableName)
   }
 }
 
 /**
- * Create mid tables and corresponding indexes.
+ * Create mid tables and corresponding indexes.n
  */
 export async function initMidTables(
   dbConnection: Knex,
@@ -72,15 +74,19 @@ export async function initMidTables(
   logger: DiagnosticsLogger
 ) {
   const existingTables = await listMidTables(dbConnection)
-  for (const modelIndexArgs of modelsToIndex) {
-    const tableName = asTableName(modelIndexArgs.model)
-    if (existingTables.includes(tableName)) {
-      continue
-    }
-    logger.imp(`Creating Compose DB Indexing table for model: ${tableName}`)
-    const relationColumns = relationsDefinitionsToColumnInfo(modelIndexArgs.relations)
-    await createModelTable(dbConnection, tableName, relationColumns)
+  await Promise.all(modelsToIndex.map( modelIndexArgs => {
+    return initMidTable(modelIndexArgs, existingTables, dbConnection, logger)
+  }))
+}
+
+async function initMidTable(modelIndexArgs: IndexModelArgs, existingTables: Array<string>, dbConnection: Knex, logger: DiagnosticsLogger) {
+  const tableName = asTableName(modelIndexArgs.model)
+  if (existingTables.includes(tableName)) {
+    return
   }
+  logger.imp(`Creating Compose DB Indexing table for model: ${tableName}`)
+  const relationColumns = relationsDefinitionsToColumnInfo(modelIndexArgs.relations)
+  await createModelTable(dbConnection, tableName, relationColumns)
 }
 
 /**
@@ -88,18 +94,22 @@ export async function initMidTables(
  * @param dataSource
  * @param modelsToIndex
  */
-async function _verifyConfigTables(dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {
-  const configTables = await listConfigTables()
-  for (const table of configTables) {
-    const columns = await dataSource.table(table.tableName).columnInfo()
-    const validSchema = JSON.stringify(table.validSchema)
+async function _verifyConfigTables(dataSource: Knex) {
+  const configTables = listConfigTables()
+  await Promise.all(configTables.map( configTable => {
+    return _verifyConfigTable(configTable, dataSource)
+  }))
+}
 
-    if (validSchema != JSON.stringify(columns)) {
-      throw new Error(
-        `Schema verification failed for config table: ${table.tableName}. Please make sure node has been setup correctly.`
-      )
-      process.exit(-1)
-    }
+async function _verifyConfigTable(table: ConfigTable, dataSource: Knex) {
+  const columns = await dataSource.table(table.tableName).columnInfo()
+  const validSchema = JSON.stringify(table.validSchema)
+
+  if (validSchema != JSON.stringify(columns)) {
+    throw new Error(
+      `Schema verification failed for config table: ${table.tableName}. Please make sure node has been setup correctly.`
+    )
+    process.exit(-1)
   }
 }
 
@@ -109,31 +119,34 @@ async function _verifyConfigTables(dataSource: Knex, modelsToIndex: Array<IndexM
  * @param modelsToIndex
  */
 async function _verifyMidTables(dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {
-  const tables = await listMidTables(dataSource)
+  const tableNames = await listMidTables(dataSource)
+  await Promise.all(tableNames.map( tableName => {
+    return _verifyMidTable(tableName, dataSource, modelsToIndex)
+  }))
+}
 
-  for (const tableName of tables) {
-    const modelIndexArgs = modelsToIndex.find((model) => tableName == asTableName(model.model))
-    if (!modelIndexArgs) {
-      // TODO: CDB-1869 - This means that there's is a table for a model that is no longer indexed. Should this table have been deleted?
-      continue
-    }
+async function _verifyMidTable(tableName: string, dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {
+  const modelIndexArgs = modelsToIndex.find((model) => tableName == asTableName(model.model))
+  if (!modelIndexArgs) {
+    // TODO: CDB-1869 - This means that there's is a table for a model that is no longer indexed. Should this table have been deleted?
+    return
+  }
 
-    // Clone the COMMON_TABLE_STRUCTURE object that has the fields expected for all tables so we can
-    // extend it with the model-specific fields expected
-    const expectedTableStructure = Object.assign({}, COMMON_TABLE_STRUCTURE)
-    if (modelIndexArgs.relations) {
-      for (const relation of Object.keys(modelIndexArgs.relations)) {
-        expectedTableStructure[relation] = RELATION_COLUMN_STRUCTURE
-      }
+  // Clone the COMMON_TABLE_STRUCTURE object that has the fields expected for all tables so we can
+  // extend it with the model-specific fields expected
+  const expectedTableStructure = Object.assign({}, COMMON_TABLE_STRUCTURE)
+  if (modelIndexArgs.relations) {
+    for (const relation of Object.keys(modelIndexArgs.relations)) {
+      expectedTableStructure[relation] = RELATION_COLUMN_STRUCTURE
     }
-    const validSchema = JSON.stringify(expectedTableStructure)
+  }
+  const validSchema = JSON.stringify(expectedTableStructure)
 
-    const columns = await dataSource.table(tableName).columnInfo()
-    if (validSchema != JSON.stringify(columns)) {
-      throw new Error(
-        `Schema verification failed for index: ${tableName}. Please make sure latest migrations have been applied.`
-      )
-    }
+  const columns = await dataSource.table(tableName).columnInfo()
+  if (validSchema != JSON.stringify(columns)) {
+    throw new Error(
+      `Schema verification failed for index: ${tableName}. Please make sure latest migrations have been applied.`
+    )
   }
 }
 
@@ -145,7 +158,7 @@ async function _verifyMidTables(dataSource: Knex, modelsToIndex: Array<IndexMode
 // TODO (NET-1635): unify logic between postgres & sqlite
 export async function verifyTables(dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {
   await Promise.all([
-    _verifyConfigTables(dataSource, modelsToIndex),
+    _verifyConfigTables(dataSource),
     _verifyMidTables(dataSource, modelsToIndex)
   ])
 }

--- a/packages/core/src/indexing/sqlite/init-tables.ts
+++ b/packages/core/src/indexing/sqlite/init-tables.ts
@@ -35,11 +35,17 @@ export async function listMidTables(dbConnection: Knex): Promise<Array<string>> 
   return result.map((r) => r.name)
 }
 
+/**
+ * List existing config tables.
+ */
 export function listConfigTables(): Array<ConfigTable> {
   // TODO (CDB-1852): extend with ceramic_auth; If it will need to be async, see if it can be parallelised within initConfigTables(...)
   return [{ tableName: INDEXED_MODEL_CONFIG_TABLE_NAME, validSchema: CONFIG_TABLE_MODEL_INDEX_STRUCTURE }]
 }
 
+/**
+ * Create a list of db column info for relations in a given model
+ */
 function relationsDefinitionsToColumnInfo(relations?: ModelRelationsDefinition): Array<ColumnInfo> {
   if (!relations) {
     return []
@@ -57,6 +63,9 @@ export async function initConfigTables(dataSource: Knex, logger: DiagnosticsLogg
   await Promise.all(configTables.map( table => { return initConfigTable(table, dataSource, logger) } ))
 }
 
+/**
+ * Create a single DB config table
+ */
 async function initConfigTable(table: ConfigTable, dataSource: Knex, logger: DiagnosticsLogger) {
   const exists = await dataSource.schema.hasTable(table.tableName)
   if (!exists) {
@@ -79,6 +88,9 @@ export async function initMidTables(
   }))
 }
 
+/**
+ * Create a single mid table for a given model
+ */
 async function initMidTable(modelIndexArgs: IndexModelArgs, existingTables: Array<string>, dbConnection: Knex, logger: DiagnosticsLogger) {
   const tableName = asTableName(modelIndexArgs.model)
   if (existingTables.includes(tableName)) {
@@ -91,8 +103,6 @@ async function initMidTable(modelIndexArgs: IndexModelArgs, existingTables: Arra
 
 /**
  * Compose DB configuration table schema verification
- * @param dataSource
- * @param modelsToIndex
  */
 async function _verifyConfigTables(dataSource: Knex) {
   const configTables = listConfigTables()
@@ -101,6 +111,9 @@ async function _verifyConfigTables(dataSource: Knex) {
   }))
 }
 
+/**
+ * Verify a single config table schema
+ */
 async function _verifyConfigTable(table: ConfigTable, dataSource: Knex) {
   const columns = await dataSource.table(table.tableName).columnInfo()
   const validSchema = JSON.stringify(table.validSchema)
@@ -115,8 +128,6 @@ async function _verifyConfigTable(table: ConfigTable, dataSource: Knex) {
 
 /**
  * Compose DB Model Instance Document table schema verification
- * @param dataSource
- * @param modelsToIndex
  */
 async function _verifyMidTables(dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {
   const tableNames = await listMidTables(dataSource)
@@ -125,6 +136,9 @@ async function _verifyMidTables(dataSource: Knex, modelsToIndex: Array<IndexMode
   }))
 }
 
+/**
+ * Verify a single mid table schema
+ */
 async function _verifyMidTable(tableName: string, dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {
   const modelIndexArgs = modelsToIndex.find((model) => tableName == asTableName(model.model))
   if (!modelIndexArgs) {
@@ -152,8 +166,6 @@ async function _verifyMidTable(tableName: string, dataSource: Knex, modelsToInde
 
 /**
  * Public function to run table schema verification helpers
- * @param dataSource
- * @param modelsToIndex
  */
 // TODO (NET-1635): unify logic between postgres & sqlite
 export async function verifyTables(dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {

--- a/packages/core/src/indexing/sqlite/init-tables.ts
+++ b/packages/core/src/indexing/sqlite/init-tables.ts
@@ -144,6 +144,8 @@ async function _verifyMidTables(dataSource: Knex, modelsToIndex: Array<IndexMode
  */
 // TODO (NET-1635): unify logic between postgres & sqlite
 export async function verifyTables(dataSource: Knex, modelsToIndex: Array<IndexModelArgs>) {
-  await _verifyConfigTables(dataSource, modelsToIndex)
-  await _verifyMidTables(dataSource, modelsToIndex)
+  await Promise.all([
+    _verifyConfigTables(dataSource, modelsToIndex),
+    _verifyMidTables(dataSource, modelsToIndex)
+  ])
 }

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -85,7 +85,6 @@ export class SqliteIndexApi implements DatabaseIndexApi {
   private async indexModelsInDatabase(models: Array<IndexModelArgs>): Promise<void> {
     if (models.length === 0) return
     await initMidTables(this.dbConnection, models, this.logger)
-    this.logger.imp('ARTUR WDOWIARSKI: WILL VERIFY TABLES')
     await this.verifyTables(models)
     const now = asTimestamp(new Date())
     // FIXME: CDB-1866 - populate the updated_by field properly when auth is implemented

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -84,8 +84,8 @@ export class SqliteIndexApi implements DatabaseIndexApi {
 
   private async indexModelsInDatabase(models: Array<IndexModelArgs>): Promise<void> {
     if (models.length === 0) return
-
     await initMidTables(this.dbConnection, models, this.logger)
+    this.logger.imp('ARTUR WDOWIARSKI: WILL VERIFY TABLES')
     await this.verifyTables(models)
     const now = asTimestamp(new Date())
     // FIXME: CDB-1866 - populate the updated_by field properly when auth is implemented


### PR DESCRIPTION
## Description

Paralellised the table operations using `await Promise.all(...)`, because I didn't find methods in `Knex` to e.g. create several tables at once (which I'd expect to be done in parallel, if possible).

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Ran manual tests against sqlite on locally my MacBook Pro 16" 2021 with M1 Pro chip and 32GB or RAM, creating a composite consisting of 50 simple models (I used logs to roughly measure the times):
  - MID table creation on current `develop` branch: 17.462 seconds
  - table verification on current `develop` branch: 8 milliseconds
  - MID table creation on this PR's branch: 16.533 seconds
  - table verification on this PR's branch: 8 milliseconds
- [X] Ran manual tests against postgres on locally my MacBook Pro 16" 2021 with M1 Pro chip and 32GB or RAM, creating a composite consisting of 50 simple models:
  - MID table creation on current `develop` branch: 390 milliseconds
  - table verification on current `develop` branch: 259 milliseconds
  - MID table creation on this PR's branch: 170 milliseconds
  - table verification on this PR's branch: 49 milliseconds

I ran all tests only once.

## PR checklist

Before submitting this PR, please make sure:

- [X] I have tagged the relevant reviewers and interested parties
- [X] I have updated the READMEs of affected packages
- [X] I have made corresponding changes to the documentation

