### PR TITLE
chore: remove errata in 3id-did-resolver README

### DIFF
--- a/packages/3id-did-resolver/README.md
+++ b/packages/3id-did-resolver/README.md
@@ -23,7 +23,6 @@ import { Resolver } from 'did-resolver'
 
 // You need an instance of Ceramic to call getResolver.
 // This can be either @ceramicnetwork/core or @ceramicnetwork/http-client.
-// You can also set an address for your own ethr-did-registry contract
 const ceramic = // ...
 
 // getResolver will return an object with a key/value pair of { '3': resolver }


### PR DESCRIPTION
## Description

README previously included some text that referred to the did-ethr resolver

## Note

Found this because the Veramo team added a resolver for did:3 to our DID Driver, so we can add did:3 support to the Universal Resolver. If anyone from Ceramic wants to review our work, that'd be great

https://github.com/uport-project/uport-did-driver/pull/103