### PR TITLE
fix: allow elp as composedb network config

### DIFF
--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -94,12 +94,14 @@ export function indices(tableName: string): TableIndices {
 function getNetworkDefaultConfig(networkName: string): { [key: string]: any } {
   switch (networkName) {
     case 'mainnet':
+    case 'elp': {
       return {
         enable_historical_sync: true,
         allow_queries_before_historical_sync: false,
         run_historical_sync_worker: true,
       }
       break
+    }
     case 'testnet-clay':
       return {
         enable_historical_sync: true,


### PR DESCRIPTION
## Description

Allow `elp` as option for network config to comply with internal infrastructure settings.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] tested locally that elp populates `ceramic_config` with expected default values

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:
recommended for internal use only. No need for docs update
