### PR TITLE
feat: Add option to wait until anchor requests are durably created on the CAS

### DIFF
--- a/packages/common/src/anchor-service.ts
+++ b/packages/common/src/anchor-service.ts
@@ -51,11 +51,12 @@ export interface AnchorService {
   url: string
 
   /**
-   * Request anchor commit on blockchain
-   * @param streamId - Stream ID
-   * @param tip - CID tip
+   * Send request to the anchoring service
+   * @param carFile - CAR file containing all necessary data for the CAS to anchor
+   * @param waitForConfirmation - if true, waits until the CAS has acknowledged receipt of the anchor
+   *   request before returning.
    */
-  requestAnchor(carFile: CAR): Promise<Observable<CASResponse>>
+  requestAnchor(carFile: CAR, waitForConfirmation: boolean): Promise<Observable<CASResponse>>
 
   /**
    * Start polling the anchor service to learn of the results of an existing anchor request for the

--- a/packages/common/src/anchor-service.ts
+++ b/packages/common/src/anchor-service.ts
@@ -55,7 +55,7 @@ export interface AnchorService {
    * @param streamId - Stream ID
    * @param tip - CID tip
    */
-  requestAnchor(carFile: CAR): Observable<CASResponse>
+  requestAnchor(carFile: CAR): Promise<Observable<CASResponse>>
 
   /**
    * Start polling the anchor service to learn of the results of an existing anchor request for the

--- a/packages/common/src/ceramic-api.ts
+++ b/packages/common/src/ceramic-api.ts
@@ -1,6 +1,6 @@
 import type { DID } from 'dids'
 import type { Stream, StreamHandler, CeramicCommit, StreamState } from './stream.js'
-import type { CreateOpts, LoadOpts, PublishOpts, UpdateOpts } from './streamopts.js'
+import type { AnchorOpts, CreateOpts, LoadOpts, PublishOpts, UpdateOpts } from './streamopts.js'
 import type { StreamID, CommitID } from '@ceramicnetwork/streamid'
 import type { LoggerProvider } from './logger-provider.js'
 import type { GenesisCommit } from './index.js'
@@ -209,7 +209,7 @@ export interface CeramicApi extends CeramicSigner {
    * @param streamId
    * @param opts used to load the current Stream state
    */
-  requestAnchor(streamId: StreamID | string, opts?: LoadOpts): Promise<AnchorStatus>
+  requestAnchor(streamId: StreamID | string, opts?: LoadOpts & AnchorOpts): Promise<AnchorStatus>
 
   /**
    * Sets the DID instance that will be used to author commits to stream. The DID instance

--- a/packages/common/src/streamopts.ts
+++ b/packages/common/src/streamopts.ts
@@ -118,6 +118,13 @@ export interface AnchorOpts {
    * Whether or not to request an anchor after performing the operation.
    */
   anchor?: boolean
+
+  /**
+   * If true, the write operation won't return until the anchor request has been successfully and
+   * durably created on the Anchor Service.  Note this does NOT wait for the write to be fully
+   * anchored, it only waits until we are confident that the write will *eventually* be anchored.
+   */
+  waitForAnchorConfirmation?: boolean
 }
 
 /**

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -637,7 +637,7 @@ describe('anchor', () => {
       )
       // Emulate CAS responses to the 1st commit
       const fauxCASResponse$ = new Subject<CASResponse>()
-      requestAnchorSpy.mockReturnValueOnce(fauxCASResponse$)
+      requestAnchorSpy.mockReturnValueOnce(Promise.resolve(fauxCASResponse$))
       // Subscription for the 1st commit
       const stillProcessingFirst = await ceramic.repository.stateManager.anchor(stream$)
       // The emulated CAS accepts the request
@@ -861,7 +861,7 @@ describe('anchor', () => {
 
         // Emulate CAS responses to the 1st commit
         const firstCASResponse$ = new Subject<CASResponse>()
-        requestAnchorSpy.mockImplementationOnce((streamId, commit) => {
+        requestAnchorSpy.mockImplementationOnce(async (streamId, commit) => {
           originalPollForAnchorResponse(streamId, commit)
           return firstCASResponse$
         })
@@ -898,7 +898,7 @@ describe('anchor', () => {
         await tile.update({ abc: 456, def: 789 }, null, { anchor: false })
         // Emulate CAS responses to the 2nd commit
         const secondCASResponse$ = new Subject<CASResponse>()
-        requestAnchorSpy.mockReturnValueOnce(secondCASResponse$)
+        requestAnchorSpy.mockReturnValueOnce(Promise.resolve(secondCASResponse$))
         // Anchor the 2nd commit and subscribe
         await ceramic.repository.stateManager.anchor(stream$)
         expect(await anchorRequestStore.load(tile.id).then((ar) => ar.cid.toString())).toEqual(
@@ -942,7 +942,7 @@ describe('anchor', () => {
 
         // Emulate CAS responses to the 1st commit
         const firstCASResponse$ = new Subject<CASResponse>()
-        requestAnchorSpy.mockReturnValueOnce(firstCASResponse$)
+        requestAnchorSpy.mockReturnValueOnce(Promise.resolve(firstCASResponse$))
         // Anchor the 1st commit and subscribe
         const firstAnchorResponseSub = await ceramic.repository.stateManager.anchor(stream$)
         expect(await anchorRequestStore.load(tile.id).then((ar) => ar.cid.toString())).toEqual(
@@ -1050,7 +1050,7 @@ describe('anchor', () => {
 
         // Emulate CAS responses to the 1st commit
         const firstCASResponse$ = new Subject<CASResponse>()
-        requestAnchorSpy.mockReturnValueOnce(firstCASResponse$)
+        requestAnchorSpy.mockReturnValueOnce(Promise.resolve(firstCASResponse$))
         // Anchor the first commit and subscribe
         const firstAnchorResponseSub = await ceramic.repository.stateManager.anchor(stream$)
         expect(await anchorRequestStore.load(tile.id).then((ar) => ar.cid.toString())).toEqual(
@@ -1078,7 +1078,7 @@ describe('anchor', () => {
         await tile.update({ abc: 456, def: 789 }, null, { anchor: false })
         // Emulate CAS responses to the 2nd commit
         const secondCASResponse$ = new Subject<CASResponse>()
-        requestAnchorSpy.mockReturnValueOnce(secondCASResponse$)
+        requestAnchorSpy.mockReturnValueOnce(Promise.resolve(secondCASResponse$))
         // Anchor the 2nd commit and subscribe
         const secondAnchorRequestSub = await ceramic.repository.stateManager.anchor(stream$)
         expect(await anchorRequestStore.load(tile.id).then((ar) => ar.cid.toString())).toEqual(
@@ -1137,7 +1137,7 @@ describe('anchor', () => {
 
         // Emulate CAS responses for the 1st commit
         const fauxCASResponse$ = new Subject<CASResponse>()
-        requestAnchorSpy.mockReturnValueOnce(fauxCASResponse$)
+        requestAnchorSpy.mockReturnValueOnce(Promise.resolve(fauxCASResponse$))
         // anchor the first commit and subscribe
         const firstAnchorResponseSub = await ceramic.repository.stateManager.anchor(stream$)
         expect(await anchorRequestStore.load(tile.id).then((ar) => ar.cid.toString())).toEqual(

--- a/packages/core/src/anchor/ethereum/__tests__/authenticated-anchor-service.test.ts
+++ b/packages/core/src/anchor/ethereum/__tests__/authenticated-anchor-service.test.ts
@@ -60,7 +60,7 @@ describe('AuthenticatedEthereumAnchorServiceTest', () => {
       return { status: AnchorRequestStatusName.PENDING }
     })
 
-    const observable = await anchorService.requestAnchor(generateFakeCarFile())
+    const observable = await anchorService.requestAnchor(generateFakeCarFile(), false)
     const anchorStatus = await lastValueFrom(observable)
     expect(anchorStatus.status).toEqual(AnchorRequestStatusName.FAILED) // because the response didn't match the expected format
 

--- a/packages/core/src/anchor/ethereum/__tests__/authenticated-anchor-service.test.ts
+++ b/packages/core/src/anchor/ethereum/__tests__/authenticated-anchor-service.test.ts
@@ -60,7 +60,7 @@ describe('AuthenticatedEthereumAnchorServiceTest', () => {
       return { status: AnchorRequestStatusName.PENDING }
     })
 
-    const observable = anchorService.requestAnchor(generateFakeCarFile())
+    const observable = await anchorService.requestAnchor(generateFakeCarFile())
     const anchorStatus = await lastValueFrom(observable)
     expect(anchorStatus.status).toEqual(AnchorRequestStatusName.FAILED) // because the response didn't match the expected format
 

--- a/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-service.retry-failure.test.ts
+++ b/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-service.retry-failure.test.ts
@@ -45,7 +45,7 @@ test('re-request an anchor till get a response', async () => {
     POLL_INTERVAL
   )
   let lastResponse: any
-  const subscription = (await anchorService.requestAnchor(generateFakeCarFile())).subscribe(
+  const subscription = (await anchorService.requestAnchor(generateFakeCarFile(), false)).subscribe(
     (response) => {
       if (response.status === AnchorRequestStatusName.PROCESSING) {
         lastResponse = response

--- a/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-service.retry-failure.test.ts
+++ b/packages/core/src/anchor/ethereum/__tests__/ethereum-anchor-service.retry-failure.test.ts
@@ -45,12 +45,14 @@ test('re-request an anchor till get a response', async () => {
     POLL_INTERVAL
   )
   let lastResponse: any
-  const subscription = anchorService.requestAnchor(generateFakeCarFile()).subscribe((response) => {
-    if (response.status === AnchorRequestStatusName.PROCESSING) {
-      lastResponse = response
-      subscription.unsubscribe()
+  const subscription = (await anchorService.requestAnchor(generateFakeCarFile())).subscribe(
+    (response) => {
+      if (response.status === AnchorRequestStatusName.PROCESSING) {
+        lastResponse = response
+        subscription.unsubscribe()
+      }
     }
-  })
+  )
   await whenSubscriptionDone(subscription)
   expect(lastResponse.message).toEqual(casProcessingResponse.message)
   expect(errSpy).toBeCalledTimes(3)

--- a/packages/core/src/anchor/ethereum/__tests__/ethereum-did-auth-anchor-service.retry-failure.test.ts
+++ b/packages/core/src/anchor/ethereum/__tests__/ethereum-did-auth-anchor-service.retry-failure.test.ts
@@ -64,12 +64,14 @@ test('re-request an anchor till get a response', async () => {
   )
 
   let lastResponse: any
-  const subscription = anchorService.requestAnchor(generateFakeCarFile()).subscribe((response) => {
-    if (response.status === codecs.AnchorRequestStatusName.PROCESSING) {
-      lastResponse = response
-      subscription.unsubscribe()
+  const subscription = (await anchorService.requestAnchor(generateFakeCarFile())).subscribe(
+    (response) => {
+      if (response.status === codecs.AnchorRequestStatusName.PROCESSING) {
+        lastResponse = response
+        subscription.unsubscribe()
+      }
     }
-  })
+  )
   await whenSubscriptionDone(subscription)
   expect(lastResponse.message).toEqual(casProcessingResponse.message)
   expect(errSpy).toBeCalledTimes(3)

--- a/packages/core/src/anchor/ethereum/__tests__/ethereum-did-auth-anchor-service.retry-failure.test.ts
+++ b/packages/core/src/anchor/ethereum/__tests__/ethereum-did-auth-anchor-service.retry-failure.test.ts
@@ -64,7 +64,7 @@ test('re-request an anchor till get a response', async () => {
   )
 
   let lastResponse: any
-  const subscription = (await anchorService.requestAnchor(generateFakeCarFile())).subscribe(
+  const subscription = (await anchorService.requestAnchor(generateFakeCarFile(), false)).subscribe(
     (response) => {
       if (response.status === codecs.AnchorRequestStatusName.PROCESSING) {
         lastResponse = response

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -87,9 +87,15 @@ export class EthereumAnchorService implements AnchorService {
   }
 
   /**
-   * Requests anchoring service for current tip of the stream
+   * Send request to the anchoring service
+   * @param carFile - CAR file containing all necessary data for the CAS to anchor
+   * @param waitForConfirmation - if true, waits until the CAS has acknowledged receipt of the anchor
+   *   request before returning.
    */
