### PR TITLE
Fix interference between tests

### DIFF
--- a/packages/stream-tests/src/__tests__/model.test.ts
+++ b/packages/stream-tests/src/__tests__/model.test.ts
@@ -8,12 +8,6 @@ import { Ceramic } from '@ceramicnetwork/core'
 import { CeramicDaemon, DaemonConfig } from '@ceramicnetwork/cli'
 import { CeramicClient } from '@ceramicnetwork/http-client'
 
-const PLACEHOLDER_CONTENT = { name: 'myModel' }
-
-function modelContentWithTestName(): ModelDefinition {
-  return { name: expect.getState().currentTestName, schema: {}, accountRelation: { type: 'list' } }
-}
-
 const MODEL_DEFINITION: ModelDefinition = {
   name: 'myModel',
   schema: {},
@@ -90,8 +84,7 @@ describe('Model API http-client tests', () => {
   })
 
   test('Anchor genesis', async () => {
-    const modelContent = modelContentWithTestName()
-    const model = await Model.create(ceramic, modelContent)
+    const model = await Model.create(ceramic, MODEL_DEFINITION)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await TestUtils.anchorUpdate(core, model)
@@ -101,13 +94,12 @@ describe('Model API http-client tests', () => {
     expect(model.state.log.length).toEqual(2)
     expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
     expect(model.state.log[1].type).toEqual(CommitType.ANCHOR)
-    expect(JSON.stringify(model.content)).toEqual(JSON.stringify(modelContent))
+    expect(model.content).toEqual(MODEL_DEFINITION)
   })
 
   test('Models are created deterministically', async () => {
-    const modelContent = modelContentWithTestName()
-    const model1 = await Model.create(ceramic, modelContent)
-    const model2 = await Model.create(ceramic, modelContent)
+    const model1 = await Model.create(ceramic, MODEL_DEFINITION)
+    const model2 = await Model.create(ceramic, MODEL_DEFINITION)
 
     expect(model1.id.toString()).toEqual(model2.id.toString())
   })
@@ -155,9 +147,7 @@ describe('Model API http-client tests', () => {
   })
 
   test('Can load a complete stream', async () => {
-    const modelContent = modelContentWithTestName()
-
-    const model = await Model.create(ceramic, modelContent)
+    const model = await Model.create(ceramic, MODEL_DEFINITION)
     await TestUtils.anchorUpdate(core, model)
     await model.sync()
 
@@ -200,8 +190,7 @@ describe('Model API multi-node tests', () => {
   })
 
   test('load basic model', async () => {
-    const modelContent = modelContentWithTestName()
-    const model = await Model.create(ceramic0, modelContent)
+    const model = await Model.create(ceramic0, MODEL_DEFINITION)
 
     const loaded = await Model.load(ceramic1, model.id)
 
@@ -216,8 +205,7 @@ describe('Model API multi-node tests', () => {
   })
 
   test('load anchored model', async () => {
-    const modelContent = modelContentWithTestName()
-    const model = await Model.create(ceramic0, modelContent)
+    const model = await Model.create(ceramic0, MODEL_DEFINITION)
     await TestUtils.anchorUpdate(ceramic0, model)
 
     const loaded = await Model.load(ceramic1, model.id)


### PR DESCRIPTION
Seems that the reason that the tests interfered with each other had to do with the fact that the InMemoryAnchorService was getting multiple anchor requests for the same commit (the genesis commit for the Model).  When it picked which request to anchor, it would randomly choose one of the two identical requests to anchor, but mark the other as failed due to conflict resolution, which would send an event on the Observable polling the anchor service saying the request was failed.

I still don't totally understand then why the test would *hang* rather than erroring that the anchoring had failed, but I think at this point that's enough time spent digging on this.