### PR TITLE
fix(core): warn instead of throw on pin opts for stream crud (#2764

### DIFF
--- a/packages/core/src/__tests__/ceramic-pinning.test.ts
+++ b/packages/core/src/__tests__/ceramic-pinning.test.ts
@@ -266,14 +266,14 @@ describe('Ceramic stream pinning', () => {
       pin: false,
     })
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
-    await expect(
-      stream.update({ foo: 'baz' }, null, { anchor: false, publish: false, pin: true })
-    ).rejects.toThrow(/Cannot pin or unpin streams through the CRUD APIs/)
+    // await expect(
+    //   stream.update({ foo: 'baz' }, null, { anchor: false, publish: false, pin: true })
+    // ).rejects.toThrow(/Cannot pin or unpin streams through the CRUD APIs/)
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
     await stream.sync()
-    await expect(
-      stream.update({ foo: 'foobarbaz' }, null, { anchor: false, publish: false, pin: false })
-    ).rejects.toThrow(/Cannot pin or unpin streams through the CRUD APIs/)
+    // await expect(
+    //   stream.update({ foo: 'foobarbaz' }, null, { anchor: false, publish: false, pin: false })
+    // ).rejects.toThrow(/Cannot pin or unpin streams through the CRUD APIs/)
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
     await ceramic.close()
   })
@@ -330,25 +330,25 @@ describe('Ceramic stream pinning', () => {
     await stream.update({ foo: 'bar' }, null, { anchor: false, publish: false })
 
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
-    await expect(
-      TileDocument.deterministic(
-        ceramic,
-        { family: 'testAbc' },
-        { sync: SyncOptions.NEVER_SYNC, pin: true }
-      )
-    ).rejects.toThrow(/Cannot pin or unpin streams through the CRUD APIs/)
+    // await expect(
+    //   TileDocument.deterministic(
+    //     ceramic,
+    //     { family: 'testAbc' },
+    //     { sync: SyncOptions.NEVER_SYNC, pin: true }
+    //   )
+    // ).rejects.toThrow(/Cannot pin or unpin streams through the CRUD APIs/)
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
 
     await ceramic.admin.pin.add(stream.id)
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeTruthy()
 
-    await expect(
-      TileDocument.deterministic(
-        ceramic,
-        { family: 'testAbc' },
-        { sync: SyncOptions.NEVER_SYNC, pin: false }
-      )
-    ).rejects.toThrow(/Cannot pin or unpin streams through the CRUD APIs/)
+    // await expect(
+    //   TileDocument.deterministic(
+    //     ceramic,
+    //     { family: 'testAbc' },
+    //     { sync: SyncOptions.NEVER_SYNC, pin: false }
+    //   )
+    // ).rejects.toThrow(/Cannot pin or unpin streams through the CRUD APIs/)
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeTruthy()
 
     await ceramic.close()

--- a/packages/core/src/__tests__/ceramic-pinning.test.ts
+++ b/packages/core/src/__tests__/ceramic-pinning.test.ts
@@ -266,14 +266,8 @@ describe('Ceramic stream pinning', () => {
       pin: false,
     })
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
-    // await expect(
-    //   stream.update({ foo: 'baz' }, null, { anchor: false, publish: false, pin: true })
-    // ).rejects.toThrow(/Cannot pin or unpin streams through the CRUD APIs/)
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
     await stream.sync()
-    // await expect(
-    //   stream.update({ foo: 'foobarbaz' }, null, { anchor: false, publish: false, pin: false })
-    // ).rejects.toThrow(/Cannot pin or unpin streams through the CRUD APIs/)
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
     await ceramic.close()
   })
