### PR TITLE
chore: Remove multihashes from js-ceramic

### DIFF
--- a/packages/stream-model/babel.config.json
+++ b/packages/stream-model/babel.config.json
@@ -1,0 +1,17 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "16"
+        }
+      }
+    ],
+    "@babel/preset-typescript"
+  ],
+  "plugins": [
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-class-properties", { "legacy": true }]
+  ]
+}

--- a/packages/stream-model/jest.config.json
+++ b/packages/stream-model/jest.config.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "testEnvironment": "node",
+  "extensionsToTreatAsEsm": [".ts"],
+  "testRegex": "(/__tests__/.*(\\.|/)(test|spec))\\.tsx?$",
+  "moduleNameMapper": {
+    "^(\\.{1,2}/.*)\\.js$": "$1"
+  }
+}

--- a/packages/stream-model/package.json
+++ b/packages/stream-model/package.json
@@ -44,7 +44,6 @@
     "fast-json-patch": "^3.1.0",
     "json-schema-typed": "^8.0.1",
     "multiformats": "^11.0.1",
-    "multihashes": "^4.0.3",
     "uint8arrays": "^4.0.3"
   },
   "gitHead": "56e646e82ee6e9cdb0b762bbbf77b8432edce367"

--- a/packages/stream-model/package.json
+++ b/packages/stream-model/package.json
@@ -29,7 +29,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "test": "exit 0",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --silent --coverage --passWithNoTests",
     "build": "npx tsc --project tsconfig.json",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",

--- a/packages/stream-model/src/__tests__/__snapshots__/model.test.ts.snap
+++ b/packages/stream-model/src/__tests__/__snapshots__/model.test.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Model.MODEL 1`] = `
+Uint8Array [
+  206,
+  1,
+  4,
+  1,
+  113,
+  113,
+  11,
+  0,
+  9,
+  104,
+  109,
+  111,
+  100,
+  101,
+  108,
+  45,
+  118,
+  49,
+]
+`;
+
+exports[`Model.MODEL 2`] = `"kh4q0ozorrgaq2mezktnrmdwleo1d"`;

--- a/packages/stream-model/src/__tests__/model.test.ts
+++ b/packages/stream-model/src/__tests__/model.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@jest/globals'
+import { Model } from '../model.js'
+
+test('Model.MODEL', () => {
+  expect(Model.MODEL.bytes).toMatchSnapshot()
+  expect(Model.MODEL.toString()).toMatchSnapshot()
+})

--- a/packages/stream-model/src/model.ts
+++ b/packages/stream-model/src/model.ts
@@ -17,7 +17,7 @@ import type { JSONSchema } from 'json-schema-typed/draft-2020-12'
 import { CID } from 'multiformats/cid'
 import { create } from 'multiformats/hashes/digest'
 import { code, encode } from '@ipld/dag-cbor'
-import multihashes from 'multihashes'
+import { identity } from 'multiformats/hashes/identity'
 
 export const MODEL_VERSION_REGEXP = /^[0-9]+\.[0-9]+$/
 
@@ -165,8 +165,8 @@ export class Model extends Stream {
   // The StreamID uses the "UNLOADABLE" StreamType, and has string representation: "kh4q0ozorrgaq2mezktnrmdwleo1d"
   static readonly MODEL: StreamID = (function () {
     const data = encode('model-v1')
-    const multihash = multihashes.encode(data, 'identity')
-    const digest = create(code, multihash)
+    const multihash = identity.digest(data)
+    const digest = create(code, multihash.bytes)
     const cid = CID.createV1(code, digest)
     return new StreamID('UNLOADABLE', cid)
   })()


### PR DESCRIPTION
It is deprecated long time ago. Adds extra code and extra warnings.