### PR TITLE
fix: fix postgresql database url not accepted

### DIFF
--- a/packages/core/src/indexing/build-indexing.ts
+++ b/packages/core/src/indexing/build-indexing.ts
@@ -73,7 +73,8 @@ export function buildIndexing(
         network
       )
     }
-    case 'postgres': {
+    case 'postgres':
+    case 'postgresql': {
       logger.imp('Initializing PostgreSQL connection')
       const dataSource = knex({
         client: 'pg',


### PR DESCRIPTION
## Description

When trying to run the ceramic node with a postgres database, I faced an issue with the env variable being injected by the provider. The format was `postgresql://janedoe:mypassword@localhost:5432/mydb?schema=sample` but the node is expecting a string with the protocol `postgres`. Most of the cloud providers inject an URL with `postgresql` as a prefix so I think both should be accepted to make it work out of the box with render, supabase etc.. 

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

- Prisma documentation https://www.prisma.io/docs/reference/database-reference/connection-urls
