### PR TITLE
feat(cli, core): add sync worker flag to config file with default values

### DIFF
--- a/packages/cli/src/__tests__/make-ceramic-core.ts
+++ b/packages/cli/src/__tests__/make-ceramic-core.ts
@@ -14,6 +14,7 @@ export async function makeCeramicCore(
       db: `sqlite://${stateStoreDirectory}/ceramic.sqlite`,
       allowQueriesBeforeHistoricalSync: true,
       disableComposedb: false,
+      runHistoricalSyncWorker: false,
     },
   })
 

--- a/packages/cli/src/__tests__/make-ceramic-core.ts
+++ b/packages/cli/src/__tests__/make-ceramic-core.ts
@@ -14,7 +14,7 @@ export async function makeCeramicCore(
       db: `sqlite://${stateStoreDirectory}/ceramic.sqlite`,
       allowQueriesBeforeHistoricalSync: true,
       disableComposedb: false,
-      runHistoricalSyncWorker: false,
+      enableHistoricalSync: false,
     },
   })
 

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -27,7 +27,7 @@ import { handleHeapdumpSignal } from './daemon/handle-heapdump-signal.js'
 import { handleSigintSignal } from './daemon/handle-sigint-signal.js'
 import { generateSeedUrl } from './daemon/did-utils.js'
 import { TypedJSON } from 'typedjson'
-import { getNetworkDefaultConfig } from '../../core/lib/indexing/migrations/1-create-model-table.js'
+import { getDefaultCDBDatabaseConfig } from '../../core/lib/indexing/migrations/1-create-model-table.js'
 
 const HOMEDIR = new URL(`file://${os.homedir()}/`)
 const CWD = new URL(`file://${process.cwd()}/`)
