### PR TITLE
feat(core) CDB-1655: Verify Indices

### DIFF
--- a/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
+++ b/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
@@ -19,6 +19,7 @@ import {
 import { readCsvFixture } from './read-csv-fixture.util.js'
 import { addColumnPrefix } from '../../column-name.util.js'
 import { CONFIG_TABLE_NAME } from '../../config.js'
+import { indices } from '../migrations/1-create-model-table.js'
 
 const STREAM_ID_A = 'kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd'
 const STREAM_ID_B = 'kjzl6cwe1jw147dvq16zluojmraqvwdmbh61dx9e0c59i344lcrsgqfohexp60s'
@@ -212,6 +213,13 @@ describe('init', () => {
         table.dateTime('first_anchored_at').nullable()
         table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
         table.dateTime('updated_at').notNullable().defaultTo(dbConnection.fn.now())
+
+        let tableIndices = indices(tableName)
+        for (const indexToCreate of tableIndices.indices) {
+          table.index(indexToCreate.keys, indexToCreate.name, {
+            storageEngineIndexType: indexToCreate.indexType,
+          })
+        }
       })
 
       await expect(indexApi.verifyTables(modelsToIndexArgs([modelToIndex]))).resolves.not.toThrow()
@@ -239,6 +247,44 @@ describe('init', () => {
         table.dateTime('last_anchored_at').nullable()
         table.dateTime('first_anchored_at').nullable()
         table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
+
+        let tableIndices = indices(tableName)
+        for (const indexToCreate of tableIndices.indices) {
+          if(!indexToCreate.keys.includes("updated_at")) { //updated_at not added as part of table
+            table.index(indexToCreate.keys, indexToCreate.name, {
+              storageEngineIndexType: indexToCreate.indexType,
+            })
+          }
+        }
+      })
+
+      await expect(indexApi.verifyTables(modelsToIndexArgs([modelToIndex]))).rejects.toThrow(
+        /Schema verification failed for index/
+      )
+    })
+
+    test('Fail table validation if indices are missing', async () => {
+      const modelToIndex = StreamID.fromString(STREAM_ID_A)
+      const tableName = asTableName(modelToIndex)
+      const indexApi = new PostgresIndexApi(dbConnection, true, logger, Networks.INMEMORY)
+      await indexApi.init()
+
+      // Create the table in the database with all expected fields but one (leaving off 'updated_at')
+      await dbConnection.schema.createTable(tableName, (table) => {
+        // create unique index name <64 chars that are still capable of being referenced to MID table
+        const indexName = tableName.substring(tableName.length - 10)
+
+        table
+          .string('stream_id')
+          .primary(`idx_${indexName}_pkey`)
+          .unique(`constr_${indexName}_unique`)
+        table.string('controller_did', 1024).notNullable()
+        table.jsonb('stream_content').notNullable()
+        table.string('tip').notNullable()
+        table.dateTime('last_anchored_at').nullable()
+        table.dateTime('first_anchored_at').nullable()
+        table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
+        table.dateTime('updated_at').notNullable().defaultTo(dbConnection.fn.now())
       })
 
       await expect(indexApi.verifyTables(modelsToIndexArgs([modelToIndex]))).rejects.toThrow(
@@ -275,6 +321,13 @@ describe('init', () => {
         table.dateTime('first_anchored_at').nullable()
         table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
         table.dateTime('updated_at').notNullable().defaultTo(dbConnection.fn.now())
+
+        let tableIndices = indices(tableName)
+        for (const indexToCreate of tableIndices.indices) {
+          table.index(indexToCreate.keys, indexToCreate.name, {
+            storageEngineIndexType: indexToCreate.indexType,
+          })
+        }
       })
 
       await expect(indexApi.verifyTables(indexModelsArgs)).rejects.toThrow(

--- a/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
+++ b/packages/core/src/indexing/postgres/__tests__/postgres-index-api.test.ts
@@ -214,7 +214,7 @@ describe('init', () => {
         table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
         table.dateTime('updated_at').notNullable().defaultTo(dbConnection.fn.now())
 
-        let tableIndices = indices(tableName)
+        const tableIndices = indices(tableName)
         for (const indexToCreate of tableIndices.indices) {
           table.index(indexToCreate.keys, indexToCreate.name, {
             storageEngineIndexType: indexToCreate.indexType,
@@ -248,7 +248,7 @@ describe('init', () => {
         table.dateTime('first_anchored_at').nullable()
         table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
 
-        let tableIndices = indices(tableName)
+        const tableIndices = indices(tableName)
         for (const indexToCreate of tableIndices.indices) {
           if(!indexToCreate.keys.includes("updated_at")) { //updated_at not added as part of table
             table.index(indexToCreate.keys, indexToCreate.name, {
@@ -322,7 +322,7 @@ describe('init', () => {
         table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
         table.dateTime('updated_at').notNullable().defaultTo(dbConnection.fn.now())
 
-        let tableIndices = indices(tableName)
+        const tableIndices = indices(tableName)
         for (const indexToCreate of tableIndices.indices) {
           table.index(indexToCreate.keys, indexToCreate.name, {
             storageEngineIndexType: indexToCreate.indexType,

--- a/packages/core/src/indexing/postgres/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/postgres/migrations/1-create-model-table.ts
@@ -21,16 +21,74 @@ export type ColumnInfo = {
   type: ColumnType
 }
 
+export type TableIndex = {
+  keys: Array<string>,
+  name: string,
+  indexType: Knex.storageEngineIndexType,
+}
+
+export type TableIndices = {
+  indexName: string,
+  indices: Array<TableIndex>,
+}
+
+export function indices(tableName: string): TableIndices {
+  // create unique index name less than 64 chars that are still capable of being referenced to MID table.
+  // We are creating the unique index name by grabbing the last 10 characters of the table name
+  // which is normally the stream id. This combined with the rest of the index information should
+  // be less than 64 characters. See CDB-1600 for more information
+  const indexName = tableName.substring(tableName.length - 10)
+
+  // index names with additional naming information should be less than
+  // 64 characters, which means additional information should be less than 54 characters
+  const indices: Array<TableIndex> = [
+    {
+      keys: ['stream_id'],
+      name: `idx_${indexName}_stream_id`,
+      indexType: 'hash',
+    },
+    {
+      keys: ['last_anchored_at'],
+      name: `idx_${indexName}_last_anchored_at`,
+      indexType: 'hash',
+    },
+    {
+      keys: ['first_anchored_at'],
+      name: `idx_${indexName}_first_anchored_at`,
+      indexType: 'hash',
+    },
+    {
+      keys: ['created_at'],
+      name: `idx_${indexName}_created_at`,
+      indexType: 'hash',
+    },
+    {
+      keys: ['updated_at'],
+      name: `idx_${indexName}_updated_at`,
+      indexType: 'hash',
+    },
+    {
+      keys: ['last_anchored_at', 'created_at'],
+      name: `idx_${indexName}_last_anchored_at_created_at`,
+      indexType: 'hash',
+    },
+  ]
+
+  return {
+    indexName: indexName,
+    indices: indices,
+  }
+}
+
 export async function createModelTable(
   dataSource: Knex,
   tableName: string,
   extraColumns: Array<ColumnInfo>
 ) {
   await dataSource.schema.createTable(tableName, function (table) {
-    // create unique index name <64 chars that are still capable of being referenced to MID table
-    const indexName = tableName.substring(tableName.length - 10)
+    const idx = indices(tableName)
 
-    table.string('stream_id').primary(`idx_${indexName}_pkey`).unique(`constr_${indexName}_unique`)
+    table.string('stream_id').primary(`idx_${idx.indexName}_pkey`).unique(`constr_${idx.indexName}_unique`)
     table.string('controller_did', 1024).notNullable()
     table.jsonb('stream_content').notNullable()
     table.string('tip').notNullable()
@@ -43,35 +101,18 @@ export async function createModelTable(
       switch (column.type) {
         case ColumnType.STRING:
           table.string(column.name, 1024).notNullable()
-          table.index([column.name], `idx_${tableName}_${column.name}`)
+          table.index([column.name], `idx_${idx.indexName}_${column.name}`)
           break
         default:
           throw new UnreachableCaseError(column.type, `Invalid column type`)
       }
     }
 
-    table.index(['stream_id'], `idx_${indexName}_stream_id`, {
-      storageEngineIndexType: 'hash',
-    })
-    table.index(['last_anchored_at'], `idx_${indexName}_last_anchored_at`, {
-      storageEngineIndexType: 'hash',
-    })
-    table.index(['first_anchored_at'], `idx_${indexName}_first_anchored_at`, {
-      storageEngineIndexType: 'hash',
-    })
-    table.index(['created_at'], `idx_${indexName}_created_at`, {
-      storageEngineIndexType: 'hash',
-    })
-    table.index(['updated_at'], `idx_${indexName}_updated_at`, {
-      storageEngineIndexType: 'hash',
-    })
-    table.index(
-      ['last_anchored_at', 'created_at'],
-      `idx_${indexName}_last_anchored_at_created_at`,
-      {
-        storageEngineIndexType: 'hash',
-      }
-    )
+    for (const indexToCreate of idx.indices) {
+      table.index(indexToCreate.keys, indexToCreate.name, {
+        storageEngineIndexType: indexToCreate.indexType,
+      })
+    }
   })
 }
 

--- a/packages/core/src/indexing/postgres/migrations/__tests__/1-create-model-table.test.ts
+++ b/packages/core/src/indexing/postgres/migrations/__tests__/1-create-model-table.test.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals'
-import { indices } from '../1-create-model-table'
+import { indices } from '../1-create-model-table.js'
 
 describe('indices', () => {
     test('correctly build default indices for a table name', () => {

--- a/packages/core/src/indexing/postgres/migrations/__tests__/1-create-model-table.test.ts
+++ b/packages/core/src/indexing/postgres/migrations/__tests__/1-create-model-table.test.ts
@@ -1,0 +1,10 @@
+import { jest } from '@jest/globals'
+import { indices } from '../1-create-model-table'
+
+describe('indices', () => {
+    test('correctly build default indices for a table name', () => {
+        const t = indices('dropped_for_thisstuffy')
+        expect(t.indexName).toEqual('thisstuffy')
+        expect(t.indices.length).toEqual(6)
+    })
+})


### PR DESCRIPTION
Add checks when a node starts up to verify that indices are present.

Additionally fix code that was using too long of a name, switching from tableName to indexName.