### PR TITLE
feat: CDB-2493 Adjust API to support model index changes

### DIFF
--- a/packages/cli/src/__tests__/admin-api.test.ts
+++ b/packages/cli/src/__tests__/admin-api.test.ts
@@ -381,7 +381,7 @@ describe('admin api', () => {
     it('Old code used with models GET', async () => {
       const code = (await fetchJson(`http://localhost:${daemon.port}/api/v0/admin/getCode`)).code
       const now = new Date().getTime()
-      MockDate.set(now + (1000 * 60 * 1 + 1000)) // One minute one second in the future
+      MockDate.set(now + (1000 * 60 + 1000)) // One minute one second in the future
       expect(true).toBeTruthy()
       await expect(
         fetchJson(`http://localhost:${daemon.port}/api/v0/admin/models`, {
@@ -565,9 +565,7 @@ describe('admin api', () => {
           method: 'POST',
           body: { jws: await buildJWS(adminDid, code, MODEL_PATH) },
         })
-      ).rejects.toThrow(
-        /The 'models' parameter is required and it has to be an array containing at least one model stream id/
-      )
+      ).rejects.toThrow(/Expected models to be present/)
     })
 
     it('Empty models for models POST', async () => {
@@ -577,9 +575,7 @@ describe('admin api', () => {
           method: 'POST',
           body: { jws: await buildJWS(adminDid, code, MODEL_PATH, []) },
         })
-      ).rejects.toThrow(
-        /The 'models' parameter is required and it has to be an array containing at least one model stream id/
-      )
+      ).rejects.toThrow(/Expected models to be present/)
     })
 
     it('No models for models DELETE', async () => {
@@ -589,9 +585,7 @@ describe('admin api', () => {
           method: 'DELETE',
           body: { jws: await buildJWS(adminDid, code, MODEL_PATH) },
         })
-      ).rejects.toThrow(
-        /The 'models' parameter is required and it has to be an array containing at least one model stream id/
-      )
+      ).rejects.toThrow(/Expected models to be present/)
     })
 
     it('Empty models for models DELETE', async () => {
@@ -601,9 +595,7 @@ describe('admin api', () => {
           method: 'DELETE',
           body: { jws: await buildJWS(adminDid, code, MODEL_PATH, []) },
         })
-      ).rejects.toThrow(
-        /The 'models' parameter is required and it has to be an array containing at least one model stream id/
-      )
+      ).rejects.toThrow(/Expected models to be present/)
     })
 
     it('Disallow re-indexing on POST', async () => {

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -758,13 +758,15 @@ export class CeramicDaemon {
             break
           }
           case 'modelIDs': {
-            const models = parsedJWS.models?.map((modelIDString) => StreamID.fromString(modelIDString))
+            const models = parsedJWS.models?.map((modelIDString) =>
+              StreamID.fromString(modelIDString)
+            )
             if (!models || models.length == 0) {
               return {
                 statusCode: StatusCodes.BAD_REQUEST,
                 error: `Expected models to be present and contain at least one StreamID: : ${JSON.stringify(
                   parsedJWS
-                )}`
+                )}`,
               }
             }
             onSuccess = () => successCallback.method(models)
@@ -775,7 +777,7 @@ export class CeramicDaemon {
       return {
         kid: parsedJWS.kid,
         code: parsedJWS.code,
-        onSuccess
+        onSuccess,
       }
     }
   }
@@ -786,7 +788,11 @@ export class CeramicDaemon {
     successCallback: AdminApiMutationMethod
   ): Promise<void> {
     // Parse request
-    const jwsValidation = await this._validateAdminApiJWS(req.baseUrl, req.body.jws, successCallback)
+    const jwsValidation = await this._validateAdminApiJWS(
+      req.baseUrl,
+      req.body.jws,
+      successCallback
+    )
     if (jwsValidation.error) {
       if (jwsValidation.statusCode) {
         res.status(jwsValidation.statusCode)
@@ -943,8 +949,11 @@ export class CeramicDaemon {
 
   async stopIndexingModelData(req: Request, res: Response): Promise<void> {
     await this._processAdminModelsMutationRequest(req, res, {
-      type: 'modelIDs',
-      method: (modelsIDs) => this.ceramic.admin.stopIndexingModels(modelsIDs),
+      type: 'modelData',
+      method: (modelData) => {
+        const modelIds = modelData.map((data) => data.streamID)
+        return this.ceramic.admin.stopIndexingModels(modelIds)
+      },
     })
   }
 

--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -96,7 +96,7 @@ export interface AdminApi {
   getIndexedModels(): Promise<Array<StreamID>>
 
   /**
-   * List indexed model streams with data
+   * List indexed model streams with additional model data (such as the defined field indices)
    */
   getIndexedModelData(): Promise<Array<ModelData>>
 

--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -11,7 +11,7 @@ import type { AnchorStatus } from '@ceramicnetwork/common'
 /**
  * Field definition for index
  */
-export interface Field {
+export type Field = {
   path: Array<string>
 }
 

--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -9,6 +9,30 @@ import { NodeStatusResponse } from './node-status-interface.js'
 import type { AnchorStatus } from '@ceramicnetwork/common'
 
 /**
+ * Field definition for index
+ */
+export interface Field {
+  path: Array<string>
+}
+
+/**
+ * Index for a model
+ */
+export type FieldsIndex = {
+  fields: Array<Field>
+}
+
+/**
+ * Data for a model. Contains
+ *  * streamID: StreamID of the model
+ *  * indices: Array of field indices
+ */
+export type ModelData = {
+  streamID: StreamID
+  indices?: Array<FieldsIndex>
+}
+
+/**
  * Describes Ceramic pinning functionality
  */
 export interface PinApi {
@@ -72,11 +96,22 @@ export interface AdminApi {
   getIndexedModels(): Promise<Array<StreamID>>
 
   /**
+   * List indexed model streams with data
+   */
+  getIndexedModelData(): Promise<Array<ModelData>>
+
+  /**
    * Adds model streams to index
    *
    * @param modelsIDs - array of model stream IDs to add to index
    */
   startIndexingModels(modelsIDs: Array<StreamID>): Promise<void>
+
+  /**
+   * Adds model streams to index as specified by ModelData
+   * @param modelData - array of model streams with field indices to index
+   */
+  startIndexingModelData(modelData: Array<ModelData>): Promise<void>
 
   /**
    * Removes model streams from index

--- a/packages/core/src/local-admin-api.ts
+++ b/packages/core/src/local-admin-api.ts
@@ -1,4 +1,4 @@
-import { AdminApi, NodeStatusResponse, PinApi } from '@ceramicnetwork/common'
+import { AdminApi, ModelData, NodeStatusResponse, PinApi } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { LocalIndexApi } from './indexing/local-index-api.js'
 import { SyncApi } from './sync/sync-api.js'
@@ -25,8 +25,21 @@ export class LocalAdminApi implements AdminApi {
     await this.syncApi.startModelSync(modelsIDs.map((id) => id.toString()))
   }
 
+  async startIndexingModelData(modelData: Array<ModelData>): Promise<void> {
+    await this.startIndexingModels(modelData.map((d) => d.streamID))
+  }
+
   getIndexedModels(): Promise<Array<StreamID>> {
     return Promise.resolve(this.indexApi.indexedModels() ?? [])
+  }
+
+  async getIndexedModelData(): Promise<Array<ModelData>> {
+    const models = await this.getIndexedModels()
+    return models.map((id) => {
+      return {
+        streamID: id,
+      }
+    })
   }
 
   async stopIndexingModels(modelsIDs: Array<StreamID>): Promise<void> {

--- a/packages/stream-tests/src/__tests__/admin-api.test.ts
+++ b/packages/stream-tests/src/__tests__/admin-api.test.ts
@@ -161,5 +161,47 @@ describe('Admin API tests', () => {
         /is not indexed on this node/
       )
     })
+
+    test('Dynamic indexing with fields', async () => {
+      const model = await Model.create(ceramic, MODEL_DEFINITION)
+
+      const doc1 = await ModelInstanceDocument.create(ceramic, CONTENT0, { model: model.id })
+
+      ceramic.did = adminDid
+
+      let indexedModels = await ceramic.admin.getIndexedModelData()
+      expect(indexedModels.length).toEqual(0)
+
+      await expect(ceramic.index.count({ model: model.id })).rejects.toThrow(
+        /is not indexed on this node/
+      )
+
+      // Now start indexing the first model
+      await ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+          indices: [{ fields: [{ path: ['myData'] }] }],
+        },
+      ])
+      indexedModels = await ceramic.admin.getIndexedModelData()
+      expect(indexedModels.length).toEqual(1)
+
+      // Doesn't know about the doc created before the model was indexed
+      await expect(ceramic.index.count({ model: model.id })).resolves.toEqual(0)
+      await ModelInstanceDocument.create(ceramic, CONTENT0, { model: model.id })
+      await expect(ceramic.index.count({ model: model.id })).resolves.toEqual(1)
+      // Discovers the first doc when it is updated
+      ceramic.did = nonAdminDid // Set did back to the stream controller so it can be updated
+      await doc1.replace(CONTENT1)
+      await expect(ceramic.index.count({ model: model.id })).resolves.toEqual(2)
+
+      // Now stop indexing the model
+      ceramic.did = adminDid
+      await ceramic.admin.stopIndexingModels([model.id])
+
+      await expect(ceramic.index.count({ model: model.id })).rejects.toThrow(
+        /is not indexed on this node/
+      )
+    })
   })
 })


### PR DESCRIPTION
Adjusts AdminAPI to support new functionality around adding indices to models. New structure ModelData is added, and new methods are start, stop, and get indices related to ModelData are added.

This splits out part of the changes in https://github.com/ceramicnetwork/js-ceramic/pull/2829