### PR TITLE
feat(core): Validate anchors and extract timestamp information before commit application

### DIFF
--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -135,12 +135,36 @@ export interface LogEntry {
  * Includes additional fields that significantly reduce the number of IPFS lookups required while processing commits.
  */
 export interface CommitData extends LogEntry {
-  commit: any
-  envelope?: DagJWS
-  proof?: AnchorProof
-  capability?: Cacao
   /**
-   * Do not time-check a signature.
+   * The underlying payload of the commit
+   */
+  commit: any
+
+  /**
+   * If this is a signed commit, then this will have the commit envelope with the signature.
+   */
+  envelope?: DagJWS
+
+  /**
+   * If this is an anchor commit, this will have the anchor proof.
+   */
+  proof?: AnchorProof
+
+  /**
+   * If this is an anchor commit and this may get set after validating the anchor commit if the
+   * validation fails for any reason.  This is so that the error can be thrown later when applying
+   * the anchor commit (which happens at a different time than when the anchor is validated).
+   */
+  anchorValidationError?: Error
+
+  /**
+   * If this is a signed commit that was signed using a CACAO, this contains it.
+   */
+  capability?: Cacao
+
+  /**
+   * An option to pass down when doing signature verification on the commit that indicated not to
+   * time-check a signature.
    */
   disableTimecheck?: boolean
 }

--- a/packages/core/src/__tests__/conflict-resolution.test.ts
+++ b/packages/core/src/__tests__/conflict-resolution.test.ts
@@ -213,11 +213,8 @@ describe('fetchLog', () => {
     ])
     const cid = CID.create(1, SHA256_CODE, decodeMultiHash(body))
     if (type == CommitType.ANCHOR) {
-      const timestamp = Math.floor(Math.random() * 100000)
       const proofCID = TestUtils.randomCID()
-      cidCommits[proofCID.toString()] = {
-        blockTimestamp: timestamp,
-      }
+      cidCommits[proofCID.toString()] = {}
       cidCommits[cid.toString()] = {
         proof: proofCID,
         prev: prev,
@@ -225,7 +222,6 @@ describe('fetchLog', () => {
       return {
         cid: cid,
         type: type,
-        timestamp: timestamp,
       }
     } else {
       if (prev) {
@@ -246,35 +242,53 @@ describe('fetchLog', () => {
     }
   }
 
-  test('no anchor commit', async () => {
+  test('single new commit', async () => {
     const a = logEntry(CommitType.GENESIS)
     const b = logEntry(CommitType.SIGNED, a.cid)
     const history = new HistoryLog(fauxDispatcher, [a])
 
     const result = await fetchLog(fauxDispatcher, b.cid, history)
-    const target = result.find((entry) => entry.cid.equals(b.cid))
-    expect(target.timestamp).toBeUndefined()
+    expect(result.length).toEqual(1)
+    expect(result[0].cid).toEqual(b.cid)
   })
-  test('immediately next anchor commit', async () => {
+  test('two new commits', async () => {
     const a = logEntry(CommitType.GENESIS)
     const b = logEntry(CommitType.SIGNED, a.cid)
     const c = logEntry(CommitType.ANCHOR, b.cid)
     const history = new HistoryLog(fauxDispatcher, [a])
 
     const result = await fetchLog(fauxDispatcher, c.cid, history)
-    const target = result.find((entry) => entry.cid.equals(b.cid))
-    expect(target.timestamp).toEqual(c.timestamp)
+    expect(result.length).toEqual(2)
+    expect(result[0].cid).toEqual(b.cid)
+    expect(result[1].cid).toEqual(c.cid)
   })
-  test('next anchor commit', async () => {
+  test('two new commits on top of two existing commits', async () => {
     const a = logEntry(CommitType.GENESIS)
     const b = logEntry(CommitType.SIGNED, a.cid)
     const c = logEntry(CommitType.SIGNED, b.cid)
     const d = logEntry(CommitType.ANCHOR, c.cid)
-    const history = new HistoryLog(fauxDispatcher, [a])
+    const history = new HistoryLog(fauxDispatcher, [a, b])
 
     const result = await fetchLog(fauxDispatcher, d.cid, history)
-    const target = result.find((entry) => entry.cid.equals(b.cid))
-    expect(target.timestamp).toEqual(d.timestamp)
+    expect(result.length).toEqual(2)
+    expect(result[0].cid).toEqual(c.cid)
+    expect(result[1].cid).toEqual(d.cid)
+  })
+  test('conflicting history', async () => {
+    // Current history:            A <- B <- C <- D
+    // New conflicting history:    A <- B <- E <- F
+    const a = logEntry(CommitType.GENESIS)
+    const b = logEntry(CommitType.SIGNED, a.cid)
+    const c = logEntry(CommitType.SIGNED, b.cid)
+    const d = logEntry(CommitType.ANCHOR, c.cid)
+    const e = logEntry(CommitType.ANCHOR, b.cid)
+    const f = logEntry(CommitType.ANCHOR, e.cid)
+    const history = new HistoryLog(fauxDispatcher, [a, b, c, d])
+
+    const result = await fetchLog(fauxDispatcher, f.cid, history)
+    expect(result.length).toEqual(2)
+    expect(result[0].cid).toEqual(e.cid)
+    expect(result[1].cid).toEqual(f.cid)
   })
   test('not in log', async () => {
     const a = logEntry(CommitType.GENESIS)

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -250,6 +250,7 @@ export class Ceramic implements CeramicApi {
     // This initialization block below has to be redone.
     // Things below should be passed here as `modules` variable.
     const conflictResolution = new ConflictResolution(
+      this.loggerProvider.getDiagnosticsLogger(),
       modules.anchorValidator,
       this.dispatcher,
       this.context,

--- a/packages/core/src/conflict-resolution.ts
+++ b/packages/core/src/conflict-resolution.ts
@@ -417,8 +417,8 @@ export class ConflictResolution {
     }
 
     const stateLog = HistoryLog.fromState(this.dispatcher, initialState)
-    const log = await fetchLog(this.dispatcher, tip, stateLog).then((log) =>
-      verifyAnchorAndApplyTimestamps(this.logger, this.dispatcher, this.anchorValidator, log)
+    const logWithoutTimestamps = await fetchLog(this.dispatcher, tip, stateLog)
+    const log = await verifyAnchorAndApplyTimestamps(this.logger, this.dispatcher, this.anchorValidator, logWithoutTimestamps)
     )
 
     if (log.length) {

--- a/packages/core/src/conflict-resolution.ts
+++ b/packages/core/src/conflict-resolution.ts
@@ -418,7 +418,11 @@ export class ConflictResolution {
 
     const stateLog = HistoryLog.fromState(this.dispatcher, initialState)
     const logWithoutTimestamps = await fetchLog(this.dispatcher, tip, stateLog)
-    const log = await verifyAnchorAndApplyTimestamps(this.logger, this.dispatcher, this.anchorValidator, logWithoutTimestamps)
+    const log = await verifyAnchorAndApplyTimestamps(
+      this.logger,
+      this.dispatcher,
+      this.anchorValidator,
+      logWithoutTimestamps
     )
 
     if (log.length) {

--- a/packages/core/src/conflict-resolution.ts
+++ b/packages/core/src/conflict-resolution.ts
@@ -1,11 +1,11 @@
 import type { CID } from 'multiformats/cid'
 import {
-  AnchorProof,
   AnchorStatus,
   AnchorValidator,
   CommitData,
   CommitType,
   Context,
+  DiagnosticsLogger,
   InternalOpts,
   LogEntry,
   Stream,
@@ -182,6 +182,39 @@ export class HistoryLog {
 }
 
 /**
+ * Validates all the anchor commits in the log, applying timestamp information to the CommitData
+ * entries in the log along the way. Defers throwing errors resulting from anchor validation
+ * failures until later, when the anchor commits are actually applied.
+ * @param logger
+ * @param dispatcher
+ * @param anchorValidator
+ * @param log
+ */
+async function verifyAnchorAndApplyTimestamps(
+  logger: DiagnosticsLogger,
+  dispatcher: Dispatcher,
+  anchorValidator: AnchorValidator,
+  log: CommitData[]
+): Promise<CommitData[]> {
+  let timestamp = null
+  for (let i = log.length - 1; i >= 0; i--) {
+    const commitData = log[i]
+    if (commitData.type == CommitType.ANCHOR) {
+      try {
+        timestamp = await verifyAnchorCommit(dispatcher, anchorValidator, commitData)
+      } catch (err) {
+        // Save the error for now to be thrown when trying to actually apply the anchor commit.
+        logger.warn(`Error when validating anchor commit: ${err}`)
+        commitData.anchorValidationError = err
+      }
+    }
+    commitData.timestamp = timestamp
+  }
+
+  return log
+}
+
+/**
  * Fetch log to find a connection for the given CID.
  * Expands SignedCommits and adds a CID into the log for their inner `link` commits
  *
@@ -189,24 +222,20 @@ export class HistoryLog {
  * @param cid - Commit CID
  * @param stateLog - Log from the current stream state
  * @param unappliedCommits - Unapplied commits found so far
- * @param timestamp - Previously found timestamp
  * @private
  */
 export async function fetchLog(
   dispatcher: Dispatcher,
   cid: CID,
   stateLog: HistoryLog,
-  unappliedCommits: CommitData[] = [],
-  timestamp?: number
+  unappliedCommits: CommitData[] = []
 ): Promise<CommitData[]> {
   if (stateLog.includes(cid)) {
     // already processed
     return []
   }
   // Fetch expanded `CommitData` using the CID and running timestamp
-  const nextCommitData = await Utils.getCommitData(dispatcher, cid, stateLog.streamId, timestamp)
-  // Update the running timestamp if it was updated via an anchor commit fetch
-  timestamp = nextCommitData.timestamp
+  const nextCommitData = await Utils.getCommitData(dispatcher, cid, stateLog.streamId)
   const prevCid: CID = nextCommitData.commit.prev
   if (!prevCid) {
     // Someone sent a tip that is a fake log, i.e. a log that at some point does not refer to a previous or genesis
@@ -220,7 +249,7 @@ export async function fetchLog(
     // we found the connection to the canonical log
     return unappliedCommits.reverse()
   }
-  return fetchLog(dispatcher, prevCid, stateLog, unappliedCommits, timestamp)
+  return fetchLog(dispatcher, prevCid, stateLog, unappliedCommits)
 }
 
 export function commitAtTime(stateHolder: StreamStateHolder, timestamp: number): CommitID {
@@ -239,40 +268,12 @@ export function commitAtTime(stateHolder: StreamStateHolder, timestamp: number):
 
 export class ConflictResolution {
   constructor(
+    public logger: DiagnosticsLogger,
     public anchorValidator: AnchorValidator,
     private readonly dispatcher: Dispatcher,
     private readonly context: Context,
     private readonly handlers: HandlersMap
   ) {}
-
-  /**
-   * Helper function for applying a single commit to a StreamState.
-   * TODO: Most of this logic should be pushed down into the StreamHandler so it can be StreamType-specific.
-   * @param commitData - the commit to apply
-   * @param state - the state to apply the commit to
-   * @param handler - the handler for the StreamType
-   * @private
-   */
-  private async applyCommitDataToState<T extends Stream>(
-    commitData: CommitData,
-    state: StreamState,
-    handler: StreamHandler<T>
-  ): Promise<StreamState> {
-    if (StreamUtils.isAnchorCommitData(commitData)) {
-      // It's an anchor commit
-      const anchorTimestamp = await verifyAnchorCommit(
-        this.dispatcher,
-        this.anchorValidator,
-        commitData
-      )
-      // Add the anchor's blockTimestamp that we learned when verifying the anchor commit
-      // inclusion on chain to the CommitData.  This will allow that timestamp information to be
-      // available when applying the anchor commit.
-      commitData.timestamp = anchorTimestamp
-    }
-
-    return handler.applyCommit(commitData, this.context, state)
-  }
 
   /**
    * Applies the log to the stream and updates the state.
@@ -307,12 +308,12 @@ export class ConflictResolution {
   ): Promise<StreamState> {
     for (const entry of unappliedCommits) {
       try {
-        state = await this.applyCommitDataToState(entry, state, handler)
+        state = await handler.applyCommit(entry, this.context, state)
       } catch (err) {
         const streamId = state ? StreamUtils.streamIdFromState(state).toString() : null
-        this.context.loggerProvider
-          .getDiagnosticsLogger()
-          .warn(`Error while applying commit ${entry.cid.toString()} to stream ${streamId}: ${err}`)
+        this.logger.warn(
+          `Error while applying commit ${entry.cid.toString()} to stream ${streamId}: ${err}`
+        )
         if (opts.throwOnInvalidCommit) {
           throw err
         } else {
@@ -416,7 +417,10 @@ export class ConflictResolution {
     }
 
     const stateLog = HistoryLog.fromState(this.dispatcher, initialState)
-    const log = await fetchLog(this.dispatcher, tip, stateLog)
+    const log = await fetchLog(this.dispatcher, tip, stateLog).then((log) =>
+      verifyAnchorAndApplyTimestamps(this.logger, this.dispatcher, this.anchorValidator, log)
+    )
+
     if (log.length) {
       return this.applyLog(initialState, stateLog, log, opts)
     }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -93,7 +93,6 @@ export class Utils {
     } else if (StreamUtils.isAnchorCommit(commit)) {
       commitData.type = CommitType.ANCHOR
       commitData.proof = await dispatcher.retrieveFromIPFS(commit.proof)
-      commitData.timestamp = commitData.proof.blockTimestamp
     }
     if (!commitData.commit.prev) commitData.type = CommitType.GENESIS
     return commitData

--- a/packages/stream-handler-common/src/anchor-commit-utils.ts
+++ b/packages/stream-handler-common/src/anchor-commit-utils.ts
@@ -32,6 +32,13 @@ export async function applyAnchorCommit(
   state: StreamState
 ): Promise<StreamState> {
   StreamUtils.assertCommitLinksToState(state, commitData.commit)
+
+  // If the anchor commit failed validation when the log was first fetched, we should throw that
+  // error now as part of trying to apply it.
+  if (commitData.anchorValidationError) {
+    throw commitData.anchorValidationError
+  }
+
   state = cloneDeep(state) // don't modify the source object
 
   state.anchorStatus = AnchorStatus.ANCHORED


### PR DESCRIPTION
I went with this approach, where we validate the anchor commits right after fetching the log, but before applying them, and remember any validation errors so they can be thrown later during commit application.

This was the shortest path to making the changes needed for Graceful Block Reorgs while preserving existing functionality and not making major changes to how signatures are verified or how CACAO timeouts are handled.

That means this is a temporary fix.  We will hit against this problem again when we move log syncing to happen in a single pass where we go from oldest commit to newest commit, without the preliminary pass that first loads commits from newer to older.  We will need to make sure the scope for StreamSync includes time to think about how CACAO timeouts get validated and where the proper separation of concern boundaries lie between the CACAO/DIDs library and js-ceramic.  We might even want to consider a project here sooner so that we can ensure that the CACAO and DIDs libraries have the right APIs and boundaries around how timestamp information is handled asap before they get adopted outside of js-ceramic.