### PR TITLE
Custom build for zkTruth to allow ignoring CACAO errors

### DIFF
--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -254,7 +254,9 @@ export class Repository {
       }
     })
 
-    StreamUtils.checkForCacaoExpiration(state$.state)
+    if (opts.sync == SyncOptions.SYNC_ALWAYS || opts.sync == SyncOptions.SYNC_ON_ERROR) {
+      StreamUtils.checkForCacaoExpiration(state$.state)
+    }
 
     await this.handlePinOpts(state$, opts)
     if (synced && state$.isPinned) {


### PR DESCRIPTION
For streams that are already in the node's state store, this build will allow loadStream requests to succeed and return the current state from the state store even if the state is based off of commits with expired CACAOs.

DO NOT MERGE THIS.  It is not intended to be released in the normal Ceramic codebase.