### PR TITLE
fix: Do not stop polling for anchor result on a network error

### DIFF
--- a/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-service.retry-failure.test.ts
+++ b/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-service.retry-failure.test.ts
@@ -3,6 +3,9 @@ import { whenSubscriptionDone } from '../../../__tests__/when-subscription-done.
 import { generateFakeCarFile, FAKE_STREAM_ID, FAKE_TIP_CID } from './generateFakeCarFile.js'
 
 const MAX_FAILED_ATTEMPTS = 2
+const POLL_INTERVAL = 100 // ms
+const MAX_POLL_TIME = 500 // ms - to test if polling stops after this threshold
+
 let fetchAttemptNum = 0
 
 const casProcessingResponse = {
@@ -36,7 +39,11 @@ test('re-request an anchor till get a response', async () => {
   const { EthereumAnchorService } = await import('../ethereum-anchor-service.js')
   const diagnosticsLogger = new LoggerProvider().getDiagnosticsLogger()
   const errSpy = jest.spyOn(diagnosticsLogger, 'err')
-  const anchorService = new EthereumAnchorService('http://example.com', diagnosticsLogger, 100)
+  const anchorService = new EthereumAnchorService(
+    'http://example.com',
+    diagnosticsLogger,
+    POLL_INTERVAL
+  )
   let lastResponse: any
   const subscription = anchorService.requestAnchor(generateFakeCarFile()).subscribe((response) => {
     if (response.status === AnchorRequestStatusName.PROCESSING) {
@@ -56,7 +63,11 @@ test('re-poll on fetch error', async () => {
   const { EthereumAnchorService } = await import('../ethereum-anchor-service.js')
   const diagnosticsLogger = new LoggerProvider().getDiagnosticsLogger()
   const errSpy = jest.spyOn(diagnosticsLogger, 'err')
-  const anchorService = new EthereumAnchorService('http://example.com', diagnosticsLogger, 100)
+  const anchorService = new EthereumAnchorService(
+    'http://example.com',
+    diagnosticsLogger,
+    POLL_INTERVAL
+  )
   const streamId = FAKE_STREAM_ID
   const anchorResponse$ = anchorService.pollForAnchorResponse(streamId, streamId.cid)
   let lastResponse: any
@@ -86,7 +97,12 @@ test('stop polling after max time', async () => {
   const { LoggerProvider } = await import('@ceramicnetwork/common')
   const { EthereumAnchorService } = await import('../ethereum-anchor-service.js')
   const diagnosticsLogger = new LoggerProvider().getDiagnosticsLogger()
-  const anchorService = new EthereumAnchorService('http://example.com', diagnosticsLogger, 100, 500)
+  const anchorService = new EthereumAnchorService(
+    'http://example.com',
+    diagnosticsLogger,
+    POLL_INTERVAL,
+    MAX_POLL_TIME
+  )
   const streamId = FAKE_STREAM_ID
   const anchorResponse$ = anchorService.pollForAnchorResponse(streamId, streamId.cid)
   let error

--- a/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-service.retry-failure.test.ts
+++ b/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-service.retry-failure.test.ts
@@ -1,9 +1,9 @@
-import { jest } from '@jest/globals'
+import { jest, test, expect } from '@jest/globals'
 import { whenSubscriptionDone } from '../../../__tests__/when-subscription-done.util.js'
 import { generateFakeCarFile, FAKE_STREAM_ID, FAKE_TIP_CID } from './generateFakeCarFile.js'
 
 const MAX_FAILED_ATTEMPTS = 2
-let attemptNum = 0
+let fetchAttemptNum = 0
 
 const casProcessingResponse = {
   id: '',
@@ -17,8 +17,8 @@ jest.unstable_mockModule('cross-fetch', () => {
   const fetchFunc = jest.fn(async (url: string, opts: any = {}) => ({
     ok: true,
     json: async () => {
-      attemptNum += 1
-      if (attemptNum <= MAX_FAILED_ATTEMPTS + 1) {
+      fetchAttemptNum += 1
+      if (fetchAttemptNum <= MAX_FAILED_ATTEMPTS + 1) {
         throw new Error(`Cas is unavailable`)
       }
       return casProcessingResponse
@@ -30,16 +30,16 @@ jest.unstable_mockModule('cross-fetch', () => {
 })
 
 test('re-request an anchor till get a response', async () => {
-  const common = await import('@ceramicnetwork/common')
-  const codecs = await import('@ceramicnetwork/codecs')
-  const eas = await import('../ethereum-anchor-service.js')
-  const loggerProvider = new common.LoggerProvider()
-  const diagnosticsLogger = loggerProvider.getDiagnosticsLogger()
+  fetchAttemptNum = 0
+  const { LoggerProvider } = await import('@ceramicnetwork/common')
+  const { AnchorRequestStatusName } = await import('@ceramicnetwork/codecs')
+  const { EthereumAnchorService } = await import('../ethereum-anchor-service.js')
+  const diagnosticsLogger = new LoggerProvider().getDiagnosticsLogger()
   const errSpy = jest.spyOn(diagnosticsLogger, 'err')
-  const anchorService = new eas.EthereumAnchorService('http://example.com', diagnosticsLogger, 100)
+  const anchorService = new EthereumAnchorService('http://example.com', diagnosticsLogger, 100)
   let lastResponse: any
   const subscription = anchorService.requestAnchor(generateFakeCarFile()).subscribe((response) => {
-    if (response.status === codecs.AnchorRequestStatusName.PROCESSING) {
+    if (response.status === AnchorRequestStatusName.PROCESSING) {
       lastResponse = response
       subscription.unsubscribe()
     }
@@ -47,4 +47,44 @@ test('re-request an anchor till get a response', async () => {
   await whenSubscriptionDone(subscription)
   expect(lastResponse.message).toEqual(casProcessingResponse.message)
   expect(errSpy).toBeCalledTimes(3)
+})
+
+test('re-poll on fetch error', async () => {
+  fetchAttemptNum = 0
+  const { LoggerProvider } = await import('@ceramicnetwork/common')
+  const { AnchorRequestStatusName } = await import('@ceramicnetwork/codecs')
+  const { EthereumAnchorService } = await import('../ethereum-anchor-service.js')
+  const diagnosticsLogger = new LoggerProvider().getDiagnosticsLogger()
+  const errSpy = jest.spyOn(diagnosticsLogger, 'err')
+  const anchorService = new EthereumAnchorService('http://example.com', diagnosticsLogger, 100)
+  const streamId = FAKE_STREAM_ID
+  const anchorResponse$ = anchorService.pollForAnchorResponse(streamId, streamId.cid)
+  let lastResponse: any
+  const subscription = anchorResponse$.subscribe((response) => {
+    if (response.status === AnchorRequestStatusName.PROCESSING) {
+      lastResponse = response
+      subscription.unsubscribe()
+    }
+  })
+  await whenSubscriptionDone(subscription)
+  expect(lastResponse.message).toEqual(casProcessingResponse.message)
+  expect(errSpy).toBeCalledTimes(3)
+})
+
+test('stop polling after max time', async () => {
+  fetchAttemptNum = 0
+  const { LoggerProvider } = await import('@ceramicnetwork/common')
+  const { EthereumAnchorService } = await import('../ethereum-anchor-service.js')
+  const diagnosticsLogger = new LoggerProvider().getDiagnosticsLogger()
+  const anchorService = new EthereumAnchorService('http://example.com', diagnosticsLogger, 100, 500)
+  const streamId = FAKE_STREAM_ID
+  const anchorResponse$ = anchorService.pollForAnchorResponse(streamId, streamId.cid)
+  let error
+  const subscription = anchorResponse$.subscribe({
+    error: (e) => {
+      error = e
+    },
+  })
+  await whenSubscriptionDone(subscription)
+  expect(String(error)).toEqual('Error: Exceeded max anchor polling time limit')
 })

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -11,7 +11,7 @@ import {
   FetchRequest,
 } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
-import { Observable, interval, from, concat, of, defer } from 'rxjs'
+import { Observable, interval, from, concat, timer, of, defer } from 'rxjs'
 import { concatMap, catchError, map, retry } from 'rxjs/operators'
 import { CAR } from 'cartonne'
 import { AnchorRequestCarFileReader } from '../anchor-request-car-file-reader.js'
@@ -132,15 +132,13 @@ export class EthereumAnchorService implements AnchorService {
    */
   private _makeAnchorRequest(carFileReader: AnchorRequestCarFileReader): Observable<CASResponse> {
     return defer(() =>
-      from(
-        this.sendRequest(this.requestsApiEndpoint, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/vnd.ipld.car',
-          },
-          body: carFileReader.carFile.bytes,
-        })
-      )
+      this.sendRequest(this.requestsApiEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/vnd.ipld.car',
+        },
+        body: carFileReader.carFile.bytes,
+      })
     ).pipe(
       retry({
         delay: (error) => {
@@ -151,7 +149,7 @@ export class EthereumAnchorService implements AnchorService {
               }`
             )
           )
-          return interval(this.pollInterval)
+          return timer(this.pollInterval)
         },
       }),
       map((response) => {


### PR DESCRIPTION
Handle fetch errors by retrying when polling for an anchor.

There is a programmatic test. Also, tested manually:
1. create a stream, wait till the initial request to CAS passes.
2. Turn off Wi-Fi. This results in errors on the log (as expected).
3. Turn on Wi-Fi back. Polling continues.