### PR TITLE
chore: setMaxListeners for child AbortSignal

### DIFF
--- a/packages/common/src/utils/abort-signal-utils.ts
+++ b/packages/common/src/utils/abort-signal-utils.ts
@@ -1,5 +1,6 @@
 import { timer, fromEvent, merge, Subscription } from 'rxjs'
 import { first } from 'rxjs/operators'
+import { setMaxListeners } from 'node:events'
 
 export function mergeAbortSignals(signals: AbortSignal[]): AbortSignal {
   const controller = new AbortController()
@@ -62,6 +63,7 @@ export async function abortable<T>(
   }
   original.addEventListener('abort', onAbort)
   if (original.aborted) controller.abort()
+  setMaxListeners(Infinity, controller.signal)
   return fn(controller.signal).finally(() => {
     original.removeEventListener('abort', onAbort)
   })


### PR DESCRIPTION
Should eliminate `MaxListenersExceededWarning`. Based on a hypothesis: ipfs-http-client reuses single passed AbortSignal too much adding listeners and never removing them.