### PR TITLE
feat: add eventIDs

### DIFF
--- a/packages/streamid/package.json
+++ b/packages/streamid/package.json
@@ -30,9 +30,11 @@
   "author": "Zach Ferland <zachferland@gmail.com>",
   "license": "(Apache-2.0 OR MIT)",
   "dependencies": {
+    "cborg": "^1.10.2",
     "@ipld/dag-cbor": "^7.0.0",
     "mapmoize": "^1.2.1",
     "multiformats": "^11.0.1",
+    "@stablelib/sha256": "^1.0.1",
     "uint8arrays": "^4.0.3",
     "varint": "^6.0.0"
   },

--- a/packages/streamid/src/__tests__/event-id.test.ts
+++ b/packages/streamid/src/__tests__/event-id.test.ts
@@ -1,0 +1,67 @@
+import { EventID } from '../event-id.js'
+import { base16 } from 'multiformats/bases/base16'
+
+const separator = "kh4q0ozorrgaq2mezktnrmdwleo1d"
+const controller = "did:key:z6MkgSV3tAuw7gUWqKCUY7ae6uWNxqYgdwPhUJbJhF9EFXm9"
+const init = "bagcqceraplay4erv6l32qrki522uhiz7rf46xccwniw7ypmvs3cvu2b3oulq"
+const eventHeight = 255; // so we get 2 bytes b'\x18\xff'
+const eventCid = "bafyreihu557meceujusxajkaro3epfe6nnzjgbjaxsapgtml7ox5ezb5qy"
+const eventIDHex = "fce0130002a30541a6fbdca4645cc7c072ff729ea683b751718ff01711220f4ef7ec208944d257025408bb647949e6b72930520bc80f34d8bfbafd2643d86"
+const eventID = "knbm43eudivgnrlswgh1oqxfn5hs26elo8676fjdaenhwd4izj5rarfghhgxw1vuhundzpcng2v0ks23kztn105ba7bpg10na"
+const eventIDBytes = Uint8Array.from([
+  206,   1,  48,   0,  42,  48,  84,  26, 111, 189, 202,
+   70,  69, 204, 124,   7,  47, 247,  41, 234, 104,  59,
+  117,  23,  24, 255,   1, 113,  18,  32, 244, 239, 126,
+  194,   8, 148,  77,  37, 112,  37,  64, 139, 182,  71,
+  148, 158, 107, 114, 147,   5,  32, 188, 128, 243,  77,
+  139, 251, 175, 210, 100,  61, 134
+]) 
+
+describe('Event Id: ', () => {
+  test('create by parts', () => {
+    const eventid = EventID.create("mainnet", separator, controller, init, eventHeight, eventCid)
+    const hexstring = base16.encode(eventid.bytes)
+    expect(hexstring).toEqual(eventIDHex)
+  })
+
+  test('create from string', () => {
+    const eventid = EventID.fromString(eventID)
+    const hexstring = base16.encode(eventid.bytes)
+    expect(hexstring).toEqual(eventIDHex)
+  })
+
+  test('create from bytes', () => {
+    const eventid = EventID.fromBytes(eventIDBytes)
+    const hexstring = base16.encode(eventid.bytes)
+    expect(hexstring).toEqual(eventIDHex)
+  })
+
+  test('roundtrip', () => {
+    const eventid = EventID.fromString(eventID)
+    const eventID2 = eventid.toString()
+    expect(eventID).toEqual(eventID2)
+  })
+
+  test('roundtrip larger event height', () => {
+    const eventid = EventID.create("mainnet", separator, controller, init, 3333, eventCid)
+    const eventid2 = EventID.fromString(eventid.toString())
+    expect(eventid.equals(eventid2)).toBeTruthy()
+  })
+
+  test('equal', () => {
+    const eventid = EventID.create("mainnet", separator, controller, init, eventHeight, eventCid)
+    const eventid2 = EventID.fromString(eventID)
+    expect(eventid.equals(eventid2)).toBeTruthy()
+  })
+
+  test('not equal', () => {
+    const eventid = EventID.create("mainnet", separator, controller, init, eventHeight, eventCid)
+    const eventid2 = EventID.create("mainnet", separator, controller, init, 10, eventCid)
+    expect(eventid.equals(eventid2)).toBeFalsy()
+  })
+
+  test('invalid eventid string', () => {
+    expect(() => EventID.fromString('knbm43eediggnrlswgh1oqxfn5hs26el')).toThrow("Invalid EventID:")
+  })
+})
+

