### PR TITLE
feat(core): Throw when loading or updating a stream with expired CACAOs in the log

### DIFF
--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -310,6 +310,26 @@ export class StreamUtils {
     if (commitData?.capability?.p?.exp) {
       logEntry.expirationTime = Math.floor(Date.parse(commitData.capability.p.exp) / 1000)
     }
+    if (commitData.timestamp) {
+      logEntry.timestamp = commitData.timestamp
+    }
     return logEntry
+  }
+
+  /**
+   * Takes a StreamState and validates that none of the commits in its log are based on expired CACAOs.
+   */
+  static checkForCacaoExpiration(state: StreamState): void {
+    const now = Math.floor(Date.now() / 1000) // convert millis to seconds
+    for (const logEntry of state.log) {
+      const timestamp = logEntry.timestamp ?? now
+      if (logEntry.expirationTime && logEntry.expirationTime < timestamp) {
+        throw new Error(
+          `CACAO expired: Commit ${logEntry.cid.toString()} of Stream ${StreamUtils.streamIdFromState(
+            state
+          ).toString()} has a CACAO that expired at ${logEntry.expirationTime}`
+        )
+      }
+    }
   }
 }

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -475,6 +475,13 @@ describe('Ceramic API', () => {
       expect(streams[streamE.id.toString()]).toBeTruthy()
     })
 
