### PR TITLE
fix: increase timeout for build indexing test

### DIFF
--- a/packages/core/src/indexing/__tests__/build-indexing.test.ts
+++ b/packages/core/src/indexing/__tests__/build-indexing.test.ts
@@ -1,4 +1,5 @@
 import tmp from 'tmp-promise'
+import { jest } from '@jest/globals'
 import { buildIndexing, UnsupportedDatabaseProtocolError } from '../build-indexing.js'
 import { PostgresIndexApi } from '../postgres/postgres-index-api.js'
 import { SqliteIndexApi } from '../sqlite/sqlite-index-api.js'
@@ -8,6 +9,8 @@ import pgTest from '@databases/pg-test'
 const diagnosticsLogger = new LoggerProvider().getDiagnosticsLogger()
 // @ts-ignore default import
 const getDatabase = pgTest.default
+
+jest.setTimeout(20000)
 
 describe('sqlite', () => {
   let databaseFolder: tmp.DirectoryResult


### PR DESCRIPTION
The build-indexing test times out when running the tests locally.
This pr extends the test timeout which allows it to pass.

## Repro
Running
```
cd js-ceramic
npm install
npm run build
npm run test
```

Produces
```
Summary of all failing tests
 FAIL  src/indexing/__tests__/build-indexing.test.ts (6.255 s)
  ● build for postgres connection string

    thrown: "Exceeded timeout of 5000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."

      50 | })
      51 |
    > 52 | test('build for postgres connection string', async () => {
         | ^
      53 |   const { databaseURL, kill } = await getDatabase()
      54 |   const indexingApi = buildIndexing(
      55 |     {

      at test (src/indexing/__tests__/build-indexing.test.ts:52:1)
```