@@ -47,7 +47,7 @@ const DEFAULT_INDEXING_DB_FILENAME = new URL('./indexing.sqlite', DEFAULT_CONFIG
  */
 const generateDefaultDaemonConfig = () => {
   const privateSeedUrl = generateSeedUrl()
-  const getIndexingConfig = getNetworkDefaultConfig(Networks.TESTNET_CLAY)
+  const defaultIndexingConfig = getDefaultCDBDatabaseConfig(Networks.TESTNET_CLAY)
 
   return DaemonConfig.fromObject({
     anchor: {
@@ -70,8 +70,9 @@ const generateDefaultDaemonConfig = () => {
     indexing: {
       db: `sqlite://${DEFAULT_INDEXING_DB_FILENAME.pathname}`,
       'disable-composedb': false,
-      'run-historical-sync-worker': getIndexingConfig.run_historical_sync_worker,
-      'allow-queries-before-historical-sync': getIndexingConfig.allow_queries_before_historical_sync,
+      'run-historical-sync-worker': defaultIndexingConfig.run_historical_sync_worker,
+      'allow-queries-before-historical-sync':
+        defaultIndexingConfig.allow_queries_before_historical_sync,
     },
   })
 }
@@ -205,10 +206,6 @@ export class CeramicCliUtils {
       }
       if (network) {
         config.network.name = network
-        const getIndexingConfig = getNetworkDefaultConfig(network)
-        config.indexing.allowQueriesBeforeHistoricalSync =
-          getIndexingConfig.allow_queries_before_historical_sync
-        config.indexing.runHistoricalSyncWorker = getIndexingConfig.run_historical_sync_worker
       }
       if (pubsubTopic) {
         config.network.pubsubTopic = pubsubTopic

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -27,7 +27,7 @@ import { handleHeapdumpSignal } from './daemon/handle-heapdump-signal.js'
 import { handleSigintSignal } from './daemon/handle-sigint-signal.js'
 import { generateSeedUrl } from './daemon/did-utils.js'
 import { TypedJSON } from 'typedjson'
-import { getNetworkDefaultConfig } from '../../core/lib/indexing/migrations/1-create-model-table.js' //'@ceramicnetwork/core/lib/indexing/migrations/1-create-model-table.js'
+import { getNetworkDefaultConfig } from '../../core/lib/indexing/migrations/1-create-model-table.js'
 
 const HOMEDIR = new URL(`file://${os.homedir()}/`)
 const CWD = new URL(`file://${process.cwd()}/`)

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -70,7 +70,7 @@ const generateDefaultDaemonConfig = () => {
     indexing: {
       db: `sqlite://${DEFAULT_INDEXING_DB_FILENAME.pathname}`,
       'disable-composedb': false,
-      'run-historical-sync-worker': defaultIndexingConfig.run_historical_sync_worker,
+      'enable-historical-sync': defaultIndexingConfig.run_historical_sync_worker,
       'allow-queries-before-historical-sync':
         defaultIndexingConfig.allow_queries_before_historical_sync,
     },

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -69,8 +69,9 @@ const generateDefaultDaemonConfig = () => {
     },
     indexing: {
       db: `sqlite://${DEFAULT_INDEXING_DB_FILENAME.pathname}`,
-      'disable-composedb': getIndexingConfig.allow_queries_before_historical_sync,
+      'disable-composedb': false,
       'run-historical-sync-worker': getIndexingConfig.run_historical_sync_worker,
+      'allow-queries-before-historical-sync': getIndexingConfig.allow_queries_before_historical_sync,
     },
   })
 }

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises'
 import { homedir } from 'os'
 import { AnchorServiceAuthMethods } from '@ceramicnetwork/common'
 import { StartupError } from './daemon/error-handler.js'
+import { json } from 'express'
 
 /**
  * Replace `~/` with `<homedir>/` absolute path, and `~+/` with `<cwd>/`.
@@ -242,10 +243,21 @@ export class IndexingConfig {
   })
   allowQueriesBeforeHistoricalSync = false
 
+  /**
+   * Allow Ceramic node to run in stand-along mode without Compose DB enabled
+   */
   @jsonMember(Boolean, {
     name: 'disable-composedb',
   })
   disableComposedb = false
+
+  /**
+   * Enable Historical data sync worker for Compose DB indexing
+   */
+  @jsonMember(Boolean, {
+    name: 'run-historical-sync-worker',
+  })
+  runHistoricalSyncWorker = false
 }
 
 @jsonObject
@@ -486,9 +498,9 @@ export class DaemonConfig {
 }
 
 /**
-  * Validate the config object has the expected settings.
-  *
-  */
+ * Validate the config object has the expected settings.
+ *
+ */
 export function validateConfig(config: DaemonConfig) {
   if (config.anchor) {
     if (config.anchor.authMethod == AnchorServiceAuthMethods.DID) {

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -257,7 +257,7 @@ export class IndexingConfig {
   @jsonMember(Boolean, {
     name: 'enable-historical-sync',
   })
-  runHistoricalSyncWorker = false
+  enableHistoricalSync = false
 }
 
 @jsonObject

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -255,7 +255,7 @@ export class IndexingConfig {
    * Enable Historical data sync worker for Compose DB indexing
    */
   @jsonMember(Boolean, {
-    name: 'run-historical-sync-worker',
+    name: 'enable-historical-sync',
   })
   runHistoricalSyncWorker = false
 }

--- a/packages/core/src/__tests__/ceramic-pinning.test.ts
+++ b/packages/core/src/__tests__/ceramic-pinning.test.ts
@@ -53,7 +53,7 @@ const createCeramic = async (
       db: connectionString.href,
       allowQueriesBeforeHistoricalSync: true,
       disableComposedb: true,
-      runHistoricalSyncWorker: false,
+      enableHistoricalSync: false,
     },
     pubsubTopic: '/ceramic/inmemory/test', // necessary so Ceramic instances can talk to each other
   })

--- a/packages/core/src/__tests__/ceramic-pinning.test.ts
+++ b/packages/core/src/__tests__/ceramic-pinning.test.ts
@@ -53,6 +53,7 @@ const createCeramic = async (
       db: connectionString.href,
       allowQueriesBeforeHistoricalSync: true,
       disableComposedb: true,
+      runHistoricalSyncWorker: false,
     },
     pubsubTopic: '/ceramic/inmemory/test', // necessary so Ceramic instances can talk to each other
   })

--- a/packages/core/src/__tests__/create-ceramic.ts
+++ b/packages/core/src/__tests__/create-ceramic.ts
@@ -28,6 +28,7 @@ export async function createCeramic(
       db: databaseUrl.href,
       allowQueriesBeforeHistoricalSync: false,
       disableComposedb: false,
+      runHistoricalSyncWorker: false,
     },
     ...config,
   }

