### PR TITLE
feat(cli): Don't allow running IPFS in bundled mode on mainnet

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -13,6 +13,7 @@ import {
   LogStyle,
   ModelData,
   MultiQuery,
+  Networks,
   StreamUtils,
   SyncOptions,
 } from '@ceramicnetwork/common'
@@ -28,7 +29,7 @@ import { addAsync, ExpressWithAsync } from '@awaitjs/express'
 import { instrumentRequests } from './daemon/instrument-requests.js'
 import { logRequests } from './daemon/log-requests.js'
 import type { Server } from 'http'
-import { DaemonConfig, StateStoreMode } from './daemon-config.js'
+import { DaemonConfig, IpfsMode, StateStoreMode } from './daemon-config.js'
 import type { ResolverRegistry } from 'did-resolver'
 import { ErrorHandlingRouter } from './error-handling-router.js'
 import { collectionQuery, countQuery } from './daemon/collection-queries.js'
@@ -284,6 +285,12 @@ export class CeramicDaemon {
   static async create(opts: DaemonConfig): Promise<CeramicDaemon> {
     const ceramicConfig = makeCeramicConfig(opts)
 
+    const onMainnet = opts.network?.name == Networks.MAINNET || opts.network?.name == Networks.ELP
+    if (opts.ipfs.mode != IpfsMode.REMOTE && onMainnet) {
+      throw new Error(
+        "Cannot run IPFS in 'bundled' mode on Mainnet. Bundled IPFS is for testing only and not suitable for production deployments.  Please set up a dedicated IPFS node and provide the URL for a REMOTE connection"
+      )
+    }
     const ipfs = await IpfsConnectionFactory.buildIpfsConnection(
       opts.ipfs.mode,
       opts.network?.name,

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -285,8 +285,7 @@ export class CeramicDaemon {
   static async create(opts: DaemonConfig): Promise<CeramicDaemon> {
     const ceramicConfig = makeCeramicConfig(opts)
 
-    const onMainnet = opts.network?.name == Networks.MAINNET || opts.network?.name == Networks.ELP
-    if (opts.ipfs.mode != IpfsMode.REMOTE && onMainnet) {
+    if (opts.ipfs.mode != IpfsMode.REMOTE && opts.network?.name == Networks.MAINNET) {
       throw new Error(
         "Cannot run IPFS in 'bundled' mode on Mainnet. Bundled IPFS is for testing only and not suitable for production deployments.  Please set up a dedicated IPFS node and provide the URL for a REMOTE connection"
       )


### PR DESCRIPTION
Note this is technically a breaking change for any deployments currently relying on bundled mode on mainnet.  If they upgrade to the new version their node will fail to start up unless they switch to a dedicated IPFS node. Do we need to make a major version bump then?  Or can we just communicate it on discord and to the partners we know are using 'bundled' mode?

FYI @jpham2023