### PR TITLE
fix(cli): Export S3Store type

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,4 @@
 export * from './ceramic-cli-utils.js'
 export * from './ceramic-daemon.js'
 export * from './daemon-config.js'
+export * from './s3-store.js'


### PR DESCRIPTION
This is critical to fix the integration tests, as they cannot run the newest version of Ceramic currently, as they cannot build Ceramic with the S3 state store as the S3 store implementation moved and stopped being exported in https://github.com/ceramicnetwork/js-ceramic/commit/2754643e7503a9f5103cc5af14d1614a3ee07245#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834c