### PR TITLE
feat(core): finalize block threshold for switch to smart contract anchoring

### DIFF
--- a/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-validator.test.ts
+++ b/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-validator.test.ts
@@ -19,7 +19,7 @@ const TEST_TRANSACTION = {
   blockNumber: 3,
   blockTimestamp: 1586784008,
   blockHash: '0x752fcd3593c140db9f206b421c47d875e0f92e425983f8c72ab04c0e969b072a',
-  to: '0xD3f84Cf6Be3DD0EB16dC89c972f7a27B441A39f2',
+  to: '0x231055A0852D67C7107Ad0d0DFeab60278fE6AdC',
 }
 
 const MockJsonRpcProvider = {

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
@@ -45,20 +45,18 @@ const BASE_CHAIN_ID = 'eip155'
 const MAX_PROVIDERS_COUNT = 100
 const TRANSACTION_CACHE_SIZE = 50
 const BLOCK_CACHE_SIZE = 50
-const V0_PROOF_TYPE = 'raw'
 const V1_PROOF_TYPE = 'f(bytes32)' // See: https://namespaces.chainagnostic.org/eip155/caip168
 
 const ABI = ['function anchorDagCbor(bytes32)']
 
 const iface = new Interface(ABI)
 
-//TODO (NET-1659): Finalize block numbers and smart contract addresses once CAS is creating smart contract anchors
 const BLOCK_THRESHHOLDS = {
-  'eip155:1': 1000000000, //mainnet
+  'eip155:1': 16688195, //mainnet
   'eip155:3': 1000000000, //ropsten
-  'eip155:5': 1000000000, //goerli
-  'eip155:100': 1000000000, //gnosis
-  'eip155:1337': 1000000, //ganache
+  'eip155:5': 8498671, //goerli
+  'eip155:100': 26509835, //gnosis
+  'eip155:1337': 1, //ganache
 }
 const ANCHOR_CONTRACT_ADDRESS = '0x231055A0852D67C7107Ad0d0DFeab60278fE6AdC'
 


### PR DESCRIPTION
Methodology for selecting block numbers:
- go to etherscan for the appropriate chain (eth mainnet, goerli, and gnosis).
- search for our anchor smart contract address: [0x231055A0852D67C7107Ad0d0DFeab60278fE6AdC](https://github.com/ceramicnetwork/js-ceramic/blob/94b51b6e11279a9e9daf007bcc3c9f00a283e6f1/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts#L63)
- Take the block number of the very first `anchorDagCbor` transaction (which is always the third overall transaction on the address - after contract creation and ownership transfer)