### PR TITLE
fix: Provide Access-Control-Allow-Credentials header

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -241,6 +241,7 @@ export class CeramicDaemon {
     this.app.use(
       cors({
         origin: opts.httpApi?.corsAllowedOrigins,
+        credentials: true,
         maxAge: 7200, // 2 hours
       })
     )


### PR DESCRIPTION
Fix a forgotten flag that resulted in an annoying issue.

To use sticky sessions in future, we have enabled `credentials: include` previously. 

From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials):
> The Access-Control-Allow-Credentials response header tells browsers whether to expose the response to the frontend JavaScript code when the request's credentials mode ([Request.credentials](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)) is include.

I forgot (and did not know, to be honest) to add a server counterpart `credentials: true`.