### PR TITLE
feat(core): Add SyncOption to resync stream on error

### DIFF
--- a/packages/common/src/streamopts.ts
+++ b/packages/common/src/streamopts.ts
@@ -15,14 +15,16 @@ export interface PinningOpts {
  */
 export enum SyncOptions {
   /**
-   *  If the stream is found in the node's in-memory cache or pin store, then return the cached version
-   *  without performing any query to the pubsub network for the current tip.
+   *  If the stream is found in the node's in-memory cache or state store, then return the cached
+   *  version without performing any query to the pubsub network for the current tip.
    */
   PREFER_CACHE,
 
   /**
    *  Always query pubsub for the current tip for the stream and wait up to 'syncTimeoutSeconds'
-   *   for the response, regardless of whether or not the stream is found in the node's cache
+   *   for the response, regardless of whether or not the stream is found in the node's cache.
+   *   Note that this can result in lost writes as commits that cannot be successfully applied are
+   *   discarded.
    */
   SYNC_ALWAYS,
 
@@ -31,6 +33,13 @@ export enum SyncOptions {
    * is not in cache or the pin store, then only the genesis commit for the stream will be returned
    */
   NEVER_SYNC,
+
+  /**
+   * If there's an error with the state in the cache or state store, then automatically trigger
+   * a full resync of the stream to restore it to a valid state (may result in lost writes as
+   * commits that cannot be successfully applied are discarded).
+   */
+  SYNC_ON_ERROR,
 }
 
 /**

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -737,13 +737,29 @@ export class Ceramic implements CeramicApi {
       const snapshot$ = await this.repository.loadAtTime(streamRef, opts)
       return streamFromState<T>(this.context, this._streamHandlers, snapshot$.value)
     } else {
-      const base$ = await this.repository.load(streamRef.baseID, opts)
-      return streamFromState<T>(
-        this.context,
-        this._streamHandlers,
-        base$.value,
-        this.repository.updates$
-      )
+      try {
+        const base$ = await this.repository.load(streamRef.baseID, opts)
+        return streamFromState<T>(
+          this.context,
+          this._streamHandlers,
+          base$.value,
+          this.repository.updates$
+        )
+      } catch (err) {
+        if (opts.sync != SyncOptions.SYNC_ON_ERROR) {
+          throw err
+        }
+
+        // Retry with a full resync
+        opts.sync = SyncOptions.SYNC_ALWAYS
+        const base$ = await this.repository.load(streamRef.baseID, opts)
+        return streamFromState<T>(
+          this.context,
+          this._streamHandlers,
+          base$.value,
+          this.repository.updates$
+        )
+      }
     }
   }
 

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -215,7 +215,8 @@ export class Repository {
 
     const [state$, synced] = await this.loadingQ.forStream(streamId).run(async () => {
       switch (opts.sync) {
-        case SyncOptions.PREFER_CACHE: {
+        case SyncOptions.PREFER_CACHE:
+        case SyncOptions.SYNC_ON_ERROR: {
           const [streamState$, alreadySynced] = await this._loadGenesis(streamId)
           if (alreadySynced) {
             return [streamState$, alreadySynced]

--- a/packages/stream-tests/src/__tests__/capability.test.ts
+++ b/packages/stream-tests/src/__tests__/capability.test.ts
@@ -577,7 +577,7 @@ describe('CACAO Integration test', () => {
       const opts = { asDID: didKeyWithCapability, anchor: false, publish: false }
       const tile = await TileDocument.deterministic(
         ceramic,
-        { controllers: [`did:pkh:eip155:1:${wallet.address}`], family: 'loving-one' },
+        { controllers: [`did:pkh:eip155:1:${wallet.address}`], family: 'loving-two' },
         opts
       )
       await tile.update({ a: 2 }, null, { ...opts, anchor: true })

--- a/packages/stream-tests/src/__tests__/capability.test.ts
+++ b/packages/stream-tests/src/__tests__/capability.test.ts
@@ -553,19 +553,49 @@ describe('CACAO Integration test', () => {
         { controllers: [`did:pkh:eip155:1:${wallet.address}`], family: 'loving-one' },
         opts
       )
-      await tile.update({ a: 2 }, null, opts)
+      await tile.update({ a: 2 }, null, { ...opts, anchor: true })
+      await TestUtils.anchorUpdate(ceramic, tile)
       await tile.update({ a: 3 }, null, opts)
 
       // 1. While CACAO is valid: Loading is ok
       const loaded0 = await TileDocument.load(ceramic, tile.id, { sync: SyncOptions.SYNC_ALWAYS })
       const loaded1 = await TileDocument.load(ceramic, tile.id)
+      expect(tile.content['a']).toEqual(3)
       expect(loaded0.state).toEqual(tile.state)
       expect(loaded1.state).toEqual(tile.state)
       // 2. It is expired: Rewrite the state!
       expireCacao()
       await expect(TileDocument.load(ceramic, tile.id)).rejects.toThrow(/CACAO expired/) // No sync options
       const loaded3 = await TileDocument.load(ceramic, tile.id, { sync: SyncOptions.SYNC_ALWAYS })
-      expect(loaded3.state.log).toEqual(tile.state.log.slice(0, 1))
+      expect(loaded3.content['a']).toEqual(2)
+      expect(loaded3.state.log).toEqual(tile.state.log.slice(0, 3))
+      const loaded4 = await TileDocument.load(ceramic, tile.id) // Has the state been rewritten?
+      expect(loaded4.state.log).toEqual(loaded3.state.log) // Rewritten!
+    }, 30000)
+
+    test('overwrite expired capability when using RESYNC_ON_ERROR', async () => {
+      const opts = { asDID: didKeyWithCapability, anchor: false, publish: false }
+      const tile = await TileDocument.deterministic(
+        ceramic,
+        { controllers: [`did:pkh:eip155:1:${wallet.address}`], family: 'loving-one' },
+        opts
+      )
+      await tile.update({ a: 2 }, null, { ...opts, anchor: true })
+      await TestUtils.anchorUpdate(ceramic, tile)
+      await tile.update({ a: 3 }, null, opts)
+
+      // 1. While CACAO is valid: Loading is ok
+      const loaded0 = await TileDocument.load(ceramic, tile.id, { sync: SyncOptions.SYNC_ALWAYS })
+      const loaded1 = await TileDocument.load(ceramic, tile.id)
+      expect(tile.content['a']).toEqual(3)
+      expect(loaded0.state).toEqual(tile.state)
+      expect(loaded1.state).toEqual(tile.state)
+      // 2. It is expired: Rewrite the state!
+      expireCacao()
+      await expect(TileDocument.load(ceramic, tile.id)).rejects.toThrow(/CACAO expired/) // No sync options
+      const loaded3 = await TileDocument.load(ceramic, tile.id, { sync: SyncOptions.SYNC_ON_ERROR })
+      expect(loaded3.content['a']).toEqual(2)
+      expect(loaded3.state.log).toEqual(tile.state.log.slice(0, 3))
       const loaded4 = await TileDocument.load(ceramic, tile.id) // Has the state been rewritten?
       expect(loaded4.state.log).toEqual(loaded3.state.log) // Rewritten!
     }, 30000)


### PR DESCRIPTION
This may be useful for apps that are encountering CACAO errors and want those CACAO errors to be handled by resetting the stream state back to the last valid commit (even at the cost of throwing away writes), but don't want to have to manually catch CACAO errors and trigger a reload with the SYNC_ALWAYS flag.  If they use this new flag for all their stream loads instead, then for healthy streams there will be no extra overhead, but when there's an error loading the stream we will get the behavior of resyncing the full stream log to try to repair it.

This would also be useful to use on our CAS, as our CAS Ceramic node now has streams in its state store that have expired CACAOs and so those streams will never be able to be successfully anchored again until the state in the CAS Ceramic node is reset.  Using this flag on all stream loads in the CAS let us recover those streams and enable them to be anchored again.