### PR TITLE
feat(core) CDB-1655: Verify Indices

### DIFF
--- a/packages/core/src/indexing/__tests__/database-index-api.test.ts
+++ b/packages/core/src/indexing/__tests__/database-index-api.test.ts
@@ -16,7 +16,7 @@ import {
   SqliteIndexApi,
   asTimestamp,
 } from '../database-index-api.js'
-import { DatabaseType } from '../migrations/1-create-model-table.js'
+import {DatabaseType, indices} from '../migrations/1-create-model-table.js'
 import { STRUCTURES } from '../migrations/cdb-schema-verification.js'
 import { readCsvFixture } from './read-csv-fixture.util.js'
 import { CONFIG_TABLE_NAME } from '../config.js'
@@ -221,6 +221,13 @@ describe('postgres', () => {
           table.dateTime('first_anchored_at').nullable()
           table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
           table.dateTime('updated_at').notNullable().defaultTo(dbConnection.fn.now())
+
+          const tableIndices = indices(tableName)
+          for (const indexToCreate of tableIndices.indices) {
+            table.index(indexToCreate.keys, indexToCreate.name, {
+              storageEngineIndexType: indexToCreate.indexType,
+            })
+          }
         })
 
         await expect(
@@ -250,11 +257,49 @@ describe('postgres', () => {
           table.dateTime('last_anchored_at').nullable()
           table.dateTime('first_anchored_at').nullable()
           table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
+
+          const tableIndices = indices(tableName)
+          for (const indexToCreate of tableIndices.indices) {
+            if(!indexToCreate.keys.includes("updated_at")) { //updated_at not added as part of table
+              table.index(indexToCreate.keys, indexToCreate.name, {
+                storageEngineIndexType: indexToCreate.indexType,
+              })
+            }
+          }
         })
 
         await expect(
           indexApi.tablesManager.verifyTables(modelsToIndexArgs([modelToIndex]))
         ).rejects.toThrow(/Schema verification failed for index/)
+      })
+
+      test('Fail table validation if indices are missing', async () => {
+        const modelToIndex = StreamID.fromString(STREAM_ID_A)
+        const tableName = asTableName(modelToIndex)
+        const indexApi = new PostgresIndexApi(dbConnection, true, logger, Networks.INMEMORY)
+        await indexApi.init()
+
+        // Create the table in the database with all expected fields but one (leaving off 'updated_at')
+        await dbConnection.schema.createTable(tableName, (table) => {
+          // create unique index name <64 chars that are still capable of being referenced to MID table
+          const indexName = tableName.substring(tableName.length - 10)
+
+          table
+            .string('stream_id')
+            .primary(`idx_${indexName}_pkey`)
+            .unique(`constr_${indexName}_unique`)
+          table.string('controller_did', 1024).notNullable()
+          table.jsonb('stream_content').notNullable()
+          table.string('tip').notNullable()
+          table.dateTime('last_anchored_at').nullable()
+          table.dateTime('first_anchored_at').nullable()
+          table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
+          table.dateTime('updated_at').notNullable().defaultTo(dbConnection.fn.now())
+        })
+
+        await expect(indexApi.tablesManager.verifyTables(modelsToIndexArgs([modelToIndex]))).rejects.toThrow(
+          /Schema verification failed for index/
+        )
       })
 
       test('Fail table validation if relation column missing', async () => {
@@ -286,6 +331,13 @@ describe('postgres', () => {
           table.dateTime('first_anchored_at').nullable()
           table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
           table.dateTime('updated_at').notNullable().defaultTo(dbConnection.fn.now())
+
+          const tableIndices = indices(tableName)
+          for (const indexToCreate of tableIndices.indices) {
+            table.index(indexToCreate.keys, indexToCreate.name, {
+              storageEngineIndexType: indexToCreate.indexType,
+            })
+          }
         })
 
         await expect(indexApi.tablesManager.verifyTables(indexModelsArgs)).rejects.toThrow(

--- a/packages/core/src/indexing/__tests__/database-index-api.test.ts
+++ b/packages/core/src/indexing/__tests__/database-index-api.test.ts
@@ -16,7 +16,7 @@ import {
   SqliteIndexApi,
   asTimestamp,
 } from '../database-index-api.js'
-import {DatabaseType, indices} from '../migrations/1-create-model-table.js'
+import { DatabaseType, indices } from '../migrations/1-create-model-table.js'
 import { STRUCTURES } from '../migrations/cdb-schema-verification.js'
 import { readCsvFixture } from './read-csv-fixture.util.js'
 import { CONFIG_TABLE_NAME } from '../config.js'
@@ -260,7 +260,8 @@ describe('postgres', () => {
 
           const tableIndices = indices(tableName)
           for (const indexToCreate of tableIndices.indices) {
-            if(!indexToCreate.keys.includes("updated_at")) { //updated_at not added as part of table
+            if (!indexToCreate.keys.includes('updated_at')) {
+              //updated_at not added as part of table
               table.index(indexToCreate.keys, indexToCreate.name, {
                 storageEngineIndexType: indexToCreate.indexType,
               })
@@ -297,9 +298,9 @@ describe('postgres', () => {
           table.dateTime('updated_at').notNullable().defaultTo(dbConnection.fn.now())
         })
 
-        await expect(indexApi.tablesManager.verifyTables(modelsToIndexArgs([modelToIndex]))).rejects.toThrow(
-          /Schema verification failed for index/
-        )
+        await expect(
+          indexApi.tablesManager.verifyTables(modelsToIndexArgs([modelToIndex]))
+        ).rejects.toThrow(/Schema verification failed for index/)
       })
 
       test('Fail table validation if relation column missing', async () => {

--- a/packages/core/src/indexing/__tests__/database-index-api.test.ts
+++ b/packages/core/src/indexing/__tests__/database-index-api.test.ts
@@ -834,7 +834,8 @@ describe('sqlite', () => {
         await indexApi.init()
 
         // Create the table in the database with all expected fields but one (leaving off 'updated_at')
-        await dbConnection.schema.createTable(asTableName(modelToIndex), (table) => {
+        const tableName = asTableName(modelToIndex)
+        await dbConnection.schema.createTable(tableName, (table) => {
           table.string('stream_id', 1024).primary().unique().notNullable()
           table.string('controller_did', 1024).notNullable()
           table.string('stream_content').notNullable()
@@ -843,6 +844,13 @@ describe('sqlite', () => {
           table.integer('first_anchored_at').nullable()
           table.integer('created_at').notNullable()
           table.integer('updated_at').notNullable()
+
+          const tableIndices = indices(tableName)
+          for (const indexToCreate of tableIndices.indices) {
+            table.index(indexToCreate.keys, indexToCreate.name, {
+              storageEngineIndexType: indexToCreate.indexType,
+            })
+          }
         })
 
         await expect(
@@ -856,7 +864,40 @@ describe('sqlite', () => {
         await indexApi.init()
 
         // Create the table in the database with all expected fields but one (leaving off 'updated_at')
-        await dbConnection.schema.createTable(asTableName(modelToIndex), (table) => {
+        const tableName = asTableName(modelToIndex)
+        await dbConnection.schema.createTable(tableName, (table) => {
+          table.string('stream_id', 1024).primary().unique().notNullable()
+          table.string('controller_did', 1024).notNullable()
+          table.string('stream_content').notNullable()
+          table.string('tip').notNullable()
+          table.integer('last_anchored_at').nullable()
+          table.integer('first_anchored_at').nullable()
+          table.integer('created_at').notNullable()
+
+          const tableIndices = indices(tableName)
+          for (const indexToCreate of tableIndices.indices) {
+            if (!indexToCreate.keys.includes('updated_at')) {
+              //updated_at not added as part of table
+              table.index(indexToCreate.keys, indexToCreate.name, {
+                storageEngineIndexType: indexToCreate.indexType,
+              })
+            }
+          }
+        })
+
+        await expect(
+          indexApi.tablesManager.verifyTables(modelsToIndexArgs([modelToIndex]))
+        ).rejects.toThrow(/Schema verification failed for index/)
+      })
+
+      test('Fail table validation if indices are missing', async () => {
+        const modelToIndex = StreamID.fromString(STREAM_ID_A)
+        const indexApi = new SqliteIndexApi(dbConnection, true, logger, Networks.INMEMORY)
+        await indexApi.init()
+
+        // Create the table in the database with all expected fields but one (leaving off 'updated_at')
+        const tableName = asTableName(modelToIndex)
+        await dbConnection.schema.createTable(tableName, (table) => {
           table.string('stream_id', 1024).primary().unique().notNullable()
           table.string('controller_did', 1024).notNullable()
           table.string('stream_content').notNullable()
@@ -884,7 +925,8 @@ describe('sqlite', () => {
         await indexApi.init()
 
         // Create the table in the database with all expected fields but one (leaving off 'updated_at')
-        await dbConnection.schema.createTable(asTableName(modelToIndex), (table) => {
+        const tableName = asTableName(modelToIndex)
+        await dbConnection.schema.createTable(tableName, (table) => {
           table.string('stream_id', 1024).primary().unique().notNullable()
           table.string('controller_did', 1024).notNullable()
           table.string('stream_content').notNullable()
@@ -893,6 +935,16 @@ describe('sqlite', () => {
           table.integer('first_anchored_at').nullable()
           table.integer('created_at').notNullable()
           table.integer('updated_at').notNullable()
+
+          const tableIndices = indices(tableName)
+          for (const indexToCreate of tableIndices.indices) {
+            if (!indexToCreate.keys.includes('updated_at')) {
+              //updated_at not added as part of table
+              table.index(indexToCreate.keys, indexToCreate.name, {
+                storageEngineIndexType: indexToCreate.indexType,
+              })
+            }
+          }
         })
 
         await expect(indexApi.tablesManager.verifyTables(indexModelsArgs)).rejects.toThrow(

--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -28,14 +28,14 @@ export type ColumnInfo = {
 }
 
 export type TableIndex = {
-  keys: Array<string>,
-  name: string,
-  indexType: Knex.storageEngineIndexType,
+  keys: Array<string>
+  name: string
+  indexType: Knex.storageEngineIndexType
 }
 
 export type TableIndices = {
-  indexName: string,
-  indices: Array<TableIndex>,
+  indexName: string
+  indices: Array<TableIndex>
 }
 
 export function indices(tableName: string): TableIndices {
@@ -159,7 +159,10 @@ export async function createPostgresModelTable(
   await dataSource.schema.createTable(tableName, function (table) {
     const idx = indices(tableName)
 
-    table.string('stream_id').primary(`idx_${idx.indexName}_pkey`).unique(`constr_${idx.indexName}_unique`)
+    table
+      .string('stream_id')
+      .primary(`idx_${idx.indexName}_pkey`)
+      .unique(`constr_${idx.indexName}_unique`)
     table.string('controller_did', 1024).notNullable()
     table.jsonb('stream_content').notNullable()
     table.string('tip').notNullable()

--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -27,9 +27,63 @@ export type ColumnInfo = {
   type: ColumnType
 }
 
-function getIndexName(tableName: string): string {
-  // create unique index name <64 chars that are still capable of being referenced to MID table
-  return tableName.substring(tableName.length - 10)
+export type TableIndex = {
+  keys: Array<string>,
+  name: string,
+  indexType: Knex.storageEngineIndexType,
+}
+
+export type TableIndices = {
+  indexName: string,
+  indices: Array<TableIndex>,
+}
+
+export function indices(tableName: string): TableIndices {
+  // create unique index name less than 64 chars that are still capable of being referenced to MID table.
+  // We are creating the unique index name by grabbing the last 10 characters of the table name
+  // which is normally the stream id. This combined with the rest of the index information should
+  // be less than 64 characters. See CDB-1600 for more information
+  const indexName = tableName.substring(tableName.length - 10)
+
+  // index names with additional naming information should be less than
+  // 64 characters, which means additional information should be less than 54 characters
+  const indices: Array<TableIndex> = [
+    {
+      keys: ['stream_id'],
+      name: `idx_${indexName}_stream_id`,
+      indexType: 'hash',
+    },
+    {
+      keys: ['last_anchored_at'],
+      name: `idx_${indexName}_last_anchored_at`,
+      indexType: 'hash',
+    },
+    {
+      keys: ['first_anchored_at'],
+      name: `idx_${indexName}_first_anchored_at`,
+      indexType: 'hash',
+    },
+    {
+      keys: ['created_at'],
+      name: `idx_${indexName}_created_at`,
+      indexType: 'hash',
+    },
+    {
+      keys: ['updated_at'],
+      name: `idx_${indexName}_updated_at`,
+      indexType: 'hash',
+    },
+    {
+      keys: ['last_anchored_at', 'created_at'],
+      name: `idx_${indexName}_last_anchored_at_created_at`,
+      indexType: 'hash',
+    },
+  ]
+
+  return {
+    indexName: indexName,
+    indices: indices,
+  }
 }
 
 /**
@@ -81,10 +135,9 @@ function getNetworkDefaultConfig(networkName: string): { [key: string]: any } {
 
 function createExtraColumns(
   table: Knex.CreateTableBuilder,
-  tableName: string,
+  indexName: string,
   extraColumns: Array<ColumnInfo>
 ): void {
-  const indexName = getIndexName(tableName)
   for (const column of extraColumns) {
     const columnName = addColumnPrefix(column.name)
     switch (column.type) {
@@ -104,9 +157,9 @@ export async function createPostgresModelTable(
   extraColumns: Array<ColumnInfo>
 ): Promise<void> {
   await dataSource.schema.createTable(tableName, function (table) {
-    const indexName = getIndexName(tableName)
+    const idx = indices(tableName)
 
-    table.string('stream_id').primary(`idx_${indexName}_pkey`).unique(`constr_${indexName}_unique`)
+    table.string('stream_id').primary(`idx_${idx.indexName}_pkey`).unique(`constr_${idx.indexName}_unique`)
     table.string('controller_did', 1024).notNullable()
     table.jsonb('stream_content').notNullable()
     table.string('tip').notNullable()
@@ -115,30 +168,13 @@ export async function createPostgresModelTable(
     table.dateTime('created_at').notNullable().defaultTo(dataSource.fn.now())
     table.dateTime('updated_at').notNullable().defaultTo(dataSource.fn.now())
 
-    createExtraColumns(table, tableName, extraColumns)
+    createExtraColumns(table, idx.indexName, extraColumns)
 
-    table.index(['stream_id'], `idx_${indexName}_stream_id`, {
-      storageEngineIndexType: 'hash',
-    })
-    table.index(['last_anchored_at'], `idx_${indexName}_last_anchored_at`, {
-      storageEngineIndexType: 'hash',
-    })
-    table.index(['first_anchored_at'], `idx_${indexName}_first_anchored_at`, {
-      storageEngineIndexType: 'hash',
-    })
-    table.index(['created_at'], `idx_${indexName}_created_at`, {
-      storageEngineIndexType: 'hash',
-    })
-    table.index(['updated_at'], `idx_${indexName}_updated_at`, {
-      storageEngineIndexType: 'hash',
-    })
-    table.index(
-      ['last_anchored_at', 'created_at'],
-      `idx_${indexName}_last_anchored_at_created_at`,
-      {
-        storageEngineIndexType: 'hash',
-      }
-    )
+    for (const indexToCreate of idx.indices) {
+      table.index(indexToCreate.keys, indexToCreate.name, {
+        storageEngineIndexType: indexToCreate.indexType,
+      })
+    }
   })
 }
 
@@ -148,7 +184,7 @@ export async function createSqliteModelTable(
   extraColumns: Array<ColumnInfo>
 ): Promise<void> {
   await dataSource.schema.createTable(tableName, (table) => {
-    const indexName = getIndexName(tableName)
+    const idx = indices(tableName)
 
     table.string('stream_id', 1024).primary().unique().notNullable()
     table.string('controller_did', 1024).notNullable()
@@ -161,15 +197,11 @@ export async function createSqliteModelTable(
 
     createExtraColumns(table, tableName, extraColumns)
 
-    table.index(['last_anchored_at'], `idx_${indexName}_last_anchored_at`)
-    table.index(['created_at'], `idx_${indexName}_created_at`)
-    table.index(['updated_at'], `idx_${indexName}_updated_at`)
-    table.index(['last_anchored_at', 'created_at'], `idx_${indexName}_last_anchored_at_created_at`)
-    table.index(['first_anchored_at'], `idx_${indexName}_first_anchored_at`)
-    table.index(
-      ['first_anchored_at', 'created_at'],
-      `idx_${indexName}_first_anchored_at_created_at`
-    )
+    for (const indexToCreate of idx.indices) {
+      table.index(indexToCreate.keys, indexToCreate.name, {
+        storageEngineIndexType: indexToCreate.indexType,
+      })
+    }
   })
 }
 

--- a/packages/core/src/indexing/tables-manager.ts
+++ b/packages/core/src/indexing/tables-manager.ts
@@ -4,7 +4,8 @@ import {
   ColumnType,
   createConfigTable,
   createPostgresModelTable,
-  createSqliteModelTable, indices,
+  createSqliteModelTable,
+  indices,
 } from './migrations/1-create-model-table.js'
 import { asTableName } from './as-table-name.util.js'
 import { Knex } from 'knex'
@@ -99,7 +100,10 @@ export class TablesManager {
       this.logger.imp(`Creating Compose DB config table: ${table.tableName}`)
       await createConfigTable(this.dataSource, table.tableName, network)
     } else if (table.tableName === CONFIG_TABLE_NAME) {
-      const config = await this.dataSource.from(table.tableName).where('option', 'network').first('value')
+      const config = await this.dataSource
+        .from(table.tableName)
+        .where('option', 'network')
+        .first('value')
       if (config.value !== network) {
         throw new Error(
           `Initialization failed for config table: ${table.tableName}. The database is configured to use the network ${config.value} but the current network is ${network}.`
@@ -173,7 +177,7 @@ export class TablesManager {
       )
     }
 
-    if(!await this.hasMidIndices(tableName)) {
+    if (!(await this.hasMidIndices(tableName))) {
       throw new Error(
         `Schema verification failed for index: ${tableName}. Please make sure latest migrations have been applied.`
       )
@@ -241,9 +245,8 @@ export class PostgresTablesManager extends TablesManager {
    * @param tableName
    */
   async hasMidIndices(tableName: string): Promise<boolean> {
-    const expectedIndices =
-      indices(tableName).indices.flatMap((index) => index.name);
-    const sqlIndices = expectedIndices.map(s => `'${s}'`)
+    const expectedIndices = indices(tableName).indices.flatMap((index) => index.name)
+    const sqlIndices = expectedIndices.map((s) => `'${s}'`)
     const actualIndices = await this.dataSource.raw(`
   select
     distinct i.relname as index_name
@@ -313,9 +316,8 @@ export class SqliteTablesManager extends TablesManager {
    * @param tableName
    */
   async hasMidIndices(tableName: string): Promise<boolean> {
-    const expectedIndices =
-      indices(tableName).indices.flatMap((index) => index.name);
-    const sqlIndices = expectedIndices.map(s => `'${s}'`)
+    const expectedIndices = indices(tableName).indices.flatMap((index) => index.name)
+    const sqlIndices = expectedIndices.map((s) => `'${s}'`)
     const actualIndices = await this.dataSource.raw(`
 select name, tbl_name
 FROM sqlite_master

--- a/packages/core/src/indexing/tables-manager.ts
+++ b/packages/core/src/indexing/tables-manager.ts
@@ -326,6 +326,6 @@ and tbl_name like '${tableName}'
 and name in (${sqlIndices})
 ;
   `)
-    return expectedIndices.length == actualIndices.rowCount
+    return expectedIndices.length == actualIndices.length
   }
 }


### PR DESCRIPTION
Add checks when a node starts up to verify that indices are present.

Additionally fix code that was using too long of a name, switching from tableName to indexName.