### PR TITLE
fix(anchor-listener, core): batch get logs

### DIFF
--- a/packages/anchor-listener/src/__tests__/loader.test.ts
+++ b/packages/anchor-listener/src/__tests__/loader.test.ts
@@ -1,20 +1,23 @@
-import type { Block, Provider } from '@ethersproject/providers'
+import type { Block, Provider, Log } from '@ethersproject/providers'
 import { jest } from '@jest/globals'
 import { firstValueFrom, from, of, toArray } from 'rxjs'
 
 import {
-  createAncestorBlocksProofsLoader,
-  createAnchorProofsLoader,
   createBlockLoader,
-  createBlocksProofsLoader,
-  loadAnchorProofs,
   loadBlock,
+  mapLoadBlockForBlockProofs,
+  createBlockProofsLoaderForRange,
+  createAncestorBlocksProofsLoader,
+  createBlocksProofsLoader,
+  loadBlockProofsForRange,
   mapLoadBlockProofs,
-  mapLoadBlocks,
+  mapLoadBlockProofsForRange,
+  type BlockProofs,
+  BlockRangeFilter,
 } from '../loader.js'
 import { createAnchorProof } from '../utils.js'
 
-import { createLog, delay, mockedLogs, mockedLogsProofs } from './test-utils.js'
+import { createLog, delay, mockedLogs, mockedBlockProofs } from './test-utils.js'
 
 describe('loader', () => {
   describe('createBlockLoader()', () => {
@@ -58,113 +61,168 @@ describe('loader', () => {
     expect(getBlock).toHaveBeenCalledWith('foo')
   })
 
-  test('mapLoadBlocks() operator pushes loaded blocks in input order', async () => {
-    const blockNumbers = [100, 101, 102]
-    const loadedOrder: Array<number> = []
-    const getBlock = jest.fn(async (number: number) => {
+  test('mapLoadBlockForBlockProofs() operator adds loaded blocks to block proofs in input order', async () => {
+    const blockProofs = [
+      { blockHash: '100' },
+      { blockHash: '101' },
+      { blockHash: '102' },
+    ] as Array<BlockProofs>
+    const loadedOrder: Array<string> = []
+    const getBlock = jest.fn(async (hash: string) => {
       // Blocks will be resolved with delay so they are received out of order
       let wait = 0
-      if (number === 100) {
+      if (hash === '100') {
         wait = 200
-      } else if (number === 101) {
+      } else if (hash === '101') {
         wait = 50
-      } else if (number === 102) {
+      } else if (hash === '102') {
         wait = 100
       }
       await delay(wait)
-      loadedOrder.push(number)
-      return { number } as Block
+      loadedOrder.push(hash)
+      return { hash } as Block
     })
     const provider = { getBlock } as unknown as Provider
 
-    const loadedBlocks$ = of(blockNumbers).pipe(mapLoadBlocks(provider), toArray())
+    const loadedBlocks$ = of(blockProofs).pipe(mapLoadBlockForBlockProofs(provider), toArray())
     // Blocks should get pushed in input order...
-    await expect(firstValueFrom(loadedBlocks$)).resolves.toEqual([
-      { number: 100 },
-      { number: 101 },
-      { number: 102 },
-    ])
+    await expect(firstValueFrom(loadedBlocks$)).resolves.toEqual(
+      blockProofs.map((proofs) => ({ proofs, block: { hash: proofs.blockHash } }))
+    )
     // ... even if they got received out of order when loaded in parallel
-    expect(loadedOrder).toEqual([101, 102, 100])
+    expect(loadedOrder).toEqual(['101', '102', '100'])
   })
 
-  describe('createAnchorProofsLoader()', () => {
+  describe('createBlockProofsLoaderForRange()', () => {
     test('Pushes an error if there is no contract address for the wanted chainId', async () => {
       // @ts-expect-error invalid chainId
-      const anchorProofs$ = createAnchorProofsLoader({} as Provider, 'eip155:0', {} as Block)
+      const anchorProofs$ = createBlockProofsLoaderForRange({} as Provider, 'eip155:0', {} as Block)
       await expect(firstValueFrom(anchorProofs$)).rejects.toThrowError(
         'No known contract address for network: eip155:0'
       )
     })
 
-    test('Pushes an array of anchor proofs', async () => {
-      const logs = [0, 1, 2].map((i) => createLog(new Uint8Array(new Array(32).fill(i))))
+    test('Pushes an array of block proofs', async () => {
+      const logs = [10, 11, 12].map((blockNumber) =>
+        createLog(blockNumber, new Uint8Array(new Array(32).fill(blockNumber)))
+      )
       const getLogs = jest.fn(() => Promise.resolve(logs))
       const provider = { getLogs } as unknown as Provider
 
-      const anchorProofs$ = createAnchorProofsLoader(provider, 'eip155:1337', 10)
-      await expect(firstValueFrom(anchorProofs$)).resolves.toEqual([
-        createAnchorProof('eip155:1337', logs[0]),
-        createAnchorProof('eip155:1337', logs[1]),
-        createAnchorProof('eip155:1337', logs[2]),
-      ])
+      const blockProofs$ = createBlockProofsLoaderForRange(provider, 'eip155:1337', {
+        fromBlock: 10,
+        toBlock: 12,
+      })
+      await expect(firstValueFrom(blockProofs$)).resolves.toEqual(
+        [10, 11, 12].map((blockNumber, i) => ({
+          blockHash: blockNumber.toString(),
+          blockNumber,
+          proofs: [createAnchorProof('eip155:1337', logs[i])],
+        }))
+      )
     })
   })
 
-  describe('loadAnchorProofs()', () => {
+  describe('loadBlockProofsForRange()', () => {
     test('Pushes an error if there is no contract address for the wanted chainId', async () => {
-      // @ts-expect-error invalid chainId
-      await expect(loadAnchorProofs({} as Provider, 'eip155:0', {} as Block)).rejects.toThrowError(
-        'No known contract address for network: eip155:0'
-      )
+      await expect(
+        // @ts-expect-error invalid chainId
+        loadBlockProofsForRange({} as Provider, 'eip155:0', {} as Block)
+      ).rejects.toThrowError('No known contract address for network: eip155:0')
     })
 
-    test('Pushes an array of anchor proofs', async () => {
+    test('Pushes an array of block proofs', async () => {
       const getLogs = jest.fn(() => Promise.resolve(mockedLogs))
       const provider = { getLogs } as unknown as Provider
-      await expect(loadAnchorProofs(provider, 'eip155:1337', 10)).resolves.toEqual(mockedLogsProofs)
+      await expect(
+        loadBlockProofsForRange(provider, 'eip155:1337', { fromBlock: 0, toBlock: 2 })
+      ).resolves.toEqual(mockedBlockProofs)
     })
   })
 
   test('mapLoadBlockProofs() operator loads the proofs', async () => {
-    const getLogs = jest.fn(() => Promise.resolve(mockedLogs))
+    const getLogs = jest.fn(({ fromBlock, toBlock }) => {
+      expect(fromBlock).toEqual(toBlock)
+      return Promise.resolve([mockedLogs[fromBlock]])
+    })
     const provider = { getLogs } as unknown as Provider
     const blocks = [
-      { number: 10, timestamp: 1000 },
-      { number: 11, timestamp: 1100 },
+      { number: 0, timestamp: 1000 },
+      { number: 1, timestamp: 1100 },
+      { number: 2, timestamp: 1200 },
     ] as Array<Block>
 
-    const blocksWithProofs$ = from(blocks).pipe(
-      mapLoadBlockProofs(provider, 'eip155:1337'),
+    const blockProofs$ = from(blocks).pipe(mapLoadBlockProofs(provider, 'eip155:1337'), toArray())
+
+    await expect(firstValueFrom(blockProofs$)).resolves.toEqual(mockedBlockProofs)
+  })
+
+  test('mapLoadBlockProofsForRange() operator loads the proofs for a given range', async () => {
+    const logsByBlockNumber = {
+      10: [
+        createLog(10, new Uint8Array(new Array(32).fill(10))),
+        createLog(10, new Uint8Array(new Array(32).fill(20))),
+      ],
+      11: [createLog(11, new Uint8Array(new Array(32).fill(11)))],
+      12: [createLog(12, new Uint8Array(new Array(32).fill(12)))],
+    }
+
+    const getLogs = jest.fn(async ({ fromBlock, toBlock }) => {
+      const logs: Array<Log> = []
+      for (let i = fromBlock; i <= toBlock; i++) {
+        logs.push(...logsByBlockNumber[i])
+      }
+      if (fromBlock === 10) {
+        await delay(1000)
+      }
+      return logs
+    })
+
+    const provider = { getLogs } as unknown as Provider
+    const blockRanges = [
+      { fromBlock: 10, toBlock: 11 },
+      { fromBlock: 12, toBlock: 12 },
+    ] as Array<BlockRangeFilter>
+
+    const blockProofs$ = from(blockRanges).pipe(
+      mapLoadBlockProofsForRange(provider, 'eip155:1337'),
       toArray()
     )
-    await expect(firstValueFrom(blocksWithProofs$)).resolves.toEqual([
-      { block: blocks[0], proofs: mockedLogsProofs },
-      { block: blocks[1], proofs: mockedLogsProofs },
+
+    await expect(firstValueFrom(blockProofs$)).resolves.toEqual([
+      [
+        {
+          blockNumber: 10,
+          blockHash: '10',
+          proofs: logsByBlockNumber[10].map((log) => createAnchorProof('eip155:1337', log)),
+        },
+        {
+          blockNumber: 11,
+          blockHash: '11',
+          proofs: logsByBlockNumber[11].map((log) => createAnchorProof('eip155:1337', log)),
+        },
+      ],
+      [
+        {
+          blockNumber: 12,
+          blockHash: '12',
+          proofs: logsByBlockNumber[12].map((log) => createAnchorProof('eip155:1337', log)),
+        },
+      ],
     ])
   })
 
   test('createBlocksProofsLoader() loads the proofs', async () => {
-    const blocks = [
-      { number: 100, timestamp: 1000 },
-      { number: 101, timestamp: 1100 },
-      { number: 102, timestamp: 1200 },
-    ] as Array<Block>
-    const getBlock = jest.fn((blockNumber: number) => Promise.resolve(blocks[blockNumber - 100]))
     const getLogs = jest.fn(() => Promise.resolve(mockedLogs))
-    const provider = { getBlock, getLogs } as unknown as Provider
+    const provider = { getLogs } as unknown as Provider
 
-    const blocksWithProofs$ = createBlocksProofsLoader({
+    const blockProofs$ = createBlocksProofsLoader({
       provider,
       chainId: 'eip155:1337',
       fromBlock: 100,
       toBlock: 102,
     })
-    await expect(firstValueFrom(blocksWithProofs$.pipe(toArray()))).resolves.toEqual([
-      { block: blocks[0], proofs: mockedLogsProofs },
-      { block: blocks[1], proofs: mockedLogsProofs },
-      { block: blocks[2], proofs: mockedLogsProofs },
-    ])
+    await expect(firstValueFrom(blockProofs$.pipe(toArray()))).resolves.toEqual(mockedBlockProofs)
   })
 
   test('createAncestorBlocksProofsLoader() loads the proofs', async () => {
@@ -174,8 +232,13 @@ describe('loader', () => {
       block2: { parentHash: 'block1', number: 102, timestamp: 1200 } as Block,
       latest: { parentHash: 'block2', number: 103, timestamp: 1300 } as Block,
     }
+
+    const mockedLogs = [100, 101, 102, 103].map((i) =>
+      createLog(i, new Uint8Array(new Array(32).fill(i)))
+    ) as [Log, Log, Log]
+
     const getBlock = jest.fn((blockTag: string) => Promise.resolve(blocks[blockTag]))
-    const getLogs = jest.fn(() => Promise.resolve(mockedLogs))
+    const getLogs = jest.fn(({ fromBlock }) => Promise.resolve([mockedLogs[fromBlock - 100]]))
     const provider = { getBlock, getLogs } as unknown as Provider
 
     const blocksWithProofs$ = createAncestorBlocksProofsLoader({
@@ -184,10 +247,16 @@ describe('loader', () => {
       initialBlock: 'latest',
       targetAncestorHash: 'block0',
     })
-    await expect(firstValueFrom(blocksWithProofs$.pipe(toArray()))).resolves.toEqual([
-      { block: blocks.latest, proofs: mockedLogsProofs },
-      { block: blocks.block2, proofs: mockedLogsProofs },
-      { block: blocks.block1, proofs: mockedLogsProofs },
-    ])
+
+    await expect(firstValueFrom(blocksWithProofs$.pipe(toArray()))).resolves.toEqual(
+      mockedLogs
+        .slice(1)
+        .reverse()
+        .map((log) => ({
+          blockNumber: log.blockNumber,
+          blockHash: log.blockHash,
+          proofs: [createAnchorProof('eip155:1337', log)],
+        }))
+    )
   })
 })

--- a/packages/anchor-listener/src/__tests__/test-utils.ts
+++ b/packages/anchor-listener/src/__tests__/test-utils.ts
@@ -18,15 +18,21 @@ export const transactionHashCid = CID.parse(
   'bagjqcgza7mvdlzewbfbq35peso2atjydg3ekalew5vmze7w2a5cbhmav4rmq'
 )
 
-export function createLog(bytes = bytes32, txHash = transactionHashCid): Log {
+export function createLog(blockNumber: number, bytes = bytes32, txHash = transactionHashCid): Log {
   return {
+    blockNumber,
+    blockHash: blockNumber.toString(),
     data: defaultAbiCoder.encode(['bytes32'], [bytes]),
     transactionHash: '0x' + toString(decode(txHash.multihash.bytes).digest, 'base16'),
   } as Log
 }
 
 export const mockedLogs = [0, 1, 2].map((i) =>
-  createLog(new Uint8Array(new Array(32).fill(i)))
+  createLog(i, new Uint8Array(new Array(32).fill(i)))
 ) as [Log, Log, Log]
 
-export const mockedLogsProofs = mockedLogs.map((log) => createAnchorProof('eip155:1337', log))
+export const mockedBlockProofs = mockedLogs.map((log) => ({
+  blockNumber: log.blockNumber,
+  blockHash: log.blockHash,
+  proofs: [createAnchorProof('eip155:1337', log)],
+}))

--- a/packages/anchor-listener/src/__tests__/utils.test.ts
+++ b/packages/anchor-listener/src/__tests__/utils.test.ts
@@ -6,7 +6,7 @@ import { createLog, transactionHashCid } from './test-utils.js'
 
 describe('utils', () => {
   test('createAnchorProof() creates an AnchorProof object', () => {
-    const log = createLog()
+    const log = createLog(1)
     const proof = createAnchorProof('eip155:1337', log)
 
     expect(proof).toMatchObject({

--- a/packages/anchor-listener/src/loader.ts
+++ b/packages/anchor-listener/src/loader.ts
@@ -1,6 +1,6 @@
 import { type SupportedNetwork, ANCHOR_CONTRACT_ADDRESSES } from '@ceramicnetwork/anchor-utils'
 import type { AnchorProof } from '@ceramicnetwork/common'
-import type { Block, BlockTag, Provider } from '@ethersproject/providers'
+import type { Block, BlockTag, Provider, Log } from '@ethersproject/providers'
 import {
   EMPTY,
   type Observable,
@@ -12,18 +12,30 @@ import {
   expand,
   firstValueFrom,
   map,
-  mergeMap,
   pipe,
+  mergeMap,
   range,
   retry,
   throwError,
+  from,
 } from 'rxjs'
 
 import { createAnchorProof } from './utils.js'
 
 export type BlockProofs = {
-  block: Block
+  blockNumber: number
+  blockHash: string
   proofs: Array<AnchorProof>
+}
+
+export type BlockRangeFilter = {
+  fromBlock: BlockTag
+  toBlock: BlockTag
+}
+
+export type BlockAndBlockProofs = {
+  block: Block
+  proofs: BlockProofs
 }
 
 /**
@@ -59,19 +71,22 @@ export async function loadBlock(
 }
 
 /**
- * Rx operator to load blocks based on input array of block numbers
+ * Rx operator to load blocks for each input blocks proofs
  *
  * @param provider ethers.js Provider
  * @param retryConfig optional Rx retry config
- * @returns OperatorFunction<Array<number>, Block>
+ * @returns OperatorFunction<Array<BlockProofs>, BlockAndBlockProofs>
  */
-export function mapLoadBlocks(
+export function mapLoadBlockForBlockProofs(
   provider: Provider,
   retryConfig: RetryConfig = { count: 3 }
-): OperatorFunction<Array<number>, Block> {
+): OperatorFunction<Array<BlockProofs>, BlockAndBlockProofs> {
   return pipe(
-    mergeMap((blockNumbers) => {
-      return blockNumbers.map((block) => loadBlock(provider, block, retryConfig))
+    mergeMap((blockProofsForRange) => {
+      return blockProofsForRange.map(async (proofs) => {
+        const block = await loadBlock(provider, proofs.blockHash, retryConfig)
+        return { block, proofs }
+      })
     }),
     // Use concatMap here to ensure ordering
     concatMap(async (blockPromise) => await blockPromise)
@@ -79,77 +94,81 @@ export function mapLoadBlocks(
 }
 
 /**
- * Create an Observable loading anchor proofs for a given block
+ * Groups logs by their block numbers
+ * @param logs ethers.js Log
+ * @returns Record<number, Array<Log>>
+ */
+const groupLogsByBlockNumber = (logs: Array<Log>): Record<number, Array<Log>> =>
+  logs.reduce((logsByBlockNumber, log) => {
+    const { blockNumber } = log
+
+    if (!logsByBlockNumber[blockNumber]) logsByBlockNumber[blockNumber] = []
+
+    logsByBlockNumber[blockNumber]?.push(log)
+    return logsByBlockNumber
+  }, {} as Record<number, Array<Log>>)
+
+/**
+ * Create an Observable loading block proofs for a range of blocks
  *
  * @param provider ethers.js Provider
  * @param chainId supported anchor network chain ID
- * @param block ethers.js BlockTag
+ * @param blockRangeFilter BlockRangeFilter providing the fromBlock and toBlock, each represented by ether.js BlockTag
  * @param retryConfig optional Rx retry config
- * @returns Observable<Array<AnchorProof>>
+ * @returns Observable<Array<BlockProofs>>
  */
-export function createAnchorProofsLoader(
+export function createBlockProofsLoaderForRange(
   provider: Provider,
   chainId: SupportedNetwork,
-  block: BlockTag,
+  blockRangeFilter: BlockRangeFilter,
   retryConfig: RetryConfig = { count: 3 }
-): Observable<Array<AnchorProof>> {
+): Observable<Array<BlockProofs>> {
   const address = ANCHOR_CONTRACT_ADDRESSES[chainId]
   if (address == null) {
     return throwError(() => new Error(`No known contract address for network: ${chainId}`))
   }
 
   return defer(async () => {
-    return await provider.getLogs({ address, fromBlock: block, toBlock: block })
+    return await provider.getLogs({
+      address,
+      fromBlock: blockRangeFilter.fromBlock,
+      toBlock: blockRangeFilter.toBlock,
+    })
   }).pipe(
     retry(retryConfig),
-    map((logs) => {
-      return logs.map((log) => createAnchorProof(chainId, log))
+    map(groupLogsByBlockNumber),
+    map((logsByBlockNumber) => {
+      return Object.values(logsByBlockNumber).map((logs) => ({
+        blockNumber: logs[0]?.blockNumber as number,
+        blockHash: logs[0]?.blockHash as string,
+        proofs: logs.map((log) => createAnchorProof(chainId, log)),
+      }))
     })
   )
 }
 
 /**
- * Load anchor proofs for a given block
+ * Load block proofs for a given block range
  *
  * @param provider ethers.js Provider
  * @param chainId supported anchor network chain ID
- * @param block ethers.js BlockTag
+ * @param blockRangeFilter BlockRangeFilter providing the fromBlock and toBlock, each represented by ether.js BlockTag
  * @param retryConfig optional Rx retry config
  * @returns Observable<Array<AnchorProof>>
  */
-export async function loadAnchorProofs(
+export async function loadBlockProofsForRange(
   provider: Provider,
   chainId: SupportedNetwork,
-  block: BlockTag,
+  blockRangeFilter: BlockRangeFilter,
   retryConfig?: RetryConfig
-): Promise<Array<AnchorProof>> {
-  return await firstValueFrom(createAnchorProofsLoader(provider, chainId, block, retryConfig))
+): Promise<Array<BlockProofs>> {
+  return await firstValueFrom(
+    createBlockProofsLoaderForRange(provider, chainId, blockRangeFilter, retryConfig)
+  )
 }
 
 /**
- * Load a block with anchor proofs for a given block tag
- *
- * @param provider ethers.js Provider
- * @param chainId supported anchor network chain ID
- * @param blockTag ethers.js BlockTag
- * @param retryConfig optional Rx retry config
- * @returns Promise<BlockProofs>
- */
-export async function loadBlockProofs(
-  provider: Provider,
-  chainId: SupportedNetwork,
-  blockTag: BlockTag,
-  retryConfig?: RetryConfig
-): Promise<BlockProofs> {
-  const [block, proofs] = await Promise.all([
-    loadBlock(provider, blockTag, retryConfig),
-    loadAnchorProofs(provider, chainId, blockTag, retryConfig),
-  ])
-  return { block, proofs }
-}
-
-/**
- * Rx operator to load anchor proofs for input blocks
+ * Rx operator to load block proofs for input blocks
  *
  * @param provider ethers.js Provider
  * @param chainId supported anchor network chain ID
@@ -163,32 +182,41 @@ export function mapLoadBlockProofs(
 ): OperatorFunction<Block, BlockProofs> {
   return pipe(
     concatMap(async (block) => {
-      return { block, proofs: await loadAnchorProofs(provider, chainId, block.number, retryConfig) }
+      const result = await loadBlockProofsForRange(
+        provider,
+        chainId,
+        { fromBlock: block.number, toBlock: block.number },
+        retryConfig
+      )
+
+      if (result.length !== 1) {
+        throw Error(
+          `Did not receive exactly one set of proofs for block ${block.number}. Received ${result.length} sets`
+        )
+      }
+
+      return result[0] as BlockProofs
     })
   )
 }
 
 /**
- * Rx operator to load anchor proofs for input blocks
+ * Rx operator to load block proofs for input blocks ranges
  *
  * @param provider ethers.js Provider
  * @param chainId supported anchor network chain ID
  * @param retryConfig optional Rx retry config
  * @returns OperatorFunction<Array<number>, BlockProofs>
  */
-export function mapLoadBlocksProofs(
+export function mapLoadBlockProofsForRange(
   provider: Provider,
   chainId: SupportedNetwork,
   retryConfig: RetryConfig = { count: 3 }
-): OperatorFunction<Array<number>, BlockProofs> {
+): OperatorFunction<BlockRangeFilter, Array<BlockProofs>> {
   return pipe(
-    mergeMap((blockNumbers) => {
-      return blockNumbers.map(async (blockNumber) => {
-        return await loadBlockProofs(provider, chainId, blockNumber, retryConfig)
-      })
-    }),
-    // Use concatMap here to ensure ordering
-    concatMap(async (blockPromise) => await blockPromise)
+    concatMap((blockRangeFilter: BlockRangeFilter) => {
+      return loadBlockProofsForRange(provider, chainId, blockRangeFilter, retryConfig)
+    })
   )
 }
 
@@ -208,7 +236,7 @@ export type BlocksProofsLoaderParams = {
 }
 
 /**
- * Create an Observable loading blocks and their anchor proofs for a given range of blocks
+ * Create an Observable loading blockProofs for a given range of blocks
  *
  * @param params BlocksProofsLoaderParams
  * @returns Observable<BlockProofs>
@@ -223,8 +251,13 @@ export function createBlocksProofsLoader({
 }: BlocksProofsLoaderParams): Observable<BlockProofs> {
   const retry = retryConfig ?? { count: 3 }
   return range(fromBlock, toBlock - fromBlock + 1).pipe(
-    bufferCount(blockLoadBuffer ?? 5),
-    mapLoadBlocksProofs(provider, chainId, retry)
+    bufferCount(blockLoadBuffer ?? 100),
+    map((values) => ({
+      fromBlock: values[0] as number,
+      toBlock: values[values.length - 1] as number,
+    })),
+    mapLoadBlockProofsForRange(provider, chainId, retry),
+    concatMap((blockProofsForRange) => from(blockProofsForRange))
   )
 }
 

--- a/packages/core/src/sync/__tests__/ceramic-sync.test.ts
+++ b/packages/core/src/sync/__tests__/ceramic-sync.test.ts
@@ -89,7 +89,7 @@ const parseBlockHashOrBlockTag = async (
     return parsed
   }
 
-  return parseInt(blockHashOrBlockTag.split('_')[0], 10)
+  return parseInt(blockHashOrBlockTag.split('_')[1], 10)
 }
 
 class MockProvider extends EventEmitter {

--- a/packages/core/src/sync/workers/__tests__/sync.test.ts
+++ b/packages/core/src/sync/workers/__tests__/sync.test.ts
@@ -12,7 +12,8 @@ const ERROR_BLOCK = 100
 
 const createBlockProof = (chainId: string, blockNumber: number) => {
   return {
-    block: { number: blockNumber } as Block,
+    blockNumber: blockNumber,
+    blockHash: blockNumber.toString(),
     proofs: [
       {
         chainId,
@@ -34,7 +35,7 @@ const createBlocksProofsLoader = (params: BlocksProofsLoaderParams): Observable<
 
   return of(...blockProofs).pipe(
     map((blockProofs) => {
-      if (blockProofs.block.number === ERROR_BLOCK) {
+      if (blockProofs.blockNumber === ERROR_BLOCK) {
         throw Error('test error')
       }
 

--- a/packages/core/src/sync/workers/sync.ts
+++ b/packages/core/src/sync/workers/sync.ts
@@ -69,7 +69,7 @@ export class SyncWorker implements Worker<SyncJobData> {
           throw Error('Error loading block proof')
         }
 
-        const { proofs, block } = blockProofs
+        const { proofs, blockNumber } = blockProofs
         if (proofs.length > 0) {
           const jobs: Job<RebuildAnchorJobData>[] = proofs.map((proof) =>
             createRebuildAnchorJob(proof, models)
@@ -79,7 +79,7 @@ export class SyncWorker implements Worker<SyncJobData> {
         }
 
         await this.jobQueue.updateJob(job.id, {
-          fromBlock: block.number + 1,
+          fromBlock: blockNumber + 1,
           toBlock,
           models,
         })


### PR DESCRIPTION
Get logs in the anchor-listener get logs for a range now (set to 100 blocks as default)