### PR TITLE
fix(core): programmatically change PG sslmode to avoid self signed cert errors

### DIFF
--- a/packages/core/src/indexing/build-indexing.ts
+++ b/packages/core/src/indexing/build-indexing.ts
@@ -85,6 +85,18 @@ export function buildIndexing(
     case 'postgres':
     case 'postgresql': {
       logger.imp('Initializing PostgreSQL connection')
+
+      if (connectionString.searchParams.has('sslmode')) {
+        const uriSSLConfig = connectionString.searchParams.get('sslmode')
+
+        if (uriSSLConfig != 'disable' && uriSSLConfig != 'no-verify') {
+          connectionString.searchParams.set('sslmode', 'no-verify')
+          logger.warn(
+            `Changed "?sslmode=${uriSSLConfig}" to "no-verify" to avoid self signed cert errors during cloud deployments.`
+          )
+        }
+      }
+
       const dataSource = knex({
         client: 'pg',
         connection: connectionString.toString(),


### PR DESCRIPTION
## Description

This addresses a common issue that Postgres will throw a self signed cert error with cloud deployments/PaaS (e.g. Heroku, DigitalOcean) and terminate connections because of the reliance on self signed certificated within a VPC and ultimate fail a build. Trying to address the issue directly in the ORM library Knex with the SSL connection properties of: `{ rejectUnauthorized: false }` did not yield the desired effect and the only other recourse would've been to disable TLS verification completely (`process.env.NODE_TLS_REJECT_UNAUTHORIZED`), which is highly undesirable.

Updating the mode programmatically was chosen over the option to inform the user and do it manually or integrating it into the config file to avoid further friction during node deployments. Overall, this approach should not introduce any security risks as well as a MITM (man in the middle attack) between a node deployment and the Postgres instance within a VPC is fairly unlikely. 


**Before Fix:**
With a PaaS default connection URL example of: `postgres://ceramic:password@127.0.0.1:5432/ceramic?sslmode=required`

<img width="814" alt="Screenshot 2023-03-29 at 22 13 15" src="https://user-images.githubusercontent.com/3518175/228735931-fee083c8-409f-4a4a-8738-408b714af324.png">

**After Fix:**
<img width="812" alt="Screenshot 2023-03-29 at 22 11 34" src="https://user-images.githubusercontent.com/3518175/228735664-ec4c6860-9348-4b71-9178-a01b95c5dbfb.png">

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Local replication of described issue
- [ ] tested all valid `?sslmode=XYZ` config options to verify functionality

## References:

This should most likely be listed or called out in the documentation referencing DigitalOcean & Heroku as source for the motivation.
