### PR TITLE
Temporarily allow disabling anchor polling retry logic

### DIFF
--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -166,6 +166,14 @@ export class EthereumAnchorService implements AnchorService {
    * @param tip - Tip CID of the stream
    */
   pollForAnchorResponse(streamId: StreamID, tip: CID): Observable<CASResponse> {
+    if (process.env.CERAMIC_DISABLE_POLLING_RETRIES == 'true') {
+      return this._pollForAnchorResponseLegacy(streamId, tip)
+    } else {
+      return this._pollForAnchorResponse(streamId, tip)
+    }
+  }
+
+  private _pollForAnchorResponse(streamId: StreamID, tip: CID): Observable<CASResponse> {
     const started = new Date().getTime()
     const maxTime = started + this.maxPollTime
     const requestUrl = [this.requestsApiEndpoint, tip.toString()].join('/')
@@ -194,6 +202,30 @@ export class EthereumAnchorService implements AnchorService {
         }
       }),
       map((response) => this.parseResponse(cidStream, response))
+    )
+  }
+
+  /**
+   * The old version of polling that has a bug where polling stops if there's a network error.
+   * TODO: REMOVE THIS!  We're only putting this back temporarily to investigate if it caused
+   * a performance regression.
+   */
+  private _pollForAnchorResponseLegacy(streamId: StreamID, tip: CID): Observable<CASResponse> {
+    const started = new Date().getTime()
+    const maxTime = started + this.maxPollTime
+    const requestUrl = [this.requestsApiEndpoint, tip.toString()].join('/')
+    const cidStream = { cid: tip, streamId }
+
+    return interval(this.pollInterval).pipe(
+      concatMap(async () => {
+        const now = new Date().getTime()
+        if (now > maxTime) {
+          throw new Error('Exceeded max anchor polling time limit')
+        } else {
+          const response = await this.sendRequest(requestUrl)
+          return this.parseResponse(cidStream, response)
+        }
+      })
     )
   }
 

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -166,7 +166,7 @@ export class EthereumAnchorService implements AnchorService {
    * @param tip - Tip CID of the stream
    */
   pollForAnchorResponse(streamId: StreamID, tip: CID): Observable<CASResponse> {
-    if (process.env.CERAMIC_DISABLE_POLLING_RETRIES == 'true') {
+    if (process.env.CERAMIC_DISABLE_ANCHOR_POLLING_RETRIES == 'true') {
       return this._pollForAnchorResponseLegacy(streamId, tip)
     } else {
       return this._pollForAnchorResponse(streamId, tip)

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -626,6 +626,12 @@ export class Ceramic implements CeramicApi {
         .catch((error) => {
           this._logger.err(`Error while resuming anchors: ${error}`)
         })
+
+      if (process.env.CERAMIC_DISABLE_ANCHOR_POLLING_RETRIES == 'true') {
+        this._logger.warn(
+          `Running with anchor polling retries disabled. This is not recommended in production`
+        )
+      }
     } catch (err) {
       await this.close()
       throw err


### PR DESCRIPTION
Adds an env var `CERAMIC_DISABLE_POLLING_RETRIES` which if set to true reverts the node's behavior to be what it was before https://github.com/ceramicnetwork/js-ceramic/commit/07ff4e5b0558fd3ae6069c2fe2bdff5c6de69306#diff-7920408ff457031025a51c6c64241f297dc91febb1a810e724475548c154c781.

This is not a good fix and should be reverted before we do the next release, but if we can have gitcoin run with this flag enabled it could help us confirm whether or not the polling fix is what caused the recent node lockup