### PR TITLE
Update stream content in DB on stream updates

### DIFF
--- a/packages/core/src/indexing/postgres/postgres-index-api.ts
+++ b/packages/core/src/indexing/postgres/postgres-index-api.ts
@@ -73,6 +73,7 @@ export class PostgresIndexApi implements DatabaseIndexApi {
       .onConflict('stream_id')
       .merge({
         stream_content: indexingArgs.streamContent,
+        tip: indexingArgs.tip.toString(),
         last_anchored_at: indexingArgs.lastAnchor,
         updated_at: indexingArgs.updatedAt || new Date(), // we don't use this.dbConnection.fn.now(), because postgres datetime may have higher precision than js date; TODO: CDB-2006: set postgres created_at and updated_at precision to 3
       })

--- a/packages/core/src/indexing/postgres/postgres-index-api.ts
+++ b/packages/core/src/indexing/postgres/postgres-index-api.ts
@@ -72,6 +72,7 @@ export class PostgresIndexApi implements DatabaseIndexApi {
       .insert(indexedData)
       .onConflict('stream_id')
       .merge({
+        stream_content: indexingArgs.streamContent,
         last_anchored_at: indexingArgs.lastAnchor,
         updated_at: indexingArgs.updatedAt || new Date(), // we don't use this.dbConnection.fn.now(), because postgres datetime may have higher precision than js date; TODO: CDB-2006: set postgres created_at and updated_at precision to 3
       })

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -85,6 +85,7 @@ export class SqliteIndexApi implements DatabaseIndexApi {
       .onConflict('stream_id')
       .merge({
         stream_content: JSON.stringify(indexingArgs.streamContent),
+        tip: indexingArgs.tip.toString(),
         last_anchored_at: asTimestamp(indexingArgs.lastAnchor),
         updated_at: asTimestamp(indexingArgs.updatedAt) || now,
       })

--- a/packages/core/src/indexing/sqlite/sqlite-index-api.ts
+++ b/packages/core/src/indexing/sqlite/sqlite-index-api.ts
@@ -84,6 +84,7 @@ export class SqliteIndexApi implements DatabaseIndexApi {
       .insert(indexedData)
       .onConflict('stream_id')
       .merge({
+        stream_content: JSON.stringify(indexingArgs.streamContent),
         last_anchored_at: asTimestamp(indexingArgs.lastAnchor),
         updated_at: asTimestamp(indexingArgs.updatedAt) || now,
       })


### PR DESCRIPTION
## Description

Indexing streams to DB works well for new streams but not for the updates.
It only updates `last_anchored_at` and `updated_at` fields for existing streams.
This commit simply adds `stream_content` field for both SQLite and PostgreSQL indexers.
