### PR TITLE
feat(core, anchor-utils): sync start block 24 hours before model anchor

### DIFF
--- a/packages/anchor-utils/src/__tests__/cid.test.ts
+++ b/packages/anchor-utils/src/__tests__/cid.test.ts
@@ -9,6 +9,8 @@ import {
   DAG_CBOR_CODE,
   createCidFromHexValue,
   getCidFromAnchorEventLog,
+  convertEthHashToCid,
+  convertCidToEthHash,
 } from '../cid.js'
 
 function createCID(digest: Uint8Array = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7])): CID {
@@ -32,5 +34,16 @@ describe('root CID extraction', () => {
     const log = { data: defaultAbiCoder.encode(['bytes32'], [bytes]) } as Log
     const cid = getCidFromAnchorEventLog(log)
     expect(cid.equals(createCID(bytes))).toBe(true)
+  })
+})
+
+describe('eth hash conversion', () => {
+  test('can convert hash to and from CID', () => {
+    const hash = '0x7ac547fc3e4b84e026adecdff83f2c14583b138f665a23281b5fcfcce1c816f2'
+
+    const cid = convertEthHashToCid(hash)
+    const convertedHash = convertCidToEthHash(cid)
+
+    expect(convertedHash).toEqual('hash')
   })
 })

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
@@ -1,5 +1,4 @@
 import * as uint8arrays from 'uint8arrays'
-import { decode } from 'multiformats/hashes/digest'
 import * as providers from '@ethersproject/providers'
 import lru from 'lru_map'
 import { AnchorProof, AnchorValidator, DiagnosticsLogger } from '@ceramicnetwork/common'
@@ -7,6 +6,7 @@ import { Block, TransactionResponse } from '@ethersproject/providers'
 import { Interface } from '@ethersproject/abi'
 import { create as createMultihash } from 'multiformats/hashes/digest'
 import { CID } from 'multiformats/cid'
+import { convertCidToEthHash } from '@ceramicnetwork/anchor-utils'
 
 const SHA256_CODE = 0x12
 const DAG_CBOR_CODE = 0x71
@@ -205,8 +205,7 @@ export class EthereumAnchorValidator implements AnchorValidator {
   }
 
   async validateChainInclusion(anchorProof: AnchorProof): Promise<number> {
-    const decoded = decode(anchorProof.txHash.multihash.bytes)
-    const txHash = '0x' + uint8arrays.toString(decoded.digest, 'base16')
+    const txHash = convertCidToEthHash(anchorProof.txHash)
     const [txResponse, block] = await this._getTransactionAndBlockInfo(anchorProof.chainId, txHash)
     const txCid = getCidFromTransaction(anchorProof.txType, txResponse)
 

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -59,7 +59,6 @@ import { AnchorResumingService } from './state-management/anchor-resuming-servic
 import { SyncApi } from './sync/sync-api.js'
 import { ProvidersCache } from './providers-cache.js'
 import crypto from 'crypto'
-import { SyncJobData } from './sync/interfaces.js'
 
 const DEFAULT_CACHE_LIMIT = 500 // number of streams stored in the cache
 const DEFAULT_QPS_LIMIT = 10 // Max number of pubsub query messages that can be published per second without rate limiting
@@ -305,7 +304,13 @@ export class Ceramic implements CeramicApi {
     )
     const pinApi = this._buildPinApi()
     this.repository.index.setSyncQueryApi(this.syncApi)
-    this.admin = new LocalAdminApi(localIndex, this.syncApi, this.nodeStatus.bind(this), pinApi)
+    this.admin = new LocalAdminApi(
+      localIndex,
+      this.syncApi,
+      this.nodeStatus.bind(this),
+      pinApi,
+      this.loadStream.bind(this)
+    )
   }
 
   get index(): LocalIndexApi {

--- a/packages/core/src/sync/__tests__/sync-api.test.ts
+++ b/packages/core/src/sync/__tests__/sync-api.test.ts
@@ -322,11 +322,13 @@ describe('Sync API', () => {
         logger
       )
 
+      // @ts-ignore private field
+      sync.initialIndexingBlock = 0
       const addSyncJob = jest.fn()
       sync._addSyncJob = addSyncJob as any
 
       const data = { fromBlock: 1, toBlock: 10, models: ['abc123'] }
-      await sync.startModelSync('abc123', data.fromBlock, data.toBlock)
+      await sync.startModelSync('abc123', { startBlock: data.fromBlock, endBlock: data.toBlock })
       expect(addSyncJob).toHaveBeenCalledWith(HISTORY_SYNC_JOB, expect.objectContaining(data))
       expect(Array.from(sync.modelsToSync)).toEqual(data.models)
     })
