### PR TITLE
feat(core) CDB-1952: Warn if no pubsub messages

### DIFF
--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -32,7 +32,7 @@ const IPFS_GET_RETRIES = 3
 const DEFAULT_IPFS_GET_TIMEOUT = 30000 // 30 seconds per retry, 3 retries = 90 seconds total timeout
 const IPFS_MAX_COMMIT_SIZE = 256000 // 256 KB
 const IPFS_RESUBSCRIBE_INTERVAL_DELAY = 1000 * 15 // 15 sec
-const IPFS_NO_MESSAGE_INTERVAL = 1000 * 60 * 5 // 5 minutes
+const IPFS_NO_MESSAGE_INTERVAL = 1000 * 60 * 1 // 1 minutes
 const MAX_PUBSUB_PUBLISH_INTERVAL = 60 * 1000 // one minute
 const MAX_INTERVAL_WITHOUT_KEEPALIVE = 24 * 60 * 60 * 1000 // one day
 const IPFS_CACHE_SIZE = 1024 // maximum cache size of 256MB

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -32,6 +32,7 @@ const IPFS_GET_RETRIES = 3
 const DEFAULT_IPFS_GET_TIMEOUT = 30000 // 30 seconds per retry, 3 retries = 90 seconds total timeout
 const IPFS_MAX_COMMIT_SIZE = 256000 // 256 KB
 const IPFS_RESUBSCRIBE_INTERVAL_DELAY = 1000 * 15 // 15 sec
+const IPFS_NO_MESSAGE_INTERVAL = 1000 * 60 * 5 // 5 minutes
 const MAX_PUBSUB_PUBLISH_INTERVAL = 60 * 1000 // one minute
 const MAX_INTERVAL_WITHOUT_KEEPALIVE = 24 * 60 * 60 * 1000 // one day
 const IPFS_CACHE_SIZE = 1024 // maximum cache size of 256MB
