### PR TITLE
Fixed the implementation of S3Store.exists(...)

### DIFF
--- a/packages/cli/src/s3-store.ts
+++ b/packages/cli/src/s3-store.ts
@@ -94,7 +94,8 @@ export class S3Store implements IKVStore {
   async exists(key: string, useCaseName?: string): Promise<boolean> {
     const store = await this.#storeMap.get(useCaseName)
     try {
-      return typeof (await store.get(key).toString()) === 'string'
+      const value = await store.get(key)
+      return value !== undefined
     } catch (e) {
       if (/Key not found in database/.test(e.toString())) {
         return false


### PR DESCRIPTION
## Description

There was a typo in the implementation of `S3Store.exists(...)` which caused crashes when checking, if a running state should be resumed for a `StreamID`.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [X] Tested manually with S3 and clay-testnet using a local node (after reproducing the error)

## PR checklist

Before submitting this PR, please make sure:

- [X] I have tagged the relevant reviewers and interested parties
