### PR TITLE
feat(cli,http-client): Add node status admin API endpoint skeleton

### DIFF
--- a/packages/cli/src/__tests__/admin-api.test.ts
+++ b/packages/cli/src/__tests__/admin-api.test.ts
@@ -260,7 +260,7 @@ describe('admin api', () => {
     })
 
     it('Old code used with status GET', async () => {
-      const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/code`)).code
+      const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       const now = new Date().getTime()
       MockDate.set(now + (1000 * 60 * 1 + 1000)) // One minute one second in the future
       expect(true).toBeTruthy()

--- a/packages/cli/src/__tests__/admin-api.test.ts
+++ b/packages/cli/src/__tests__/admin-api.test.ts
@@ -23,6 +23,9 @@ const MY_MODEL_1_CONTENT: ModelDefinition = {
   accountRelation: { type: 'list' },
 }
 
+const MODEL_PATH = '/api/v0/admin/models'
+const STATUS_PATH = '/api/v0/admin/nodeStatus'
+
 describe('admin api', () => {
   let daemon: CeramicDaemon
   let adminDid: DID
@@ -79,105 +82,163 @@ describe('admin api', () => {
     process.env.CERAMIC_ENABLE_EXPERIMENTAL_COMPOSE_DB = originalEnvVarVal
   })
 
-  async function buildJWS(did: DID, code: string, models?: Array<string>): Promise<string> {
+  async function buildJWS(
+    did: DID,
+    code: string,
+    requestPath,
+    models?: Array<string>
+  ): Promise<string> {
     const body = models ? { models: models } : undefined
     const jws = await did.createJWS({
       code: code,
-      requestPath: '/api/v0/admin/models',
+      requestPath,
       requestBody: body,
     })
     return `${jws.signatures[0].protected}.${jws.payload}.${jws.signatures[0].signature}`
   }
 
-  it('admin models API CRUD test', async () => {
-    const adminURLString = `http://localhost:${daemon.port}/api/v0/admin/models`
+  it('admin API CRUD test', async () => {
+    const statusURLString = `http://localhost:${daemon.port}/api/v0/admin/nodeStatus`
+    const modelsURLString = `http://localhost:${daemon.port}/api/v0/admin/models`
 
     const fetchCode = async (): Promise<string> => {
       return (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
     }
 
-    const getResult = await fetchJson(adminURLString, {
+    const statusResult = await fetchJson(statusURLString, {
       headers: {
-        authorization: `Authorization: Basic ${await buildJWS(adminDid, await fetchCode())}`,
+        authorization: `Authorization: Basic ${await buildJWS(
+          adminDid,
+          await fetchCode(),
+          STATUS_PATH
+        )}`,
+      },
+    })
+    expect(statusResult).toEqual({})
+
+    const getResult = await fetchJson(modelsURLString, {
+      headers: {
+        authorization: `Authorization: Basic ${await buildJWS(
+          adminDid,
+          await fetchCode(),
+          MODEL_PATH
+        )}`,
       },
     })
     expect(getResult.models).toEqual([])
 
-    const postResult = await fetchJson(adminURLString, {
+    const postResult = await fetchJson(modelsURLString, {
       method: 'POST',
-      body: { jws: await buildJWS(adminDid, await fetchCode(), [exampleModelStreamId]) },
+      body: {
+        jws: await buildJWS(adminDid, await fetchCode(), MODEL_PATH, [exampleModelStreamId]),
+      },
     })
     expect(postResult.result).toEqual('success')
 
-    const newGetResult = await fetchJson(adminURLString, {
+    const newGetResult = await fetchJson(modelsURLString, {
       headers: {
-        authorization: `Authorization: Basic ${await buildJWS(adminDid, await fetchCode())}`,
+        authorization: `Authorization: Basic ${await buildJWS(
+          adminDid,
+          await fetchCode(),
+          MODEL_PATH
+        )}`,
       },
     })
     expect(newGetResult.models).toEqual([exampleModelStreamId])
 
-    const deleteResult = await fetchJson(adminURLString, {
+    const deleteResult = await fetchJson(modelsURLString, {
       method: 'DELETE',
-      body: { jws: await buildJWS(adminDid, await fetchCode(), [exampleModelStreamId]) },
+      body: {
+        jws: await buildJWS(adminDid, await fetchCode(), MODEL_PATH, [exampleModelStreamId]),
+      },
     })
     expect(deleteResult.result).toEqual('success')
 
-    const getResultAfterDelete = await fetchJson(adminURLString, {
+    const getResultAfterDelete = await fetchJson(modelsURLString, {
       headers: {
-        authorization: `Authorization: Basic ${await buildJWS(adminDid, await fetchCode())}`,
+        authorization: `Authorization: Basic ${await buildJWS(
+          adminDid,
+          await fetchCode(),
+          MODEL_PATH
+        )}`,
       },
     })
     expect(getResultAfterDelete.models).toEqual([])
   })
 
-  describe('admin models API validation test', () => {
-    it('No admin code for GET', async () => {
+  describe('admin API validation test', () => {
+    it('No admin code for nodeStatus GET', async () => {
       await expect(
-        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/nodeStatus`, {
           headers: {
-            authorization: `Authorization: Basic ${await buildJWS(adminDid, '')}`,
+            authorization: `Authorization: Basic ${await buildJWS(adminDid, '', STATUS_PATH)}`,
           },
         })
       ).rejects.toThrow(/Admin code is missing from the the jws block/)
     })
 
-    it('No admin code for POST', async () => {
-      await expect(
-        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
-          method: 'POST',
-          body: { jws: await buildJWS(adminDid, '') },
-        })
-      ).rejects.toThrow(/Admin code is missing from the the jws block/)
-    })
-
-    it('No admin code for DELETE', async () => {
-      await expect(
-        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
-          method: 'POST',
-          body: { jws: await buildJWS(adminDid, '') },
-        })
-      ).rejects.toThrow(/Admin code is missing from the the jws block/)
-    })
-
-    it('Arbitrary admin code for GET', async () => {
+    it('No admin code for models GET', async () => {
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           headers: {
+            authorization: `Authorization: Basic ${await buildJWS(adminDid, '', MODEL_PATH)}`,
+          },
+        })
+      ).rejects.toThrow(/Admin code is missing from the the jws block/)
+    })
+
+    it('No admin code for models POST', async () => {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+          method: 'POST',
+          body: { jws: await buildJWS(adminDid, '', MODEL_PATH) },
+        })
+      ).rejects.toThrow(/Admin code is missing from the the jws block/)
+    })
+
+    it('No admin code for models DELETE', async () => {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+          method: 'POST',
+          body: { jws: await buildJWS(adminDid, '', MODEL_PATH) },
+        })
+      ).rejects.toThrow(/Admin code is missing from the the jws block/)
+    })
+
+    it('Arbitrary admin code for status GET', async () => {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/nodeStatus`, {
+          headers: {
             authorization: `Authorization: Basic ${await buildJWS(
               adminDid,
-              '1B7F4C45-C0E8-4BF3-88E4-8F7C81AB3BEC'
+              '1B7F4C45-C0E8-4BF3-88E4-8F7C81AB3BEC',
+              STATUS_PATH
             )}`,
           },
         })
       ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
     })
 
-    it('Arbitrary admin code for POST', async () => {
+    it('Arbitrary admin code for models GET', async () => {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+          headers: {
+            authorization: `Authorization: Basic ${await buildJWS(
+              adminDid,
+              '1B7F4C45-C0E8-4BF3-88E4-8F7C81AB3BEC',
+              MODEL_PATH
+            )}`,
+          },
+        })
+      ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
+    })
+
+    it('Arbitrary admin code for models POST', async () => {
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
           body: {
-            jws: await buildJWS(adminDid, '1B7F4C45-C0E8-4BF3-88E4-8F7C81AB3BEC', [
+            jws: await buildJWS(adminDid, '1B7F4C45-C0E8-4BF3-88E4-8F7C81AB3BEC', MODEL_PATH, [
               exampleModelStreamId,
             ]),
           },
@@ -185,12 +246,12 @@ describe('admin api', () => {
       ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
     })
 
-    it('Arbitrary admin code for DELETE', async () => {
+    it('Arbitrary admin code for models DELETE', async () => {
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
           body: {
-            jws: await buildJWS(adminDid, '1B7F4C45-C0E8-4BF3-88E4-8F7C81AB3BEC', [
+            jws: await buildJWS(adminDid, '1B7F4C45-C0E8-4BF3-88E4-8F7C81AB3BEC', MODEL_PATH, [
               exampleModelStreamId,
             ]),
           },
@@ -198,7 +259,23 @@ describe('admin api', () => {
       ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
     })
 
-    it('Old code used with GET', async () => {
+    it('Old code used with status GET', async () => {
+      const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/code`)).code
+      const now = new Date().getTime()
+      MockDate.set(now + (1000 * 60 * 1 + 1000)) // One minute one second in the future
+      expect(true).toBeTruthy()
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/nodeStatus`, {
+          headers: {
+            authorization: `Authorization: Basic ${await buildJWS(adminDid, code, STATUS_PATH)}`,
+          },
+        })
+      ).rejects.toThrow(
+        /Unauthorized access: expired admin code - admin codes are only valid for 60 seconds/
+      )
+    })
+
+    it('Old code used with models GET', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       const now = new Date().getTime()
       MockDate.set(now + (1000 * 60 * 1 + 1000)) // One minute one second in the future
@@ -206,7 +283,7 @@ describe('admin api', () => {
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           headers: {
-            authorization: `Authorization: Basic ${await buildJWS(adminDid, code)}`,
+            authorization: `Authorization: Basic ${await buildJWS(adminDid, code, MODEL_PATH)}`,
           },
         })
       ).rejects.toThrow(
@@ -214,7 +291,7 @@ describe('admin api', () => {
       )
     })
 
-    it('Old code used with POST', async () => {
+    it('Old code used with models POST', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       const now = new Date().getTime()
       MockDate.set(now + (1000 * 60 * 1 + 1000)) // One minute one second in the future
@@ -222,14 +299,14 @@ describe('admin api', () => {
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
-          body: { jws: await buildJWS(adminDid, code, [exampleModelStreamId]) },
+          body: { jws: await buildJWS(adminDid, code, MODEL_PATH, [exampleModelStreamId]) },
         })
       ).rejects.toThrow(
         /Unauthorized access: expired admin code - admin codes are only valid for 60 seconds/
       )
     })
 
-    it('Old code used with DELETE', async () => {
+    it('Old code used with models DELETE', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       const now = new Date().getTime()
       MockDate.set(now + (1000 * 60 * 1 + 1000)) // One minute one second in the future
@@ -237,98 +314,132 @@ describe('admin api', () => {
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'DELETE',
-          body: { jws: await buildJWS(adminDid, code, [exampleModelStreamId]) },
+          body: { jws: await buildJWS(adminDid, code, MODEL_PATH, [exampleModelStreamId]) },
         })
       ).rejects.toThrow(
         /Unauthorized access: expired admin code - admin codes are only valid for 60 seconds/
       )
     })
 
-    it('Same code used again for GET', async () => {
+    it('Same code used again for status GET', async () => {
+      const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
+      expect(true).toBeTruthy()
+      await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/nodeStatus`, {
+        headers: {
+          authorization: `Authorization: Basic ${await buildJWS(adminDid, code, STATUS_PATH)}`,
+        },
+      })
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/nodeStatus`, {
+          headers: {
+            authorization: `Authorization: Basic ${await buildJWS(adminDid, code, STATUS_PATH)}`,
+          },
+        })
+      ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
+    })
+
+    it('Same code used again for models GET', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       expect(true).toBeTruthy()
       await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
         headers: {
-          authorization: `Authorization: Basic ${await buildJWS(adminDid, code)}`,
+          authorization: `Authorization: Basic ${await buildJWS(adminDid, code, MODEL_PATH)}`,
         },
       })
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           headers: {
-            authorization: `Authorization: Basic ${await buildJWS(adminDid, code)}`,
+            authorization: `Authorization: Basic ${await buildJWS(adminDid, code, MODEL_PATH)}`,
           },
         })
       ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
     })
 
-    it('Same code used again for POST', async () => {
+    it('Same code used again for models POST', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       expect(true).toBeTruthy()
       await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
         method: 'POST',
-        body: { jws: await buildJWS(adminDid, code, [exampleModelStreamId]) },
+        body: { jws: await buildJWS(adminDid, code, MODEL_PATH, [exampleModelStreamId]) },
       })
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
-          body: { jws: await buildJWS(adminDid, code, [exampleModelStreamId]) },
+          body: { jws: await buildJWS(adminDid, code, MODEL_PATH, [exampleModelStreamId]) },
         })
       ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
     })
 
-    it('Same code used again for DELETE', async () => {
+    it('Same code used again for models DELETE', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       expect(true).toBeTruthy()
       await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
         method: 'DELETE',
-        body: { jws: await buildJWS(adminDid, code, [exampleModelStreamId]) },
+        body: { jws: await buildJWS(adminDid, code, MODEL_PATH, [exampleModelStreamId]) },
       })
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'DELETE',
-          body: { jws: await buildJWS(adminDid, code, [exampleModelStreamId]) },
+          body: { jws: await buildJWS(adminDid, code, MODEL_PATH, [exampleModelStreamId]) },
         })
       ).rejects.toThrow(/Unauthorized access: invalid\/already used admin code/)
     })
 
-    it('Unauthorised DID for GET', async () => {
+    it('Unauthorised DID for status GET', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       await expect(
-        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/nodeStatus`, {
           headers: {
-            authorization: `Authorization: Basic ${await buildJWS(nonAdminDid, code)}`,
+            authorization: `Authorization: Basic ${await buildJWS(nonAdminDid, code, STATUS_PATH)}`,
           },
         })
       ).rejects.toThrow(/Unauthorized access/)
     })
 
-    it('Unauthorised DID for POST', async () => {
+    it('Unauthorised DID for models GET', async () => {
+      const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
+          headers: {
+            authorization: `Authorization: Basic ${await buildJWS(nonAdminDid, code, MODEL_PATH)}`,
+          },
+        })
+      ).rejects.toThrow(/Unauthorized access/)
+    })
+
+    it('Unauthorised DID for models POST', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
-          body: { jws: await buildJWS(nonAdminDid, code, [exampleModelStreamId]) },
+          body: { jws: await buildJWS(nonAdminDid, code, MODEL_PATH, [exampleModelStreamId]) },
         })
       ).rejects.toThrow(/Unauthorized access/)
     })
 
-    it('Unauthorised DID for DELETE', async () => {
+    it('Unauthorised DID for models DELETE', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'DELETE',
-          body: { jws: await buildJWS(nonAdminDid, code, [exampleModelStreamId]) },
+          body: { jws: await buildJWS(nonAdminDid, code, MODEL_PATH, [exampleModelStreamId]) },
         })
       ).rejects.toThrow(/Unauthorized access/)
     })
 
-    it('No authorization for GET', async () => {
+    it('No authorization for status GET', async () => {
+      await expect(
+        fetchJson(`http://localhost:${daemon.port}/api/v0/admin/nodeStatus`)
+      ).rejects.toThrow(/Missing authorization header/)
+    })
+
+    it('No authorization for models GET', async () => {
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`)
       ).rejects.toThrow(/Missing authorization header/)
     })
 
-    it('No authorization for POST', async () => {
+    it('No authorization for models POST', async () => {
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
@@ -336,7 +447,7 @@ describe('admin api', () => {
       ).rejects.toThrow(/Missing authorization jws/)
     })
 
-    it('No authorization for DELETE', async () => {
+    it('No authorization for models DELETE', async () => {
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'DELETE',
@@ -344,48 +455,48 @@ describe('admin api', () => {
       ).rejects.toThrow(/Missing authorization jws/)
     })
 
-    it('No models for POST', async () => {
+    it('No models for models POST', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
-          body: { jws: await buildJWS(adminDid, code) },
+          body: { jws: await buildJWS(adminDid, code, MODEL_PATH) },
         })
       ).rejects.toThrow(
         /The 'models' parameter is required and it has to be an array containing at least one model stream id/
       )
     })
 
-    it('Empty models for POST', async () => {
+    it('Empty models for models POST', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'POST',
-          body: { jws: await buildJWS(adminDid, code, []) },
+          body: { jws: await buildJWS(adminDid, code, MODEL_PATH, []) },
         })
       ).rejects.toThrow(
         /The 'models' parameter is required and it has to be an array containing at least one model stream id/
       )
     })
 
-    it('No models for DELETE', async () => {
+    it('No models for models DELETE', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'DELETE',
-          body: { jws: await buildJWS(adminDid, code) },
+          body: { jws: await buildJWS(adminDid, code, MODEL_PATH) },
         })
       ).rejects.toThrow(
         /The 'models' parameter is required and it has to be an array containing at least one model stream id/
       )
     })
 
-    it('Empty models for DELETE', async () => {
+    it('Empty models for models DELETE', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
           method: 'DELETE',
-          body: { jws: await buildJWS(adminDid, code, []) },
+          body: { jws: await buildJWS(adminDid, code, MODEL_PATH, []) },
         })
       ).rejects.toThrow(
         /The 'models' parameter is required and it has to be an array containing at least one model stream id/

--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -59,6 +59,12 @@ export interface CeramicSigner extends CeramicCommon {
  */
 export interface AdminApi {
   /**
+   * Returns a JSON object with various diagnostic and introspection information about the running
+   * node.
+   */
+  nodeStatus(): Promise<any> // TODO Use a typed return value
+
+  /**
    * List indexed model streams
    */
   getIndexedModels(): Promise<Array<StreamID>>

--- a/packages/core/src/local-admin-api.ts
+++ b/packages/core/src/local-admin-api.ts
@@ -9,6 +9,11 @@ import { SyncApi } from './sync/sync-api.js'
 export class LocalAdminApi implements AdminApi {
   constructor(private readonly indexApi: LocalIndexApi, private readonly syncApi: SyncApi) {}
 
+  // todo use stronger type
+  async nodeStatus(): Promise<any> {
+    return {}
+  }
+
   async startIndexingModels(modelsIDs: Array<StreamID>): Promise<void> {
     await Promise.all([
       this.indexApi.indexModels(modelsIDs),

--- a/packages/http-client/src/__tests__/remote-admin-api.test.ts
+++ b/packages/http-client/src/__tests__/remote-admin-api.test.ts
@@ -37,6 +37,21 @@ beforeAll(async () => {
   expectedKid = `${did.id}#${didKeyVerStr}`
 })
 
+test('nodeStatus()', async () => {
+  const adminApi = new RemoteAdminApi(FAUX_ENDPOINT, getDidFn)
+  const fauxFetch = jest.fn(async () => GET_RESPONSE) as typeof fetchJson
+  ;(adminApi as any)._fetchJson = fauxFetch
+  await adminApi.nodeStatus()
+
+  expect(fauxFetch.mock.calls[0][0]).toEqual(new URL(`https://example.com/admin/getCode`))
+  expect(fauxFetch.mock.calls[1][0]).toEqual(new URL(`https://example.com/admin/nodeStatus`))
+  const sentPayload = fauxFetch.mock.calls[1][1]
+  const sentJws = sentPayload.headers.Authorization.split('Basic ')[1]
+
+  const jwsResult = await did.verifyJWS(sentJws)
+  expect(jwsResult.kid).toEqual(expectedKid)
+})
+
 test('getIndexedModels()', async () => {
   const adminApi = new RemoteAdminApi(FAUX_ENDPOINT, getDidFn)
   const fauxFetch = jest.fn(async () => GET_RESPONSE) as typeof fetchJson

--- a/packages/http-client/src/remote-admin-api.ts
+++ b/packages/http-client/src/remote-admin-api.ts
@@ -19,6 +19,7 @@ export class RemoteAdminApi implements AdminApi {
 
   readonly modelsPath = './admin/models'
   readonly getCodePath = './admin/getCode'
+  readonly nodeStatusPath = './admin/nodeStatus'
 
   constructor(private readonly _apiUrl: URL, private readonly _getDidFn: () => DID) {}
   private getCodeUrl(): URL {
@@ -29,9 +30,14 @@ export class RemoteAdminApi implements AdminApi {
     return new URL(this.modelsPath, this._apiUrl)
   }
 
+  private getStatusUrl(): URL {
+    return new URL(this.nodeStatusPath, this._apiUrl)
+  }
+
   private async buildJWS(
     actingDid: DID,
     code: string,
+    requestPath: string,
     modelsIDs?: Array<StreamID>
   ): Promise<string> {
     if (!actingDid) throw new MissingDIDError()
@@ -40,7 +46,7 @@ export class RemoteAdminApi implements AdminApi {
       : undefined
     const jws = await actingDid.createJWS({
       code: code,
-      requestPath: this.getModelsUrl().pathname,
+      requestPath,
       requestBody: body,
     })
     return `${jws.signatures[0].protected}.${jws.payload}.${jws.signatures[0].signature}`
@@ -50,18 +56,40 @@ export class RemoteAdminApi implements AdminApi {
     return (await this._fetchJson(this.getCodeUrl())).code
   }
 
+  // todo use stronger type
+  async nodeStatus(): Promise<any> {
+    const code = await this.generateCode()
+    return this._fetchJson(this.getStatusUrl(), {
+      headers: {
+        Authorization: `Basic ${await this.buildJWS(
+          this._getDidFn(),
+          code,
+          this.getStatusUrl().pathname
+        )}`,
+      },
+    })
+  }
+
   async startIndexingModels(modelsIDs: Array<StreamID>): Promise<void> {
     const code = await this.generateCode()
     await this._fetchJson(this.getModelsUrl(), {
       method: 'post',
-      body: { jws: await this.buildJWS(this._getDidFn(), code, modelsIDs) },
+      body: {
+        jws: await this.buildJWS(this._getDidFn(), code, this.getModelsUrl().pathname, modelsIDs),
+      },
     })
   }
 
   async getIndexedModels(): Promise<Array<StreamID>> {
     const code = await this.generateCode()
     const response = await this._fetchJson(this.getModelsUrl(), {
-      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code)}` },
+      headers: {
+        Authorization: `Basic ${await this.buildJWS(
+          this._getDidFn(),
+          code,
+          this.getModelsUrl().pathname
+        )}`,
+      },
     })
     return response.models.map((modelStreamIDString: string) => {
       return StreamID.fromString(modelStreamIDString)
@@ -72,7 +100,9 @@ export class RemoteAdminApi implements AdminApi {
     const code = await this.generateCode()
     await this._fetchJson(this.getModelsUrl(), {
       method: 'delete',
-      body: { jws: await this.buildJWS(this._getDidFn(), code, modelsIDs) },
+      body: {
+        jws: await this.buildJWS(this._getDidFn(), code, this.getModelsUrl().pathname, modelsIDs),
+      },
     })
   }
 }

--- a/packages/stream-tests/src/__tests__/admin-api.test.ts
+++ b/packages/stream-tests/src/__tests__/admin-api.test.ts
@@ -88,6 +88,19 @@ describe('Admin API tests', () => {
     await core.close()
   })
 
+  describe('nodeStatus tests', () => {
+    test('Fails with non-admin DID', async () => {
+      await expect(ceramic.admin.getIndexedModels()).rejects.toThrow(/Unauthorized access/)
+    })
+
+    test('basic node status test', async () => {
+      ceramic.did = adminDid
+
+      const status = await ceramic.admin.nodeStatus()
+      expect(status).toEqual({})
+    })
+  })
+
   describe('Indexing config tests', () => {
     test('Fails with non-admin DID', async () => {
       const model = await Model.create(ceramic, MODEL_DEFINITION)


### PR DESCRIPTION
No real functionality yet (beyond the admin api authorization), just returns an empty response body.