### PR TITLE
fix(cli): legacy pin api, empty 200 on add to support 3id-connect, ot…

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -370,7 +370,7 @@ export class CeramicDaemon {
     baseRouter.use('/pins', legacyPinsRouter)
     legacyPinsRouter.getAsync('/:streamid', this._pinNotSupported.bind(this))
     legacyPinsRouter.getAsync('/', this._pinNotSupported.bind(this))
-    legacyPinsRouter.postAsync('/:streamid',  this._empty200.bind(this))
+    legacyPinsRouter.postAsync('/:streamid', this._pinWarningOk.bind(this))
     legacyPinsRouter.deleteAsync('/:streamid', this._pinNotSupported.bind(this))
 
     commitsRouter.getAsync('/:streamid', this.commits.bind(this))
@@ -972,8 +972,12 @@ export class CeramicDaemon {
       .json({ error: 'Method not supported: pin requests have moved to the admin API /admin/pins' })
   }
 
-  async _empty200(req: Request, res: Response): Promise<void> {
-    res.sendStatus(StatusCodes.OK)
+  async _pinWarningOk(req: Request, res: Response): Promise<void> {
+    res
+      .status(StatusCodes.OK)
+      .send(
+        'Pin requests have moved to the admin API /admin/pins, please make requests there. Any requests here will not pin, API returns 200 for tooling backwards compatibility, and will be removed soon.'
+      )
   }
 
   async getSupportedChains(req: Request, res: Response): Promise<void> {


### PR DESCRIPTION
Related context - https://discord.com/channels/484729862368526356/1075891586354925708/1079555831537881198

get /pins/streamid - throw error
get /pins/ - throw error 
post /pins/streamid - ~~empty 200~~ 200 with warning message, not pinned, req ignored/dropped
delete /pins/streamid - throw error

Not ideal as it doesnt communicate expected behavior, but worthwhile temporary tradeoff (ref discord). Likely less effect on pin.add as well, since streams are pinned by default on creation, people calling pin.add are likely calling it on stream already pinned, while rm/list still throw errors (and more likely to be used by node runners). With plan to change with a stable path after.