### PR TITLE
fix: added disallow HDS with SQLite check

### DIFF
--- a/packages/core/src/initialization/make-index-api.ts
+++ b/packages/core/src/initialization/make-index-api.ts
@@ -26,6 +26,17 @@ export function makeIndexApi(
   }
 
   const indexApi = buildIndexing(indexingConfig, logger, network)
+  // TODO(CDB-2078): replace env var with config option from ceramic_config
+  if (
+    process.env.CERAMIC_ENABLE_EXPERIMENTAL_SYNC === 'true' &&
+    indexApi instanceof SqliteIndexApi
+  ) {
+    throw Error(
+      'SQLite is not supported for the Compose DB indexing database with historical syncing enabled. Please setup a Postgres instance and update the config file.'
+    )
+    return undefined
+  }
+
   // TODO(CDB-2078): extend with addt. properties from startup if MAINNET or sync is enabled
   if (network === Networks.MAINNET && indexApi instanceof SqliteIndexApi) {
     throw Error(

--- a/packages/core/src/initialization/make-index-api.ts
+++ b/packages/core/src/initialization/make-index-api.ts
@@ -26,7 +26,7 @@ export function makeIndexApi(
   }
 
   const indexApi = buildIndexing(indexingConfig, logger, network)
-  // TODO(CDB-2078): replace env var with config option from ceramic_config
+  // TODO(CDB-2310): replace experimental env var with config option from ceramic_config
   if (
     process.env.CERAMIC_ENABLE_EXPERIMENTAL_SYNC === 'true' &&
     indexApi instanceof SqliteIndexApi


### PR DESCRIPTION
## Description

Historical data sync is not supported with SQLite. Added addt. check to inform dev to switch.

Include relevant motivation, context, brief description and impact of the change(s). List follow-up tasks here.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Tested locally switching between modes with both SQLite & Postgres

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
