### PR TITLE
fix(http-client): Add a dummy pin api to not break old callers

### DIFF
--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -29,6 +29,7 @@ import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
 import { StreamID, CommitID, StreamRef } from '@ceramicnetwork/streamid'
 import { RemoteIndexApi } from './remote-index-api.js'
 import { RemoteAdminApi } from './remote-admin-api.js'
+import { DummyPinApi } from './dummy-pin-api.js'
 
 const API_PATH = '/api/v0/'
 const CERAMIC_HOST = 'http://localhost:7007'
@@ -79,6 +80,7 @@ export class CeramicClient implements CeramicApi {
     this._apiUrl = new URL(API_PATH, apiHost)
     this.context = { api: this }
 
+    this.pin = new DummyPinApi()
     this.index = new RemoteIndexApi(this._apiUrl)
     const getDidFn = (() => {
       return this.did

--- a/packages/http-client/src/dummy-pin-api.ts
+++ b/packages/http-client/src/dummy-pin-api.ts
@@ -1,0 +1,23 @@
+import { PinApi, PublishOpts } from '@ceramicnetwork/common'
+import { StreamID } from '@ceramicnetwork/streamid'
+
+function warn(operation: string) {
+  console.warn(`You use a deprecated ceramic.pin.${operation} API. Please, reconsider your choices`)
+}
+
+export class DummyPinApi implements PinApi {
+  async add(): Promise<void> {
+    warn(`add`)
+    return
+  }
+
+  async ls(): Promise<AsyncIterable<string>> {
+    warn(`ls`)
+    return
+  }
+
+  async rm(streamId: StreamID, opts?: PublishOpts): Promise<void> {
+    warn(`ls`)
+    return
+  }
+}

--- a/packages/http-client/src/dummy-pin-api.ts
+++ b/packages/http-client/src/dummy-pin-api.ts
@@ -2,7 +2,7 @@ import { PinApi, PublishOpts } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
 
 function warn(operation: string) {
-  console.warn(`You use a deprecated ceramic.pin.${operation} API. Please, reconsider your choices`)
+  console.warn(`You are using the ceramic.pin.${operation} API which has been removed and is now a no-op.  This operation will not have any affect.  If you want to change the pin state of streams please use the new ceramic.admin.pin API which requires a DID that has been granted admin access on the Ceramic node.`)
 }
 
 export class DummyPinApi implements PinApi {


### PR DESCRIPTION
Do `console.warn` with a message `You use a deprecated ceramic.pin.${operation} API. Please, reconsider your choices`

Suggestions for a better message are welcome.