### PR TITLE
Update observability to 1.4.1, fix index btree type test (#2855)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
     "@ceramicnetwork/http-client": "^2.23.0",
     "@ceramicnetwork/ipfs-daemon": "^2.19.0",
     "@ceramicnetwork/logger": "^2.5.0",
-    "@ceramicnetwork/observability": "^1.2.0",
+    "@ceramicnetwork/observability": "^1.4.1",
     "@ceramicnetwork/stream-tile": "^2.22.0",
     "@ceramicnetwork/streamid": "^2.14.0",
     "@stablelib/random": "^1.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "@ceramicnetwork/codecs": "^1.1.0",
     "@ceramicnetwork/common": "^2.26.0",
     "@ceramicnetwork/ipfs-topology": "^2.20.0",
-    "@ceramicnetwork/observability": "^1.2.0",
+    "@ceramicnetwork/observability": "^1.4.1",
     "@ceramicnetwork/pinning-aggregation": "^2.18.0",
     "@ceramicnetwork/pinning-ipfs-backend": "^2.18.0",
     "@ceramicnetwork/stream-caip10-link": "^2.21.0",

--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -51,32 +51,32 @@ export function indices(tableName: string): TableIndices {
     {
       keys: ['stream_id'],
       name: `idx_${indexName}_stream_id`,
-      indexType: 'hash',
+      indexType: 'btree',
     },
     {
       keys: ['last_anchored_at'],
       name: `idx_${indexName}_last_anchored_at`,
-      indexType: 'hash',
+      indexType: 'btree',
     },
     {
       keys: ['first_anchored_at'],
       name: `idx_${indexName}_first_anchored_at`,
-      indexType: 'hash',
+      indexType: 'btree',
     },
     {
       keys: ['created_at'],
       name: `idx_${indexName}_created_at`,
-      indexType: 'hash',
+      indexType: 'btree',
     },
     {
       keys: ['updated_at'],
       name: `idx_${indexName}_updated_at`,
-      indexType: 'hash',
+      indexType: 'btree',
     },
     {
       keys: ['last_anchored_at', 'created_at'],
       name: `idx_${indexName}_last_anchored_at_created_at`,
-      indexType: 'hash',
+      indexType: 'btree',
     },
   ]
 
@@ -229,7 +229,7 @@ export async function createConfigTable(dataSource: Knex, tableName: string, net
         table.string('updated_by', 1024).notNullable()
 
         table.index(['is_indexed'], `idx_ceramic_is_indexed`, {
-          storageEngineIndexType: 'hash',
+          indexType: 'btree',
         })
       })
       break


### PR DESCRIPTION
* Update observablity to 0.14.1, fix index btree type test

* bug(core): Fix index type due to knex 2.5.0 changes

Knex 2.5.0 fixed the behavior of the index type. Previously indices would be created with the default postgres index type of btree. To maintain previous behavior, we need to set all indices to have type of btree rather than hash.

See https://github.com/knex/knex/pull/5601 for more information on change.

---------

Co-authored-by: Sergey Ukustov <sergey@ukstv.me>

Cherry-picked from commit 92bfbcee48beb4410a543a06c3d961e289be6614