### PR TITLE
chore(core): prefix columns for user-defined fields

### DIFF
--- a/packages/core/src/indexing/column-name.util.ts
+++ b/packages/core/src/indexing/column-name.util.ts
@@ -1,0 +1,5 @@
+const CUSTOM_COLUMN_PREFIX = 'custom_'
+
+export function addColumnPrefix(name: string): string {
+  return CUSTOM_COLUMN_PREFIX + name
+}

--- a/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
+++ b/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
@@ -17,6 +17,7 @@ import {
   CONFIG_TABLE_MODEL_INDEX_STRUCTURE,
 } from '../migrations/cdb-schema-verification.js'
 import { readCsvFixture } from './read-csv-fixture.util.js'
+import { addColumnPrefix } from '../../column-name.util.js'
 
 const STREAM_ID_A = 'kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd'
 const STREAM_ID_B = 'kjzl6cwe1jw147dvq16zluojmraqvwdmbh61dx9e0c59i344lcrsgqfohexp60s'
@@ -124,7 +125,7 @@ describe('init', () => {
       // Also manually check table structure
       const columns = await dbConnection.table(asTableName(indexModelsArgs[0].model)).columnInfo()
       const expectedTableStructure = Object.assign({}, COMMON_TABLE_STRUCTURE, {
-        fooRelation: RELATION_COLUMN_STRUCTURE,
+        [addColumnPrefix('fooRelation')]: RELATION_COLUMN_STRUCTURE,
       })
       expect(JSON.stringify(columns)).toEqual(JSON.stringify(expectedTableStructure))
     })

--- a/packages/core/src/indexing/postgres/insertion-order.ts
+++ b/packages/core/src/indexing/postgres/insertion-order.ts
@@ -10,6 +10,7 @@ import {
 } from '../parse-pagination.js'
 import { asTableName } from '../as-table-name.util.js'
 import { UnsupportedOrderingError } from '../unsupported-ordering-error.js'
+import { addColumnPrefix } from '../column-name.util.js'
 
 type Selected = { stream_id: string; last_anchored_at: number; created_at: number }
 
@@ -138,7 +139,7 @@ export class InsertionOrder {
     if (query.filter) {
       for (const [key, value] of Object.entries(query.filter)) {
         const filterObj = {}
-        filterObj[key] = value
+        filterObj[addColumnPrefix(key)] = value
         base = base.andWhere(filterObj)
       }
     }
@@ -178,7 +179,7 @@ export class InsertionOrder {
           if (query.filter) {
             for (const [key, value] of Object.entries(query.filter)) {
               const filterObj = {}
-              filterObj[key] = value
+              filterObj[addColumnPrefix(key)] = value
               subquery = subquery.andWhere(filterObj)
             }
           }

--- a/packages/core/src/indexing/postgres/postgres-index-api.ts
+++ b/packages/core/src/indexing/postgres/postgres-index-api.ts
@@ -7,6 +7,7 @@ import { asTableName } from '../as-table-name.util.js'
 import { Knex } from 'knex'
 import { IndexQueryNotAvailableError } from '../index-query-not-available.error.js'
 import { INDEXED_MODEL_CONFIG_TABLE_NAME } from '../database-index-api.js'
+import { addColumnPrefix } from '../column-name.util.js'
 
 export class PostgresIndexApi implements DatabaseIndexApi {
   private readonly insertionOrder: InsertionOrder
@@ -152,7 +153,7 @@ export class PostgresIndexApi implements DatabaseIndexApi {
     if (query.filter) {
       for (const [key, value] of Object.entries(query.filter)) {
         const filterObj = {}
-        filterObj[key] = value
+        filterObj[addColumnPrefix(key)] = value
         dbQuery = dbQuery.andWhere(filterObj)
       }
     }

--- a/packages/core/src/indexing/sqlite/__tests__/sqlite-index-api.test.ts
+++ b/packages/core/src/indexing/sqlite/__tests__/sqlite-index-api.test.ts
@@ -16,6 +16,7 @@ import {
   CONFIG_TABLE_MODEL_INDEX_STRUCTURE,
 } from '../migrations/cdb-schema-verfication.js'
 import { readCsvFixture } from './read-csv-fixture.util.js'
+import { addColumnPrefix } from '../../column-name.util.js'
 
 const STREAM_ID_A = 'kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd'
 const STREAM_ID_B = 'kjzl6cwe1jw147dvq16zluojmraqvwdmbh61dx9e0c59i344lcrsgqfohexp60s'
@@ -106,7 +107,7 @@ describe('init', () => {
       // Also manually check table structure
       const columns = await dbConnection.table(asTableName(indexModelsArgs[0].model)).columnInfo()
       const expectedTableStructure = Object.assign({}, COMMON_TABLE_STRUCTURE, {
-        fooRelation: RELATION_COLUMN_STRUCTURE,
+        [addColumnPrefix('fooRelation')]: RELATION_COLUMN_STRUCTURE,
       })
       expect(JSON.stringify(columns)).toEqual(JSON.stringify(expectedTableStructure))
     })

--- a/packages/core/src/indexing/sqlite/insertion-order.ts
+++ b/packages/core/src/indexing/sqlite/insertion-order.ts
@@ -10,6 +10,7 @@ import {
 } from '../parse-pagination.js'
 import { asTableName } from '../as-table-name.util.js'
 import { UnsupportedOrderingError } from '../unsupported-ordering-error.js'
+import { addColumnPrefix } from '../column-name.util.js'
 
 type Selected = { stream_id: string; last_anchored_at: number; created_at: number }
 
@@ -176,7 +177,7 @@ export class InsertionOrder {
           if (query.filter) {
             for (const [key, value] of Object.entries(query.filter)) {
               const filterObj = {}
-              filterObj[key] = value
+              filterObj[addColumnPrefix(key)] = value
               subquery = subquery.andWhere(filterObj)
             }
           }

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -7,6 +7,7 @@ import { asTableName } from '../as-table-name.util.js'
 import { InsertionOrder } from './insertion-order.js'
 import { IndexQueryNotAvailableError } from '../index-query-not-available.error.js'
 import { INDEXED_MODEL_CONFIG_TABLE_NAME } from '../database-index-api.js'
+import { addColumnPrefix } from '../column-name.util.js'
 
 /**
  * Convert `Date` to SQLite `INTEGER`.
@@ -70,7 +71,7 @@ export class SqliteIndexApi implements DatabaseIndexApi {
       updated_at: asTimestamp(indexingArgs.updatedAt) || now,
     }
     for (const field of this.modelsIndexedFields.get(indexingArgs.model.toString()) ?? []) {
-      indexedData[field] = indexingArgs.streamContent[field]
+      indexedData[addColumnPrefix(field)] = indexingArgs.streamContent[field]
     }
 
     await this.dbConnection(tableName)
@@ -166,7 +167,7 @@ export class SqliteIndexApi implements DatabaseIndexApi {
     if (query.filter) {
       for (const [key, value] of Object.entries(query.filter)) {
         const filterObj = {}
-        filterObj[key] = value
+        filterObj[addColumnPrefix(key)] = value
         dbQuery = dbQuery.andWhere(filterObj)
       }
     }


### PR DESCRIPTION
## Description

Prefixes all the columns created based on user-defined fields in model definitions, to avoid collisions with columns used internally.

## How Has This Been Tested?

- [ ] Updated tests checking the created tables for models

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
