### PR TITLE
fix(cli): legacy pin, must return json for 200 (#2769

### DIFF
--- a/packages/cli/src/__tests__/admin-api.test.ts
+++ b/packages/cli/src/__tests__/admin-api.test.ts
@@ -171,6 +171,15 @@ describe('admin api', () => {
     expect(getResultAfterDelete.models).toEqual([])
   })
 
+  it('legacy pin API should warn', async () => {
+    const legacyPinURLBaseString = `http://localhost:${daemon.port}/api/v0/pins`
+    // Legacy Pin Add
+    const postResult = await fetchJson(`${legacyPinURLBaseString}/${exampleModelStreamId}`, {
+      method: 'POST',
+    })
+    expect(Object.keys(postResult).includes('warn')).toEqual(true)
+  })
+
   it('admin pin API CRUD test', async () => {
     const adminPinURLBaseString = `http://localhost:${daemon.port}/api/v0/admin/pins`
 

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -975,9 +975,9 @@ export class CeramicDaemon {
   async _pinWarningOk(req: Request, res: Response): Promise<void> {
     res
       .status(StatusCodes.OK)
-      .send(
-        'Pin requests have moved to the admin API /admin/pins, please make requests there. Any requests here will not pin, API returns 200 for tooling backwards compatibility, and will be removed soon.'
-      )
+      .json({
+        warn: 'Pin requests have moved to the admin API /admin/pins, please make requests there. Any requests here will not pin, API returns 200 for tooling backwards compatibility, and will be removed soon.'
+      })
   }
 
   async getSupportedChains(req: Request, res: Response): Promise<void> {

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -973,11 +973,9 @@ export class CeramicDaemon {
   }
 
   async _pinWarningOk(req: Request, res: Response): Promise<void> {
-    res
-      .status(StatusCodes.OK)
-      .json({
-        warn: 'Pin requests have moved to the admin API /admin/pins, please make requests there. Any requests here will not pin, API returns 200 for tooling backwards compatibility, and will be removed soon.'
-      })
+    res.status(StatusCodes.OK).json({
+      warn: 'Pin requests have moved to the admin API /admin/pins, please make requests there. Any requests here will not pin, API returns 200 for tooling backwards compatibility, and will be removed soon.',
+    })
   }
 
   async getSupportedChains(req: Request, res: Response): Promise<void> {


### PR DESCRIPTION
Needs to be valid json response, since http clients uses fethJSON and json parse response - https://github.com/ceramicnetwork/js-ceramic/blob/develop/packages/common/src/utils/http-utils.ts#LL49C6-L49C6

otherwise json parse error will be returned 

will try to add a test now, should have the first time, pushing up now for visibility 