@@ -341,11 +343,13 @@ describe('Sync API', () => {
         logger
       )
 
+      // @ts-ignore private field
+      sync.initialIndexingBlock = 0
       const addSyncJob = jest.fn()
       sync._addSyncJob = addSyncJob as any
 
       const data = { fromBlock: 1, toBlock: 10, models: ['abc123', 'def456'] }
-      await sync.startModelSync(data.models, data.fromBlock, data.toBlock)
+      await sync.startModelSync(data.models, { startBlock: data.fromBlock, endBlock: data.toBlock })
       expect(addSyncJob).toHaveBeenCalledWith(HISTORY_SYNC_JOB, expect.objectContaining(data))
       expect(Array.from(sync.modelsToSync)).toEqual(data.models)
     })

--- a/packages/core/src/sync/interfaces.ts
+++ b/packages/core/src/sync/interfaces.ts
@@ -18,13 +18,26 @@ export interface ISyncQueryApi {
 }
 
 /**
+ * Options to configure a historical sync
+ */
+export type ModelSyncOptions = {
+  // start the sync on this block
+  startBlock?: number
+  // end the sync on this block
+  endBlock?: number
+  // start the sync on the block the transaction was mined
+  startTxHash?: string
+}
+
+/**
  * Interface used with historical sync'ing to start model sync on one or more models, or to
  * shutdown the service providing the sync'ing
  */
 export interface ISyncApi extends ISyncQueryApi {
-  startModelSync(models: string | string[], startBlock?: number, endBlock?: number): Promise<void>
+  startModelSync(models: string | string[], modelSyncOptions?: ModelSyncOptions): Promise<void>
   stopModelSync(models: string | string[]): Promise<void>
   shutdown(): Promise<void>
+  enabled: boolean
 }
 
 // handles a commit found during a sync

--- a/packages/core/src/sync/interfaces.ts
+++ b/packages/core/src/sync/interfaces.ts
@@ -17,6 +17,10 @@ export interface ISyncQueryApi {
   syncComplete(model: string): boolean
 }
 
+export type StartBeforeTxSyncOption = {
+  txHash: string
+  numberOfBlocksBeforeTx?: number
+}
 /**
  * Options to configure a historical sync
  */
@@ -25,8 +29,8 @@ export type ModelSyncOptions = {
   startBlock?: number
   // end the sync on this block
   endBlock?: number
-  // start the sync on the block the transaction was mined
-  startTxHash?: string
+  // start the sync X blocks before the block the transaction was mined on
+  startBeforeTx?: StartBeforeTxSyncOption
 }
 
 /**

--- a/packages/core/src/sync/sync-api.ts
+++ b/packages/core/src/sync/sync-api.ts
@@ -397,16 +397,21 @@ export class SyncApi implements ISyncApi {
   async _getStartBlock(syncOptions: ModelSyncOptions): Promise<number> {
     let startBlock = Math.max(this.initialIndexingBlock, syncOptions.startBlock || 0)
 
-    if (syncOptions.startTxHash) {
+    if (syncOptions.startBeforeTx) {
+      const { txHash, numberOfBlocksBeforeTx = 0 } = syncOptions.startBeforeTx
+
       if (!this.provider) {
         throw new Error(
           'Provider not set. Please initialize the sync api before using the sync api'
         )
       }
 
-      const startTx = await this.provider.getTransaction(syncOptions.startTxHash)
+      const startTx = await this.provider.getTransaction(txHash)
+      const startBlockFromTx = startTx.blockNumber
+        ? startTx.blockNumber - numberOfBlocksBeforeTx
+        : 0
 
-      startBlock = Math.max(startBlock, startTx.blockNumber || 0)
+      startBlock = Math.max(startBlock, startBlockFromTx)
     }
 
     return startBlock


### PR DESCRIPTION
For each indexed model - load the model and check when it was anchored.  Take the Model with the earliest anchor time, and then start your sync at 24 hours before that time (given that we promise to always anchor a write within 24 hours).

Another circular dependency introduced in the local admin api. sad