@@ -330,25 +324,11 @@ describe('Ceramic stream pinning', () => {
     await stream.update({ foo: 'bar' }, null, { anchor: false, publish: false })
 
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
-    // await expect(
-    //   TileDocument.deterministic(
-    //     ceramic,
-    //     { family: 'testAbc' },
-    //     { sync: SyncOptions.NEVER_SYNC, pin: true }
-    //   )
-    // ).rejects.toThrow(/Cannot pin or unpin streams through the CRUD APIs/)
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
 
     await ceramic.admin.pin.add(stream.id)
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeTruthy()
 
-    // await expect(
-    //   TileDocument.deterministic(
-    //     ceramic,
-    //     { family: 'testAbc' },
-    //     { sync: SyncOptions.NEVER_SYNC, pin: false }
-    //   )
-    // ).rejects.toThrow(/Cannot pin or unpin streams through the CRUD APIs/)
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeTruthy()
 
     await ceramic.close()

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -340,7 +340,8 @@ export class Repository {
     if (opts.pin !== undefined && opType !== OperationType.CREATE) {
       const pinStr = opts.pin ? 'pin' : 'unpin'
       const opStr = opType == OperationType.UPDATE ? 'update' : 'load'
-      throw new Error(
+      // An error should be thrown once fully deprecated
+      console.warn(
         `Cannot pin or unpin streams through the CRUD APIs. To change stream pin state use the admin.pin API with an authenticated admin DID. Attempting to ${pinStr} stream ${StreamUtils.streamIdFromState(
           state$.state
         ).toString()} as part of a ${opStr} operation`

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -340,7 +340,7 @@ export class Repository {
     if (opts.pin !== undefined && opType !== OperationType.CREATE) {
       const pinStr = opts.pin ? 'pin' : 'unpin'
       const opStr = opType == OperationType.UPDATE ? 'update' : 'load'
-      // An error should be thrown once fully deprecated
+      //TODO(CDB-2314): An error should be thrown once fully deprecated
       console.warn(
         `Cannot pin or unpin streams through the CRUD APIs. To change stream pin state use the admin.pin API with an authenticated admin DID. Attempting to ${pinStr} stream ${StreamUtils.streamIdFromState(
           state$.state

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -346,6 +346,7 @@ export class Repository {
           state$.state
         ).toString()} as part of a ${opStr} operation`
       )
+      return
     }
 
     if (

--- a/packages/stream-tests/src/__tests__/model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/model-instance-document.test.ts
@@ -343,9 +343,6 @@ describe('ModelInstanceDocument API http-client tests', () => {
     )
     const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, { model: nonIndexedModel.id })
     await expect(TestUtils.isPinned(ceramic, doc.id)).resolves.toBeTruthy()
-    // await expect(doc.replace(CONTENT1, { pin: false })).rejects.toThrow(
-    //   /Cannot pin or unpin streams through the CRUD APIs/
-    // )
     await expect(TestUtils.isPinned(ceramic, doc.id)).resolves.toBeTruthy()
   })
 

--- a/packages/stream-tests/src/__tests__/model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/model-instance-document.test.ts
@@ -343,9 +343,9 @@ describe('ModelInstanceDocument API http-client tests', () => {
     )
     const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, { model: nonIndexedModel.id })
     await expect(TestUtils.isPinned(ceramic, doc.id)).resolves.toBeTruthy()
-    await expect(doc.replace(CONTENT1, { pin: false })).rejects.toThrow(
-      /Cannot pin or unpin streams through the CRUD APIs/
-    )
+    // await expect(doc.replace(CONTENT1, { pin: false })).rejects.toThrow(
+    //   /Cannot pin or unpin streams through the CRUD APIs/
+    // )
     await expect(TestUtils.isPinned(ceramic, doc.id)).resolves.toBeTruthy()
   })
 


### PR DESCRIPTION
Similar reasoning to https://github.com/ceramicnetwork/js-ceramic/pull/2762 

Currently causes error in composedb cli /etc, those could be easily fixed, but may also cause glaze/selfid and all related dependencies to also throw errors which used these options (would have to double check these, it looks like they may only be used on create, but this would still likely be the safest short term option) 

Changes the thrown error to console.warn(if we use that all) 

~~Just commented out lines in tests, but can remove or cleanup in another way.~~ 