### PR TITLE
fix (core): set min connection pool size to 0

### DIFF
--- a/packages/core/src/indexing/build-indexing.ts
+++ b/packages/core/src/indexing/build-indexing.ts
@@ -88,6 +88,7 @@ export function buildIndexing(
       const dataSource = knex({
         client: 'pg',
         connection: connectionString.toString(),
+        pool: { min: 0 },
       })
       return new PostgresIndexApi(
         dataSource,


### PR DESCRIPTION
## Description

Community alerted us that with Knex's default value of 2 a stale Postgres connection can lead to connection issues before its re-established. Both in a Knex Github issues (https://github.com/knex/knex/issues/3523) & on the Knex docs (https://knexjs.org/guide/#pool) it is recommended to set the min pool size to 0 to avoid this exact issue and allow stale connections to be terminated.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Local Tests are passing, verified DB connection

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