-  async requestAnchor(carFile: CAR): Promise<Observable<CASResponse>> {
+  async requestAnchor(
+    carFile: CAR,
+    waitForConfirmation: boolean
+  ): Promise<Observable<CASResponse>> {
     const carFileReader = new AnchorRequestCarFileReader(carFile)
     const cidStreamPair: CidAndStream = { cid: carFileReader.tip, streamId: carFileReader.streamId }
     return concat(

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -89,7 +89,7 @@ export class EthereumAnchorService implements AnchorService {
   /**
    * Requests anchoring service for current tip of the stream
    */
-  requestAnchor(carFile: CAR): Observable<CASResponse> {
+  async requestAnchor(carFile: CAR): Promise<Observable<CASResponse>> {
     const carFileReader = new AnchorRequestCarFileReader(carFile)
     const cidStreamPair: CidAndStream = { cid: carFileReader.tip, streamId: carFileReader.streamId }
     return concat(

--- a/packages/core/src/anchor/memory/in-memory-anchor-service.ts
+++ b/packages/core/src/anchor/memory/in-memory-anchor-service.ts
@@ -286,10 +286,14 @@ export class InMemoryAnchorService implements AnchorService, AnchorValidator {
 
   /**
    * Send request to the anchoring service
-   * @param streamId - Stream ID
-   * @param tip - Commit CID
+   * @param carFile - CAR file containing all necessary data for the CAS to anchor
+   * @param waitForConfirmation - if true, waits until the CAS has acknowledged receipt of the anchor
+   *   request before returning.
    */
-  async requestAnchor(carFile: CAR): Promise<Observable<CASResponse>> {
+  async requestAnchor(
+    carFile: CAR,
+    waitForConfirmation: boolean
+  ): Promise<Observable<CASResponse>> {
     const carFileReader = new AnchorRequestCarFileReader(carFile)
     const candidate = new Candidate(carFileReader)
     if (this.#anchorOnRequest) {

--- a/packages/core/src/anchor/memory/in-memory-anchor-service.ts
+++ b/packages/core/src/anchor/memory/in-memory-anchor-service.ts
@@ -289,7 +289,7 @@ export class InMemoryAnchorService implements AnchorService, AnchorValidator {
    * @param streamId - Stream ID
    * @param tip - Commit CID
    */
-  requestAnchor(carFile: CAR): Observable<CASResponse> {
+  async requestAnchor(carFile: CAR): Promise<Observable<CASResponse>> {
     const carFileReader = new AnchorRequestCarFileReader(carFile)
     const candidate = new Candidate(carFileReader)
     if (this.#anchorOnRequest) {

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -25,6 +25,7 @@ import {
   StreamState,
   AdminApi,
   NodeStatusResponse,
+  AnchorOpts,
 } from '@ceramicnetwork/common'
 import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
 
@@ -783,11 +784,14 @@ export class Ceramic implements CeramicApi {
    * @param streamId
    * @param opts used to load the current Stream state
    */
-  async requestAnchor(streamId: string | StreamID, opts: LoadOpts = {}): Promise<AnchorStatus> {
+  async requestAnchor(
+    streamId: string | StreamID,
+    opts: LoadOpts & AnchorOpts = {}
+  ): Promise<AnchorStatus> {
     opts = { ...DEFAULT_LOAD_OPTS, ...opts, ...this._loadOptsOverride }
     const effectiveStreamId = normalizeStreamID(streamId)
     const state = await this.repository.load(effectiveStreamId, opts)
-    await this.repository.stateManager.anchor(state)
+    await this.repository.stateManager.anchor(state, opts)
     return state.state.anchorStatus
   }
 

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -347,7 +347,7 @@ export class StateManager {
     const genesisCommit = carFile.get(genesisCID)
     await this._saveAnchorRequestForState(state$, genesisCommit)
 
-    const anchorStatus$ = await this.anchorService.requestAnchor(carFile, false)
+    const anchorStatus$ = await this.anchorService.requestAnchor(carFile, true) // todo: take arg further up
 
     return this._processAnchorResponse(state$, anchorStatus$)
   }

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -347,7 +347,7 @@ export class StateManager {
     const genesisCommit = carFile.get(genesisCID)
     await this._saveAnchorRequestForState(state$, genesisCommit)
 
-    const anchorStatus$ = this.anchorService.requestAnchor(carFile)
+    const anchorStatus$ = await this.anchorService.requestAnchor(carFile)
 
     return this._processAnchorResponse(state$, anchorStatus$)
   }

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -347,7 +347,7 @@ export class StateManager {
     const genesisCommit = carFile.get(genesisCID)
     await this._saveAnchorRequestForState(state$, genesisCommit)
 
-    const anchorStatus$ = await this.anchorService.requestAnchor(carFile)
+    const anchorStatus$ = await this.anchorService.requestAnchor(carFile, false)
 
     return this._processAnchorResponse(state$, anchorStatus$)
   }

--- a/packages/core/src/state-management/state-manager.ts
+++ b/packages/core/src/state-management/state-manager.ts
@@ -14,6 +14,7 @@ import {
   DiagnosticsLogger,
   StreamUtils,
   GenesisCommit,
+  AnchorOpts,
 } from '@ceramicnetwork/common'
 import { RunningState } from './running-state.js'
 import { CID } from 'multiformats/cid'
@@ -163,7 +164,7 @@ export class StateManager {
     const anchor = (opts as any).anchor
     const publish = (opts as any).publish
     if (anchor) {
-      await this.anchor(state$)
+      await this.anchor(state$, opts)
     }
     if (publish) {
       this.publishTip(state$)
@@ -334,7 +335,7 @@ export class StateManager {
   /**
    * Request anchor for the latest stream state
    */
-  async anchor(state$: RunningState): Promise<Subscription> {
+  async anchor(state$: RunningState, opts: AnchorOpts): Promise<Subscription> {
     if (!this.anchorService) {
       throw new Error(`Anchor requested for stream ${state$.id} but anchoring is disabled`)
     }
@@ -347,7 +348,10 @@ export class StateManager {
     const genesisCommit = carFile.get(genesisCID)
     await this._saveAnchorRequestForState(state$, genesisCommit)
 
-    const anchorStatus$ = await this.anchorService.requestAnchor(carFile, true) // todo: take arg further up
+    const anchorStatus$ = await this.anchorService.requestAnchor(
+      carFile,
+      opts.waitForAnchorConfirmation
+    )
 
     return this._processAnchorResponse(state$, anchorStatus$)
   }

--- a/packages/http-client/src/ceramic-http-client.ts
+++ b/packages/http-client/src/ceramic-http-client.ts
@@ -21,6 +21,7 @@ import {
   IndexApi,
   StreamState,
   AdminApi,
+  AnchorOpts,
 } from '@ceramicnetwork/common'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { Caip10Link } from '@ceramicnetwork/stream-caip10-link'
@@ -183,7 +184,10 @@ export class CeramicClient implements CeramicApi {
     return this.buildStreamFromDocument<T>(document)
   }
 
-  async requestAnchor(streamId: string | StreamID, opts: LoadOpts = {}): Promise<AnchorStatus> {
+  async requestAnchor(
+    streamId: string | StreamID,
+    opts: LoadOpts & AnchorOpts = {}
+  ): Promise<AnchorStatus> {
     opts = { ...DEFAULT_LOAD_OPTS, ...opts }
     const { anchorStatus } = await fetchJson(
       `${this._apiUrl}/streams/${streamId.toString()}/anchor`,


### PR DESCRIPTION
For now the flag is still false by default until we've tested it further, but the plan is to make it true by default in a later release.

This is also still missing the behavior where if the anchor fails the stream state is left unmodified as if the write never happened.  That requires some refactoring of the state manager and repository and will come in a future PR (test coverage will also come at that time as that will change behavior quite a bit).  But I wanted to get this in place first so we can test the latency implications.