### PR TITLE
correct example postgres connection string

### DIFF
--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -230,7 +230,7 @@ export class IndexingConfig {
    * Connection string to a database. Only sqlite and postgres are supported.
    * Examples:
    *  - `sqlite:///path/to/database.sqlite`,
-   *  - `postgres:///user:password@host:5432/database`
+   *  - `postgres://user:password@host:5432/database`
    */
   @jsonMember(String)
   db: string

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -230,7 +230,7 @@ export class IndexingConfig {
    * Connection string to a database. Only sqlite and postgres are supported.
    * Examples:
    *  - `sqlite:///path/to/database.sqlite`,
-   *  - `postgres://user:password@host:5432/database`
+   *  - `postgres://ceramic:password@127.0.0.1:5432/ceramic`
    */
   @jsonMember(String)
   db: string


### PR DESCRIPTION
## Description

Tiny change to correct the format of the comment describing the postgres connection string.

Checked and verified manually.