### PR TITLE
feat: add config for prometheus exporter

### DIFF
--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -380,6 +380,18 @@ export class DaemonLoggerConfig {
 @toJson
 export class DaemonMetricsConfig {
   /**
+   * Controls whether the Prometheus metrics exporter is started
+   */
+  @jsonMember(Boolean, { name: 'prometheus-exporter-enabled' })
+  prometheusExporterEnabled?: boolean
+
+  /**
+   * Controls the port where Prometheus metrics will be exposed.
+   */
+  @jsonMember(Number, { name: 'prometheus-exporter-port' })
+  prometheusExporterPort?: number
+
+  /**
    * Controls whether the metrics exporter is started
    */
   @jsonMember(Boolean, { name: 'metrics-exporter-enabled' })


### PR DESCRIPTION
## Description

Adds support for Prometheus /metrics export. This is beneficial as it allows pull based metrics collection in addition to the existing OTLP pushed based collection.

Depends on https://github.com/ceramicnetwork/observability/pull/7 to merge and be published first.

## How Has This Been Tested?

Manually verified that the `/metrics` endpoint is exposed on the specified port.

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [x] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

https://github.com/ceramicnetwork/observability/pull/7 
