### PR TITLE
chore: Update error message when starting on mainet without postgres to mention disabling ComposeDB

### DIFF
--- a/packages/cli/src/bin/ceramic.ts
+++ b/packages/cli/src/bin/ceramic.ts
@@ -47,7 +47,7 @@ program
     '--sync-override <string>',
     'Global forced mode for syncing all streams. One of: "prefer-cache", "sync-always", or "never-sync". Defaults to "prefer-cache". Deprecated.'
   )
-  .option('--disable-composedb', 'Run node without Compose DB indexing enabled.')
+  .option('--disable-composedb', 'Run node without ComposeDB indexing enabled.')
   .description('Start the daemon')
   .action(
     async ({

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -108,7 +108,7 @@ export class CeramicCliUtils {
    * @param pubsubTopic - Pub/sub topic to use for protocol messages.
    * @param corsAllowedOrigins - Origins for Access-Control-Allow-Origin header. Default is all. Deprecated, use config file if you want to configure this.
    * @param syncOverride - Global forced mode for syncing all streams. Defaults to "prefer-cache". Deprecated, use config file if you want to configure this.
-   * @param disableComposedb - Disable Compose DB Indexing service.
+   * @param disableComposedb - Disable ComposeDB Indexing service.
    */
   static async createDaemon(
     configFilename: string | undefined,
@@ -151,7 +151,6 @@ export class CeramicCliUtils {
 
     // Validate the config after applying all the overrides
     validateConfig(config)
-
 
     {
       // CLI flags override values from environment variables and config file
@@ -283,7 +282,8 @@ export class CeramicCliUtils {
     const id = StreamID.fromString(streamId)
     if (id.type != TileDocument.STREAM_TYPE_ID) {
       throw new Error(
-        `CLI does not currently support updating stream types other than 'tile'. StreamID ${id.toString()} has streamtype '${id.typeName
+        `CLI does not currently support updating stream types other than 'tile'. StreamID ${id.toString()} has streamtype '${
+          id.typeName
         }'`
       )
     }

--- a/packages/core/src/indexing/database-index-api.ts
+++ b/packages/core/src/indexing/database-index-api.ts
@@ -286,7 +286,7 @@ export class DatabaseIndexApi<DateType = Date | number> {
   }
 
   /**
-   * Run Compose DB config/startup operations
+   * Run ComposeDB config/startup operations
    */
   async init(): Promise<void> {
     await this.tablesManager.initConfigTables(this.network)

--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -87,7 +87,7 @@ export function indices(tableName: string): TableIndices {
 }
 
 /**
- * Default configuration of Compose DB functionality per network.
+ * Default configuration of ComposeDB functionality per network.
  * Values can be overwritten by updating them in the ceramic_config table
  * and by restarting the node.
  */

--- a/packages/core/src/indexing/tables-manager.ts
+++ b/packages/core/src/indexing/tables-manager.ts
@@ -17,7 +17,7 @@ import { CONFIG_TABLE_NAME } from './config.js'
 import { addColumnPrefix } from './column-name.util.js'
 
 /**
- * Compose DB Config Table Type
+ * ComposeDB Config Table Type
  */
 type ConfigTable = {
   readonly tableName: string
@@ -80,7 +80,7 @@ export class TablesManager {
   }
 
   /**
-   * Create Compose DB config tables
+   * Create ComposeDB config tables
    */
   async initConfigTables(network: Networks) {
     const configTables = this.listConfigTables()
@@ -97,7 +97,7 @@ export class TablesManager {
   async initConfigTable(table: ConfigTable, network: Networks) {
     const exists = await this.dataSource.schema.hasTable(table.tableName)
     if (!exists) {
-      this.logger.imp(`Creating Compose DB config table: ${table.tableName}`)
+      this.logger.imp(`Creating ComposeDB config table: ${table.tableName}`)
       await createConfigTable(this.dataSource, table.tableName, network)
     } else if (table.tableName === CONFIG_TABLE_NAME) {
       const config = await this.dataSource
@@ -113,7 +113,7 @@ export class TablesManager {
   }
 
   /**
-   * Compose DB configuration table schema verification
+   * ComposeDB configuration table schema verification
    */
   async _verifyConfigTables() {
     const configTables = this.listConfigTables()
@@ -139,7 +139,7 @@ export class TablesManager {
   }
 
   /**
-   * Compose DB Model Instance Document table schema verification
+   * ComposeDB Model Instance Document table schema verification
    */
   async _verifyMidTables(modelsToIndex: Array<IndexModelArgs>) {
     const tableNames = await this.listMidTables()
@@ -234,7 +234,7 @@ export class PostgresTablesManager extends TablesManager {
 
     const exists = await this.dataSource.schema.hasTable(tableName)
     if (!exists) {
-      this.logger.imp(`Creating Compose DB Indexing table for model: ${tableName}`)
+      this.logger.imp(`Creating ComposeDB Indexing table for model: ${tableName}`)
       const relationColumns = relationsDefinitionsToColumnInfo(modelIndexArgs.relations)
       await createPostgresModelTable(this.dataSource, tableName, relationColumns)
     }
@@ -306,7 +306,7 @@ export class SqliteTablesManager extends TablesManager {
     if (existingTables.includes(tableName)) {
       return
     }
-    this.logger.imp(`Creating Compose DB Indexing table for model: ${tableName}`)
+    this.logger.imp(`Creating ComposeDB Indexing table for model: ${tableName}`)
     const relationColumns = relationsDefinitionsToColumnInfo(modelIndexArgs.relations)
     await createSqliteModelTable(this.dataSource, tableName, relationColumns)
   }

--- a/packages/core/src/initialization/make-index-api.ts
+++ b/packages/core/src/initialization/make-index-api.ts
@@ -13,14 +13,14 @@ export function makeIndexApi(
 ): DatabaseIndexApi | undefined {
   if (!indexingConfig) {
     logger.warn(
-      `Compose DB Indexing is not configured. Please add the indexing settings to your config file`
+      `ComposeDB Indexing is not configured. Please add the indexing settings to your config file`
     )
     return undefined
   }
 
   if (indexingConfig.disableComposedb === true) {
     logger.warn(
-      'Compose DB indexing is actively disabled. Change the corresponding CLI flag, config option or ENV variable to enable it.'
+      'ComposeDB indexing is actively disabled. Change the corresponding CLI flag, config option or ENV variable to enable it.'
     )
     return undefined
   }
@@ -32,7 +32,7 @@ export function makeIndexApi(
     indexApi instanceof SqliteIndexApi
   ) {
     throw Error(
-      'SQLite is not supported for the Compose DB indexing database with historical syncing enabled. Please setup a Postgres instance and update the config file.'
+      'SQLite is not supported for the ComposeDB indexing database with historical syncing enabled. Please setup a Postgres instance and update the config file.'
     )
     return undefined
   }
@@ -40,7 +40,7 @@ export function makeIndexApi(
   // TODO(CDB-2078): extend with addt. properties from startup if MAINNET or sync is enabled
   if (network === Networks.MAINNET && indexApi instanceof SqliteIndexApi) {
     throw Error(
-      'SQLite is not supported for the Compose DB indexing database in production use. Please setup a Postgres instance and update the config file.'
+      'SQLite is not supported for the ComposeDB indexing database in production use. Please setup a Postgres instance and update the config file to use ComposeDB, or disable ComposeDB to start up without an indexing database.'
     )
     return undefined
   }


### PR DESCRIPTION
Also update all places where we say "Compose DB" to say "ComposeDB" to match our branding and marketing material.