### PR TITLE
feat: Add sep key to model stream types

### DIFF
--- a/packages/stream-model-handler/src/__tests__/model-handler.test.ts
+++ b/packages/stream-model-handler/src/__tests__/model-handler.test.ts
@@ -295,7 +295,7 @@ describe('ModelHandler', () => {
 
     const expectedGenesis = {
       data: FINAL_CONTENT,
-      header: { controllers: [context.api.did.id], model: Model.MODEL.bytes },
+      header: { controllers: [context.api.did.id], model: Model.MODEL.bytes, sep: 'model' },
     }
 
     await checkSignedCommitMatchesExpectations(did, commit, expectedGenesis)
@@ -307,7 +307,7 @@ describe('ModelHandler', () => {
 
     const expectedGenesis = {
       data: FINAL_CONTENT_WITH_ACCOUNT_DOCUMENT_VIEW,
-      header: { controllers: [context.api.did.id], model: Model.MODEL.bytes },
+      header: { controllers: [context.api.did.id], model: Model.MODEL.bytes, sep: 'model' },
     }
 
     await checkSignedCommitMatchesExpectations(did, commit, expectedGenesis)

--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -321,7 +321,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const expectedGenesis = {
       data: CONTENT0,
-      header: { controllers: [METADATA.controller], model: METADATA.model.bytes },
+      header: { controllers: [METADATA.controller], model: METADATA.model.bytes, sep: 'model' },
     }
 
     await checkSignedCommitMatchesExpectations(did, commit, expectedGenesis)
@@ -335,7 +335,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const expectedGenesis = {
       data: CONTENT0,
-      header: { controllers: [METADATA.controller], model: METADATA.model.bytes },
+      header: { controllers: [METADATA.controller], model: METADATA.model.bytes, sep: 'model' },
     }
 
     await checkSignedCommitMatchesExpectations(did, commit, expectedGenesis)

--- a/packages/stream-model-instance/src/model-instance-document.ts
+++ b/packages/stream-model-instance/src/model-instance-document.ts
@@ -54,12 +54,6 @@ export interface ModelInstanceDocumentMetadata {
    * The StreamID of the Model that this ModelInstanceDocument belongs to.
    */
   model: StreamID
-
-  /**
-   * The separator key as specified in CIP-120.
-   * This is always 'model' for the model-instance-document stream type.
-   */
-  sep: string
 }
 
 const DEFAULT_CREATE_OPTS = {
@@ -115,7 +109,6 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
     return { 
       controller: metadata.controllers[0],
       model: metadata.model,
-      sep: 'model'
     }
   }
 
@@ -306,6 +299,7 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
     const header: GenesisHeader = {
       controllers: [controller],
       model: metadata.model.bytes,
+      sep: 'model', // See CIP-120 for more details on this field
     }
     if (!metadata.deterministic) {
       header.unique = randomBytes(12)

--- a/packages/stream-model-instance/src/model-instance-document.ts
+++ b/packages/stream-model-instance/src/model-instance-document.ts
@@ -106,10 +106,7 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
 
   get metadata(): ModelInstanceDocumentMetadata {
     const metadata = this.state$.value.metadata
-    return { 
-      controller: metadata.controllers[0],
-      model: metadata.model,
-    }
+    return { controller: metadata.controllers[0], model: metadata.model }
   }
 
   /**

--- a/packages/stream-model-instance/src/model-instance-document.ts
+++ b/packages/stream-model-instance/src/model-instance-document.ts
@@ -54,6 +54,12 @@ export interface ModelInstanceDocumentMetadata {
    * The StreamID of the Model that this ModelInstanceDocument belongs to.
    */
   model: StreamID
+
+  /**
+   * The separator key as specified in CIP-120.
+   * This is always 'model' for the model-instance-document stream type.
+   */
+  sep: string
 }
 
 const DEFAULT_CREATE_OPTS = {
@@ -106,7 +112,11 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
 
   get metadata(): ModelInstanceDocumentMetadata {
     const metadata = this.state$.value.metadata
-    return { controller: metadata.controllers[0], model: metadata.model }
+    return { 
+      controller: metadata.controllers[0],
+      model: metadata.model,
+      sep: 'model'
+    }
   }
 
   /**

--- a/packages/stream-model/src/model.ts
+++ b/packages/stream-model/src/model.ts
@@ -44,6 +44,11 @@ export interface ModelMetadata {
    * all Models.
    */
   model: StreamID
+  
+  /**
+   * The separator key as specified in CIP-120. This is always 'model' for the model stream type.
+   */
+  sep: string
 }
 
 const DEFAULT_LOAD_OPTS = { sync: SyncOptions.PREFER_CACHE }
@@ -160,7 +165,11 @@ export class Model extends Stream {
   }
 
   get metadata(): ModelMetadata {
-    return { controller: this.state$.value.metadata.controllers[0], model: Model.MODEL }
+    return {
+      controller: this.state$.value.metadata.controllers[0],
+      model: Model.MODEL,
+      sep: 'model'
+    }
   }
 
   /**

--- a/packages/stream-model/src/model.ts
+++ b/packages/stream-model/src/model.ts
@@ -44,11 +44,6 @@ export interface ModelMetadata {
    * all Models.
    */
   model: StreamID
-  
-  /**
-   * The separator key as specified in CIP-120. This is always 'model' for the model stream type.
-   */
-  sep: string
 }
 
 const DEFAULT_LOAD_OPTS = { sync: SyncOptions.PREFER_CACHE }
@@ -168,7 +163,6 @@ export class Model extends Stream {
     return {
       controller: this.state$.value.metadata.controllers[0],
       model: Model.MODEL,
-      sep: 'model'
     }
   }
 
@@ -328,6 +322,7 @@ export class Model extends Stream {
     const header: GenesisHeader = {
       controllers: [metadata.controller],
       model: Model.MODEL.bytes,
+      sep: 'model', // See CIP-120 for more details on this field
     }
     return { data: content, header }
   }

--- a/packages/stream-model/src/model.ts
+++ b/packages/stream-model/src/model.ts
@@ -160,10 +160,7 @@ export class Model extends Stream {
   }
 
   get metadata(): ModelMetadata {
-    return {
-      controller: this.state$.value.metadata.controllers[0],
-      model: Model.MODEL,
-    }
+    return { controller: this.state$.value.metadata.controllers[0], model: Model.MODEL }
   }
 
   /**

--- a/packages/stream-tests/src/__tests__/basic-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/basic-indexing.test.ts
@@ -47,7 +47,7 @@ const MODEL_DEFINITION: ModelDefinition = {
 
 // The model above will always result in this StreamID when created with the fixed did:key
 // controller used by the test.
-const MODEL_STREAM_ID = 'kjzl6hvfrbw6c9rpdsro0cldierurftxvlr0uzh5nt3yqsje7t4ykfcnnnkjxtq'
+const MODEL_STREAM_ID = 'kjzl6hvfrbw6c8fk5udeg9odlm3b2h01oytfy3rngol32g0g33ob0x5n19hi36u'
 
 // StreamID for a model that isn't indexed by the node
 const UNINDEXED_MODEL_STREAM_ID = StreamID.fromString(

--- a/packages/stream-tests/src/__tests__/model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/model-instance-document.test.ts
@@ -37,7 +37,7 @@ const MODEL_DEFINITION: ModelDefinition = {
 
 // The model above will always result in this StreamID when created with the fixed did:key
 // controller used by the test.
-const MODEL_STREAM_ID = 'kjzl6hvfrbw6c9rpdsro0cldierurftxvlr0uzh5nt3yqsje7t4ykfcnnnkjxtq'
+const MODEL_STREAM_ID = 'kjzl6hvfrbw6c8fk5udeg9odlm3b2h01oytfy3rngol32g0g33ob0x5n19hi36u'
 
 const MODEL_WITH_RELATION_DEFINITION: ModelDefinition = {
   name: 'MyModelWithARelation',

--- a/packages/stream-tests/src/__tests__/model.test.ts
+++ b/packages/stream-tests/src/__tests__/model.test.ts
@@ -16,7 +16,7 @@ const MODEL_DEFINITION: ModelDefinition = {
 
 // The model above will always result in this StreamID when created with the fixed did:key
 // controller used by the test.
-const MODEL_STREAM_ID = 'kjzl6hvfrbw6c62dn29qy8b6lot6m9xr98wz4hfq0htxfhpxgqo41ufqew22qe1'
+const MODEL_STREAM_ID = 'kjzl6hvfrbw6c8jpwg5a5y599ft77osvuv84qr9mgjaoqghhdxix4khueex13j8'
 
 const MODEL_DEFINITION_WITH_RELATION: ModelDefinition = {
   name: 'myModelWithARelation',


### PR DESCRIPTION
This PR adds the `sep` key to the genesis header as specified in CIP-120. While not used yet it will allow the future upgrade to support CIP-120 much less painful.

Note: This is a breaking change to deterministic MID documents.
