### PR TITLE
fix(ci): don't run circleci for for sergey

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,10 @@ jobs:
 
 workflows:
   build-and-test:
+    when:
+      and:
+        - not:
+            equal: [ ukstv, << pipeline.parameters.GHA_Actor >> ]
     jobs:
       - with-go-ipfs
       - dispatch-event:


### PR DESCRIPTION
This change will prevent the automatic CircleCI flows from running for @ukstv. All of Sergey's runs will be run in my name instead.

I wanted to take this additional step so that CircleCI doesn't keep seeing workflow run requests from Sergey's ID and flag our account somehow.