### PR TITLE
Feature/cdb 1068 pin api access control

### DIFF
--- a/packages/cli/src/__tests__/admin-api.test.ts
+++ b/packages/cli/src/__tests__/admin-api.test.ts
@@ -89,6 +89,16 @@ describe('admin api', () => {
     return `${jws.signatures[0].protected}.${jws.payload}.${jws.signatures[0].signature}`
   }
 
+  async function buildJWSPins(did: DID, code: string, requestPath:string): Promise<string> {
+    const body =  undefined
+    const jws = await did.createJWS({
+      code: code,
+      requestPath: '/api/v0/admin/pins',
+      requestBody: body,
+    })
+    return `${jws.signatures[0].protected}.${jws.payload}.${jws.signatures[0].signature}`
+  }
+
   it('admin models API CRUD test', async () => {
     const adminURLString = `http://localhost:${daemon.port}/api/v0/admin/models`
 
@@ -130,6 +140,66 @@ describe('admin api', () => {
     expect(getResultAfterDelete.models).toEqual([])
   })
 
+  it('admin pin API CRUD test', async () => {
+    const adminPinURLBaseString = `http://localhost:${daemon.port}/api/v0/admin/pins`
+
+    const fetchCode = async (): Promise<string> => {
+      return (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
+    }
+
+    // Get list of pins
+    const getResult = await fetchJson(adminPinURLBaseString, {
+      headers: {
+        authorization: `Authorization: Basic ${await buildJWSPins(adminDid, await fetchCode(), `/api/v0/admin/pins`)}`,
+      },
+    })
+    expect(getResult.pinnedStreamIds).toEqual([exampleModelStreamId])
+
+    // Get single pin 
+    const getIdResult = await fetchJson(`${adminPinURLBaseString}/${exampleModelStreamId}`, {
+      headers: {
+        authorization: `Authorization: Basic ${await buildJWSPins(adminDid, await fetchCode(), `/api/v0/admin/pins/${exampleModelStreamId}`)}`,
+      },
+    })
+    expect(getIdResult.pinnedStreamIds).toEqual([exampleModelStreamId])
+
+    // Delete pin
+    const deleteResult = await fetchJson(`${adminPinURLBaseString}/${exampleModelStreamId}`, {
+      method: 'DELETE',
+      headers: {
+        authorization: `Authorization: Basic ${await buildJWSPins(adminDid, await fetchCode(), `/api/v0/admin/pins/${exampleModelStreamId}`)}`,
+      }
+    })
+    expect(deleteResult.isPinned).toEqual(false)
+    expect(deleteResult.streamId).toEqual(exampleModelStreamId)
+
+    // Get single pin after delete
+    const getIdResultAfterDelete = await fetchJson(`${adminPinURLBaseString}/${exampleModelStreamId}`, {
+      headers: {
+        authorization: `Authorization: Basic ${await buildJWSPins(adminDid, await fetchCode(), `/api/v0/admin/pins/${exampleModelStreamId}`)}`,
+      },
+    })
+    expect(getIdResultAfterDelete.pinnedStreamIds).toEqual([])
+
+     // Add pin
+    const postResult = await fetchJson(`${adminPinURLBaseString}/${exampleModelStreamId}`, {
+      method: 'POST',
+      headers: {
+        authorization: `Authorization: Basic ${await buildJWSPins(adminDid, await fetchCode(), `/api/v0/admin/pins/${exampleModelStreamId}`)}`,
+      }
+    })
+    expect(postResult.isPinned).toEqual(true)
+    expect(postResult.streamId).toEqual(exampleModelStreamId)
+
+    // Get single pin after adding
+    const getIdResultAfterPost = await fetchJson(`${adminPinURLBaseString}/${exampleModelStreamId}`, {
+      headers: {
+        authorization: `Authorization: Basic ${await buildJWSPins(adminDid, await fetchCode(), `/api/v0/admin/pins/${exampleModelStreamId}`)}`,
+      },
+    })
+    expect(getIdResultAfterPost.pinnedStreamIds).toEqual([exampleModelStreamId])
+  })
+
   describe('admin models API validation test', () => {
     it('No admin code for GET', async () => {
       await expect(
@@ -140,7 +210,7 @@ describe('admin api', () => {
         })
       ).rejects.toThrow(/Admin code is missing from the the jws block/)
     })
-
+    
     it('No admin code for POST', async () => {
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {

--- a/packages/cli/src/__tests__/admin-api.test.ts
+++ b/packages/cli/src/__tests__/admin-api.test.ts
@@ -89,8 +89,8 @@ describe('admin api', () => {
     return `${jws.signatures[0].protected}.${jws.payload}.${jws.signatures[0].signature}`
   }
 
-  async function buildJWSPins(did: DID, code: string, requestPath:string): Promise<string> {
-    const body =  undefined
+  async function buildJWSPins(did: DID, code: string, requestPath: string): Promise<string> {
+    const body = undefined
     const jws = await did.createJWS({
       code: code,
       requestPath: '/api/v0/admin/pins',
@@ -150,15 +150,23 @@ describe('admin api', () => {
     // Get list of pins
     const getResult = await fetchJson(adminPinURLBaseString, {
       headers: {
-        authorization: `Authorization: Basic ${await buildJWSPins(adminDid, await fetchCode(), `/api/v0/admin/pins`)}`,
+        authorization: `Authorization: Basic ${await buildJWSPins(
+          adminDid,
+          await fetchCode(),
+          `/api/v0/admin/pins`
+        )}`,
       },
     })
     expect(getResult.pinnedStreamIds).toEqual([exampleModelStreamId])
 
-    // Get single pin 
+    // Get single pin
     const getIdResult = await fetchJson(`${adminPinURLBaseString}/${exampleModelStreamId}`, {
       headers: {
-        authorization: `Authorization: Basic ${await buildJWSPins(adminDid, await fetchCode(), `/api/v0/admin/pins/${exampleModelStreamId}`)}`,
+        authorization: `Authorization: Basic ${await buildJWSPins(
+          adminDid,
+          await fetchCode(),
+          `/api/v0/admin/pins/${exampleModelStreamId}`
+        )}`,
       },
     })
     expect(getIdResult.pinnedStreamIds).toEqual([exampleModelStreamId])
@@ -167,36 +175,58 @@ describe('admin api', () => {
     const deleteResult = await fetchJson(`${adminPinURLBaseString}/${exampleModelStreamId}`, {
       method: 'DELETE',
       headers: {
-        authorization: `Authorization: Basic ${await buildJWSPins(adminDid, await fetchCode(), `/api/v0/admin/pins/${exampleModelStreamId}`)}`,
-      }
+        authorization: `Authorization: Basic ${await buildJWSPins(
+          adminDid,
+          await fetchCode(),
+          `/api/v0/admin/pins/${exampleModelStreamId}`
+        )}`,
+      },
     })
     expect(deleteResult.isPinned).toEqual(false)
     expect(deleteResult.streamId).toEqual(exampleModelStreamId)
 
     // Get single pin after delete
-    const getIdResultAfterDelete = await fetchJson(`${adminPinURLBaseString}/${exampleModelStreamId}`, {
-      headers: {
-        authorization: `Authorization: Basic ${await buildJWSPins(adminDid, await fetchCode(), `/api/v0/admin/pins/${exampleModelStreamId}`)}`,
-      },
-    })
+    const getIdResultAfterDelete = await fetchJson(
+      `${adminPinURLBaseString}/${exampleModelStreamId}`,
+      {
+        headers: {
+          authorization: `Authorization: Basic ${await buildJWSPins(
+            adminDid,
+            await fetchCode(),
+            `/api/v0/admin/pins/${exampleModelStreamId}`
+          )}`,
+        },
+      }
+    )
     expect(getIdResultAfterDelete.pinnedStreamIds).toEqual([])
 
-     // Add pin
+    // Add pin
     const postResult = await fetchJson(`${adminPinURLBaseString}/${exampleModelStreamId}`, {
       method: 'POST',
       headers: {
-        authorization: `Authorization: Basic ${await buildJWSPins(adminDid, await fetchCode(), `/api/v0/admin/pins/${exampleModelStreamId}`)}`,
-      }
+        authorization: `Authorization: Basic ${await buildJWSPins(
+          adminDid,
+          await fetchCode(),
+          `/api/v0/admin/pins/${exampleModelStreamId}`
+        )}`,
+      },
     })
     expect(postResult.isPinned).toEqual(true)
     expect(postResult.streamId).toEqual(exampleModelStreamId)
 
     // Get single pin after adding
-    const getIdResultAfterPost = await fetchJson(`${adminPinURLBaseString}/${exampleModelStreamId}`, {
-      headers: {
-        authorization: `Authorization: Basic ${await buildJWSPins(adminDid, await fetchCode(), `/api/v0/admin/pins/${exampleModelStreamId}`)}`,
-      },
-    })
+    const getIdResultAfterPost = await fetchJson(
+      `${adminPinURLBaseString}/${exampleModelStreamId}`,
+      {
+        headers: {
+          authorization: `Authorization: Basic ${await buildJWSPins(
+            adminDid,
+            await fetchCode(),
+            `/api/v0/admin/pins/${exampleModelStreamId}`
+          )}`,
+        },
+      }
+    )
     expect(getIdResultAfterPost.pinnedStreamIds).toEqual([exampleModelStreamId])
   })
 
@@ -210,7 +240,7 @@ describe('admin api', () => {
         })
       ).rejects.toThrow(/Admin code is missing from the the jws block/)
     })
-    
+
     it('No admin code for POST', async () => {
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {

--- a/packages/cli/src/__tests__/ceramic-multi-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-multi-daemon.test.ts
@@ -73,9 +73,19 @@ describe('Ceramic interop between multiple daemons and http clients', () => {
     await adminDID.authenticate()
     const port1 = await getPort()
     const port2 = await getPort()
-    daemon1 = new CeramicDaemon(core1, DaemonConfig.fromObject({ 'http-api': { port: port1, 'admin-dids': [adminDID.id.toString()] } }))
+    daemon1 = new CeramicDaemon(
+      core1,
+      DaemonConfig.fromObject({
+        'http-api': { port: port1, 'admin-dids': [adminDID.id.toString()] },
+      })
+    )
     await daemon1.listen()
-    daemon2 = new CeramicDaemon(core2, DaemonConfig.fromObject({ 'http-api': { port: port2, 'admin-dids': [adminDID.id.toString()] } }))
+    daemon2 = new CeramicDaemon(
+      core2,
+      DaemonConfig.fromObject({
+        'http-api': { port: port2, 'admin-dids': [adminDID.id.toString()] },
+      })
+    )
     await daemon2.listen()
     client1 = new CeramicClient('http://localhost:' + port1, { syncInterval: 500 })
     client2 = new CeramicClient('http://localhost:' + port2, { syncInterval: 500 })

--- a/packages/cli/src/__tests__/ceramic-multi-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-multi-daemon.test.ts
@@ -47,6 +47,9 @@ describe('Ceramic interop between multiple daemons and http clients', () => {
   let daemon2: CeramicDaemon
   let client1: CeramicClient
   let client2: CeramicClient
+  let client1Admin: CeramicClient
+  let client2Admin: CeramicClient
+  let adminDID: DID
 
   beforeAll(async () => {
     tmpFolder1 = await tmp.dir({ unsafeCleanup: true })
@@ -66,19 +69,25 @@ describe('Ceramic interop between multiple daemons and http clients', () => {
   beforeEach(async () => {
     core1 = await makeCeramicCore(ipfs1, tmpFolder1.path)
     core2 = await makeCeramicCore(ipfs2, tmpFolder2.path)
+    adminDID = makeDID(core1, seed)
+    await adminDID.authenticate()
     const port1 = await getPort()
     const port2 = await getPort()
-    daemon1 = new CeramicDaemon(core1, DaemonConfig.fromObject({ 'http-api': { port: port1 } }))
+    daemon1 = new CeramicDaemon(core1, DaemonConfig.fromObject({ 'http-api': { port: port1, 'admin-dids': [adminDID.id.toString()] } }))
     await daemon1.listen()
-    daemon2 = new CeramicDaemon(core2, DaemonConfig.fromObject({ 'http-api': { port: port2 } }))
+    daemon2 = new CeramicDaemon(core2, DaemonConfig.fromObject({ 'http-api': { port: port2, 'admin-dids': [adminDID.id.toString()] } }))
     await daemon2.listen()
     client1 = new CeramicClient('http://localhost:' + port1, { syncInterval: 500 })
     client2 = new CeramicClient('http://localhost:' + port2, { syncInterval: 500 })
+    client1Admin = new CeramicClient('http://localhost:' + port1, { syncInterval: 500 })
+    client2Admin = new CeramicClient('http://localhost:' + port2, { syncInterval: 500 })
 
     await core1.setDID(makeDID(core1, seed))
     await client1.setDID(makeDID(client1, seed))
     await core2.setDID(makeDID(core2, seed))
     await client2.setDID(makeDID(client2, seed))
+    await client1Admin.setDID(adminDID)
+    await client2Admin.setDID(adminDID)
   })
 
   afterEach(async () => {
@@ -124,8 +133,8 @@ describe('Ceramic interop between multiple daemons and http clients', () => {
     // Create a stream, pin and load it against both nodes via the http client.
     const doc1 = await TileDocument.create(client1, initialContent, null, { anchor: false })
     const doc2 = await TileDocument.load(client2, doc1.id)
-    await client1.pin.add(doc1.id)
-    await client2.pin.add(doc2.id)
+    await client1Admin.admin.pin.add(doc1.id)
+    await client2Admin.admin.pin.add(doc2.id)
 
     // Do an update on node 1, but don't publish it so node 2 still doesn't know about it.
     await doc1.update(updatedContent, null, { publish: false, anchor: false })
@@ -136,7 +145,7 @@ describe('Ceramic interop between multiple daemons and http clients', () => {
     expect(doc1.content).toEqual(updatedContent)
 
     // Unpin from node 1 and publish tip at the same time
-    await client1.pin.rm(doc1.id, { publish: true })
+    await client1Admin.admin.pin.rm(doc1.id, { publish: true })
 
     // wait for doc2 to learn about the new state
     const receivedUpdatePromise = new Promise((resolve) => {

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -384,7 +384,7 @@ export class CeramicCliUtils {
     const id = StreamID.fromString(streamId)
 
     await CeramicCliUtils._runWithCeramicClient(async (ceramic: CeramicApi) => {
-      const result = await ceramic.pin.add(id)
+      const result = await ceramic.admin.pin.add(id)
       console.log(JSON.stringify(result, null, 2))
     })
   }
@@ -397,7 +397,7 @@ export class CeramicCliUtils {
     const id = StreamID.fromString(streamId)
 
     await CeramicCliUtils._runWithCeramicClient(async (ceramic: CeramicApi) => {
-      const result = await ceramic.pin.rm(id)
+      const result = await ceramic.admin.pin.rm(id)
       console.log(JSON.stringify(result, null, 2))
     })
   }
@@ -411,7 +411,7 @@ export class CeramicCliUtils {
 
     await CeramicCliUtils._runWithCeramicClient(async (ceramic: CeramicApi) => {
       const pinnedStreamIds = []
-      const iterator = await ceramic.pin.ls(id)
+      const iterator = await ceramic.admin.pin.ls(id)
       let i = 0
       let truncated = false
       for await (const id of iterator) {

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -654,7 +654,7 @@ export class CeramicDaemon {
       return { error: `Error while processing the authorization header ${e.message}` }
     }
     if (parsedJWS.requestPath !== basePath) {
-      return { error: `The jws block contains a request path that doesn't match the request` }
+      return { error: `The jws block contains a request path that doesn't match the request, ${parsedJWS.requestPath}, ${basePath}` }
     } else if (!parsedJWS.code) {
       return { error: 'Admin code is missing from the the jws block' }
     } else if (shouldContainModels && (!parsedJWS.models || parsedJWS.models.length === 0)) {

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -743,7 +743,7 @@ export class CeramicDaemon {
     }
   }
 
-  async validateAdminRequest(req: Request, res: Response, next:NextFunction): Promise<void> {
+  async validateAdminRequest(req: Request, res: Response, next: NextFunction): Promise<void> {
     if (!req.headers.authorization) {
       res.status(StatusCodes.UNAUTHORIZED).json({ error: 'Missing authorization header' })
       return

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -338,6 +338,8 @@ export class CeramicDaemon {
     // Admin Pins Validate JWS Middleware
     baseRouter.use('/admin/pins', this.validateAdminRequest.bind(this))
     baseRouter.use('/admin/pins', adminPinsRouter)
+    // Original pins paths not supported error, to be fuly removed/deprecated after
+    baseRouter.use('/pins', this._pinNotSupported.bind(this))
 
     commitsRouter.getAsync('/:streamid', this.commits.bind(this))
     multiqueriesRouter.postAsync('/', this.multiQuery.bind(this))
@@ -897,6 +899,12 @@ export class CeramicDaemon {
     res
       .status(StatusCodes.BAD_REQUEST)
       .json({ error: 'Method not supported by read only Ceramic Gateway' })
+  }
+
+  async _pinNotSupported(req: Request, res: Response): Promise<void> {
+    res
+      .status(StatusCodes.BAD_REQUEST)
+      .json({ error: 'Method not supported: pin requests have moved to the admin API /admin/pins' })
   }
 
   async getSupportedChains(req: Request, res: Response): Promise<void> {

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -654,7 +654,9 @@ export class CeramicDaemon {
       return { error: `Error while processing the authorization header ${e.message}` }
     }
     if (parsedJWS.requestPath !== basePath) {
-      return { error: `The jws block contains a request path that doesn't match the request, ${parsedJWS.requestPath}, ${basePath}` }
+      return {
+        error: `The jws block contains a request path that doesn't match the request, ${parsedJWS.requestPath}, ${basePath}`,
+      }
     } else if (!parsedJWS.code) {
       return { error: 'Admin code is missing from the the jws block' }
     } else if (shouldContainModels && (!parsedJWS.models || parsedJWS.models.length === 0)) {

--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -77,13 +77,14 @@ export interface AdminApi {
    */
 
   stopIndexingModels(modelsIDs: Array<StreamID>): Promise<void>
+
+  pin: PinApi
 }
 
 /**
  * Describes Ceramic node API
  */
 export interface CeramicApi extends CeramicSigner {
-  readonly pin: PinApi
   // loggerProvider: LoggerProvider; // TODO uncomment once logger is available on http-client
 
   readonly index: IndexApi

--- a/packages/common/src/utils/test-utils.ts
+++ b/packages/common/src/utils/test-utils.ts
@@ -116,7 +116,7 @@ export class TestUtils {
   }
 
   static async isPinned(ceramic: CeramicApi, streamId: StreamID): Promise<boolean> {
-    const iterator = await ceramic.pin.ls(streamId)
+    const iterator = await ceramic.admin.pin.ls(streamId)
     return (await first(iterator)) == streamId.toString()
   }
 

--- a/packages/core/src/__tests__/ceramic-pinning.test.ts
+++ b/packages/core/src/__tests__/ceramic-pinning.test.ts
@@ -232,7 +232,7 @@ describe('Ceramic stream pinning', () => {
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeTruthy()
     await stream.update({ foo: 'baz' }, null, { anchor: false, publish: false })
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeTruthy()
-    await ceramic.pin.rm(stream.id, { publish: false })
+    await ceramic.admin.pin.rm(stream.id, { publish: false })
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
     await stream.update({ foo: 'foobarbaz' })
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
@@ -263,7 +263,7 @@ describe('Ceramic stream pinning', () => {
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeTruthy()
     await TileDocument.load(ceramic, stream.id)
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeTruthy()
-    await ceramic.pin.rm(stream.id, { publish: false })
+    await ceramic.admin.pin.rm(stream.id, { publish: false })
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
     await TileDocument.load(ceramic, stream.id, { sync: SyncOptions.NEVER_SYNC })
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
@@ -294,11 +294,11 @@ describe('Ceramic stream pinning', () => {
       anchor: false,
       publish: false,
     })
-    await ceramic.pin.add(stream.id)
+    await ceramic.admin.pin.add(stream.id)
     await stream.update({ foo: 'baz' }, null, { anchor: false, publish: false })
 
     expect(publishTipSpy).toBeCalledTimes(0)
-    await ceramic.pin.rm(stream.id)
+    await ceramic.admin.pin.rm(stream.id)
     expect(publishTipSpy).toBeCalledTimes(0)
 
     await ceramic.close()
@@ -312,12 +312,12 @@ describe('Ceramic stream pinning', () => {
       publish: false,
       pin: false,
     })
-    await ceramic.pin.add(stream.id)
+    await ceramic.admin.pin.add(stream.id)
     await stream.update({ foo: 'baz' }, null, { anchor: false, publish: false })
 
     expect(publishTipSpy).toBeCalledTimes(0)
 
-    await ceramic.pin.rm(stream.id, { publish: true })
+    await ceramic.admin.pin.rm(stream.id, { publish: true })
 
     expect(publishTipSpy).toBeCalledTimes(1)
 
@@ -333,19 +333,19 @@ describe('Ceramic stream pinning', () => {
     })
     const pinSpy = jest.spyOn(ipfs1.pin, 'add')
     const saveStateSpy = jest.spyOn(ceramic.repository.pinStore.stateStore, 'save')
-    await ceramic.pin.add(stream.id)
+    await ceramic.admin.pin.add(stream.id)
 
     // 2 CIDs pinned for the one genesis commit (signed envelope + payload)
     expect(pinSpy).toBeCalledTimes(2)
     expect(saveStateSpy).toBeCalledTimes(1)
 
     // Pin a second time, shouldn't cause any more calls to ipfs.pin.add
-    await ceramic.pin.add(stream.id)
+    await ceramic.admin.pin.add(stream.id)
     expect(pinSpy).toBeCalledTimes(2)
     expect(saveStateSpy).toBeCalledTimes(1)
 
     // Now force re-pin and make sure underlying state and ipfs records get re-pinned
-    await ceramic.pin.add(stream.id, true)
+    await ceramic.admin.pin.add(stream.id, true)
     expect(pinSpy).toBeCalledTimes(4)
     expect(saveStateSpy).toBeCalledTimes(2)
 
@@ -361,7 +361,7 @@ describe('Ceramic stream pinning', () => {
     })
     const pinSpy = jest.spyOn(ipfs1.pin, 'add')
     const saveStateSpy = jest.spyOn(ceramic.repository.pinStore.stateStore, 'save')
-    await ceramic.pin.add(stream.id)
+    await ceramic.admin.pin.add(stream.id)
 
     // 2 CIDs pinned for the one genesis commit (signed envelope + payload)
     expect(pinSpy).toBeCalledTimes(2)
@@ -388,17 +388,17 @@ describe('Ceramic stream pinning', () => {
     const removeStateSpy = jest.spyOn(ceramic.repository.pinStore.stateStore, 'remove')
 
     // Pin stream
-    await ceramic.pin.add(stream.id)
+    await ceramic.admin.pin.add(stream.id)
     expect(pinSpy).toBeCalledTimes(2)
     expect(saveStateSpy).toBeCalledTimes(1)
 
     // Unpin
-    await ceramic.pin.rm(stream.id)
+    await ceramic.admin.pin.rm(stream.id)
     expect(unpinSpy).toBeCalledTimes(2)
     expect(removeStateSpy).toBeCalledTimes(1)
 
     // re-pin
-    await ceramic.pin.add(stream.id)
+    await ceramic.admin.pin.add(stream.id)
     expect(pinSpy).toBeCalledTimes(4)
     expect(saveStateSpy).toBeCalledTimes(2)
 

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -208,7 +208,6 @@ export class Ceramic implements CeramicApi {
   public readonly context: Context
   public readonly dispatcher: Dispatcher
   public readonly loggerProvider: LoggerProvider
-  public readonly pin: PinApi
   public readonly admin: AdminApi
   readonly repository: Repository
   private readonly anchorResumingService: AnchorResumingService
@@ -234,7 +233,6 @@ export class Ceramic implements CeramicApi {
     this.repository = modules.repository
     this._shutdownSignal = modules.shutdownSignal
     this.dispatcher = modules.dispatcher
-    this.pin = this._buildPinApi()
     this._anchorValidator = modules.anchorValidator
     this.providersCache = modules.providersCache
 
@@ -296,7 +294,8 @@ export class Ceramic implements CeramicApi {
       this.repository.index,
       this._logger
     )
-    this.admin = new LocalAdminApi(localIndex, this.syncApi)
+    const pinApi = this._buildPinApi()
+    this.admin = new LocalAdminApi(localIndex, this.syncApi, pinApi)
   }
 
   get index(): LocalIndexApi {

--- a/packages/core/src/local-admin-api.ts
+++ b/packages/core/src/local-admin-api.ts
@@ -1,13 +1,15 @@
-import { AdminApi } from '@ceramicnetwork/common'
+import { AdminApi, PinApi } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { LocalIndexApi } from './indexing/local-index-api.js'
 import { SyncApi } from './sync/sync-api.js'
+import { LocalPinApi } from './local-pin-api.js'
 
 /**
  * AdminApi for Ceramic core.
  */
+
 export class LocalAdminApi implements AdminApi {
-  constructor(private readonly indexApi: LocalIndexApi, private readonly syncApi: SyncApi) {}
+  constructor(private readonly indexApi: LocalIndexApi, private readonly syncApi: SyncApi, private readonly pinApi: PinApi) {}
 
   async startIndexingModels(modelsIDs: Array<StreamID>): Promise<void> {
     await Promise.all([
@@ -22,5 +24,9 @@ export class LocalAdminApi implements AdminApi {
 
   async stopIndexingModels(modelsIDs: Array<StreamID>): Promise<void> {
     await this.indexApi.stopIndexingModels(modelsIDs)
+  }
+
+  get pin(): PinApi {
+    return this.pinApi
   }
 }

--- a/packages/core/src/local-admin-api.ts
+++ b/packages/core/src/local-admin-api.ts
@@ -9,7 +9,11 @@ import { LocalPinApi } from './local-pin-api.js'
  */
 
 export class LocalAdminApi implements AdminApi {
-  constructor(private readonly indexApi: LocalIndexApi, private readonly syncApi: SyncApi, private readonly pinApi: PinApi) {}
+  constructor(
+    private readonly indexApi: LocalIndexApi,
+    private readonly syncApi: SyncApi,
+    private readonly pinApi: PinApi
+  ) {}
 
   async startIndexingModels(modelsIDs: Array<StreamID>): Promise<void> {
     await Promise.all([

--- a/packages/core/src/state-management/__tests__/cache-eviction.test.ts
+++ b/packages/core/src/state-management/__tests__/cache-eviction.test.ts
@@ -189,7 +189,7 @@ describe('evicted then subscribed', () => {
 
   test('pinned', async () => {
     const stream1 = await TileDocument.create<any>(ceramic, { foo: 'bar' })
-    await ceramic.pin.add(stream1.id)
+    await ceramic.admin.pin.add(stream1.id)
 
     const stream2 = await TileDocument.load(ceramic, stream1.id)
     expect(StreamUtils.serializeState(stream1.state)).toEqual(

--- a/packages/core/src/state-management/__tests__/repository.test.ts
+++ b/packages/core/src/state-management/__tests__/repository.test.ts
@@ -69,7 +69,7 @@ describe('#load', () => {
     const syncSpy = jest.spyOn(repository.stateManager, 'sync')
 
     const stream1 = await TileDocument.create(ceramic, { foo: 'bar' }, null, { anchor: false })
-    await ceramic.pin.add(stream1.id)
+    await ceramic.admin.pin.add(stream1.id)
 
     fromMemorySpy.mockClear()
     fromStateStoreSpy.mockClear()

--- a/packages/core/src/store/__tests__/state-store-integration.test.ts
+++ b/packages/core/src/store/__tests__/state-store-integration.test.ts
@@ -92,11 +92,11 @@ describe('Level data store', () => {
     await TestUtils.anchorUpdate(ceramic, stream)
 
     const pinSpy = jest.spyOn(realIpfs.pin, 'add')
-    await ceramic.pin.add(stream.id)
+    await ceramic.admin.pin.add(stream.id)
     expect(pinSpy).toBeCalledTimes(5)
 
     const unpinSpy = jest.spyOn(realIpfs.pin, 'rm')
-    await ceramic.pin.rm(stream.id)
+    await ceramic.admin.pin.rm(stream.id)
     expect(unpinSpy).toBeCalledTimes(3) // genesis commit envelope, genesis commit payload, and anchor commit
 
     await ceramic.close()
@@ -111,16 +111,16 @@ describe('Level data store', () => {
       anchor: false,
       publish: false,
     })
-    await ceramic.pin.add(stream1.id)
+    await ceramic.admin.pin.add(stream1.id)
 
     const stream2 = await TileDocument.create(ceramic, { stuff: 2 }, null, {
       anchor: false,
       publish: false,
     })
-    await ceramic.pin.add(stream2.id)
+    await ceramic.admin.pin.add(stream2.id)
 
     const pinned = []
-    const iterator = await ceramic.pin.ls()
+    const iterator = await ceramic.admin.pin.ls()
     for await (const id of iterator) {
       pinned.push(id)
     }
@@ -129,7 +129,7 @@ describe('Level data store', () => {
     expect(pinned.includes(stream2.id.toString())).toBeTruthy()
 
     const pinnedSingle = []
-    for await (const id of await ceramic.pin.ls(new StreamID('tile', FAKE_CID))) {
+    for await (const id of await ceramic.admin.pin.ls(new StreamID('tile', FAKE_CID))) {
       pinned.push(id)
     }
 

--- a/packages/http-client/src/__tests__/remote-admin-api.test.ts
+++ b/packages/http-client/src/__tests__/remote-admin-api.test.ts
@@ -1,11 +1,12 @@
 import { DID } from 'dids'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { fetchJson, TestUtils } from '@ceramicnetwork/common'
-import { RemoteAdminApi, MissingDIDError } from '../remote-admin-api.js'
+import { RemoteAdminApi } from '../remote-admin-api.js'
 import { jest } from '@jest/globals'
 import { Ed25519Provider } from 'key-did-provider-ed25519'
 import KeyResolver from 'key-did-resolver'
 import { randomBytes } from '@stablelib/random'
+import { MissingDIDError } from '../utils'
 
 const FAUX_ENDPOINT = new URL('https://example.com')
 const MODEL = new StreamID(1, TestUtils.randomCID())
@@ -117,4 +118,91 @@ test('removeModelsFromIndex()', async () => {
   expect(jwsResult.kid).toEqual(expectedKid)
   expect(jwsResult.payload.requestBody.models.length).toEqual(1)
   expect(jwsResult.payload.requestBody.models[0]).toEqual(MODEL.toString())
+})
+
+describe('Admin Pin API', () => {
+
+  const STREAM = new StreamID(1, TestUtils.randomCID())
+
+  test('pin.add(streamId)', async () => {
+    const adminApi = new RemoteAdminApi(FAUX_ENDPOINT, getDidFn)
+    const fauxFetch = jest.fn(async () => GET_RESPONSE) as typeof fetchJson
+    ;(adminApi as any)._fetchJson = fauxFetch
+    ;(adminApi as any).pin._fetchJson = fauxFetch
+    await adminApi.pin.add(STREAM)
+  
+    expect(fauxFetch.mock.calls[0][0]).toEqual(new URL(`https://example.com/admin/getCode`))
+    expect(fauxFetch.mock.calls[1][0]).toEqual(new URL(`https://example.com/admin/pins/${STREAM}`))
+
+    const sentPayload = fauxFetch.mock.calls[1][1]
+    const sentJws = sentPayload.headers.Authorization.split('Basic ')[1]
+  
+    const jwsResult = await did.verifyJWS(sentJws)
+    expect(jwsResult.kid).toEqual(expectedKid)
+  })
+
+  test('pin.rm(streamId)', async () => {
+    const adminApi = new RemoteAdminApi(FAUX_ENDPOINT, getDidFn)
+    const fauxFetch = jest.fn(async () => GET_RESPONSE) as typeof fetchJson
+    ;(adminApi as any)._fetchJson = fauxFetch
+    ;(adminApi as any).pin._fetchJson = fauxFetch
+    await adminApi.pin.rm(STREAM)
+  
+    expect(fauxFetch.mock.calls[0][0]).toEqual(new URL(`https://example.com/admin/getCode`))
+    expect(fauxFetch.mock.calls[1][0]).toEqual(new URL(`https://example.com/admin/pins/${STREAM}`))
+
+    const sentPayload = fauxFetch.mock.calls[1][1]
+    const sentJws = sentPayload.headers.Authorization.split('Basic ')[1]
+  
+    const jwsResult = await did.verifyJWS(sentJws)
+    expect(jwsResult.kid).toEqual(expectedKid)
+  })
+
+  test('pin.ls(streamId)', async () => {
+    const adminApi = new RemoteAdminApi(FAUX_ENDPOINT, getDidFn)
+    const fauxFetch = jest.fn(async () => GET_RESPONSE) as typeof fetchJson
+    ;(adminApi as any)._fetchJson = fauxFetch
+    ;(adminApi as any).pin._fetchJson = fauxFetch
+    await adminApi.pin.ls(STREAM)
+  
+    expect(fauxFetch.mock.calls[0][0]).toEqual(new URL(`https://example.com/admin/getCode`))
+    expect(fauxFetch.mock.calls[1][0]).toEqual(new URL(`https://example.com/admin/pins/${STREAM}`))
+
+    const sentPayload = fauxFetch.mock.calls[1][1]
+    const sentJws = sentPayload.headers.Authorization.split('Basic ')[1]
+  
+    const jwsResult = await did.verifyJWS(sentJws)
+    expect(jwsResult.kid).toEqual(expectedKid)
+  })
+
+  test('pin.ls()', async () => {
+    const adminApi = new RemoteAdminApi(FAUX_ENDPOINT, getDidFn)
+    const fauxFetch = jest.fn(async () => GET_RESPONSE) as typeof fetchJson
+    ;(adminApi as any)._fetchJson = fauxFetch
+    ;(adminApi as any).pin._fetchJson = fauxFetch
+    await adminApi.pin.ls()
+  
+    expect(fauxFetch.mock.calls[0][0]).toEqual(new URL(`https://example.com/admin/getCode`))
+    expect(fauxFetch.mock.calls[1][0]).toEqual(new URL(`https://example.com/admin/pins`))
+
+    const sentPayload = fauxFetch.mock.calls[1][1]
+    const sentJws = sentPayload.headers.Authorization.split('Basic ')[1]
+  
+    const jwsResult = await did.verifyJWS(sentJws)
+    expect(jwsResult.kid).toEqual(expectedKid)
+  })
+
+  test('missingDidFailureCases', async () => {
+    const fauxFetch = jest.fn(async () => GET_RESPONSE) as typeof fetchJson
+  
+    const failingAdminApi = new RemoteAdminApi(FAUX_ENDPOINT, noDidFn)
+    ;(failingAdminApi as any)._fetchJson = fauxFetch
+    ;(failingAdminApi as any).pin._fetchJson = fauxFetch
+  
+    await expect(failingAdminApi.pin.add(STREAM)).rejects.toThrow(MissingDIDError)
+  
+    await expect(failingAdminApi.pin.rm(STREAM)).rejects.toThrow(MissingDIDError)
+  
+    await expect(failingAdminApi.pin.ls()).rejects.toThrow(MissingDIDError)
+  })
 })

--- a/packages/http-client/src/__tests__/remote-admin-api.test.ts
+++ b/packages/http-client/src/__tests__/remote-admin-api.test.ts
@@ -121,7 +121,6 @@ test('removeModelsFromIndex()', async () => {
 })
 
 describe('Admin Pin API', () => {
-
   const STREAM = new StreamID(1, TestUtils.randomCID())
 
   test('pin.add(streamId)', async () => {
@@ -130,13 +129,13 @@ describe('Admin Pin API', () => {
     ;(adminApi as any)._fetchJson = fauxFetch
     ;(adminApi as any).pin._fetchJson = fauxFetch
     await adminApi.pin.add(STREAM)
-  
+
     expect(fauxFetch.mock.calls[0][0]).toEqual(new URL(`https://example.com/admin/getCode`))
     expect(fauxFetch.mock.calls[1][0]).toEqual(new URL(`https://example.com/admin/pins/${STREAM}`))
 
     const sentPayload = fauxFetch.mock.calls[1][1]
     const sentJws = sentPayload.headers.Authorization.split('Basic ')[1]
-  
+
     const jwsResult = await did.verifyJWS(sentJws)
     expect(jwsResult.kid).toEqual(expectedKid)
   })
@@ -147,13 +146,13 @@ describe('Admin Pin API', () => {
     ;(adminApi as any)._fetchJson = fauxFetch
     ;(adminApi as any).pin._fetchJson = fauxFetch
     await adminApi.pin.rm(STREAM)
-  
+
     expect(fauxFetch.mock.calls[0][0]).toEqual(new URL(`https://example.com/admin/getCode`))
     expect(fauxFetch.mock.calls[1][0]).toEqual(new URL(`https://example.com/admin/pins/${STREAM}`))
 
     const sentPayload = fauxFetch.mock.calls[1][1]
     const sentJws = sentPayload.headers.Authorization.split('Basic ')[1]
-  
+
     const jwsResult = await did.verifyJWS(sentJws)
     expect(jwsResult.kid).toEqual(expectedKid)
   })
@@ -164,13 +163,13 @@ describe('Admin Pin API', () => {
     ;(adminApi as any)._fetchJson = fauxFetch
     ;(adminApi as any).pin._fetchJson = fauxFetch
     await adminApi.pin.ls(STREAM)
-  
+
     expect(fauxFetch.mock.calls[0][0]).toEqual(new URL(`https://example.com/admin/getCode`))
     expect(fauxFetch.mock.calls[1][0]).toEqual(new URL(`https://example.com/admin/pins/${STREAM}`))
 
     const sentPayload = fauxFetch.mock.calls[1][1]
     const sentJws = sentPayload.headers.Authorization.split('Basic ')[1]
-  
+
     const jwsResult = await did.verifyJWS(sentJws)
     expect(jwsResult.kid).toEqual(expectedKid)
   })
@@ -181,28 +180,28 @@ describe('Admin Pin API', () => {
     ;(adminApi as any)._fetchJson = fauxFetch
     ;(adminApi as any).pin._fetchJson = fauxFetch
     await adminApi.pin.ls()
-  
+
     expect(fauxFetch.mock.calls[0][0]).toEqual(new URL(`https://example.com/admin/getCode`))
     expect(fauxFetch.mock.calls[1][0]).toEqual(new URL(`https://example.com/admin/pins`))
 
     const sentPayload = fauxFetch.mock.calls[1][1]
     const sentJws = sentPayload.headers.Authorization.split('Basic ')[1]
-  
+
     const jwsResult = await did.verifyJWS(sentJws)
     expect(jwsResult.kid).toEqual(expectedKid)
   })
 
   test('missingDidFailureCases', async () => {
     const fauxFetch = jest.fn(async () => GET_RESPONSE) as typeof fetchJson
-  
+
     const failingAdminApi = new RemoteAdminApi(FAUX_ENDPOINT, noDidFn)
     ;(failingAdminApi as any)._fetchJson = fauxFetch
     ;(failingAdminApi as any).pin._fetchJson = fauxFetch
-  
+
     await expect(failingAdminApi.pin.add(STREAM)).rejects.toThrow(MissingDIDError)
-  
+
     await expect(failingAdminApi.pin.rm(STREAM)).rejects.toThrow(MissingDIDError)
-  
+
     await expect(failingAdminApi.pin.ls()).rejects.toThrow(MissingDIDError)
   })
 })

--- a/packages/http-client/src/__tests__/remote-admin-api.test.ts
+++ b/packages/http-client/src/__tests__/remote-admin-api.test.ts
@@ -6,7 +6,7 @@ import { jest } from '@jest/globals'
 import { Ed25519Provider } from 'key-did-provider-ed25519'
 import KeyResolver from 'key-did-resolver'
 import { randomBytes } from '@stablelib/random'
-import { MissingDIDError } from '../utils'
+import { MissingDIDError } from '../utils.js'
 
 const FAUX_ENDPOINT = new URL('https://example.com')
 const MODEL = new StreamID(1, TestUtils.randomCID())

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -80,7 +80,6 @@ export class CeramicClient implements CeramicApi {
     this._apiUrl = new URL(API_PATH, apiHost)
     this.context = { api: this }
 
-    this.pin = new RemotePinApi(this._apiUrl)
     this.index = new RemoteIndexApi(this._apiUrl)
     const getDidFn = (() => {
       return this.did

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -27,7 +27,6 @@ import { Caip10Link } from '@ceramicnetwork/stream-caip10-link'
 import { Model } from '@ceramicnetwork/stream-model'
 import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
 import { StreamID, CommitID, StreamRef } from '@ceramicnetwork/streamid'
-import { RemotePinApi } from './remote-pin-api.js'
 import { RemoteIndexApi } from './remote-index-api.js'
 import { RemoteAdminApi } from './remote-admin-api.js'
 

--- a/packages/http-client/src/remote-admin-api.ts
+++ b/packages/http-client/src/remote-admin-api.ts
@@ -2,7 +2,7 @@ import { AdminApi, fetchJson, PinApi } from '@ceramicnetwork/common'
 import { RemotePinApi } from './remote-pin-api.js'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { DID } from 'dids'
-import { MissingDIDError } from './utils'
+import { MissingDIDError } from './utils.js'
 
 /**
  * AdminApi for Ceramic http client.

--- a/packages/http-client/src/remote-admin-api.ts
+++ b/packages/http-client/src/remote-admin-api.ts
@@ -72,8 +72,8 @@ export class RemoteAdminApi implements AdminApi {
   }
 
   get pin(): PinApi {
-    if (this._pinApi) return this._pinApi 
+    if (this._pinApi) return this._pinApi
     this._pinApi = new RemotePinApi(this._apiUrl, this._getDidFn)
-    return this._pinApi 
+    return this._pinApi
   }
 }

--- a/packages/http-client/src/remote-admin-api.ts
+++ b/packages/http-client/src/remote-admin-api.ts
@@ -2,14 +2,7 @@ import { AdminApi, fetchJson, PinApi } from '@ceramicnetwork/common'
 import { RemotePinApi } from './remote-pin-api.js'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { DID } from 'dids'
-
-export class MissingDIDError extends Error {
-  constructor() {
-    super(
-      'Failed to get DID.  Please make sure your Ceramic client has an authenticated DID attached'
-    )
-  }
-}
+import { MissingDIDError } from './utils'
 
 /**
  * AdminApi for Ceramic http client.
@@ -80,7 +73,7 @@ export class RemoteAdminApi implements AdminApi {
 
   get pin(): PinApi {
     if (this._pinApi) return this._pinApi 
-    this._pinApi = new RemotePinApi(this._apiUrl)
+    this._pinApi = new RemotePinApi(this._apiUrl, this._getDidFn)
     return this._pinApi 
   }
 }

--- a/packages/http-client/src/remote-admin-api.ts
+++ b/packages/http-client/src/remote-admin-api.ts
@@ -1,4 +1,5 @@
-import { AdminApi, fetchJson } from '@ceramicnetwork/common'
+import { AdminApi, fetchJson, PinApi } from '@ceramicnetwork/common'
+import { RemotePinApi } from './remote-pin-api.js'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { DID } from 'dids'
 
@@ -16,6 +17,7 @@ export class MissingDIDError extends Error {
 export class RemoteAdminApi implements AdminApi {
   // Stored as a member to make it easier to inject a mock in unit tests
   private readonly _fetchJson: typeof fetchJson = fetchJson
+  private _pinApi: PinApi
 
   readonly modelsPath = './admin/models'
   readonly getCodePath = './admin/getCode'
@@ -74,5 +76,11 @@ export class RemoteAdminApi implements AdminApi {
       method: 'delete',
       body: { jws: await this.buildJWS(this._getDidFn(), code, modelsIDs) },
     })
+  }
+
+  get pin(): PinApi {
+    if (this._pinApi) return this._pinApi 
+    this._pinApi = new RemotePinApi(this._apiUrl)
+    return this._pinApi 
   }
 }

--- a/packages/http-client/src/remote-pin-api.ts
+++ b/packages/http-client/src/remote-pin-api.ts
@@ -23,10 +23,13 @@ export class RemotePinApi implements PinApi {
   }
 
   readonly getCodePath = './admin/getCode'
-  readonly baseUrl = new URL(`./admin/pins`, this._apiUrl)
 
   private getCodeUrl(): URL {
     return new URL(this.getCodePath, this._apiUrl)
+  }
+
+  private getBaseUrl(): URL {
+    return new URL(`./admin/pins`, this._apiUrl)
   }
 
   private async generateCode(): Promise<string> {
@@ -42,7 +45,7 @@ export class RemotePinApi implements PinApi {
     const url = new URL(`./admin/pins/${streamId}`, this._apiUrl)
     await this._fetchJson(url, {
       headers: {
-        Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.baseUrl)}`,
+        Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.getBaseUrl())}`,
       },
       method: 'post',
       body: args,
@@ -54,7 +57,7 @@ export class RemotePinApi implements PinApi {
     const url = new URL(`./admin/pins/${streamId}`, this._apiUrl)
     await this._fetchJson(url, {
       headers: {
-        Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.baseUrl)}`,
+        Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.getBaseUrl())}`,
       },
       method: 'delete',
       body: { opts },
@@ -69,7 +72,7 @@ export class RemotePinApi implements PinApi {
     const code = await this.generateCode()
     const result = await this._fetchJson(url, {
       headers: {
-        Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.baseUrl)}`,
+        Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.getBaseUrl())}`,
       },
     })
     const { pinnedStreamIds } = result

--- a/packages/http-client/src/remote-pin-api.ts
+++ b/packages/http-client/src/remote-pin-api.ts
@@ -2,7 +2,7 @@ import { fetchJson, PinApi } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { PublishOpts } from '@ceramicnetwork/common'
 import { DID } from 'dids'
-import { MissingDIDError } from './utils'
+import { MissingDIDError } from './utils.js'
 
 /**
  * PinApi for Ceramic HTTP client

--- a/packages/http-client/src/remote-pin-api.ts
+++ b/packages/http-client/src/remote-pin-api.ts
@@ -23,7 +23,7 @@ export class RemotePinApi implements PinApi {
   }
 
   readonly getCodePath = './admin/getCode'
-  readonly baseUrl =  new URL(`./admin/pins`, this._apiUrl)
+  readonly baseUrl = new URL(`./admin/pins`, this._apiUrl)
 
   private getCodeUrl(): URL {
     return new URL(this.getCodePath, this._apiUrl)
@@ -41,7 +41,9 @@ export class RemotePinApi implements PinApi {
     const code = await this.generateCode()
     const url = new URL(`./admin/pins/${streamId}`, this._apiUrl)
     await this._fetchJson(url, {
-      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.baseUrl)}` },
+      headers: {
+        Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.baseUrl)}`,
+      },
       method: 'post',
       body: args,
     })
@@ -51,7 +53,9 @@ export class RemotePinApi implements PinApi {
     const code = await this.generateCode()
     const url = new URL(`./admin/pins/${streamId}`, this._apiUrl)
     await this._fetchJson(url, {
-      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.baseUrl)}` },
+      headers: {
+        Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.baseUrl)}`,
+      },
       method: 'delete',
       body: { opts },
     })
@@ -64,7 +68,9 @@ export class RemotePinApi implements PinApi {
     }
     const code = await this.generateCode()
     const result = await this._fetchJson(url, {
-      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.baseUrl)}` },
+      headers: {
+        Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.baseUrl)}`,
+      },
     })
     const { pinnedStreamIds } = result
     return {

--- a/packages/http-client/src/remote-pin-api.ts
+++ b/packages/http-client/src/remote-pin-api.ts
@@ -13,11 +13,7 @@ export class RemotePinApi implements PinApi {
 
   constructor(private readonly _apiUrl: URL, private readonly _getDidFn: () => DID) {}
 
-  private async buildJWS(
-    actingDid: DID,
-    code: string,
-    url: URL
-  ): Promise<string> {
+  private async buildJWS(actingDid: DID, code: string, url: URL): Promise<string> {
     if (!actingDid) throw new MissingDIDError()
     const jws = await actingDid.createJWS({
       code: code,

--- a/packages/http-client/src/remote-pin-api.ts
+++ b/packages/http-client/src/remote-pin-api.ts
@@ -23,6 +23,7 @@ export class RemotePinApi implements PinApi {
   }
 
   readonly getCodePath = './admin/getCode'
+  readonly baseUrl =  new URL(`./admin/pins`, this._apiUrl)
 
   private getCodeUrl(): URL {
     return new URL(this.getCodePath, this._apiUrl)
@@ -40,7 +41,7 @@ export class RemotePinApi implements PinApi {
     const code = await this.generateCode()
     const url = new URL(`./admin/pins/${streamId}`, this._apiUrl)
     await this._fetchJson(url, {
-      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, url)}` },
+      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.baseUrl)}` },
       method: 'post',
       body: args,
     })
@@ -50,7 +51,7 @@ export class RemotePinApi implements PinApi {
     const code = await this.generateCode()
     const url = new URL(`./admin/pins/${streamId}`, this._apiUrl)
     await this._fetchJson(url, {
-      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, url)}` },
+      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.baseUrl)}` },
       method: 'delete',
       body: { opts },
     })
@@ -63,7 +64,7 @@ export class RemotePinApi implements PinApi {
     }
     const code = await this.generateCode()
     const result = await this._fetchJson(url, {
-      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, url)}` },
+      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, this.baseUrl)}` },
     })
     const { pinnedStreamIds } = result
     return {

--- a/packages/http-client/src/remote-pin-api.ts
+++ b/packages/http-client/src/remote-pin-api.ts
@@ -1,39 +1,74 @@
 import { fetchJson, PinApi } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { PublishOpts } from '@ceramicnetwork/common'
+import { DID } from 'dids'
+import { MissingDIDError } from './utils'
 
 /**
  * PinApi for Ceramic HTTP client
  */
 export class RemotePinApi implements PinApi {
-  constructor(private readonly _apiUrl: URL) {}
+  // Stored as a member to make it easier to inject a mock in unit tests
+  private readonly _fetchJson: typeof fetchJson = fetchJson
+
+  constructor(private readonly _apiUrl: URL, private readonly _getDidFn: () => DID) {}
+
+  private async buildJWS(
+    actingDid: DID,
+    code: string,
+    url: URL
+  ): Promise<string> {
+    if (!actingDid) throw new MissingDIDError()
+    const jws = await actingDid.createJWS({
+      code: code,
+      requestPath: url.pathname,
+    })
+    return `${jws.signatures[0].protected}.${jws.payload}.${jws.signatures[0].signature}`
+  }
+
+  readonly getCodePath = './admin/getCode'
+
+  private getCodeUrl(): URL {
+    return new URL(this.getCodePath, this._apiUrl)
+  }
+
+  private async generateCode(): Promise<string> {
+    return (await this._fetchJson(this.getCodeUrl())).code
+  }
 
   async add(streamId: StreamID, force?: boolean): Promise<void> {
     const args: any = {}
     if (force) {
       args.force = true
     }
-    const url = new URL(`./pins/${streamId}`, this._apiUrl)
-    await fetchJson(url, {
+    const code = await this.generateCode()
+    const url = new URL(`./admin/pins/${streamId}`, this._apiUrl)
+    await this._fetchJson(url, {
+      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, url)}` },
       method: 'post',
       body: args,
     })
   }
 
   async rm(streamId: StreamID, opts?: PublishOpts): Promise<void> {
-    const url = new URL(`./pins/${streamId}`, this._apiUrl)
-    await fetchJson(url, {
+    const code = await this.generateCode()
+    const url = new URL(`./admin/pins/${streamId}`, this._apiUrl)
+    await this._fetchJson(url, {
+      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, url)}` },
       method: 'delete',
       body: { opts },
     })
   }
 
   async ls(streamId?: StreamID): Promise<AsyncIterable<string>> {
-    let url = new URL('./pins', this._apiUrl)
+    let url = new URL('./admin/pins', this._apiUrl)
     if (streamId) {
-      url = new URL(`./pins/${streamId.toString()}`, this._apiUrl)
+      url = new URL(`./admin/pins/${streamId.toString()}`, this._apiUrl)
     }
-    const result = await fetchJson(url)
+    const code = await this.generateCode()
+    const result = await this._fetchJson(url, {
+      headers: { Authorization: `Basic ${await this.buildJWS(this._getDidFn(), code, url)}` },
+    })
     const { pinnedStreamIds } = result
     return {
       [Symbol.asyncIterator](): AsyncIterator<string, any, undefined> {

--- a/packages/http-client/src/utils.ts
+++ b/packages/http-client/src/utils.ts
@@ -40,3 +40,15 @@ export function serializeObjectForHttpPost(query: Record<string, any>): Record<s
   }
   return result
 }
+
+/**
+ * Admin API Error
+ */
+export class MissingDIDError extends Error {
+  constructor() {
+    super(
+      'Failed to get DID.  Please make sure your Ceramic client has an authenticated DID attached'
+    )
+  }
+}
+

--- a/packages/http-client/src/utils.ts
+++ b/packages/http-client/src/utils.ts
@@ -51,4 +51,3 @@ export class MissingDIDError extends Error {
     )
   }
 }
-

--- a/packages/stream-tests/src/__tests__/model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/model-instance-document.test.ts
@@ -322,7 +322,9 @@ describe('ModelInstanceDocument API http-client tests', () => {
   test('unpinning indexed stream fails', async () => {
     const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
     await expect(TestUtils.isPinned(ceramic, doc.id)).toBeTruthy()
-    await expect(ceramic.admin.pin.rm(doc.id)).rejects.toThrow(/Cannot unpin actively indexed stream/)
+    await expect(ceramic.admin.pin.rm(doc.id)).rejects.toThrow(
+      /Cannot unpin actively indexed stream/
+    )
   })
 
   test('replace respects anchor flag', async () => {

--- a/packages/stream-tests/src/__tests__/model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/model-instance-document.test.ts
@@ -322,7 +322,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
   test('unpinning indexed stream fails', async () => {
     const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
     await expect(TestUtils.isPinned(ceramic, doc.id)).toBeTruthy()
-    await expect(ceramic.pin.rm(doc.id)).rejects.toThrow(/Cannot unpin actively indexed stream/)
+    await expect(ceramic.admin.pin.rm(doc.id)).rejects.toThrow(/Cannot unpin actively indexed stream/)
   })
 
   test('replace respects anchor flag', async () => {
@@ -346,7 +346,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
 
   test(`Pinning a ModelInstanceDocument pins its Model`, async () => {
     // Unpin Model streams so we can test that pinning the MID causes the Model to become pinned
-    await ceramic.pin.rm(model.id)
+    await ceramic.admin.pin.rm(model.id)
     await expect(TestUtils.isPinned(ceramic, model.id)).resolves.toBeFalsy()
 
     const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)


### PR DESCRIPTION
Move pin api to admin api, ~~draft until all todos are done~~

- [x] local api implemented,  moves ceramic.pin -> ceramic.admin.pin
- [x] daemon endpoints added/moved, behind admin api, jws middleware validation, basic tests 
- [x] implement remote admin pins api, tests
- [x] any higher level / integration tests 

~~do we want to keep existing pins paths, and add unsupported warnings?~~ 

~~does this need to be added CLI as well?~~ see other story for this now