+    /**
+     * Asserts that the given timestamps are within 5 seconds of each other
+     */
+    function expectTimestampsClose(givenTimestamp: number, expectedTimestamp: number) {
+      expect(Math.abs(expectedTimestamp - givenTimestamp)).toBeLessThan(5)
+    }
+
     it('loads the same stream at multiple points in time', async () => {
       // test data for the atTime feature
       streamFStates.push(streamF.state)
@@ -519,6 +526,13 @@ describe('Ceramic API', () => {
       // annoying thing, was pending when snapshotted but will
       // obviously not be when loaded at a specific commit
       streamFStates[0].anchorStatus = 0
+
+      // first stream state didn't have an anchor timestamp when it was added to the streamFStates
+      // array, but it does get a timestamp after being anchored
+      // Assert that the timestamp it got from being anchored is within 10 seconds of when it was created
+      expect(Math.abs(states[0].log[0].timestamp - streamFTimestamps[0])).toBeLessThan(5)
+      delete states[0].log[0].timestamp
+
       expect(states[0]).toEqual(streamFStates[0])
       expect(states[1]).toEqual(streamFStates[1])
       expect(states[2]).toEqual(streamFStates[2])

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -172,14 +172,14 @@ test('handleTip for commit already in log', async () => {
   await (ceramic2.repository.stateManager as any)._handleTip(streamState2, stream1.state.log[1].cid)
 
   expect(streamState2.state).toEqual(stream1.state)
-  // 4 IPFS retrievals - 2 each (signed commit and linked commit) for CID of commit to be applied and CID of lone
-  // genesis commit already in the stream state.
-  expect(retrieveCommitSpy).toBeCalledTimes(4)
+  // 2 IPFS retrievals - the signed commit and its linked commit payload for the commit to be
+  // applied
+  expect(retrieveCommitSpy).toBeCalledTimes(2)
 
   // Now re-apply the same commit and don't expect any additional calls to IPFS
   await (ceramic2.repository.stateManager as any)._handleTip(streamState2, stream1.state.log[1].cid)
   await (ceramic2.repository.stateManager as any)._handleTip(streamState2, stream1.state.log[0].cid)
-  expect(retrieveCommitSpy).toBeCalledTimes(4)
+  expect(retrieveCommitSpy).toBeCalledTimes(2)
 
   // Add another update to stream 1
   const moreNewContent = { foo: 'baz' }
@@ -612,7 +612,6 @@ describe('sync', () => {
         log: [{ type: CommitType.GENESIS, cid: FAKE_STREAM_ID }],
       },
     } as unknown as RunningState
-    stateManager.conflictResolution.verifyLoneGenesis = jest.fn()
     await stateManager.sync(state$, 1000)
     expect(fakeHandleTip).toBeCalledTimes(5)
     response.slice(0, 5).forEach((r) => {
@@ -634,7 +633,6 @@ describe('sync', () => {
         log: [{ type: CommitType.GENESIS, cid: FAKE_STREAM_ID }],
       },
     } as unknown as RunningState
-    stateManager.conflictResolution.verifyLoneGenesis = jest.fn()
     await stateManager.sync(state$, MAX_RESPONSE_INTERVAL * 10)
     expect(fakeHandleTip).toBeCalledTimes(20)
   })

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -223,12 +223,11 @@ export class Repository {
             return [streamState$, alreadySynced]
           } else {
             await this.stateManager.sync(streamState$, opts.syncTimeoutSeconds * 1000)
-            return [await streamState$, true]
+            return [streamState$, true]
           }
         }
         case SyncOptions.NEVER_SYNC: {
-          const [streamState$, alreadySynced] = await this._loadGenesis(streamId)
-          return [await streamState$, alreadySynced]
+          return this._loadGenesis(streamId)
         }
         case SyncOptions.SYNC_ALWAYS: {
           // When SYNC_ALWAYS is provided, we want to reapply and re-validate

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -106,18 +106,6 @@ export class StateManager {
   }
 
   /**
-   * If it is a lone genesis, verify the signature.
-   * @param state$
-   */
-  async verifyLoneGenesis(state$: RunningState): Promise<RunningState> {
-    if (state$.value.log.length > 1) {
-      return state$
-    }
-    await this.conflictResolution.verifyLoneGenesis(state$.value)
-    return state$
-  }
-
-  /**
    * Take the version of a stream state and a specific commit and returns a snapshot of a state
    * at the requested commit. If the requested commit is for a branch of history that conflicts with the
    * known commits, throw an error. If the requested commit is ahead of the currently known state

--- a/packages/stream-model-handler/src/__tests__/__snapshots__/model-handler.test.ts.snap
+++ b/packages/stream-model-handler/src/__tests__/__snapshots__/model-handler.test.ts.snap
@@ -216,6 +216,7 @@ Object {
         ],
         "version": 1,
       },
+      "timestamp": 1647037687,
       "type": 0,
     },
   ],

--- a/packages/stream-model-handler/src/__tests__/model-handler.test.ts
+++ b/packages/stream-model-handler/src/__tests__/model-handler.test.ts
@@ -538,7 +538,7 @@ describe('ModelHandler', () => {
       type: CommitType.GENESIS,
       commit: payload,
       envelope: genesisCommit.jws,
-      timestamp: rotateDate.valueOf() / 1000 + 60 * 60,
+      timestamp: Math.floor(rotateDate.valueOf() / 1000) + 60 * 60,
     }
     const state = await handler.applyCommit(genesisCommitData, context)
     expect(state).toMatchSnapshot()

--- a/packages/stream-model-instance-handler/src/__tests__/__snapshots__/model-instance-document-handler.test.ts.snap
+++ b/packages/stream-model-instance-handler/src/__tests__/__snapshots__/model-instance-document-handler.test.ts.snap
@@ -380,6 +380,7 @@ Object {
         ],
         "version": 1,
       },
+      "timestamp": 1647037687,
       "type": 0,
     },
   ],

--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -1017,7 +1017,7 @@ describe('ModelInstanceDocumentHandler', () => {
       type: CommitType.GENESIS,
       commit: payload,
       envelope: genesisCommit.jws,
-      timestamp: rotateDate.valueOf() / 1000 + 60 * 60,
+      timestamp: Math.floor(rotateDate.valueOf() / 1000) + 60 * 60,
     }
     const state = await handler.applyCommit(genesisCommitData, context)
     delete state.metadata.unique

--- a/packages/stream-tile-handler/src/__tests__/__snapshots__/tile-document-handler.test.ts.snap
+++ b/packages/stream-tile-handler/src/__tests__/__snapshots__/tile-document-handler.test.ts.snap
@@ -204,6 +204,7 @@ Object {
         ],
         "version": 1,
       },
+      "timestamp": 1647037687,
       "type": 0,
     },
   ],

--- a/packages/stream-tile-handler/src/__tests__/tile-document-handler.test.ts
+++ b/packages/stream-tile-handler/src/__tests__/tile-document-handler.test.ts
@@ -924,7 +924,7 @@ describe('TileDocumentHandler', () => {
       type: CommitType.GENESIS,
       commit: payload,
       envelope: genesisCommit.jws,
-      timestamp: rotateDate.valueOf() / 1000 + 60 * 60,
+      timestamp: Math.floor(rotateDate.valueOf() / 1000) + 60 * 60,
     }
     const state = await tileDocumentHandler.applyCommit(genesisCommitData, context)
     delete state.metadata.unique


### PR DESCRIPTION
This has the nice bonus of removing the need for the "lone genesis" check since we now check for expired CACAOs every time we load or update a stream anyway, which lets us simplify the code a bit