--- a/packages/core/src/__tests__/create-ceramic.ts
+++ b/packages/core/src/__tests__/create-ceramic.ts
@@ -28,7 +28,7 @@ export async function createCeramic(
       db: databaseUrl.href,
       allowQueriesBeforeHistoricalSync: false,
       disableComposedb: false,
-      runHistoricalSyncWorker: false,
+      enableHistoricalSync: false,
     },
     ...config,
   }

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -542,7 +542,7 @@ export class Ceramic implements CeramicApi {
       indexingConfig: config.indexing,
       networkOptions,
       loadOptsOverride,
-      sync: config.indexing.runHistoricalSyncWorker,
+      sync: config.indexing.enableHistoricalSync,
     }
 
     const modules: CeramicModules = {

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -130,8 +130,6 @@ export interface CeramicConfig {
   gateway?: boolean
 
   indexing?: IndexingConfig
-  // TODO: Replace in CDB-2072
-  sync?: boolean
 
   networkName?: string
   pubsubTopic?: string
@@ -538,18 +536,13 @@ export class Ceramic implements CeramicApi {
       maxQueriesPerSecond
     )
 
-    const sync =
-      config.sync == undefined
-        ? process.env.CERAMIC_ENABLE_EXPERIMENTAL_SYNC === 'true'
-        : config.sync
-
     const params: CeramicParameters = {
       gateway: config.gateway,
       stateStoreDirectory: config.stateStoreDirectory,
       indexingConfig: config.indexing,
       networkOptions,
       loadOptsOverride,
-      sync,
+      sync: config.indexing.runHistoricalSyncWorker,
     }
 
     const modules: CeramicModules = {

--- a/packages/core/src/indexing/__tests__/build-indexing.test.ts
+++ b/packages/core/src/indexing/__tests__/build-indexing.test.ts
@@ -30,6 +30,7 @@ describe('sqlite', () => {
       {
         db: databaseUrl.href,
         allowQueriesBeforeHistoricalSync: true,
+        runHistoricalSyncWorker: false,
       },
       diagnosticsLogger,
       Networks.INMEMORY
@@ -43,6 +44,7 @@ describe('sqlite', () => {
       {
         db: databaseUrl.href,
         allowQueriesBeforeHistoricalSync: true,
+        runHistoricalSyncWorker: false,
       },
       diagnosticsLogger,
       Networks.INMEMORY
@@ -57,6 +59,7 @@ test('build for postgres connection string', async () => {
     {
       db: databaseURL,
       allowQueriesBeforeHistoricalSync: true,
+      runHistoricalSyncWorker: false,
     },
     diagnosticsLogger,
     Networks.INMEMORY
@@ -80,6 +83,7 @@ describe('postgres', () => {
       {
         db: databaseURL,
         allowQueriesBeforeHistoricalSync: true,
+        runHistoricalSyncWorker: false,
       },
       diagnosticsLogger,
       Networks.INMEMORY

--- a/packages/core/src/indexing/__tests__/build-indexing.test.ts
+++ b/packages/core/src/indexing/__tests__/build-indexing.test.ts
@@ -30,7 +30,7 @@ describe('sqlite', () => {
       {
         db: databaseUrl.href,
         allowQueriesBeforeHistoricalSync: true,
-        runHistoricalSyncWorker: false,
+        enableHistoricalSync: false,
       },
       diagnosticsLogger,
       Networks.INMEMORY
@@ -44,7 +44,7 @@ describe('sqlite', () => {
       {
         db: databaseUrl.href,
         allowQueriesBeforeHistoricalSync: true,
-        runHistoricalSyncWorker: false,
+        enableHistoricalSync: false,
       },
       diagnosticsLogger,
       Networks.INMEMORY
@@ -59,7 +59,7 @@ test('build for postgres connection string', async () => {
     {
       db: databaseURL,
       allowQueriesBeforeHistoricalSync: true,
-      runHistoricalSyncWorker: false,
+      enableHistoricalSync: false,
     },
     diagnosticsLogger,
     Networks.INMEMORY
@@ -83,7 +83,7 @@ describe('postgres', () => {
       {
         db: databaseURL,
         allowQueriesBeforeHistoricalSync: true,
-        runHistoricalSyncWorker: false,
+        enableHistoricalSync: false,
       },
       diagnosticsLogger,
       Networks.INMEMORY

--- a/packages/core/src/indexing/build-indexing.ts
+++ b/packages/core/src/indexing/build-indexing.ts
@@ -22,7 +22,7 @@ export type IndexingConfig = {
   /**
    * Setting this to true allows a Ceramic node to sync historical data for actively indexed models
    */
-  runHistoricalSyncWorker: boolean
+  enableHistoricalSync: boolean
 }
 
 export class UnsupportedDatabaseProtocolError extends Error {

--- a/packages/core/src/indexing/build-indexing.ts
+++ b/packages/core/src/indexing/build-indexing.ts
@@ -18,6 +18,11 @@ export type IndexingConfig = {
    * Setting this to true allows a Ceramic node to start without indexing enabled
    */
   disableComposedb: boolean
+
+  /**
+   * Setting this to true allows a Ceramic node to sync historical data for actively indexed models
+   */
+  runHistoricalSyncWorker: boolean
 }
 
 export class UnsupportedDatabaseProtocolError extends Error {

--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -102,7 +102,7 @@ export function getNetworkDefaultConfig(networkName: string): { [key: string]: a
       return {
         enable_historical_sync: true,
         allow_queries_before_historical_sync: true,
-        run_historical_sync_worker: true,
+        run_historical_sync_worker: false,
       }
       break
     }

--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -95,7 +95,7 @@ export function indices(tableName: string): TableIndices {
  *   allow_queries_before_historical_sync - allow data to be queried before models have been fully synced
  *   run_historical_sync_worker - enable historical data sync on a node level
  */
-export function getNetworkDefaultConfig(networkName: string): { [key: string]: any } {
+export function getDefaultCDBDatabaseConfig(networkName: string): { [key: string]: any } {
   switch (networkName) {
     case 'mainnet':
     case 'elp': {
@@ -123,7 +123,7 @@ export function getNetworkDefaultConfig(networkName: string): { [key: string]: a
     case 'dev-unstable':
       return {
         enable_historical_sync: false,
-        allow_queries_before_historical_sync: false,
+        allow_queries_before_historical_sync: true,
         run_historical_sync_worker: false,
       }
       break
@@ -215,7 +215,7 @@ export async function createSqliteModelTable(
 }
 
 export async function createConfigTable(dataSource: Knex, tableName: string, network: Networks) {
-  const NETWORK_DEFAULT_CONFIG = getNetworkDefaultConfig(network)
+  const NETWORK_DEFAULT_CONFIG = getDefaultCDBDatabaseConfig(network)
 
   switch (tableName) {
     case INDEXED_MODEL_CONFIG_TABLE_NAME:

--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -90,6 +90,10 @@ export function indices(tableName: string): TableIndices {
  * Default configuration of ComposeDB functionality per network.
  * Values can be overwritten by updating them in the ceramic_config table
  * and by restarting the node.
+ *
+ *   enable_historical_sync - enable historical data sync on a per model basis (ceramic_models)
+ *   allow_queries_before_historical_sync - allow data to be queried before models have been fully synced
+ *   run_historical_sync_worker - enable historical data sync on a node level
  */
 function getNetworkDefaultConfig(networkName: string): { [key: string]: any } {
   switch (networkName) {
@@ -97,7 +101,7 @@ function getNetworkDefaultConfig(networkName: string): { [key: string]: any } {
     case 'elp': {
       return {
         enable_historical_sync: true,
-        allow_queries_before_historical_sync: false,
+        allow_queries_before_historical_sync: true,
         run_historical_sync_worker: true,
       }
       break
@@ -105,8 +109,8 @@ function getNetworkDefaultConfig(networkName: string): { [key: string]: any } {
     case 'testnet-clay':
       return {
         enable_historical_sync: true,
-        allow_queries_before_historical_sync: false,
-        run_historical_sync_worker: true,
+        allow_queries_before_historical_sync: true,
+        run_historical_sync_worker: false,
       }
       break
     case 'local':

--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -95,7 +95,7 @@ export function indices(tableName: string): TableIndices {
  *   allow_queries_before_historical_sync - allow data to be queried before models have been fully synced
  *   run_historical_sync_worker - enable historical data sync on a node level
  */
-function getNetworkDefaultConfig(networkName: string): { [key: string]: any } {
+export function getNetworkDefaultConfig(networkName: string): { [key: string]: any } {
   switch (networkName) {
     case 'mainnet':
     case 'elp': {

--- a/packages/core/src/initialization/make-index-api.ts
+++ b/packages/core/src/initialization/make-index-api.ts
@@ -27,10 +27,7 @@ export function makeIndexApi(
 
   const indexApi = buildIndexing(indexingConfig, logger, network)
   // TODO(CDB-2310): replace experimental env var with config option from ceramic_config
-  if (
-    process.env.CERAMIC_ENABLE_EXPERIMENTAL_SYNC === 'true' &&
-    indexApi instanceof SqliteIndexApi
-  ) {
+  if (indexingConfig.runHistoricalSyncWorker && indexApi instanceof SqliteIndexApi) {
     throw Error(
       'SQLite is not supported for the ComposeDB indexing database with historical syncing enabled. Please setup a Postgres instance and update the config file.'
     )

--- a/packages/core/src/initialization/make-index-api.ts
+++ b/packages/core/src/initialization/make-index-api.ts
@@ -27,7 +27,7 @@ export function makeIndexApi(
 
   const indexApi = buildIndexing(indexingConfig, logger, network)
   // TODO(CDB-2310): replace experimental env var with config option from ceramic_config
-  if (indexingConfig.runHistoricalSyncWorker && indexApi instanceof SqliteIndexApi) {
+  if (indexingConfig.enableHistoricalSync && indexApi instanceof SqliteIndexApi) {
     throw Error(
       'SQLite is not supported for the ComposeDB indexing database with historical syncing enabled. Please setup a Postgres instance and update the config file.'
     )

--- a/packages/core/src/sync/__tests__/ceramic-sync.test.ts
+++ b/packages/core/src/sync/__tests__/ceramic-sync.test.ts
@@ -300,7 +300,7 @@ describe('Sync tests', () => {
         indexing: {
           db: process.env.DATABASE_URL as string,
           allowQueriesBeforeHistoricalSync: true,
-          runHistoricalSyncWorker: false,
+          enableHistoricalSync: false,
         },
         sync: true,
         // change pubsub topic so that we aren't getting updates via pubsub

--- a/packages/core/src/sync/__tests__/ceramic-sync.test.ts
+++ b/packages/core/src/sync/__tests__/ceramic-sync.test.ts
@@ -300,6 +300,7 @@ describe('Sync tests', () => {
         indexing: {
           db: process.env.DATABASE_URL as string,
           allowQueriesBeforeHistoricalSync: true,
+          runHistoricalSyncWorker: false,
         },
         sync: true,
         // change pubsub topic so that we aren't getting updates via pubsub

--- a/packages/stream-tests/src/__tests__/admin-api.test.ts
+++ b/packages/stream-tests/src/__tests__/admin-api.test.ts
@@ -61,7 +61,7 @@ describe('Admin API tests', () => {
       indexing: {
         db: `sqlite://${indexingDirectory}/ceramic.sqlite`,
         allowQueriesBeforeHistoricalSync: true,
-        runHistoricalSyncWorker: false,
+        enableHistoricalSync: false,
       },
     })
 

--- a/packages/stream-tests/src/__tests__/admin-api.test.ts
+++ b/packages/stream-tests/src/__tests__/admin-api.test.ts
@@ -61,6 +61,7 @@ describe('Admin API tests', () => {
       indexing: {
         db: `sqlite://${indexingDirectory}/ceramic.sqlite`,
         allowQueriesBeforeHistoricalSync: true,
+        runHistoricalSyncWorker: false,
       },
     })
 

--- a/packages/stream-tests/src/__tests__/basic-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/basic-indexing.test.ts
@@ -129,7 +129,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       indexing: {
         db: dbURL,
         allowQueriesBeforeHistoricalSync: true,
-        runHistoricalSyncWorker: false,
+        enableHistoricalSync: false,
       },
       stateStoreDirectory: stateStoreURL,
     })

--- a/packages/stream-tests/src/__tests__/basic-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/basic-indexing.test.ts
@@ -129,6 +129,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       indexing: {
         db: dbURL,
         allowQueriesBeforeHistoricalSync: true,
+        runHistoricalSyncWorker: false,
       },
       stateStoreDirectory: stateStoreURL,
     })

--- a/packages/stream-tests/src/__tests__/cross-node-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/cross-node-indexing.test.ts
@@ -107,6 +107,7 @@ describe.each(envs)(
           indexing: {
             db: process.env.DATABASE_URL,
             allowQueriesBeforeHistoricalSync: true,
+            runHistoricalSyncWorker: false,
           },
         })
       } else {
@@ -153,6 +154,7 @@ describe.each(envs)(
           db: ceramic1DbUrl,
           models: [],
           allowQueriesBeforeHistoricalSync: true,
+          runHistoricalSyncWorker: false,
         },
       })
       await ceramic1.index.indexModels([model.id])
@@ -161,6 +163,7 @@ describe.each(envs)(
         indexing: {
           db: ceramic2DbUrl,
           allowQueriesBeforeHistoricalSync: true,
+          runHistoricalSyncWorker: false,
         },
       })
       await ceramic2.index.indexModels([model.id])

--- a/packages/stream-tests/src/__tests__/cross-node-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/cross-node-indexing.test.ts
@@ -107,7 +107,7 @@ describe.each(envs)(
           indexing: {
             db: process.env.DATABASE_URL,
             allowQueriesBeforeHistoricalSync: true,
-            runHistoricalSyncWorker: false,
+            enableHistoricalSync: false,
           },
         })
       } else {
@@ -154,7 +154,7 @@ describe.each(envs)(
           db: ceramic1DbUrl,
           models: [],
           allowQueriesBeforeHistoricalSync: true,
-          runHistoricalSyncWorker: false,
+          enableHistoricalSync: false,
         },
       })
       await ceramic1.index.indexModels([model.id])
@@ -163,7 +163,7 @@ describe.each(envs)(
         indexing: {
           db: ceramic2DbUrl,
           allowQueriesBeforeHistoricalSync: true,
-          runHistoricalSyncWorker: false,
+          enableHistoricalSync: false,
         },
       })
       await ceramic2.index.indexModels([model.id])

--- a/packages/stream-tests/src/__tests__/model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/model-instance-document.test.ts
@@ -97,7 +97,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
       indexing: {
         allowQueriesBeforeHistoricalSync: true,
         disableComposedb: false,
-        runHistoricalSyncWorker: false,
+        enableHistoricalSync: false,
       },
     })
 

--- a/packages/stream-tests/src/__tests__/model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/model-instance-document.test.ts
@@ -97,6 +97,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
       indexing: {
         allowQueriesBeforeHistoricalSync: true,
         disableComposedb: false,
+        runHistoricalSyncWorker: false,
       },
     })
 

--- a/packages/stream-tests/src/create-ceramic.ts
+++ b/packages/stream-tests/src/create-ceramic.ts
@@ -19,6 +19,7 @@ export async function createCeramic(
         db: `sqlite://${stateStoreDirectory}/ceramic.sqlite`,
         allowQueriesBeforeHistoricalSync: false,
         disableComposedb: false,
+        runHistoricalSyncWorker: false,
       },
       sync: false,
     },

--- a/packages/stream-tests/src/create-ceramic.ts
+++ b/packages/stream-tests/src/create-ceramic.ts
@@ -19,7 +19,7 @@ export async function createCeramic(
         db: `sqlite://${stateStoreDirectory}/ceramic.sqlite`,
         allowQueriesBeforeHistoricalSync: false,
         disableComposedb: false,
-        runHistoricalSyncWorker: false,
+        enableHistoricalSync: false,
       },
       sync: false,
     },


### PR DESCRIPTION
## Description

Moves HDS configuration flag from experimental env variable (`CERAMIC_ENABLE_EXPERIMENTAL_SYNC`) to be set in the config file. This populates both `allow-queries-before-historical-sync` & `run-historical-sync-worker` by network specific default values.

This PR has default options `3` implemented as outlined in the product discussion: https://www.notion.so/threebox/HDS-Default-Behavior-f5314ebbaba54e1d86ad3af613056f2c

## How Has This Been Tested?

- [ ] Locally verified config file creation

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
