### PR TITLE
fix(core): Update expected smart contract address

### DIFF
--- a/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-validator.test.ts
+++ b/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-validator.test.ts
@@ -77,11 +77,27 @@ describe('EthereumAnchorValidator Test', () => {
         await ethAnchorValidator.validateChainInclusion(ANCHOR_PROOF)
       })
 
-      test('throws if not from correct contract address', async () => {
+      test('does not throw if not from correct contract address for txns before the threshold', async () => {
         MockJsonRpcProvider.getTransaction = jest.fn(() => {
           return Promise.resolve(
             Object.assign({}, TEST_TRANSACTION, {
               to: '0xc2Ca3c25E44a96Ea78708009AA459F7901F8De4d',
+              blockNumber: 1000000000 - 1,
+            })
+          )
+        }) as any
+
+        await expect(ethAnchorValidator.validateChainInclusion(ANCHOR_PROOF)).rejects.toThrowError(
+          'This is not the official anchoring contract address'
+        )
+      })
+
+      test('throws if not from correct contract address for txns after the threshold', async () => {
+        MockJsonRpcProvider.getTransaction = jest.fn(() => {
+          return Promise.resolve(
+            Object.assign({}, TEST_TRANSACTION, {
+              to: '0xc2Ca3c25E44a96Ea78708009AA459F7901F8De4d',
+              blockNumber: 1000000001,
             })
           )
         }) as any

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
@@ -60,13 +60,7 @@ const BLOCK_THRESHHOLDS = {
   'eip155:100': 1000000000, //gnosis
   'eip155:1337': 1000000, //ganache
 }
-const ANCHOR_CONTRACT_ADDRESSES = {
-  'eip155:1': '0xD3f84Cf6Be3DD0EB16dC89c972f7a27B441A39f2', //mainnet
-  'eip155:3': '0xD3f84Cf6Be3DD0EB16dC89c972f7a27B441A39f2', //ropsten
-  'eip155:5': '0xD3f84Cf6Be3DD0EB16dC89c972f7a27B441A39f2', //goerli
-  'eip155:100': '0xD3f84Cf6Be3DD0EB16dC89c972f7a27B441A39f2', //gnosis
-  'eip155:1337': '0xD3f84Cf6Be3DD0EB16dC89c972f7a27B441A39f2', //ganache
-}
+const ANCHOR_CONTRACT_ADDRESS = '0x231055A0852D67C7107Ad0d0DFeab60278fE6AdC'
 
 const getCidFromV0Transaction = (txResponse: TransactionResponse): CID => {
   const withoutPrefix = txResponse.data.replace(/^(0x0?)/, '')
@@ -218,11 +212,12 @@ export class EthereumAnchorValidator implements AnchorValidator {
       throw new Error(`The root CID ${anchorProof.root.toString()} is not in the transaction`)
     }
 
+    if (txResponse.blockNumber <= BLOCK_THRESHHOLDS[this._chainId]) {
+      return block.timestamp
+    }
+
     // if the block number is greater than the threshold and the txType is `raw` or non existent
-    if (
-      txResponse.blockNumber > BLOCK_THRESHHOLDS[this._chainId] &&
-      (anchorProof.txType === V0_PROOF_TYPE || !anchorProof.txType)
-    ) {
+    if (anchorProof.txType !== V1_PROOF_TYPE) {
       throw new Error(
         `Any anchor proofs created after block ${
           BLOCK_THRESHHOLDS[this._chainId]
@@ -230,16 +225,9 @@ export class EthereumAnchorValidator implements AnchorValidator {
       )
     }
 
-    if (
-      anchorProof.txType === V1_PROOF_TYPE &&
-      txResponse.to !== ANCHOR_CONTRACT_ADDRESSES[this._chainId]
-    ) {
+    if (txResponse.to != ANCHOR_CONTRACT_ADDRESS) {
       throw new Error(
-        `Anchor was created using address ${
-          txResponse.to
-        }. This is not the official anchoring contract address ${
-          ANCHOR_CONTRACT_ADDRESSES[this._chainId]
-        }`
+        `Anchor was created using address ${txResponse.to}. This is not the official anchoring contract address ${ANCHOR_CONTRACT_ADDRESS}`
       )
     }
 


### PR DESCRIPTION
The code will enforce that anchors go to the proper smart contract address for all anchors after the BLOCK_THRESHOLD.  We will set the blockThreshold to whatever is the first block after we update the CAS to use the actual correct smart contract address