### PR TITLE
feat(core): add postgres schema support to indexer

### DIFF
--- a/packages/core/src/indexing/build-indexing.ts
+++ b/packages/core/src/indexing/build-indexing.ts
@@ -77,6 +77,7 @@ export function buildIndexing(
       const dataSource = knex({
         client: 'pg',
         connection: connectionString.toString(),
+        searchPath: connectionString.searchParams.has('schema') ? connectionString.searchParams.get('schema') : 'public',
       })
       return new PostgresIndexApi(
         dataSource,


### PR DESCRIPTION
## Description

When using `CERAMIC_ENABLE_EXPERIMENTAL_COMPOSE_DB='true'` it is possible to specify a postgres database uri instead of the default leveldb. When using this configuration, attempting to pass a different schema result has no effect.
This PR add support for postgres schema being specified in configuration for the indexer.

## How Has This Been Tested?

- Set the ceramic configuration for indexer to postgres URI with schema 
`postgres://postgres:password@localhost:5432/ceramic?schema=composedb`
- Load a composeDB setup. You will notice the datas are registered in the public schema instead of the one specified
- Test with the current PR properly write datas under the specified schema

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
Please advise
- [ ] I have updated the READMEs of affected packages
No updates needed
- [ ] I have made corresponding changes to the documentation
No updates needed

## References:

knex postgres configuration exemple: 
```
const pg = require('knex')({
  client: 'pg',
  connection: process.env.PG_CONNECTION_STRING,
  searchPath: ['knex', 'public'],
});
```
https://knexjs.org/guide/#configuration-options