@@ -100,6 +101,7 @@ export class Dispatcher {
       _ipfs,
       topic,
       IPFS_RESUBSCRIBE_INTERVAL_DELAY,
+      IPFS_NO_MESSAGE_INTERVAL,
       _pubsubLogger,
       _logger,
       tasks

--- a/packages/core/src/pubsub/__tests__/incoming-channel.test.ts
+++ b/packages/core/src/pubsub/__tests__/incoming-channel.test.ts
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals'
 import { IpfsApi, LoggerProvider, TestUtils } from '@ceramicnetwork/common'
 import { from, firstValueFrom, lastValueFrom } from 'rxjs'
+import { delay } from 'rxjs/operators'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
 import { IncomingChannel, filterExternal, PubsubIncoming } from '../incoming-channel.js'
@@ -30,7 +31,7 @@ describe('connection', () => {
   })
 
   test('subscribe and unsubscribe', async () => {
-    const incoming$ = new IncomingChannel(ipfs, TOPIC, 30000, pubsubLogger, diagnosticsLogger)
+    const incoming$ = new IncomingChannel(ipfs, TOPIC, 30000, 1, pubsubLogger, diagnosticsLogger)
     const subscribeSpy = jest.spyOn(ipfs.pubsub, 'subscribe')
     const unsubscribeSpy = jest.spyOn(ipfs.pubsub, 'unsubscribe')
     const subscription = incoming$.subscribe()
@@ -50,6 +51,7 @@ describe('connection', () => {
       ipfs,
       TOPIC,
       resubscribePeriod,
+      1,
       pubsubLogger,
       diagnosticsLogger
     )
@@ -88,13 +90,45 @@ test('pass incoming message', async () => {
     },
     id: async () => ({ id: PEER_ID }),
   } as unknown as IpfsApi
-  const incoming$ = new IncomingChannel(ipfs, TOPIC, 30000, pubsubLogger, diagnosticsLogger)
+  const incoming$ = new IncomingChannel(ipfs, TOPIC, 30000, 1, pubsubLogger, diagnosticsLogger)
   const result: any[] = []
   const subscription = incoming$.subscribe((message) => {
     result.push(message)
   })
   await TestUtils.delay(200) // Wait till rxjs machinery is done
   expect(result).toEqual(messages)
+  subscription.unsubscribe()
+})
+
+test('warn if no messages come from ipfs in a timely manner', async () => {
+  let sawLog = false
+  jest.spyOn(diagnosticsLogger, 'log')
+    .mockImplementation((_, content) => {
+      if(content.toString().includes("please check your IPFS configuration.")) {
+        sawLog = true
+      }
+    })
+  const feed$ = from([]).pipe(
+    delay(2000)
+  )
+  const ipfs = {
+    pubsub: {
+      subscribe: async (_, handler) => {
+        feed$.subscribe(handler)
+      },
+      unsubscribe: jest.fn(),
+      ls: jest.fn(() => []),
+    },
+    id: async () => ({ id: PEER_ID }),
+  } as unknown as IpfsApi
+  const incoming$ = new IncomingChannel(ipfs, TOPIC, 30000, 1, pubsubLogger, diagnosticsLogger)
+  const result: any[] = []
+  const subscription = incoming$.subscribe((message) => {
+    result.push(message)
+  })
+  await TestUtils.delay(2500) // Wait till rxjs machinery is done
+  expect(sawLog).toBeTruthy()
+  expect(result.length).toEqual(0)
   subscription.unsubscribe()
 })
 
@@ -159,6 +193,32 @@ describe('PubsubIncoming', () => {
     const incoming$ = new PubsubIncoming(
       fauxIpfs as unknown as IpfsApi,
       TOPIC,
+      pubsubLogger,
+      diagnosticsLogger,
+      new TaskQueue()
+    )
+    const subscription = incoming$.subscribe()
+    await TestUtils.delay(200) // Wait till rxjs machinery is done
+    expect(fauxIpfs.pubsub.subscribe).toBeCalledTimes(1)
+    expect(fauxIpfs.pubsub.unsubscribe).toBeCalledTimes(0)
+    subscription.unsubscribe()
+    await TestUtils.delay(200) // Wait till rxjs machinery is done
+    expect(fauxIpfs.pubsub.subscribe).toBeCalledTimes(1)
+    expect(fauxIpfs.pubsub.unsubscribe).toBeCalledTimes(1)
+  })
+
+  test('log if messages are not timely', async () => {
+    const fauxIpfs = {
+      id: jest.fn(async () => ({ id: 'peer-id' })),
+      pubsub: {
+        subscribe: jest.fn(async () => void {}),
+        unsubscribe: jest.fn(async () => void {}),
+      },
+    }
+    const incoming$ = new PubsubIncoming(
+      fauxIpfs as unknown as IpfsApi,
+      TOPIC,
+      1,
       pubsubLogger,
       diagnosticsLogger,
       new TaskQueue()

--- a/packages/core/src/pubsub/__tests__/pubsub-keepalive.test.ts
+++ b/packages/core/src/pubsub/__tests__/pubsub-keepalive.test.ts
@@ -11,6 +11,7 @@ const pubsubLogger = loggerProvider.makeServiceLogger('pubsub')
 const diagnosticsLogger = loggerProvider.getDiagnosticsLogger()
 
 const PEER_ID = 'PEER_ID'
+const LATE_MESSAGE_AFTER = 1000
 
 describe('pubsub keepalive', () => {
   test('sends keepalive if no messages over a period of time', async () => {
@@ -27,6 +28,7 @@ describe('pubsub keepalive', () => {
       ipfs as unknown as IpfsApi,
       TOPIC,
       3000,
+      LATE_MESSAGE_AFTER,
       pubsubLogger,
       diagnosticsLogger
     )
@@ -63,6 +65,7 @@ describe('pubsub keepalive', () => {
       ipfs as unknown as IpfsApi,
       TOPIC,
       3000,
+      LATE_MESSAGE_AFTER,
       pubsubLogger,
       diagnosticsLogger
     )
@@ -100,6 +103,7 @@ describe('pubsub keepalive', () => {
       ipfs as unknown as IpfsApi,
       TOPIC,
       3000,
+      LATE_MESSAGE_AFTER,
       pubsubLogger,
       diagnosticsLogger
     )

--- a/packages/core/src/pubsub/__tests__/pubsub-ratelimit.test.ts
+++ b/packages/core/src/pubsub/__tests__/pubsub-ratelimit.test.ts
@@ -20,6 +20,7 @@ const PEER_ID = 'PEER_ID'
 const QUERIES_PER_SECOND = 5
 const MAX_QUEUED_QUERIES = QUERIES_PER_SECOND * 10
 const ONE_SECOND = 1000 // in ms
+const LATE_MESSAGE_AFTER = 1000
 
 function randomQueryMessage(): QueryMessage {
   return {
@@ -63,7 +64,7 @@ describe('pubsub with queries rate limited', () => {
       },
       id: jest.fn(async () => ({ id: PEER_ID })),
     } as unknown as IpfsApi
-    vanillaPubsub = new Pubsub(ipfs, TOPIC, 3000, pubsubLogger, diagnosticsLogger)
+    vanillaPubsub = new Pubsub(ipfs, TOPIC, 3000, LATE_MESSAGE_AFTER, pubsubLogger, diagnosticsLogger)
     pubsub = new PubsubRateLimit(
       vanillaPubsub,
       new LoggerProvider().getDiagnosticsLogger(),

--- a/packages/core/src/pubsub/__tests__/pubsub.test.ts
+++ b/packages/core/src/pubsub/__tests__/pubsub.test.ts
@@ -8,7 +8,7 @@ import { bufferCount, concatMap, delay, map } from 'rxjs/operators'
 import * as random from '@stablelib/random'
 import { asIpfsMessage } from './as-ipfs-message.js'
 import { from, first, firstValueFrom } from 'rxjs'
-import {IPFSPubsubMessage} from "../incoming-channel";
+import {IPFSPubsubMessage} from "../incoming-channel.js";
 
 const TOPIC = 'test'
 const loggerProvider = new LoggerProvider()

--- a/packages/core/src/pubsub/__tests__/pubsub.test.ts
+++ b/packages/core/src/pubsub/__tests__/pubsub.test.ts
@@ -37,6 +37,7 @@ const OUTER_GARBAGE = Array.from({ length: LENGTH }).map(() => {
     seqno: random.randomBytes(10),
   }
 })
+const LATE_MESSAGE_AFTER = 1000
 
 test('pass incoming messages, omit garbage', async () => {
   const feed$ = from(OUTER_GARBAGE.concat(OUTER_MESSAGES))
@@ -50,7 +51,7 @@ test('pass incoming messages, omit garbage', async () => {
     },
     id: jest.fn(async () => ({ id: PEER_ID })),
   }
-  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, 1, pubsubLogger, diagnosticsLogger)
+  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, LATE_MESSAGE_AFTER, pubsubLogger, diagnosticsLogger)
   // Even if garbage is first, we only receive well-formed messages
   const received = firstValueFrom(pubsub.pipe(bufferCount(LENGTH)))
   expect(await received).toEqual(MESSAGES)
@@ -67,7 +68,7 @@ test('publish', async () => {
     },
     id: jest.fn(async () => ({ id: PEER_ID })),
   }
-  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, 1, pubsubLogger, diagnosticsLogger)
+  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, LATE_MESSAGE_AFTER, pubsubLogger, diagnosticsLogger)
   const message = {
     typ: MsgType.QUERY as MsgType.QUERY,
     id: random.randomString(32),
@@ -113,7 +114,7 @@ test('warn if no messages', async () => {
     },
     id: jest.fn(async () => ({ id: PEER_ID })),
   }
-  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, 1, pubsubLogger, diagnosticsLogger)
+  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, LATE_MESSAGE_AFTER, pubsubLogger, diagnosticsLogger)
   const result: any[] = []
   const subscription = pubsub.subscribe((message) => {
     result.push(message)
@@ -152,7 +153,7 @@ test('warn if no internal messages', async () => {
     },
     id: jest.fn(async () => ({ id: PEER_ID })),
   }
-  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, 1, pubsubLogger, diagnosticsLogger)
+  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, LATE_MESSAGE_AFTER, pubsubLogger, diagnosticsLogger)
   const result: any[] = []
   const subscription = pubsub.subscribe((message) => {
     result.push(message)
@@ -214,7 +215,7 @@ test('continue even if a timeout occurs', async () => {
     },
     id: jest.fn(async () => ({ id: PEER_ID })),
   }
-  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, 1, pubsubLogger, diagnosticsLogger)
+  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, LATE_MESSAGE_AFTER, pubsubLogger, diagnosticsLogger)
   const result: any[] = []
   const subscription = pubsub.subscribe((message) => {
     result.push(message)

--- a/packages/core/src/pubsub/__tests__/pubsub.test.ts
+++ b/packages/core/src/pubsub/__tests__/pubsub.test.ts
@@ -23,7 +23,7 @@ const PEER_ID = 'PEER_ID'
 const LENGTH = 2
 const MESSAGES = Array.from({ length: LENGTH }).map((_, index) => {
   return {
-    typ: <MsgType.QUERY>MsgType.QUERY,
+    typ: MsgType.QUERY as MsgType.QUERY,
     id: index.toString(),
     stream: FAKE_STREAM_ID,
   }
@@ -81,6 +81,12 @@ test('publish', async () => {
   expect(ipfs.id).toBeCalledTimes(1)
 })
 
+function checkLog(func: (string) => void) {
+  jest.spyOn(diagnosticsLogger, 'log')
+    .mockImplementation((_, content) => {
+      func(content.toString())
+    })
+}
 test('warn if no messages', async () => {
   const messages = [
     asIpfsMessage({
@@ -91,12 +97,11 @@ test('warn if no messages', async () => {
   ]
   const feed = from(messages)
   let sawLog = false
-  const loggerSpy = jest.spyOn(diagnosticsLogger, 'log')
-    .mockImplementation((_, content) => {
-      if(content.toString().includes("please check your IPFS configuration.")) {
-        sawLog = true
-      }
-    })
+  checkLog((s) => {
+    if(s.includes("please check your IPFS configuration.")) {
+      sawLog = true
+    }
+  })
   const ipfs = {
     pubsub: {
       subscribe: async (_, handler) => {
@@ -131,12 +136,11 @@ test('warn if no internal messages', async () => {
   ]
   const feed = from(messages)
   let sawLog = false
-  jest.spyOn(diagnosticsLogger, 'log')
-    .mockImplementation((_, content) => {
-      if(content.toString().includes("please check your IPFS configuration.")) {
-        sawLog = true
-      }
-    })
+  checkLog((s) => {
+    if(s.includes("please check your IPFS configuration.")) {
+      sawLog = true
+    }
+  })
   const ipfs = {
     pubsub: {
       subscribe: async (_, handler) => {
@@ -194,12 +198,11 @@ test('continue even if a timeout occurs', async () => {
     })
   )
   let sawLog = false
-  const loggerSpy = jest.spyOn(diagnosticsLogger, 'log')
-    .mockImplementation((_, content) => {
-      if(content.toString().includes("please check your IPFS configuration.")) {
-        sawLog = true
-      }
-    })
+  checkLog((s) => {
+    if(s.includes("please check your IPFS configuration.")) {
+      sawLog = true
+    }
+  })
   const ipfs = {
     pubsub: {
       subscribe: async (_, handler) => {

--- a/packages/core/src/pubsub/__tests__/pubsub.test.ts
+++ b/packages/core/src/pubsub/__tests__/pubsub.test.ts
@@ -1,12 +1,14 @@
-import { jest } from '@jest/globals'
-import { IpfsApi, LoggerProvider } from '@ceramicnetwork/common';
+import { jest, test, expect } from '@jest/globals'
+import {IpfsApi, LoggerProvider, TestUtils} from '@ceramicnetwork/common';
 import { Pubsub } from '../pubsub.js'
 import { MsgType, serialize } from '../pubsub-message.js'
 import { StreamID } from '@ceramicnetwork/streamid'
-import { bufferCount } from 'rxjs/operators'
+import { of } from 'rxjs'
+import { bufferCount, concatMap, delay, map } from 'rxjs/operators'
 import * as random from '@stablelib/random'
 import { asIpfsMessage } from './as-ipfs-message.js'
-import { from, firstValueFrom } from 'rxjs'
+import { from, first, firstValueFrom } from 'rxjs'
+import {IPFSPubsubMessage} from "../incoming-channel";
 
 const TOPIC = 'test'
 const loggerProvider = new LoggerProvider()
@@ -21,7 +23,7 @@ const PEER_ID = 'PEER_ID'
 const LENGTH = 2
 const MESSAGES = Array.from({ length: LENGTH }).map((_, index) => {
   return {
-    typ: MsgType.QUERY as MsgType.QUERY,
+    typ: <MsgType.QUERY>MsgType.QUERY,
     id: index.toString(),
     stream: FAKE_STREAM_ID,
   }
@@ -48,7 +50,7 @@ test('pass incoming messages, omit garbage', async () => {
     },
     id: jest.fn(async () => ({ id: PEER_ID })),
   }
-  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, pubsubLogger, diagnosticsLogger)
+  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, 1, pubsubLogger, diagnosticsLogger)
   // Even if garbage is first, we only receive well-formed messages
   const received = firstValueFrom(pubsub.pipe(bufferCount(LENGTH)))
   expect(await received).toEqual(MESSAGES)
@@ -65,7 +67,7 @@ test('publish', async () => {
     },
     id: jest.fn(async () => ({ id: PEER_ID })),
   }
-  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, pubsubLogger, diagnosticsLogger)
+  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, 1, pubsubLogger, diagnosticsLogger)
   const message = {
     typ: MsgType.QUERY as MsgType.QUERY,
     id: random.randomString(32),
@@ -77,4 +79,146 @@ test('publish', async () => {
     expect(ipfs.pubsub.publish).toBeCalledWith(TOPIC, serialize(message))
   })
   expect(ipfs.id).toBeCalledTimes(1)
+})
+
+test('warn if no messages', async () => {
+  const messages = [
+    asIpfsMessage({
+      typ: MsgType.QUERY,
+      id: "1",
+      stream: FAKE_STREAM_ID,
+    })
+  ]
+  const feed = from(messages)
+  let sawLog = false
+  const loggerSpy = jest.spyOn(diagnosticsLogger, 'log')
+    .mockImplementation((_, content) => {
+      if(content.toString().includes("please check your IPFS configuration.")) {
+        sawLog = true
+      }
+    })
+  const ipfs = {
+    pubsub: {
+      subscribe: async (_, handler) => {
+        feed.subscribe(handler)
+      },
+      unsubscribe: jest.fn(),
+      ls: jest.fn(() => []),
+      publish: jest.fn(),
+    },
+    id: jest.fn(async () => ({ id: PEER_ID })),
+  }
+  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, 1, pubsubLogger, diagnosticsLogger)
+  const result: any[] = []
+  const subscription = pubsub.subscribe((message) => {
+    result.push(message)
+  })
+  await TestUtils.delay(2000)
+  expect(sawLog).toBeTruthy()
+  expect(result.length).toEqual(messages.length)
+  subscription.unsubscribe()
+})
+
+test('warn if no internal messages', async () => {
+  const messages = [
+    asIpfsMessage({
+      typ: MsgType.QUERY,
+      id: "1",
+      stream: StreamID.fromString(
+        'kjzl6cwe1jw147dvq16zluojmraqvwdmbh61dx9e0c59i344lcrsgqfohexp60t'
+      ),
+    })
+  ]
+  const feed = from(messages)
+  let sawLog = false
+  jest.spyOn(diagnosticsLogger, 'log')
+    .mockImplementation((_, content) => {
+      if(content.toString().includes("please check your IPFS configuration.")) {
+        sawLog = true
+      }
+    })
+  const ipfs = {
+    pubsub: {
+      subscribe: async (_, handler) => {
+        feed.subscribe(handler)
+      },
+      unsubscribe: jest.fn(),
+      ls: jest.fn(() => []),
+      publish: jest.fn(),
+    },
+    id: jest.fn(async () => ({ id: PEER_ID })),
+  }
+  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, 1, pubsubLogger, diagnosticsLogger)
+  const result: any[] = []
+  const subscription = pubsub.subscribe((message) => {
+    result.push(message)
+  })
+  await TestUtils.delay(2000)
+  expect(sawLog).toBeTruthy()
+  expect(result.length).toEqual(messages.length)
+  subscription.unsubscribe()
+})
+
+type DelayedMessage = {
+  delay: number,
+  message: IPFSPubsubMessage
+}
+test('continue even if a timeout occurs', async () => {
+  const messages: Array<DelayedMessage> = [
+    {
+      delay: 0,
+      message: asIpfsMessage({
+        typ: MsgType.QUERY,
+        id: "1",
+        stream: FAKE_STREAM_ID,
+      })
+    },
+    {
+      delay: 2000,
+      message: asIpfsMessage({
+        typ: MsgType.QUERY,
+        id: "2",
+        stream: FAKE_STREAM_ID,
+      })
+    }
+  ]
+  const feed = from(messages).pipe(
+    concatMap(msg => {
+      const d = msg.delay
+      return of(msg.message).pipe(
+        delay(msg.delay),
+        map(msg => {
+          return msg
+        })
+      )
+    })
+  )
+  let sawLog = false
+  const loggerSpy = jest.spyOn(diagnosticsLogger, 'log')
+    .mockImplementation((_, content) => {
+      if(content.toString().includes("please check your IPFS configuration.")) {
+        sawLog = true
+      }
+    })
+  const ipfs = {
+    pubsub: {
+      subscribe: async (_, handler) => {
+        feed.subscribe(handler)
+      },
+      unsubscribe: jest.fn(),
+      ls: jest.fn(() => []),
+      publish: jest.fn(),
+    },
+    id: jest.fn(async () => ({ id: PEER_ID })),
+  }
+  const pubsub = new Pubsub(ipfs as unknown as IpfsApi, TOPIC, 3000, 1, pubsubLogger, diagnosticsLogger)
+  const result: any[] = []
+  const subscription = pubsub.subscribe((message) => {
+    result.push(message)
+  })
+  await TestUtils.delay(2000)
+  expect(sawLog).toBeTruthy()
+  await TestUtils.delay(2000) //let rxjs finish
+  expect(result.length).toEqual(messages.length)
+  subscription.unsubscribe()
 })

--- a/packages/core/src/pubsub/incoming-channel.ts
+++ b/packages/core/src/pubsub/incoming-channel.ts
@@ -121,9 +121,12 @@ export function checkSlowObservable(
   }
   let outstanding = createTimeout()
   return pipe(
-    tap(() => {
-      clearTimeout(outstanding)
-      outstanding = createTimeout()
+    tap({
+      next: () => {
+        clearTimeout(outstanding)
+        outstanding = createTimeout()
+      },
+      complete: () => clearTimeout(outstanding)
     })
   )
 }

--- a/packages/core/src/pubsub/incoming-channel.ts
+++ b/packages/core/src/pubsub/incoming-channel.ts
@@ -4,7 +4,6 @@ import { DiagnosticsLogger, ServiceLogger } from '@ceramicnetwork/common'
 import { pipe, MonoTypeOperatorFunction } from 'rxjs'
 import { map, filter, concatMap, retryWhen, tap, delay } from 'rxjs/operators'
 import { TaskQueue } from './task-queue.js'
-import { asyncScheduler } from 'rxjs'
 
 // Typestub for pubsub message.
 // At some future time this type definition should be provided by IPFS.

--- a/packages/core/src/pubsub/pubsub.ts
+++ b/packages/core/src/pubsub/pubsub.ts
@@ -1,10 +1,10 @@
-import { Observable, EMPTY, pipe, of, from, Subscription, UnaryFunction } from 'rxjs'
+import { Observable, EMPTY, pipe, of, from, Subscription, UnaryFunction, TimeoutError, MonoTypeOperatorFunction, SchedulerLike } from 'rxjs'
 import { map, catchError, mergeMap, withLatestFrom } from 'rxjs/operators'
 import { IpfsApi } from '@ceramicnetwork/common'
 import { deserialize, PubsubMessage, serialize } from './pubsub-message.js'
 import { DiagnosticsLogger, ServiceLogger } from '@ceramicnetwork/common'
 import { toString as uint8ArrayToString } from 'uint8arrays'
-import { IncomingChannel, filterExternal, IPFSPubsubMessage } from './incoming-channel.js'
+import {IncomingChannel, filterExternal, IPFSPubsubMessage, checkSlowObservable} from './incoming-channel.js'
 import { TaskQueue } from './task-queue.js';
 
 const textDecoder = new TextDecoder('utf-8')
@@ -53,15 +53,20 @@ export class Pubsub extends Observable<PubsubMessage> {
     private readonly ipfs: IpfsApi,
     private readonly topic: string,
     private readonly resubscribeEvery: number,
+    private readonly lateMessageAfterSeconds: number,
     private readonly pubsubLogger: ServiceLogger,
     private readonly logger: DiagnosticsLogger,
     readonly tasks: TaskQueue = new TaskQueue()
   ) {
     super((subscriber) => {
-      const incoming$ = new IncomingChannel(ipfs, topic, resubscribeEvery, pubsubLogger, logger, tasks)
+      const incoming$ = new IncomingChannel(ipfs, topic, resubscribeEvery, lateMessageAfterSeconds, pubsubLogger, logger, tasks)
 
       incoming$
-        .pipe(filterExternal(this.peerId$), ipfsToPubsub(this.peerId$, pubsubLogger, topic))
+        .pipe(
+          filterExternal(this.peerId$),
+          checkSlowObservable(lateMessageAfterSeconds * 1000, logger, `IPFS did not provide any internal messages, please check your IPFS configuration.`),
+          ipfsToPubsub(this.peerId$, pubsubLogger, topic),
+        )
         .subscribe(subscriber)
     })
     // Textually, `this.peerId$` appears after it is called.

--- a/packages/core/src/pubsub/pubsub.ts
+++ b/packages/core/src/pubsub/pubsub.ts
@@ -53,18 +53,18 @@ export class Pubsub extends Observable<PubsubMessage> {
     private readonly ipfs: IpfsApi,
     private readonly topic: string,
     private readonly resubscribeEvery: number,
-    private readonly lateMessageAfterSeconds: number,
+    private readonly lateMessageAfter: number,
     private readonly pubsubLogger: ServiceLogger,
     private readonly logger: DiagnosticsLogger,
     readonly tasks: TaskQueue = new TaskQueue()
   ) {
     super((subscriber) => {
-      const incoming$ = new IncomingChannel(ipfs, topic, resubscribeEvery, lateMessageAfterSeconds, pubsubLogger, logger, tasks)
+      const incoming$ = new IncomingChannel(ipfs, topic, resubscribeEvery, lateMessageAfter, pubsubLogger, logger, tasks)
 
       incoming$
         .pipe(
           filterExternal(this.peerId$),
-          checkSlowObservable(lateMessageAfterSeconds * 1000, logger, `IPFS did not provide any internal messages, please check your IPFS configuration.`),
+          checkSlowObservable(lateMessageAfter, logger, `IPFS did not provide any internal messages, please check your IPFS configuration.`),
           ipfsToPubsub(this.peerId$, pubsubLogger, topic),
         )
         .subscribe(subscriber)

--- a/packages/core/src/pubsub/pubsub.ts
+++ b/packages/core/src/pubsub/pubsub.ts
@@ -1,4 +1,4 @@
-import { Observable, EMPTY, pipe, of, from, Subscription, UnaryFunction, TimeoutError, MonoTypeOperatorFunction, SchedulerLike } from 'rxjs'
+import { Observable, EMPTY, pipe, of, from, Subscription, UnaryFunction } from 'rxjs'
 import { map, catchError, mergeMap, withLatestFrom } from 'rxjs/operators'
 import { IpfsApi } from '@ceramicnetwork/common'
 import { deserialize, PubsubMessage, serialize } from './pubsub-message.js'


### PR DESCRIPTION
Emit a log warning if we receive no messages from IPFS within 5 minutes, or if we receive no internal messages (messages intended for the node). 4 additional tests added to verify behavior