### PR TITLE
feat (core): extend config table with addt. indexing options

### DIFF
--- a/packages/cli/src/__tests__/make-ceramic-daemon.ts
+++ b/packages/cli/src/__tests__/make-ceramic-daemon.ts
@@ -14,7 +14,6 @@ export async function makeCeramicDaemon(
     {
       'http-api': { port },
       indexing: {
-        'allow-queries-before-historical-sync': true,
       },
     },
     opts

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -46,7 +46,6 @@ const DEFAULT_DAEMON_CONFIG = DaemonConfig.fromObject({
   },
   indexing: {
     db: `sqlite://${DEFAULT_INDEXING_DB_FILENAME.pathname}`,
-    'allow-queries-before-historical-sync': true,
   },
 })
 

--- a/packages/core/src/indexing/database-index-api.ts
+++ b/packages/core/src/indexing/database-index-api.ts
@@ -99,7 +99,7 @@ export class DatabaseIndexApi<DateType = Date | number> {
         models.map((indexModelArgs) => {
           return {
             model: indexModelArgs.model.toString(),
-            updated_by: '<FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>',
+            updated_by: '0', // TODO: FIXME: CDB-1866 - <FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>',
           }
         })
       )
@@ -107,7 +107,7 @@ export class DatabaseIndexApi<DateType = Date | number> {
       .merge({
         updated_at: this.now(),
         is_indexed: true,
-        updated_by: '<FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>',
+        updated_by: '0', // TODO: FIXME: CDB-1866 - <FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>',
       })
   }
 
@@ -133,7 +133,7 @@ export class DatabaseIndexApi<DateType = Date | number> {
           return {
             model: model.toString(),
             is_indexed: false,
-            updated_by: '<FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>',
+            updated_by: '0', // TODO: FIXME: CDB-1866 - <FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>',
           }
         })
       )
@@ -141,7 +141,7 @@ export class DatabaseIndexApi<DateType = Date | number> {
       .merge({
         updated_at: this.now(),
         is_indexed: false,
-        updated_by: '<FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>',
+        updated_by: '0', // TODO: FIXME: CDB-1866 - <FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>',
       })
   }
 

--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -203,9 +203,6 @@ export async function createConfigTable(dataSource: Knex, tableName: string, net
       })
 
       await dataSource.into(tableName).insert({ option: 'network', value: network })