--- a/packages/streamid/src/__tests__/event-id.test.ts
+++ b/packages/streamid/src/__tests__/event-id.test.ts
@@ -1,25 +1,24 @@
 import { EventID } from '../event-id.js'
 import { base16 } from 'multiformats/bases/base16'
 
-const separator = "kh4q0ozorrgaq2mezktnrmdwleo1d"
-const controller = "did:key:z6MkgSV3tAuw7gUWqKCUY7ae6uWNxqYgdwPhUJbJhF9EFXm9"
-const init = "bagcqceraplay4erv6l32qrki522uhiz7rf46xccwniw7ypmvs3cvu2b3oulq"
-const eventHeight = 255; // so we get 2 bytes b'\x18\xff'
-const eventCid = "bafyreihu557meceujusxajkaro3epfe6nnzjgbjaxsapgtml7ox5ezb5qy"
-const eventIDHex = "fce0130002a30541a6fbdca4645cc7c072ff729ea683b751718ff01711220f4ef7ec208944d257025408bb647949e6b72930520bc80f34d8bfbafd2643d86"
-const eventID = "knbm43eudivgnrlswgh1oqxfn5hs26elo8676fjdaenhwd4izj5rarfghhgxw1vuhundzpcng2v0ks23kztn105ba7bpg10na"
+const separator = 'kh4q0ozorrgaq2mezktnrmdwleo1d'
+const controller = 'did:key:z6MkgSV3tAuw7gUWqKCUY7ae6uWNxqYgdwPhUJbJhF9EFXm9'
+const init = 'bagcqceraplay4erv6l32qrki522uhiz7rf46xccwniw7ypmvs3cvu2b3oulq'
+const eventHeight = 255 // so we get 2 bytes b'\x18\xff'
+const eventCid = 'bafyreihu557meceujusxajkaro3epfe6nnzjgbjaxsapgtml7ox5ezb5qy'
+const eventIDHex =
+  'fce0171002a30541a6fbdca4645cc7c072ff729ea683b751718ff01711220f4ef7ec208944d257025408bb647949e6b72930520bc80f34d8bfbafd2643d86'
+const eventID =
+  'knbm9c0h4p2u47ijtencfb6cywy89byg00yajvzt6a8tzbmkvjg3frktdt4rvewodpz7i5o1sqmefuwavvg963i7euvend5s6'
 const eventIDBytes = Uint8Array.from([
-  206,   1,  48,   0,  42,  48,  84,  26, 111, 189, 202,
-   70,  69, 204, 124,   7,  47, 247,  41, 234, 104,  59,
-  117,  23,  24, 255,   1, 113,  18,  32, 244, 239, 126,
-  194,   8, 148,  77,  37, 112,  37,  64, 139, 182,  71,
-  148, 158, 107, 114, 147,   5,  32, 188, 128, 243,  77,
-  139, 251, 175, 210, 100,  61, 134
-]) 
+  206, 1, 48, 0, 42, 48, 84, 26, 111, 189, 202, 70, 69, 204, 124, 7, 47, 247, 41, 234, 104, 59, 117,
+  23, 24, 255, 1, 113, 18, 32, 244, 239, 126, 194, 8, 148, 77, 37, 112, 37, 64, 139, 182, 71, 148,
+  158, 107, 114, 147, 5, 32, 188, 128, 243, 77, 139, 251, 175, 210, 100, 61, 134,
+])
 
 describe('Event Id: ', () => {
   test('create by parts', () => {
-    const eventid = EventID.create("mainnet", separator, controller, init, eventHeight, eventCid)
+    const eventid = EventID.create('mainnet', separator, controller, init, eventHeight, eventCid)
     const hexstring = base16.encode(eventid.bytes)
     expect(hexstring).toEqual(eventIDHex)
   })
@@ -43,25 +42,24 @@ describe('Event Id: ', () => {
   })
 
   test('roundtrip larger event height', () => {
-    const eventid = EventID.create("mainnet", separator, controller, init, 3333, eventCid)
+    const eventid = EventID.create('mainnet', separator, controller, init, 3333, eventCid)
     const eventid2 = EventID.fromString(eventid.toString())
     expect(eventid.equals(eventid2)).toBeTruthy()
   })
 
   test('equal', () => {
-    const eventid = EventID.create("mainnet", separator, controller, init, eventHeight, eventCid)
+    const eventid = EventID.create('mainnet', separator, controller, init, eventHeight, eventCid)
     const eventid2 = EventID.fromString(eventID)
     expect(eventid.equals(eventid2)).toBeTruthy()
   })
 
   test('not equal', () => {
-    const eventid = EventID.create("mainnet", separator, controller, init, eventHeight, eventCid)
-    const eventid2 = EventID.create("mainnet", separator, controller, init, 10, eventCid)
+    const eventid = EventID.create('mainnet', separator, controller, init, eventHeight, eventCid)
+    const eventid2 = EventID.create('mainnet', separator, controller, init, 10, eventCid)
     expect(eventid.equals(eventid2)).toBeFalsy()
   })
 
   test('invalid eventid string', () => {
-    expect(() => EventID.fromString('knbm43eediggnrlswgh1oqxfn5hs26el')).toThrow("Invalid EventID:")
+    expect(() => EventID.fromString('knbm43eediggnrlswgh1oqxfn5hs26el')).toThrow('Invalid EventID:')
   })
 })
-

--- a/packages/streamid/src/__tests__/event-id.test.ts
+++ b/packages/streamid/src/__tests__/event-id.test.ts
@@ -7,9 +7,9 @@ const init = 'bagcqceraplay4erv6l32qrki522uhiz7rf46xccwniw7ypmvs3cvu2b3oulq'
 const eventHeight = 255 // so we get 2 bytes b'\x18\xff'
 const eventCid = 'bafyreihu557meceujusxajkaro3epfe6nnzjgbjaxsapgtml7ox5ezb5qy'
 const eventIDHex =
-  'fce0171002a30541a6fbdca4645cc7c072ff729ea683b751718ff01711220f4ef7ec208944d257025408bb647949e6b72930520bc80f34d8bfbafd2643d86'
+  'fce0105002a30541a6fbdca4645cc7c072ff729ea683b751718ff01711220f4ef7ec208944d257025408bb647949e6b72930520bc80f34d8bfbafd2643d86'
 const eventID =
-  'knbm9c0h4p2u47ijtencfb6cywy89byg00yajvzt6a8tzbmkvjg3frktdt4rvewodpz7i5o1sqmefuwavvg963i7euvend5s6'
+  'knbm0mn8ocjxseb7rtv5nshk6icfol0d8o0wn07xsn3uecgeewtdqa5tjx0md38l8yal1wa3fghvu4kvzecgoru0jv2juk4g6'
 const eventIDBytes = Uint8Array.from([
   206, 1, 48, 0, 42, 48, 84, 26, 111, 189, 202, 70, 69, 204, 124, 7, 47, 247, 41, 234, 104, 59, 117,
   23, 24, 255, 1, 113, 18, 32, 244, 239, 126, 194, 8, 148, 77, 37, 112, 37, 64, 139, 182, 71, 148,

--- a/packages/streamid/src/event-id.ts
+++ b/packages/streamid/src/event-id.ts
@@ -10,7 +10,7 @@ import { Memoize } from 'mapmoize'
 const TAG = Symbol.for('@ceramicnetwork/streamid/EventID')
 
 // Stream Codecs and Event Codec https://github.com/ceramicnetwork/CIPs/blob/main/tables/streamtypes.csv
-const EVENT_ID_CODEC = 0x71
+const EVENT_ID_CODEC = 0x05
 const STREAMID_CODEC_LEN = 2
 const EVENT_ID_CODEC_LEN = 1
 

--- a/packages/streamid/src/event-id.ts
+++ b/packages/streamid/src/event-id.ts
@@ -70,14 +70,15 @@ export class EventID {
    */
   static create(
     networkID: number | string,
-    separator: string,
+    separator: string | Uint8Array,
     controller: string,
     init: CID | string,
     eventHeight: number,
     event: CID | string
   ): EventID {
     const networkIDInt = typeof networkID === 'string' ? networkByName(networkID) : networkID
-    const separatorBytes = sha256(u8a.fromString(separator)).slice(-8)
+    const separatorAllBytes = typeof separator === 'string' ? u8a.fromString(separator) : separator
+    const separatorBytes = sha256(separatorAllBytes).slice(-8)
     const controllerBytes = sha256(u8a.fromString(controller)).slice(-8)
     const initCid = typeof init === 'string' ? CID.parse(init) : init
     const initBytes = initCid.bytes.slice(-4)

--- a/packages/streamid/src/event-id.ts
+++ b/packages/streamid/src/event-id.ts
@@ -1,0 +1,202 @@
+import { CID } from 'multiformats/cid'
+import { base36 } from 'multiformats/bases/base36'
+import { hash as sha256 } from '@stablelib/sha256';
+import varint from 'varint'
+import * as cbor from 'cborg'
+import * as u8a from 'uint8arrays'
+import { STREAMID_CODEC } from './constants.js'
+import { Memoize } from 'mapmoize'
+
+const TAG = Symbol.for('@ceramicnetwork/streamid/EventID')
+
+const DAG_CBOR_CODEC = 0x30
+const STREAMID_CODEC_LEN = 2
+const DAG_CBOR_CODEC_LEN = 1
+
+const NETWORK: Record<string, number> = {
+  "mainnet":	0x00,
+  "testnet-clay":	0x01,
+  "dev-unstable":	0x02,
+  "inmemory":	0xFF
+}
+
+function networkByName(net: string):number {
+  const netId = NETWORK[net]
+  if (!netId && netId !== 0) throw new Error('Not a valid network name')
+  return netId
+}
+
+export class EventID {
+  protected readonly _tag = TAG
+
+  private readonly _networkID: number
+  private readonly _separator: Uint8Array
+  private readonly _controller: Uint8Array
+  private readonly _init: Uint8Array
+  private readonly _eventHeight: number
+  private readonly _event: CID
+
+  // WORKARDOUND Weird replacement for Symbol.hasInstance due to
+  // this old bug in Babel https://github.com/babel/babel/issues/4452
+  // which is used by CRA, which is widely popular.
+  static isInstance(instance: any): instance is EventID {
+    return typeof instance === 'object' && '_tag' in instance && instance._tag === TAG
+  }
+
+  /**
+   * Create a new EventID.
+   */
+  constructor(networkID: number, separator: Uint8Array, controller: Uint8Array, init: Uint8Array, eventHeight: number, event: CID) {
+    this._networkID = networkID
+    this._separator = separator
+    this._controller = controller
+    this._init = init
+    this._eventHeight = eventHeight
+    this._event = event
+  }
+
+  /**
+   * Create a new EventID.
+   */
+  static create(networkID: number | string, separator: string, controller: string, init: CID | string, eventHeight: number, event: CID | string ): EventID {
+    const networkIDInt = typeof networkID === 'string' ? networkByName(networkID) : networkID
+    const separatorBytes = sha256(u8a.fromString(separator)).slice(-8)
+    const controllerBytes = sha256(u8a.fromString(controller)).slice(-8)
+    const initCid = typeof init === 'string' ? CID.parse(init) : init
+    const initBytes = initCid.bytes.slice(-4)
+    const eventCid = typeof event === 'string' ? CID.parse(event) : event
+    return new EventID(networkIDInt, separatorBytes, controllerBytes, initBytes, eventHeight, eventCid)
+  }
+
+  /**
+   * Bytes representation of EventID.
+   */
+  @Memoize()
+  get bytes(): Uint8Array {
+    const streamCodec = varint.encode(STREAMID_CODEC)
+    const dagcborCodec = varint.encode(DAG_CBOR_CODEC)
+    const networkID = varint.encode(this._networkID)
+    const eventHeight = cbor.encode(this._eventHeight)
+    const event = this._event.bytes
+    return u8a.concat([streamCodec, dagcborCodec, networkID, this._separator, this._controller, this._init, eventHeight, event])
+  }
+
+  /**
+   * EventID instance from bytes
+   */
+  static fromBytes(bytes: Uint8Array): EventID {
+    try {
+      const netOffset = STREAMID_CODEC_LEN + DAG_CBOR_CODEC_LEN
+      const networkID = varint.decode(bytes, netOffset)
+      const sepOffset = varint.decode.bytes + netOffset
+      const seperator = bytes.slice(sepOffset, sepOffset + 8)
+      const conOffset = sepOffset + 8 
+      const controller = bytes.slice(conOffset, conOffset + 8)
+      const initOffest = conOffset + 8 
+      const init = bytes.slice(initOffest, initOffest + 4)
+      const ehOffset = initOffest + 4 
+      const remaining = bytes.slice(ehOffset)
+      const eventHeight = cbor.decode(bytes.slice(ehOffset, ehOffset + remaining.length - 36))
+      const event = CID.decode(remaining.slice(remaining.length - 36))
+      return new EventID(networkID, seperator, controller, init, eventHeight, event)
+    } catch(e) {
+      throw new Error(`Invalid EventID: ${(e as Error).message}`)
+    }
+  }
+ 
+  /**
+   * EventID instance from base36 string
+   */
+  static fromString(str: string): EventID {
+    const bytes = base36.decode(str)
+    return this.fromBytes(bytes)
+  }
+
+  /**
+   * Encode the EventID into a string.
+   */
+  @Memoize()
+  toString(): string {
+    return base36.encode(this.bytes)
+  }
+  
+  /**
+   * Compare equality with another EventID.
+   */
+  equals(other: EventID): boolean {
+    if (EventID.isInstance(other)) {
+      return this._networkID === other._networkID &&
+      u8a.equals(this._separator, other._separator) &&
+      u8a.equals(this._controller, other._controller) &&
+      u8a.equals(this._init, other._init) &&
+      this._eventHeight === other._eventHeight &&
+      this._event.equals(other._event)
+    } else {
+      return false
+    }
+  }
+
+  /**
+   * Encode the EventID into a base36 url.
+   */
+  @Memoize()
+  toUrl(): string {
+    return `ceramic://${this.toString()}`
+  }
+
+  /**
+   * EventID network id 
+   */
+  get networkID(): number {
+    return this._networkID
+  }
+
+  /**
+   * Seperator Bytes (8)
+   */
+  get separator(): Uint8Array {
+    return this._separator
+  }
+
+  /**
+   * Controller Bytes (8)
+   */
+  get controller(): Uint8Array {
+    return this._controller
+  }
+
+  /**
+   *  Init CID last 4 bytes (8)
+   */
+  get init(): Uint8Array {
+    return this._controller
+  }
+
+  /**
+   *  Event Height
+   */
+  get eventHeight(): number {
+    return this._eventHeight
+  }
+
+  /**
+   *  Event CID
+   */
+  get event(): CID {
+    return this._event
+  }
+
+  /**
+   * EventId(knbm43eudivgnrlswgh1oqxfn5hs26elo8676fjdaenhwd4izj5rarfghhgxw1vuhundzpcng2v0ks23kztn105ba7bpg10na)
+   */
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
+    return `EventID(${this.toString()})`
+  }
+
+  /**
+   * String representation of EventID.
+   */
+  [Symbol.toPrimitive](): string {
+    return this.toString()
+  }
+}


### PR DESCRIPTION
EventIDs for recon, ref corresponding rust pr - https://github.com/3box/rust-ceramic/pull/53/files#diff-2924eb293981196ffa6cd00553cc52fe96f0718b46b967ea3f2e436504ff0401

Placed in streamids packages, but could make sense to move elsewhere, needed to communicate later with rust ceramic/recon