### PR TITLE
Cleanups to indexing initialization and fieldIndex tracking

### DIFF
--- a/packages/core/src/indexing/__tests__/database-index-api.test.ts
+++ b/packages/core/src/indexing/__tests__/database-index-api.test.ts
@@ -17,7 +17,11 @@ import {
   PostgresIndexApi,
   SqliteIndexApi,
 } from '../database-index-api.js'
-import { DatabaseType, indices, migrateConfigTable } from '../migrations/1-create-model-table.js'
+import {
+  DatabaseType,
+  defaultIndices,
+  migrateConfigTable,
+} from '../migrations/1-create-model-table.js'
 import { STRUCTURES } from '../migrations/cdb-schema-verification.js'
 import { readCsvFixture } from './read-csv-fixture.util.js'
 import { CONFIG_TABLE_NAME } from '../config.js'
@@ -294,7 +298,7 @@ describe('postgres', () => {
           table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
           table.dateTime('updated_at').notNullable().defaultTo(dbConnection.fn.now())
 
-          const tableIndices = indices(tableName)
+          const tableIndices = defaultIndices(tableName)
           for (const indexToCreate of tableIndices.indices) {
             table.index(indexToCreate.keys, indexToCreate.name, {
               storageEngineIndexType: indexToCreate.indexType,
@@ -362,7 +366,7 @@ describe('postgres', () => {
           table.dateTime('first_anchored_at').nullable()
           table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
 
-          const tableIndices = indices(tableName)
+          const tableIndices = defaultIndices(tableName)
           for (const indexToCreate of tableIndices.indices) {
             if (!indexToCreate.keys.includes('updated_at')) {
               //updated_at not added as part of table
@@ -438,7 +442,7 @@ describe('postgres', () => {
           table.dateTime('created_at').notNullable().defaultTo(dbConnection.fn.now())
           table.dateTime('updated_at').notNullable().defaultTo(dbConnection.fn.now())
 
-          const tableIndices = indices(tableName)
+          const tableIndices = defaultIndices(tableName)
           for (const indexToCreate of tableIndices.indices) {
             table.index(indexToCreate.keys, indexToCreate.name, {
               storageEngineIndexType: indexToCreate.indexType,
@@ -1097,7 +1101,7 @@ describe('sqlite', () => {
           table.integer('created_at').notNullable()
           table.integer('updated_at').notNullable()
 
-          const tableIndices = indices(tableName)
+          const tableIndices = defaultIndices(tableName)
           for (const indexToCreate of tableIndices.indices) {
             table.index(indexToCreate.keys, indexToCreate.name, {
               storageEngineIndexType: indexToCreate.indexType,
@@ -1158,7 +1162,7 @@ describe('sqlite', () => {
           table.integer('first_anchored_at').nullable()
           table.integer('created_at').notNullable()
 
-          const tableIndices = indices(tableName)
+          const tableIndices = defaultIndices(tableName)
           for (const indexToCreate of tableIndices.indices) {
             if (!indexToCreate.keys.includes('updated_at')) {
               //updated_at not added as part of table
@@ -1221,7 +1225,7 @@ describe('sqlite', () => {
           table.integer('created_at').notNullable()
           table.integer('updated_at').notNullable()
 
-          const tableIndices = indices(tableName)
+          const tableIndices = defaultIndices(tableName)
           for (const indexToCreate of tableIndices.indices) {
             if (!indexToCreate.keys.includes('updated_at')) {
               //updated_at not added as part of table

--- a/packages/core/src/indexing/database-index-api.ts
+++ b/packages/core/src/indexing/database-index-api.ts
@@ -100,18 +100,6 @@ export abstract class DatabaseIndexApi<DateType = Date | number> {
   }
 
   /**
-   * Save model indices to the database. This does not create indices, only records them so that
-   * when MIDs are created from the model, they can have indices applied.
-   * @param model
-   * @param indices
-   */
-  async addFieldsIndex(model: StreamID, indices: Array<FieldsIndex>): Promise<void> {
-    await this.dbConnection(INDEXED_MODEL_CONFIG_TABLE_NAME)
-      .update({ indices: JSON.stringify(indices) })
-      .where('model', model.toString())
-  }
-
-  /**
    * Prepare the database to begin indexing the given models.  This generally involves creating
    * the necessary database tables and indexes.
    * @param models
@@ -132,9 +120,6 @@ export abstract class DatabaseIndexApi<DateType = Date | number> {
       if (modelArgs.relations) {
         this.modelRelations.set(modelArgs.model.toString(), Object.keys(modelArgs.relations))
       }
-      if (modelArgs.indices) {
-        await this.addFieldsIndex(modelArgs.model, modelArgs.indices) // todo fold into indexModelsInDatabase
-      }
     }
   }
 
@@ -149,6 +134,7 @@ export abstract class DatabaseIndexApi<DateType = Date | number> {
         models.map((indexModelArgs) => {
           return {
             model: indexModelArgs.model.toString(),
+            ...(indexModelArgs.indices && { indices: JSON.stringify(indexModelArgs.indices) }),
             is_indexed: true,
             updated_by: '0', // TODO: FIXME: CDB-1866 - <FIXME: PUT ADMIN DID WHEN AUTH IS IMPLEMENTED>',
             updated_at: this.now(),

--- a/packages/core/src/indexing/database-index-api.ts
+++ b/packages/core/src/indexing/database-index-api.ts
@@ -220,11 +220,9 @@ export abstract class DatabaseIndexApi<DateType = Date | number> {
         is_indexed: true,
       })
     ).map((result) => {
-      const streamID = StreamID.fromString(result.model)
-      const indices = this.parseIndices(result.indices)
       return {
-        streamID,
-        indices,
+        streamID: StreamID.fromString(result.model),
+        indices: this.parseIndices(result.indices),
       }
     })
   }

--- a/packages/core/src/indexing/local-index-api.ts
+++ b/packages/core/src/indexing/local-index-api.ts
@@ -22,11 +22,7 @@ import { ISyncQueryApi } from '../sync/interfaces.js'
  * Takes a ModelData, loads it, and returns the IndexModelArgs necessary to prepare the
  * database for indexing that model.
  */
-async function _getIndexModelArgs(
-  req: ModelData,
-  repository: Repository,
-  databaseIndexApi?: DatabaseIndexApi
-): Promise<IndexModelArgs> {
+async function _getIndexModelArgs(req: ModelData, repository: Repository): Promise<IndexModelArgs> {
   const modelStreamId = req.streamID
   if (modelStreamId.type != Model.STREAM_TYPE_ID && !modelStreamId.equals(Model.MODEL)) {
     throw new Error(`Cannot index ${modelStreamId.toString()}, it is not a Model StreamID`)
@@ -43,7 +39,7 @@ async function _getIndexModelArgs(
     if (content.relations) {
       opts.relations = content.relations
     }
-    opts.indices = req.indices ?? (await databaseIndexApi?.getFieldsIndex(modelStreamId))
+    opts.indices = req.indices ?? []
   }
 
   return opts
@@ -166,7 +162,7 @@ export class LocalIndexApi implements IndexApi {
       )
     }
 
-    return await _getIndexModelArgs(modelData, this.repository, this.databaseIndexApi)
+    return await _getIndexModelArgs(modelData, this.repository)
   }
 
   async indexModels(models: Array<ModelData>): Promise<void> {

--- a/packages/core/src/indexing/local-index-api.ts
+++ b/packages/core/src/indexing/local-index-api.ts
@@ -39,7 +39,7 @@ async function _getIndexModelArgs(req: ModelData, repository: Repository): Promi
     if (content.relations) {
       opts.relations = content.relations
     }
-    opts.indices = req.indices ?? []
+    opts.indices = req.indices
   }
 
   return opts

--- a/packages/core/src/indexing/migrations/1-create-model-table.ts
+++ b/packages/core/src/indexing/migrations/1-create-model-table.ts
@@ -46,7 +46,10 @@ export function indexNameFromTableName(tableName: string): string {
   return `idx_${tableName.substring(tableName.length - 10)}`
 }
 
-export function indices(tableName: string): TableIndices {
+/**
+ * Returns descriptions of the default system indices that are required on all MID tables.
+ */
+export function defaultIndices(tableName: string): TableIndices {
   const indexName = indexNameFromTableName(tableName)
 
   // index names with additional naming information should be less than
@@ -167,7 +170,7 @@ export async function createPostgresModelTable(
   extraColumns: Array<ColumnInfo>
 ): Promise<void> {
   await dataSource.schema.createTable(tableName, function (table) {
-    const idx = indices(tableName)
+    const idx = defaultIndices(tableName)
 
     table
       .string('stream_id')
@@ -197,7 +200,7 @@ export async function createSqliteModelTable(
   extraColumns: Array<ColumnInfo>
 ): Promise<void> {
   await dataSource.schema.createTable(tableName, (table) => {
-    const idx = indices(tableName)
+    const idx = defaultIndices(tableName)
 
     table.string('stream_id', 1024).primary().unique().notNullable()
     table.string('controller_did', 1024).notNullable()

--- a/packages/core/src/indexing/tables-manager.ts
+++ b/packages/core/src/indexing/tables-manager.ts
@@ -5,7 +5,7 @@ import {
   createConfigTable,
   createPostgresModelTable,
   createSqliteModelTable,
-  indices,
+  defaultIndices,
   createSqliteIndices,
   createPostgresIndices,
   migrateConfigTable,
@@ -269,7 +269,7 @@ export class PostgresTablesManager extends TablesManager {
    * @param args
    */
   async hasMidIndices(tableName: string, args: IndexModelArgs): Promise<boolean> {
-    const expectedIndices = indices(tableName).indices.flatMap((index) => index.name)
+    const expectedIndices = defaultIndices(tableName).indices.flatMap((index) => index.name)
     if (args && args.indices) {
       for (const index of args.indices) {
         expectedIndices.push(fieldsIndexName(index, tableName))
@@ -341,7 +341,7 @@ export class SqliteTablesManager extends TablesManager {
    * @param args IndexModelArgs for checking indices
    */
   async hasMidIndices(tableName: string, args: IndexModelArgs): Promise<boolean> {
-    const expectedIndices = indices(tableName).indices.flatMap((index) => index.name)
+    const expectedIndices = defaultIndices(tableName).indices.flatMap((index) => index.name)
     if (args && args.indices) {
       for (const index of args.indices) {
         expectedIndices.push(fieldsIndexName(index, tableName))


### PR DESCRIPTION
No real functionality changes, but cleans up and simplifies some of the logic, reduces the number of reads/writes to the database, and expands test coverage a bit.