### PR TITLE
feat: Provisionary dedupe of pinning

### DIFF
--- a/packages/core/src/__tests__/local-pin-api.test.ts
+++ b/packages/core/src/__tests__/local-pin-api.test.ts
@@ -35,7 +35,13 @@ async function toArray<A>(iterable: AsyncIterable<A>): Promise<A[]> {
 test('add', async () => {
   await pinApi.add(STREAM_ID)
   expect(repository.load).toBeCalledWith(STREAM_ID, { sync: SyncOptions.PREFER_CACHE, pin: true })
-  expect(repository.pin).toBeCalledWith(state$, undefined)
+  expect(repository.pin).not.toBeCalled()
+})
+
+test('add: force', async () => {
+  await pinApi.add(STREAM_ID, true)
+  expect(repository.load).toBeCalledWith(STREAM_ID, { sync: SyncOptions.PREFER_CACHE, pin: true })
+  expect(repository.pin).toBeCalled()
 })
 
 test('rm', async () => {

--- a/packages/core/src/__tests__/local-pin-api.test.ts
+++ b/packages/core/src/__tests__/local-pin-api.test.ts
@@ -67,6 +67,7 @@ describe('ls', () => {
     expect(actual).toEqual(expected)
     expect(repository.listPinned).toBeCalledWith(STREAM_ID)
   })
+
   test('streamId: absent: empty list', async () => {
     const expected = []
     repository.listPinned = jest.fn(async () => expected)

--- a/packages/core/src/local-pin-api.ts
+++ b/packages/core/src/local-pin-api.ts
@@ -17,7 +17,7 @@ export class LocalPinApi implements PinApi {
       sync: SyncOptions.PREFER_CACHE,
       pin: true,
     })
-    await this.repository.pin(state$, force)
+    if (force) await this.repository.pin(state$, force)
     this.logger.verbose(`Pinned stream ${streamId.toString()}`)
   }
 


### PR DESCRIPTION
Call `this.repository.pin` only if `force` is true. Otherwise it is a fancy no-op.