### PR TITLE
Wait for all relevant anchor status updates in the anchor resume test

### DIFF
--- a/packages/core/src/state-management/__tests__/anchor-resuming-service.test.ts
+++ b/packages/core/src/state-management/__tests__/anchor-resuming-service.test.ts
@@ -119,8 +119,10 @@ describe('resumeRunningStatesFromAnchorRequestStore(...) method', () => {
     )
 
     await TestUtils.waitForConditionOrTimeout(async () => {
-      return newRunnningStates$[0].state.anchorStatus === AnchorStatus.ANCHORED
-    }, 6000)
+      return newRunnningStates$.every((runningState$) => {
+        return runningState$.value.anchorStatus === AnchorStatus.ANCHORED
+      })
+    }, 10000)
 
     // We check that the newRunningStates$ loaded from newCeramic are correctly updated, which means
     // that the anchor service needs to be polled for anchor statuses


### PR DESCRIPTION
## Description

This test had been failing on CircleCi occasionally. I wasn't able to reproduce the failure locally, so I increased the timeout a bit and made the test wait for all anchor status updates before checking them. Let's see, if this make CircleCI stop failing.