### PR TITLE
Throw specific error on missing DID so composedb can be helpful - #CDB-2133

### DIFF
--- a/packages/http-client/src/__tests__/remote-admin-api.test.ts
+++ b/packages/http-client/src/__tests__/remote-admin-api.test.ts
@@ -52,10 +52,43 @@ test('getIndexedModels()', async () => {
   expect(jwsResult.kid).toEqual(expectedKid)
 
   const failingAdminApi = new RemoteAdminApi(FAUX_ENDPOINT, noDidFn)
+  ;(failingAdminApi as any)._fetchJson = fauxFetch
   await expect(failingAdminApi.getIndexedModels())
    .rejects
    .toThrow(MissingDIDError)
  
+})
+
+test('startIndexingModels()', async () => {
+  const adminApi = new RemoteAdminApi(FAUX_ENDPOINT, getDidFn)
+  const fauxFetch = jest.fn(async () => GET_RESPONSE) as typeof fetchJson
+  ;(adminApi as any)._fetchJson = fauxFetch
+  await adminApi.startIndexingModels()
+
+  expect(fauxFetch.mock.calls[0][0]).toEqual(new URL(`https://example.com/admin/getCode`))
+  expect(fauxFetch.mock.calls[1][0]).toEqual(new URL(`https://example.com/admin/models`))
+
+  const failingAdminApi = new RemoteAdminApi(FAUX_ENDPOINT, noDidFn)
+  ;(failingAdminApi as any)._fetchJson = fauxFetch
+  await expect(failingAdminApi.startIndexingModels())
+   .rejects
+   .toThrow(MissingDIDError)
+})
+
+test('stopIndexingModels()', async () => {
+  const adminApi = new RemoteAdminApi(FAUX_ENDPOINT, getDidFn)
+  const fauxFetch = jest.fn(async () => GET_RESPONSE) as typeof fetchJson
+  ;(adminApi as any)._fetchJson = fauxFetch
+  await adminApi.stopIndexingModels()
+
+  expect(fauxFetch.mock.calls[0][0]).toEqual(new URL(`https://example.com/admin/getCode`))
+  expect(fauxFetch.mock.calls[1][0]).toEqual(new URL(`https://example.com/admin/models`))
+
+  const failingAdminApi = new RemoteAdminApi(FAUX_ENDPOINT, noDidFn)
+  ;(failingAdminApi as any)._fetchJson = fauxFetch
+  await expect(failingAdminApi.stopIndexingModels())
+   .rejects
+   .toThrow(MissingDIDError)
 })
 
 test('addModelsToIndex()', async () => {

--- a/packages/http-client/src/__tests__/remote-admin-api.test.ts
+++ b/packages/http-client/src/__tests__/remote-admin-api.test.ts
@@ -50,13 +50,6 @@ test('getIndexedModels()', async () => {
 
   const jwsResult = await did.verifyJWS(sentJws)
   expect(jwsResult.kid).toEqual(expectedKid)
-
-  const failingAdminApi = new RemoteAdminApi(FAUX_ENDPOINT, noDidFn)
-  ;(failingAdminApi as any)._fetchJson = fauxFetch
-  await expect(failingAdminApi.getIndexedModels())
-   .rejects
-   .toThrow(MissingDIDError)
- 
 })
 
 test('startIndexingModels()', async () => {

--- a/packages/http-client/src/__tests__/remote-admin-api.test.ts
+++ b/packages/http-client/src/__tests__/remote-admin-api.test.ts
@@ -67,12 +67,6 @@ test('startIndexingModels()', async () => {
 
   expect(fauxFetch.mock.calls[0][0]).toEqual(new URL(`https://example.com/admin/getCode`))
   expect(fauxFetch.mock.calls[1][0]).toEqual(new URL(`https://example.com/admin/models`))
-
-  const failingAdminApi = new RemoteAdminApi(FAUX_ENDPOINT, noDidFn)
-  ;(failingAdminApi as any)._fetchJson = fauxFetch
-  await expect(failingAdminApi.startIndexingModels())
-   .rejects
-   .toThrow(MissingDIDError)
 })
 
 test('stopIndexingModels()', async () => {
@@ -83,10 +77,23 @@ test('stopIndexingModels()', async () => {
 
   expect(fauxFetch.mock.calls[0][0]).toEqual(new URL(`https://example.com/admin/getCode`))
   expect(fauxFetch.mock.calls[1][0]).toEqual(new URL(`https://example.com/admin/models`))
+})
+
+test('missingDidFailureCases', async () => {
+  const fauxFetch = jest.fn(async () => GET_RESPONSE) as typeof fetchJson
 
   const failingAdminApi = new RemoteAdminApi(FAUX_ENDPOINT, noDidFn)
   ;(failingAdminApi as any)._fetchJson = fauxFetch
+
+  await expect(failingAdminApi.getIndexedModels())
+   .rejects
+   .toThrow(MissingDIDError)
+ 
   await expect(failingAdminApi.stopIndexingModels())
+   .rejects
+   .toThrow(MissingDIDError)
+
+  await expect(failingAdminApi.startIndexingModels())
    .rejects
    .toThrow(MissingDIDError)
 })

--- a/packages/http-client/src/remote-admin-api.ts
+++ b/packages/http-client/src/remote-admin-api.ts
@@ -32,6 +32,7 @@ export class RemoteAdminApi implements AdminApi {
     code: string,
     modelsIDs?: Array<StreamID>
   ): Promise<string> {
+    if (!actingDid) throw new MissingDIDError()
     const body = modelsIDs
       ? { models: modelsIDs.map((streamID) => streamID.toString()) }
       : undefined
@@ -49,20 +50,16 @@ export class RemoteAdminApi implements AdminApi {
 
   async startIndexingModels(modelsIDs: Array<StreamID>): Promise<void> {
     const code = await this.generateCode()
-    const did = this._getDidFn()
-    if (!did) throw new MissingDIDError()
     await this._fetchJson(this.getModelsUrl(), {
       method: 'post',
-      body: { jws: await this.buildJWS(did, code, modelsIDs) },
+      body: { jws: await this.buildJWS(this._getDidFn(), code, modelsIDs) },
     })
   }
 
   async getIndexedModels(): Promise<Array<StreamID>> {
     const code = await this.generateCode()
-    const did = this._getDidFn()
-    if (!did) throw new MissingDIDError()
     const response = await this._fetchJson(this.getModelsUrl(), {
-      headers: { Authorization: `Basic ${await this.buildJWS(did, code)}` },
+      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code)}` },
     })
     return response.models.map((modelStreamIDString: string) => {
       return StreamID.fromString(modelStreamIDString)
@@ -71,11 +68,9 @@ export class RemoteAdminApi implements AdminApi {
 
   async stopIndexingModels(modelsIDs: Array<StreamID>): Promise<void> {
     const code = await this.generateCode()
-    const did = this._getDidFn()
-    if (!did) throw new MissingDIDError()
     await this._fetchJson(this.getModelsUrl(), {
       method: 'delete',
-      body: { jws: await this.buildJWS(did, code, modelsIDs) },
+      body: { jws: await this.buildJWS(this._getDidFn(), code, modelsIDs) },
     })
   }
 }

--- a/packages/http-client/src/remote-admin-api.ts
+++ b/packages/http-client/src/remote-admin-api.ts
@@ -4,7 +4,7 @@ import { DID } from 'dids'
 
 export class MissingDIDError extends Error {
   constructor() {
-    super('Failed to get DID')
+    super('Failed to get DID.  Please make sure your Ceramic client has an authenticated DID attached')
   }
 }
 

--- a/packages/http-client/src/remote-admin-api.ts
+++ b/packages/http-client/src/remote-admin-api.ts
@@ -43,9 +43,11 @@ export class RemoteAdminApi implements AdminApi {
 
   async startIndexingModels(modelsIDs: Array<StreamID>): Promise<void> {
     const code = await this.generateCode()
+    const did = this._getDidFn()
+    if (!did) throw new Error('Failed to get DID')
     await this._fetchJson(this.getModelsUrl(), {
       method: 'post',
-      body: { jws: await this.buildJWS(this._getDidFn(), code, modelsIDs) },
+      body: { jws: await this.buildJWS(did, code, modelsIDs) },
     })
   }
 

--- a/packages/http-client/src/remote-admin-api.ts
+++ b/packages/http-client/src/remote-admin-api.ts
@@ -2,6 +2,12 @@ import { AdminApi, fetchJson } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { DID } from 'dids'
 
+export class MissingDIDError extends Error {
+  constructor() {
+    super('Failed to get DID')
+  }
+}
+
 /**
  * AdminApi for Ceramic http client.
  */
@@ -44,7 +50,7 @@ export class RemoteAdminApi implements AdminApi {
   async startIndexingModels(modelsIDs: Array<StreamID>): Promise<void> {
     const code = await this.generateCode()
     const did = this._getDidFn()
-    if (!did) throw new Error('Failed to get DID')
+    if (!did) throw new MissingDIDError()
     await this._fetchJson(this.getModelsUrl(), {
       method: 'post',
       body: { jws: await this.buildJWS(did, code, modelsIDs) },

--- a/packages/http-client/src/remote-admin-api.ts
+++ b/packages/http-client/src/remote-admin-api.ts
@@ -59,8 +59,10 @@ export class RemoteAdminApi implements AdminApi {
 
   async getIndexedModels(): Promise<Array<StreamID>> {
     const code = await this.generateCode()
+    const did = this._getDidFn()
+    if (!did) throw new MissingDIDError()
     const response = await this._fetchJson(this.getModelsUrl(), {
-      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code)}` },
+      headers: { Authorization: `Basic ${await this.buildJWS(did, code)}` },
     })
     return response.models.map((modelStreamIDString: string) => {
       return StreamID.fromString(modelStreamIDString)
@@ -69,9 +71,11 @@ export class RemoteAdminApi implements AdminApi {
 
   async stopIndexingModels(modelsIDs: Array<StreamID>): Promise<void> {
     const code = await this.generateCode()
+    const did = this._getDidFn()
+    if (!did) throw new MissingDIDError()
     await this._fetchJson(this.getModelsUrl(), {
       method: 'delete',
-      body: { jws: await this.buildJWS(this._getDidFn(), code, modelsIDs) },
+      body: { jws: await this.buildJWS(did, code, modelsIDs) },
     })
   }
 }


### PR DESCRIPTION
## Description

See #CDB-2133 - several developers have run into this confusing message if they do not set DID_PRIVATE_KEY.  In order to allow composedb to return a helpful message, have the admin api return a specific error class.

```right now running composedb composite:deploy errors with Cannot read properties of undefined (reading 'createJWS') if DID_PRIVATE_KEY is undefined.  We should have a more useful error message instead.```

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ x] added unit tests to cover the new code
- [x ] made local changes and verified with composedb that the desired behavior occurs

## PR checklist

Before submitting this PR, please make sure:

- [ x] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.

See https://forum.ceramic.network/t/error-cannot-read-properties-of-undefined-reading-createjws/616  for user report - can answer there when this is deployed
