### PR TITLE
feat(common): add tezos cacao (did-session) support

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -45,8 +45,9 @@
   "dependencies": {
     "@ceramicnetwork/streamid": "^2.9.0",
     "@didtools/cacao": "^1.0.0",
-    "@didtools/pkh-ethereum": "^0.0.1",
-    "@didtools/pkh-solana": "^0.0.1",
+    "@didtools/pkh-ethereum": "^0.0.3",
+    "@didtools/pkh-solana": "^0.0.4",
+    "@didtools/pkh-tezos": "^0.0.2",
     "@stablelib/random": "^1.0.1",
     "caip": "~1.1.0",
     "cross-fetch": "^3.1.4",

--- a/packages/common/src/utils/signature_utils.ts
+++ b/packages/common/src/utils/signature_utils.ts
@@ -4,6 +4,7 @@ import type { CommitData } from '../index.js'
 import type { StreamID } from '@ceramicnetwork/streamid'
 import { getEIP191Verifier } from '@didtools/pkh-ethereum'
 import { getSolanaVerifier } from '@didtools/pkh-solana'
+import { getTezosVerifier }  from '@didtools/pkh-tezos'
 
 const DEFAULT_CACAO_REVOCATION_PHASE_OUT = 24 * 60 * 60
 
@@ -11,7 +12,8 @@ const DEFAULT_CACAO_REVOCATION_PHASE_OUT = 24 * 60 * 60
 // Register supported CACAO Verifiers
 const verifiersCACAO = {
   ...getEIP191Verifier(),
-  ...getSolanaVerifier()
+  ...getSolanaVerifier(),
+  ...getTezosVerifier()
 }
 
 /**


### PR DESCRIPTION
Adds tezos verifier from - https://github.com/ceramicnetwork/js-did/tree/main/packages/pkh-tezos

Allows support for tezos cacao/did-session 