-      await dataSource
-        .into(tableName)
-        .insert({ option: 'is-hist-sync', value: NETWORK_DEFAULT_CONFIG.is_hist_sync })
       await dataSource.into(tableName).insert({
         option: 'allow-queries-before-historical-sync',
         value: NETWORK_DEFAULT_CONFIG.allow_queries_before_historical_sync,

--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -32,45 +32,43 @@ function getIndexName(tableName: string): string {
   return tableName.substring(tableName.length - 10)
 }
 
+/**
+ * Default configuration of Compose DB functionality per network.
+ * Values can be overwritten by updating them in the ceramic_config table
+ * and by restarting the node.
+ */
 function getNetworkDefaultConfig(networkName: string): { [key: string]: any } {
-  // [key: string]: any
-  /**
-   * Default configuration of Compose DB functionality per network.
-   * Values can be overwritten by updating them in the ceramic_config table
-   * and by restarting the node.
-   */
-  let NETWORK_DEFAULT_CONFIG
   switch (networkName) {
     case 'mainnet':
-      NETWORK_DEFAULT_CONFIG = {
+      return {
         is_hist_sync: true,
         allow_queries_before_historical_sync: false,
         is_run_syncing_worker: true,
       }
       break
     case 'testnet-clay':
-      NETWORK_DEFAULT_CONFIG = {
+      return {
         is_hist_sync: true,
         allow_queries_before_historical_sync: false,
         is_run_syncing_worker: true,
       }
       break
     case 'local':
-      NETWORK_DEFAULT_CONFIG = {
+      return {
         is_hist_sync: false,
         allow_queries_before_historical_sync: true,
         is_run_syncing_worker: false,
       }
       break
     case 'dev-unstable':
-      NETWORK_DEFAULT_CONFIG = {
+      return {
         is_hist_sync: false,
         allow_queries_before_historical_sync: false,
         is_run_syncing_worker: false,
       }
       break
     case 'inmemory':
-      NETWORK_DEFAULT_CONFIG = {
+      return {
         is_hist_sync: false,
         allow_queries_before_historical_sync: true,
         is_run_syncing_worker: false,
@@ -79,7 +77,6 @@ function getNetworkDefaultConfig(networkName: string): { [key: string]: any } {
     default:
       throw new Error(`Invalid network provided during table creation: ${networkName}`)
   }
-  return NETWORK_DEFAULT_CONFIG
 }
 
 function createExtraColumns(
@@ -177,7 +174,6 @@ export async function createSqliteModelTable(
 }
 
 export async function createConfigTable(dataSource: Knex, tableName: string, network: Networks) {
-  //const NETWORK_DEFAULT_CONFIG: {[key: string]: any} = getNetworkDefaultConfig(network)
   const NETWORK_DEFAULT_CONFIG = getNetworkDefaultConfig(network)
 
   switch (tableName) {

--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -41,37 +41,37 @@ function getNetworkDefaultConfig(networkName: string): { [key: string]: any } {
   switch (networkName) {
     case 'mainnet':
       return {
-        is_hist_sync: true,
+        enable_historical_sync: true,
         allow_queries_before_historical_sync: false,
-        is_run_syncing_worker: true,
+        run_historical_sync_worker: true,
       }
       break
     case 'testnet-clay':
       return {
-        is_hist_sync: true,
+        enable_historical_sync: true,
         allow_queries_before_historical_sync: false,
-        is_run_syncing_worker: true,
+        run_historical_sync_worker: true,
       }
       break
     case 'local':
       return {
-        is_hist_sync: false,
+        enable_historical_sync: false,
         allow_queries_before_historical_sync: true,
-        is_run_syncing_worker: false,
+        run_historical_sync_worker: false,
       }
       break
     case 'dev-unstable':
       return {
-        is_hist_sync: false,
+        enable_historical_sync: false,
         allow_queries_before_historical_sync: false,
-        is_run_syncing_worker: false,
+        run_historical_sync_worker: false,
       }
       break
     case 'inmemory':
       return {
-        is_hist_sync: false,
+        enable_historical_sync: false,
         allow_queries_before_historical_sync: true,
-        is_run_syncing_worker: false,
+        run_historical_sync_worker: false,
       }
       break
     default:
@@ -182,7 +182,7 @@ export async function createConfigTable(dataSource: Knex, tableName: string, net
         // create model indexing configuration table
         table.string('model', 1024).unique().notNullable().primary()
         table.boolean('is_indexed').notNullable().defaultTo(true)
-        table.boolean('is_hist_index').notNullable().defaultTo(false)
+        table.boolean('enable_historical_sync').notNullable().defaultTo(false)
         table.dateTime('created_at').notNullable().defaultTo(dataSource.fn.now())
         table.dateTime('updated_at').notNullable().defaultTo(dataSource.fn.now())
         table.string('updated_by', 1024).notNullable()
@@ -208,8 +208,8 @@ export async function createConfigTable(dataSource: Knex, tableName: string, net
         value: NETWORK_DEFAULT_CONFIG.allow_queries_before_historical_sync,
       })
       await dataSource.into(tableName).insert({
-        option: 'is-run-syncing-worker',
-        value: NETWORK_DEFAULT_CONFIG.is_run_syncing_worker,
+        option: 'run-historical-sync-worker',
+        value: NETWORK_DEFAULT_CONFIG.run_historical_sync_worker,
       })
       break
     default:

--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -186,6 +186,7 @@ export async function createConfigTable(dataSource: Knex, tableName: string, net
         // create model indexing configuration table
         table.string('model', 1024).unique().notNullable().primary()
         table.boolean('is_indexed').notNullable().defaultTo(true)
+        table.boolean('is_hist_index').notNullable().defaultTo(false)
         table.dateTime('created_at').notNullable().defaultTo(dataSource.fn.now())
         table.dateTime('updated_at').notNullable().defaultTo(dataSource.fn.now())
         table.string('updated_by', 1024).notNullable()

--- a/packages/core/src/indexing/migrations/cdb-schema-verification.ts
+++ b/packages/core/src/indexing/migrations/cdb-schema-verification.ts
@@ -94,7 +94,7 @@ export const STRUCTURES: Record<DatabaseType, StructuresRecord> = {
         nullable: false,
         defaultValue: 'true',
       },
-      is_hist_sync: {
+      is_hist_index: {
         type: 'boolean',
         maxLength: null,
         nullable: false,
@@ -125,32 +125,32 @@ export const STRUCTURES: Record<DatabaseType, StructuresRecord> = {
      */
     CONFIG_TABLE: {
       option: {
-        type: 'varchar',
-        maxLength: '1024',
+        type: 'character varying',
+        maxLength: 1024,
         nullable: false,
         defaultValue: null
       },
       value: {
-        type: 'varchar',
-        maxLength: '1024',
+        type: 'character varying',
+        maxLength: 1024,
         nullable: false,
         defaultValue: null
       },
       created_at: {
-        type: 'datetime',
+        type: 'timestamp with time zone',
         maxLength: null,
         nullable: false,
         defaultValue: 'CURRENT_TIMESTAMP'
       },
       updated_at: {
-        type: 'datetime',
+        type: 'timestamp with time zone',
         maxLength: null,
         nullable: false,
         defaultValue: 'CURRENT_TIMESTAMP'
       },
       updated_by: {
-        type: 'varchar',
-        maxLength: '1024',
+        type: 'character varying',
+        maxLength: 1024,
         nullable: true,
         defaultValue: null
       }
@@ -242,7 +242,7 @@ export const STRUCTURES: Record<DatabaseType, StructuresRecord> = {
         type: 'boolean',
         maxLength: null,
         nullable: false,
-        defaultValue: "'1'",
+        defaultValue: "'0'",
       },
       created_at: {
         type: 'datetime',

--- a/packages/core/src/indexing/migrations/cdb-schema-verification.ts
+++ b/packages/core/src/indexing/migrations/cdb-schema-verification.ts
@@ -94,6 +94,12 @@ export const STRUCTURES: Record<DatabaseType, StructuresRecord> = {
         nullable: false,
         defaultValue: 'true',
       },
+      is_hist_sync: {
+        type: 'boolean',
+        maxLength: null,
+        nullable: false,
+        defaultValue: 'false',
+      },
       created_at: {
         type: 'timestamp with time zone',
         maxLength: null,
@@ -227,6 +233,12 @@ export const STRUCTURES: Record<DatabaseType, StructuresRecord> = {
         defaultValue: null,
       },
       is_indexed: {
+        type: 'boolean',
+        maxLength: null,
+        nullable: false,
+        defaultValue: "'1'",
+      },
+      is_hist_index: {
         type: 'boolean',
         maxLength: null,
         nullable: false,

--- a/packages/core/src/indexing/migrations/cdb-schema-verification.ts
+++ b/packages/core/src/indexing/migrations/cdb-schema-verification.ts
@@ -94,7 +94,7 @@ export const STRUCTURES: Record<DatabaseType, StructuresRecord> = {
         nullable: false,
         defaultValue: 'true',
       },
-      is_hist_index: {
+      enable_historical_sync: {
         type: 'boolean',
         maxLength: null,
         nullable: false,
@@ -238,7 +238,7 @@ export const STRUCTURES: Record<DatabaseType, StructuresRecord> = {
         nullable: false,
         defaultValue: "'1'",
       },
-      is_hist_index: {
+      enable_historical_sync: {
         type: 'boolean',
         maxLength: null,
         nullable: false,

--- a/packages/core/src/indexing/migrations/cdb-schema-verification.ts
+++ b/packages/core/src/indexing/migrations/cdb-schema-verification.ts
@@ -118,12 +118,36 @@ export const STRUCTURES: Record<DatabaseType, StructuresRecord> = {
      * Used to verify table integrity during node startup
      */
     CONFIG_TABLE: {
-      network: {
-        type: 'character varying',
-        maxLength: 1024,
+      option: {
+        type: 'varchar',
+        maxLength: '1024',
         nullable: false,
-        defaultValue: null,
+        defaultValue: null
       },
+      value: {
+        type: 'varchar',
+        maxLength: '1024',
+        nullable: false,
+        defaultValue: null
+      },
+      created_at: {
+        type: 'datetime',
+        maxLength: null,
+        nullable: false,
+        defaultValue: 'CURRENT_TIMESTAMP'
+      },
+      updated_at: {
+        type: 'datetime',
+        maxLength: null,
+        nullable: false,
+        defaultValue: 'CURRENT_TIMESTAMP'
+      },
+      updated_by: {
+        type: 'varchar',
+        maxLength: '1024',
+        nullable: true,
+        defaultValue: null
+      }
     },
   },
   [DatabaseType.SQLITE]: {
@@ -232,12 +256,36 @@ export const STRUCTURES: Record<DatabaseType, StructuresRecord> = {
      * Used to verify table integrity during node startup
      */
     CONFIG_TABLE: {
-      network: {
+      option: {
         type: 'varchar',
         maxLength: '1024',
         nullable: false,
-        defaultValue: null,
+        defaultValue: null
       },
+      value: {
+        type: 'varchar',
+        maxLength: '1024',
+        nullable: false,
+        defaultValue: null
+      },
+      created_at: {
+        type: 'datetime',
+        maxLength: null,
+        nullable: false,
+        defaultValue: 'CURRENT_TIMESTAMP'
+      },
+      updated_at: {
+        type: 'datetime',
+        maxLength: null,
+        nullable: false,
+        defaultValue: 'CURRENT_TIMESTAMP'
+      },
+      updated_by: {
+        type: 'varchar',
+        maxLength: '1024',
+        nullable: true,
+        defaultValue: null
+      }
     },
   },
 }

--- a/packages/core/src/indexing/tables-manager.ts
+++ b/packages/core/src/indexing/tables-manager.ts
@@ -91,7 +91,7 @@ export class TablesManager {
       this.logger.imp(`Creating Compose DB config table: ${table.tableName}`)
       await createConfigTable(this.dataSource, table.tableName, network)
     } else if (table.tableName === CONFIG_TABLE_NAME) {
-      const config = await this.dataSource.from(table.tableName).first('network')
+      const config = await this.dataSource.from(table.tableName).where('option').first('network')
       if (config.network !== network) {
         throw new Error(
           `Initialization failed for config table: ${table.tableName}. The database is configured to use the network ${config.network} but the current network is ${network}.`

--- a/packages/core/src/indexing/tables-manager.ts
+++ b/packages/core/src/indexing/tables-manager.ts
@@ -91,10 +91,10 @@ export class TablesManager {
       this.logger.imp(`Creating Compose DB config table: ${table.tableName}`)
       await createConfigTable(this.dataSource, table.tableName, network)
     } else if (table.tableName === CONFIG_TABLE_NAME) {
-      const config = await this.dataSource.from(table.tableName).where('option').first('network')
-      if (config.network !== network) {
+      const config = await this.dataSource.from(table.tableName).where('option', 'network').first('value')
+      if (config.value !== network) {
         throw new Error(
-          `Initialization failed for config table: ${table.tableName}. The database is configured to use the network ${config.network} but the current network is ${network}.`
+          `Initialization failed for config table: ${table.tableName}. The database is configured to use the network ${config.value} but the current network is ${network}.`
         )
       }
     }


### PR DESCRIPTION
## Description

Add Historical Data Sync config table & populate with default values depending on network chosen.

**ATTENTION**: This is a breaking change to previous versions as it changes the table structure of `ceramic_config` & `ceramic_models`.

- updated `ceramic_config` table structure & populate with default values during startup;
- extended `ceramic_models` with historical sync flag;
- remove 'allow-queries-before-historical-sync' from config file creation;
- change default value for updated_by to '0' before final feature implemented;
- changed config table and updated schema verification;

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x] Local Test
- [x] Unit tests

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation
