### PR TITLE
add workflow for publishing follow-up RCs that bump the RC version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Type of publish (one of: rc, main, both, hotfix)'
+        description: 'Type of publish (one of: rc, rc-followup, main, both, hotfix)'
         required: true
         default: 'rc'
       branch:
@@ -29,6 +29,13 @@ jobs:
     uses: ./.github/workflows/reusable-release.yml
     with:
       release_type: rc
+    secrets: inherit
+
+  rc-followup:
+    if: ${{ github.event.inputs.release_type == 'rc-followup' }}
+    uses: ./.github/workflows/reusable-release.yml
+    with:
+      release_type: rc-followup
     secrets: inherit
 
   hotfix:

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -111,7 +111,7 @@ jobs:
 
   publish_rc:
     runs-on: ubuntu-latest
-    if: ${{ inputs.release_type == 'rc' }}
+    if: ${{ inputs.release_type == 'rc' || inputs.release_type == 'rc-followup' }}
     steps:
       -
         name: Setup Node
@@ -165,84 +165,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           npm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
-          npm run publish:release-candidate -- --yes
-      -
-        name: Send Discord notification
-        run: |
-          # Prepare notification body
-          echo '{"embeds":[{"title":"**Release Candidate Published**","description":"' > embed.json
-          echo '' >> embed.json
-          git log -1 --pretty=%B >> embed.json
-          echo '","color":3581519}]}' >> embed.json
-          sed -i '3 s/\ -/-/' embed.json
-          sed -i '4,$ s/\-/\\n-/' embed.json
-          # Send notification
-          res=$(curl -X POST ${{ secrets.DISCORD_RELEASE_WEBHOOK }} -H "Content-Type: application/json" -d @embed.json) || exit 0
-      -
-        name: Update and push code to develop
-        run: |
-          git checkout develop
-          git pull
-          git merge release-candidate
-          git push
-
-  publish_rc_followup:
-    runs-on: ubuntu-latest
-    if: ${{ inputs.release_type == 'rc-followup' }}
-    steps:
-      -
-        name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      -
-        name: Checkout rc branch
-        uses: actions/checkout@v3
-        with:
-          ref: release-candidate
-          token: ${{ secrets.GH_TOKEN }}
-          fetch-depth: 0
-      -
-        name: Configure git
-        run: |
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git config user.name ${{ github.actor }}
-          git fetch --all
-      -
-        name: Merge down from rc -> develop
-        run: |
-          git checkout -B develop refs/remotes/origin/develop
-          git merge release-candidate
-          git checkout release-candidate
-      -
-        name: Merge develop -> rc
-        run: git merge develop
-      -
-        name: Install Dagger
-        uses: dagger/dagger-for-github@v3
-        with:
-          install-only: true
-          version: "0.2.36"
-      -
-        name: Verify Docker image
-        run: |
-          dagger project init
-          dagger project update
-          dagger project update "github.com/3box/pipeline-tools/ci"
-          dagger do verify -p ${{ env.DAGGER_PLAN }}
-      -
-        name: Initialize and build code
-        run: |
-          npm set unsafe-perm true
-          npm ci && npm run build
-      -
-        name: Publish packages to NPM
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          npm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
-          npm run publish:release-candidate-followup -- --yes
+          RELEASE_TYPE=${{ inputs.release_type }}
+          if [[ $RELEASE_TYPE == "rc" ]]; then
+            npm run publish:release-candidate -- --yes
+          else # $RELEASE_TYPE == "rc-followup"
+            npm run publish:release-candidate-followup -- --yes
+          fi
       -
         name: Send Discord notification
         run: |

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -186,6 +186,83 @@ jobs:
           git merge release-candidate
           git push
 
+  publish_rc_followup:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.release_type == 'rc-followup' }}
+    steps:
+      -
+        name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      -
+        name: Checkout rc branch
+        uses: actions/checkout@v3
+        with:
+          ref: release-candidate
+          token: ${{ secrets.GH_TOKEN }}
+          fetch-depth: 0
+      -
+        name: Configure git
+        run: |
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name ${{ github.actor }}
+          git fetch --all
+      -
+        name: Merge down from rc -> develop
+        run: |
+          git checkout -B develop refs/remotes/origin/develop
+          git merge release-candidate
+          git checkout release-candidate
+      -
+        name: Merge develop -> rc
+        run: git merge develop
+      -
+        name: Install Dagger
+        uses: dagger/dagger-for-github@v3
+        with:
+          install-only: true
+          version: "0.2.36"
+      -
+        name: Verify Docker image
+        run: |
+          dagger project init
+          dagger project update
+          dagger project update "github.com/3box/pipeline-tools/ci"
+          dagger do verify -p ${{ env.DAGGER_PLAN }}
+      -
+        name: Initialize and build code
+        run: |
+          npm set unsafe-perm true
+          npm ci && npm run build
+      -
+        name: Publish packages to NPM
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          npm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
+          npm run publish:release-candidate-followup -- --yes
+      -
+        name: Send Discord notification
+        run: |
+          # Prepare notification body
+          echo '{"embeds":[{"title":"**Release Candidate Published**","description":"' > embed.json
+          echo '' >> embed.json
+          git log -1 --pretty=%B >> embed.json
+          echo '","color":3581519}]}' >> embed.json
+          sed -i '3 s/\ -/-/' embed.json
+          sed -i '4,$ s/\-/\\n-/' embed.json
+          # Send notification
+          res=$(curl -X POST ${{ secrets.DISCORD_RELEASE_WEBHOOK }} -H "Content-Type: application/json" -d @embed.json) || exit 0
+      -
+        name: Update and push code to develop
+        run: |
+          git checkout develop
+          git pull
+          git merge release-candidate
+          git push
+
   publish_hotfix:
     runs-on: ubuntu-latest
     if: ${{ inputs.release_type == 'hotfix' }}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "npx lerna run build",
     "docs": "NODE_OPTIONS=--max-old-space-size=8192 npx typedoc",
     "publish:release-candidate": "npx lerna publish --dist-tag next --preid rc --no-verify-access --conventional-prerelease bump preminor",
+    "publish:release-candidate-followup": "npx lerna publish --dist-tag next --preid rc --no-verify-access --conventional-prerelease",
     "publish:release": "npx lerna publish --dist-tag latest --create-release github --no-verify-access --conventional-graduate bump minor",
     "publish:hotfix": "npx lerna publish --dist-tag latest --no-verify-access --conventional-graduate bump patch",
     "lint": "npx lerna run lint && npx prettier --check packages/**/src/**/*.ts",


### PR DESCRIPTION
Lets say the current version of the ceramic core package is `2.35.0`.  When we do an RC, we want to bump the minor version (leaving the patch version available for potential hotfix releases) and go to `2.36.0-rc.0`.  That is what our current `rc` workflow does.  Then when we do the main release it goes to `2.36.0`.  All good so far.  The problem comes if we want to do a second RC before doing a main release.  With the current workflow, the second RC will get version `2.37.0-rc.0`.  This wastes a minor version and loses information about the fact that the two RCs are linked and the second is effectively replacing the first as the candidate to become the next full release.  Instead, it would be better for the second RC to get the version `2.36.0-rc.1`.  This PR gives us a workflow to do that.

I am not attached to the name `rc-followup` for the new workflow.  Also lmk if you think it would be better to re-use the `rc` workflow but add an argument to select whether this is the first RC or a follow-up.