### PR TITLE
test(blockchain-utils-validation): Disable eos test

### DIFF
--- a/packages/blockchain-utils-linking/package.json
+++ b/packages/blockchain-utils-linking/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@ceramicnetwork/streamid": "^2.16.0-rc.0",
-    "@didtools/cacao": "^1.0.0",
+    "@didtools/cacao": "^2.1.0",
     "@stablelib/random": "^1.0.1",
     "@stablelib/sha256": "^1.0.1",
     "caip": "~1.1.0",

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/eosio.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/eosio.test.ts
@@ -31,7 +31,7 @@ const jungleProvider = new EOSIOProvider({
   },
 })
 
-describe('validateLink', () => {
+describe.skip('validateLink', () => {
   test('Telos testnet', async () => {
     const authProvider = new linking.eosio.EosioAuthProvider(
       telosTestnetProvider,

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/eosio.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/eosio.test.ts
@@ -31,8 +31,8 @@ const jungleProvider = new EOSIOProvider({
   },
 })
 
-describe.skip('validateLink', () => {
-  test('Telos testnet', async () => {
+describe('validateLink', () => {
+  test.skip('Telos testnet', async () => {
     const authProvider = new linking.eosio.EosioAuthProvider(
       telosTestnetProvider,
       telosTestnetAccount

--- a/packages/blockchain-utils-validation/src/blockchains/__tests__/eosio.test.ts
+++ b/packages/blockchain-utils-validation/src/blockchains/__tests__/eosio.test.ts
@@ -31,7 +31,7 @@ const jungleProvider = new EOSIOProvider({
   },
 })
 
-describe('validateLink', () => {
+describe.skip('validateLink', () => {
   test.skip('Telos testnet', async () => {
     const authProvider = new linking.eosio.EosioAuthProvider(
       telosTestnetProvider,

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@ceramicnetwork/codecs": "^1.4.0-rc.0",
     "@ceramicnetwork/streamid": "^2.16.0-rc.0",
-    "@didtools/cacao": "^2.0.0",
+    "@didtools/cacao": "^2.1.0",
     "@didtools/pkh-ethereum": "^0.1.0",
     "@didtools/pkh-solana": "^0.1.0",
     "@didtools/pkh-stacks": "^0.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,7 +91,7 @@
     "@ceramicnetwork/3id-did-resolver": "^2.22.0-rc.0",
     "@ceramicnetwork/ipfs-daemon": "^2.22.0-rc.0",
     "@databases/pg-test": "^3.1.2",
-    "@didtools/cacao": "^1.0.0",
+    "@didtools/cacao": "^2.1.0",
     "@types/node": "^18.0.3",
     "csv-parser": "^3.0.0",
     "did-resolver": "^4.0.1",

--- a/packages/stream-model-handler/package.json
+++ b/packages/stream-model-handler/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@ceramicnetwork/3id-did-resolver": "^2.22.0-rc.0",
-    "@didtools/cacao": "^1.0.0",
+    "@didtools/cacao": "^2.1.0",
     "@ipld/dag-cbor": "^7.0.0",
     "@stablelib/sha256": "^1.0.1",
     "@types/lodash.clonedeep": "^4.5.6",

--- a/packages/stream-model-instance-handler/package.json
+++ b/packages/stream-model-instance-handler/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@ceramicnetwork/3id-did-resolver": "^2.22.0-rc.0",
     "@ceramicnetwork/stream-model": "^1.11.0-rc.0",
-    "@didtools/cacao": "^1.0.0",
+    "@didtools/cacao": "^2.1.0",
     "@ipld/dag-cbor": "^7.0.0",
     "@stablelib/sha256": "^1.0.1",
     "@types/lodash.clonedeep": "^4.5.6",

--- a/packages/stream-tests/package.json
+++ b/packages/stream-tests/package.json
@@ -28,7 +28,7 @@
     "@ceramicnetwork/stream-tile": "^2.25.0-rc.0",
     "@ceramicnetwork/streamid": "^2.16.0-rc.0",
     "@databases/pg-test": "^3.1.2",
-    "@didtools/cacao": "^1.0.0",
+    "@didtools/cacao": "^2.1.0",
     "@stablelib/random": "^1.0.1",
     "@stablelib/sha256": "^1.0.1",
     "@truffle/hdwallet-provider": "^2.0.0",

--- a/packages/stream-tests/src/__tests__/caip10/eos.test.ts
+++ b/packages/stream-tests/src/__tests__/caip10/eos.test.ts
@@ -29,7 +29,7 @@ afterAll(async () => {
   await ipfs?.stop()
 }, 120000)
 
-test('happy path', async () => {
+test.skip('happy path', async () => {
   const authProvider = new linking.eosio.EosioAuthProvider(
     telosTestnetProvider,
     telosTestnetAccount
@@ -37,7 +37,7 @@ test('happy path', async () => {
   await happyPath(ceramic, authProvider)
 }, 120000)
 
-test('wrong proof', async () => {
+test.skip('wrong proof', async () => {
   const authProvider = new linking.eosio.EosioAuthProvider(
     telosTestnetProvider,
     telosTestnetAccount
@@ -45,7 +45,7 @@ test('wrong proof', async () => {
   await wrongProof(ceramic, authProvider)
 }, 120000)
 
-test('clear did', async () => {
+test.skip('clear did', async () => {
   const authProvider = new linking.eosio.EosioAuthProvider(
     telosTestnetProvider,
     telosTestnetAccount

--- a/packages/stream-tile-handler/package.json
+++ b/packages/stream-tile-handler/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@ceramicnetwork/3id-did-resolver": "^2.22.0-rc.0",
-    "@didtools/cacao": "^1.0.0",
+    "@didtools/cacao": "^2.1.0",
     "@ipld/dag-cbor": "^7.0.0",
     "@stablelib/sha256": "^1.0.1",
     "@types/lodash.clonedeep": "^4.5.6",


### PR DESCRIPTION
It fails due to 3rd party endpoint having an expired SSL certificate.