### PR TITLE
code reading interview: rm comments from highlighted block

### DIFF
--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -429,32 +429,25 @@ class Document extends EventEmitter {
     const isRemoteAnchored = remoteState.anchorStatus === AnchorStatus.ANCHORED
 
     if (isLocalAnchored && isRemoteAnchored) {
-      // compare anchor proofs if both states are anchored
       const { anchorProof: localProof } = localState
       const { anchorProof: remoteProof } = remoteState
 
       if (remoteProof.blockTimestamp < localProof.blockTimestamp) {
-        // if the remote state has an earlier anchor timestamp than the local, apply the remote
-        // log to our local state. Otherwise, keep present state.
         this.state = await this._applyLogToState(remoteLog, cloneDeep(canonicalState))
         return true
       }
     }
 
     if (!isLocalAnchored && isRemoteAnchored) {
-      // if the remote state is anchored before the local, apply the remote log to our local state.
-      // Otherwise, keep present state.
       this.state = await this._applyLogToState(remoteLog, cloneDeep(canonicalState))
       return true
     }
 
     if (!isLocalAnchored && !isRemoteAnchored) {
-      // if neither of them is anchored, apply the remote log
       this.state = await this._applyLogToState(remoteLog, cloneDeep(canonicalState))
       return true
     }
 
-    // Default case, we keep our original local state without applying remoteLog.
     return false
   }
 

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -399,8 +399,11 @@ class Document extends EventEmitter {
     // We have a conflict. Before getting into this function we already confirmed that
     // the 'prev' pointer from the earliest commit in the remote log does point to some valid
     // commit in our local log.  But since it doesn't point to the *most recent* commit in our
-    // local log, that means it represents a different branch of history for this stream. We
-    // now need to apply conflict resolution rules to decide which branch of history survives.
+    // local log, that means it represents a different branch of history for this stream.
+    //
+    // Since there is no way to merge histories currently, we will need to pick one branch of
+    // history to survive, and discard the other branch - losing all writes from the discarded
+    // branch.
     //
     // Example of conflict situation where the first two commits are the same, but the last two
     // commits diverge:


### PR DESCRIPTION
In response to Sergey's recent email proposing that we've made it *too* easy with all the recent comments.  I feel pretty fine about removing the comments from the highlighted block related to picking which log to keep.  I have no reservations about removing the comments there as proposed in this PR.  If there's a belief that that's still not enough and we should remove more comments from the earlier part of the function, we might want to have a call to discuss that in more detail, as that seems to me like a change that would come with more tradeoffs.