### PR TITLE
feat(core): Enable running ComposeDB on mainnet

### DIFF
--- a/packages/core/src/initialization/make-index-api.ts
+++ b/packages/core/src/initialization/make-index-api.ts
@@ -30,10 +30,6 @@ export function makeIndexApi(
   if (process.env.CERAMIC_ENABLE_EXPERIMENTAL_COMPOSE_DB != 'true') {
     return undefined
   }
-  if (network == Networks.MAINNET || network == Networks.ELP) {
-    // TODO enable Compose DB on mainnet once mainnet anchors are indexable.
-    throw new Error(`Compose DB indexing features are not yet supported on mainnet`)
-  }
   if (!indexingConfig) {
     logger.warn(`Indexing is not configured. Please add the indexing settings to your config file`)
     return undefined


### PR DESCRIPTION
We must not release this on prod until after the hard fork