### PR TITLE
the versions of the observability package must match

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
     "@ceramicnetwork/http-client": "^2.22.0-rc.0",
     "@ceramicnetwork/ipfs-daemon": "^2.18.0-rc.0",
     "@ceramicnetwork/logger": "^2.5.0",
-    "@ceramicnetwork/observability": "^1.0.6",
+    "@ceramicnetwork/observability": "^1.2.0",
     "@ceramicnetwork/stream-tile": "^2.21.0-rc.0",
     "@ceramicnetwork/streamid": "^2.14.0",
     "@stablelib/random": "^1.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
     "@ceramicnetwork/anchor-utils": "^1.8.0-rc.0",
     "@ceramicnetwork/common": "^2.25.0-rc.0",
     "@ceramicnetwork/ipfs-topology": "^2.19.0-rc.0",
-    "@ceramicnetwork/observability": "^1.0.4",
+    "@ceramicnetwork/observability": "^1.2.0",
     "@ceramicnetwork/pinning-aggregation": "^2.17.0-rc.0",
     "@ceramicnetwork/pinning-ipfs-backend": "^2.17.0-rc.0",
     "@ceramicnetwork/stream-caip10-link": "^2.20.0-rc.0",


### PR DESCRIPTION
# Fix missing js-ceramic metrics - #CDB-2399

## Description

The js-ceramic metrics other than the request instrumentation had stopped working, including the metric on ipfs timeouts

The reason was that I had let the versions of the observability package imported get out of sync, which meant that it did not act as a singleton, so the copy imported in the `core` package was not the same one that had been initialized in the daemon.  This updates the observability package to the same latest version in both packages.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x ] Tested locally in debugger, to ensure that the core metrics work correctly now
- [ x] Unit tests

## PR checklist

Before submitting this PR, please make sure:

- [ x] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
