### PR TITLE
fix(ci): run circleci for dependabot and external contributors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,6 @@ jobs:
 
 workflows:
   build-and-test:
-    # This workflow is set to be triggered conditionally, only when the GitHub Action is triggered.
-    when: << pipeline.parameters.GHA_Event >>
     jobs:
       - with-go-ipfs
       - dispatch-event:

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -8,6 +8,7 @@ jobs:
   circleci:
     name: Trigger CircleCI tests
     runs-on: ubuntu-latest
+    if: ${{ github.actor == 'ukstv' }}
     steps:
       - uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
         env:


### PR DESCRIPTION
This PR will allow CircleCI to run normally for everyone (including depandabot and external contributors) while running the CircleCI bypass specifically for @ukstv.

@ukstv, you'll now see some unrun pipelines in CircleCI because of their restrictions but, just for you, there will be the extra pipeline run via the bypass.

For everyone else, CircleCI will run normally instead of going through the bypass, which was causing issues for dependabot and external contributors.