### PR TITLE
fix: downgrade go-ipfs to 15

### DIFF
--- a/packages/ipfs-daemon/package.json
+++ b/packages/ipfs-daemon/package.json
@@ -48,7 +48,7 @@
     "dag-jose": "^2.0.0",
     "express": "^4.17.2",
     "get-port": "^6.0.0",
-    "go-ipfs": "^0.18.1",
+    "go-ipfs": "^0.15.0",
     "ipfs-core": "~0.13.0",
     "ipfs-http-client": "^55.0.0",
     "ipfsd-ctl": "^10.0.5",


### PR DESCRIPTION
18 fails to start in bundled mode