### PR TITLE
feat(core, stream-tests): negated ors/ands and multiple keys/values with where filters

### DIFF
--- a/packages/core/src/indexing/__tests__/query-filter-converter.test.ts
+++ b/packages/core/src/indexing/__tests__/query-filter-converter.test.ts
@@ -98,6 +98,16 @@ describe('Should convert query filters', () => {
     expect(query).toEqual(
       `select '${DATA_FIELD}' from 'test' where (((cast(${DATA_FIELD}->>'a' as numeric)=1)) and (cast(stream_content->>'b' as numeric) in (2,3)))`
     )
+    const query = createQuery({
+      type: 'where',
+      value: {
+        b: { type: 'number', op: 'in', value: [2, 3] },
+        a: { type: 'number', op: '=', value: 1 },
+      },
+    })
+    expect(query).toEqual(
+      `select '${DATA_FIELD}' from 'test' where ((cast(stream_content->>'b' as numeric) in (2,3)) and ((cast(${DATA_FIELD}->>'a' as numeric)=1)))`
+    )
   })
   test('that are composed of and doc filters', () => {
     const query = createQuery({

--- a/packages/core/src/indexing/__tests__/query-filter-converter.test.ts
+++ b/packages/core/src/indexing/__tests__/query-filter-converter.test.ts
@@ -1,8 +1,7 @@
-import { jest } from '@jest/globals'
 import pkg from 'knex'
 const { knex } = pkg
 import { convertQueryFilter, DATA_FIELD } from '../query-filter-converter.js'
-import { QueryFilters } from '@ceramicnetwork/common'
+import { QueryFilters } from '../query-filter-parser.js'
 
 function createQuery(query: QueryFilters): string {
   const result = convertQueryFilter(query)
@@ -19,7 +18,7 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: [{ type: 'integer', op: '=', value: 1 }],
+        a: { type: 'number', op: '=', value: 1 },
       },
     })
 
@@ -31,7 +30,7 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: [{ type: 'number', op: '=', value: 1.2 }],
+        a: { type: 'number', op: '=', value: 1.2 },
       },
     })
 
@@ -43,7 +42,7 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: [{ type: 'string', op: 'in', value: ['a', 'b'] }],
+        a: { type: 'string', op: 'in', value: ['a', 'b'] },
       },
     })
 
@@ -55,7 +54,7 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: [{ type: 'integer', op: 'null', value: true }],
+        a: { type: 'number', op: 'null', value: true },
       },
     })
 
@@ -67,7 +66,7 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: [{ type: 'number', op: 'null', value: false }],
+        a: { type: 'number', op: 'null', value: false },
       },
     })
 
@@ -79,7 +78,7 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: [{ type: 'string', op: '=', value: 'test_str' }],
+        a: { type: 'string', op: '=', value: 'test_str' },
       },
     })
 
@@ -91,22 +90,47 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: [{ type: 'number', op: '=', value: 1 }],
-        b: [{ type: 'number', op: 'in', value: [2, 3] }],
+        a: { type: 'number', op: '=', value: 1 },
+        b: { type: 'number', op: 'in', value: [2, 3] },
       },
     })
     expect(query).toEqual(
-      `select '${DATA_FIELD}' from 'test' where (((cast(${DATA_FIELD}->>'a' as numeric)=1)) and (cast(stream_content->>'b' as numeric) in (2,3)))`
+      `select '${DATA_FIELD}' from 'test' where (((cast(${DATA_FIELD}->>'a' as numeric)=1)) and (cast(${DATA_FIELD}->>'b' as numeric) in (2,3)))`
     )
     const query2 = createQuery({
       type: 'where',
       value: {
-        b: [{ type: 'number', op: 'in', value: [2, 3] }],
-        a: [{ type: 'number', op: '=', value: 1 }],
+        b: { type: 'number', op: 'in', value: [2, 3] },
+        a: { type: 'number', op: '=', value: 1 },
       },
     })
     expect(query2).toEqual(
-      `select '${DATA_FIELD}' from 'test' where ((cast(stream_content->>'b' as numeric) in (2,3)) and ((cast(${DATA_FIELD}->>'a' as numeric)=1)))`
+      `select '${DATA_FIELD}' from 'test' where ((cast(${DATA_FIELD}->>'b' as numeric) in (2,3)) and ((cast(${DATA_FIELD}->>'a' as numeric)=1)))`
+    )
+  })
+  test('that are composed of a single doc filter with multiple values, negated', () => {
+    const query = createQuery({
+      type: 'not',
+      value: {
+        type: 'where',
+        value: {
+          a: { type: 'number', op: '=', value: 1 },
+          b: { type: 'number', op: 'in', value: [2, 3] },
+        },
+      },
+    })
+    expect(query).toEqual(
+      `select '${DATA_FIELD}' from 'test' where (not (((cast(${DATA_FIELD}->>'a' as numeric)=1)) and (cast(${DATA_FIELD}->>'b' as numeric) in (2,3))))`
+    )
+    const query2 = createQuery({
+      type: 'where',
+      value: {
+        b: { type: 'number', op: 'in', value: [2, 3] },
+        a: { type: 'number', op: '=', value: 1 },
+      },
+    })
+    expect(query2).toEqual(
+      `select '${DATA_FIELD}' from 'test' where ((cast(${DATA_FIELD}->>'b' as numeric) in (2,3)) and ((cast(${DATA_FIELD}->>'a' as numeric)=1)))`
     )
   })
   test('that are composed of and doc filters', () => {
@@ -116,19 +140,19 @@ describe('Should convert query filters', () => {
         {
           type: 'where',
           value: {
-            a: [{ type: 'number', op: '=', value: 1 }],
+            a: { type: 'number', op: '=', value: 1 },
           },
         },
         {
           type: 'where',
           value: {
-            b: [{ type: 'number', op: 'in', value: [2, 3] }],
+            b: { type: 'number', op: 'in', value: [2, 3] },
           },
         },
       ],
     })
     expect(query).toEqual(
-      `select '${DATA_FIELD}' from 'test' where ((((cast(${DATA_FIELD}->>'a' as numeric)=1))) and ((cast(stream_content->>'b' as numeric) in (2,3))))`
+      `select '${DATA_FIELD}' from 'test' where ((((cast(${DATA_FIELD}->>'a' as numeric)=1))) and ((cast(${DATA_FIELD}->>'b' as numeric) in (2,3))))`
     )
   })
   test('that are composed of or doc filters', () => {
@@ -138,19 +162,19 @@ describe('Should convert query filters', () => {
         {
           type: 'where',
           value: {
-            a: [{ type: 'number', op: '=', value: 1 }],
+            a: { type: 'number', op: '=', value: 1 },
           },
         },
         {
           type: 'where',
           value: {
-            b: [{ type: 'number', op: 'in', value: [2, 3] }],
+            b: { type: 'number', op: 'in', value: [2, 3] },
           },
         },
       ],
     })
     expect(query).toEqual(
-      `select '${DATA_FIELD}' from 'test' where ((((cast(${DATA_FIELD}->>'a' as numeric)=1))) or ((cast(stream_content->>'b' as numeric) in (2,3))))`
+      `select '${DATA_FIELD}' from 'test' where ((((cast(${DATA_FIELD}->>'a' as numeric)=1))) or ((cast(${DATA_FIELD}->>'b' as numeric) in (2,3))))`
     )
   })
   test('that are composed of or doc filters negated', () => {
@@ -162,46 +186,99 @@ describe('Should convert query filters', () => {
           {
             type: 'where',
             value: {
-              a: [{ type: 'number', op: '=', value: 1 }],
+              a: { type: 'number', op: '=', value: 1 },
             },
           },
           {
             type: 'where',
             value: {
-              b: [{ type: 'number', op: 'in', value: [2, 3] }],
+              b: { type: 'number', op: 'in', value: [2, 3] },
             },
           },
         ],
       },
     })
     expect(query).toEqual(
-      `select '${DATA_FIELD}' from 'test' where ((not ((cast(${DATA_FIELD}->>'a' as numeric)=1))) or ((cast(stream_content->>'b' as numeric) not in (2,3))))`
+      `select '${DATA_FIELD}' from 'test' where (not ((((cast(${DATA_FIELD}->>'a' as numeric)=1))) or ((cast(${DATA_FIELD}->>'b' as numeric) in (2,3)))))`
     )
   })
-  test('STEPH', () => {
+  test('that are composed of and doc filters negated', () => {
     const query = createQuery({
-      type: 'or',
-      value: [
-        {
-          type: 'where',
-          value: {
-            a: [
-              { type: 'number', op: '>=', value: 3 },
-              { type: 'number', op: '<=', value: 5 },
-            ],
-            b: [{ type: 'number', op: 'in', value: [2, 3] }],
+      type: 'not',
+      value: {
+        type: 'and',
+        value: [
+          {
+            type: 'where',
+            value: {
+              a: { type: 'number', op: '=', value: 1 },
+            },
           },
-        },
-        {
-          type: 'where',
-          value: {
-            b: [{ type: 'number', op: 'in', value: [2, 3] }],
+          {
+            type: 'where',
+            value: {
+              b: { type: 'number', op: 'in', value: [2, 3] },
+            },
           },
-        },
-      ],
+        ],
+      },
     })
     expect(query).toEqual(
-      `select '${DATA_FIELD}' from 'test' where ((((cast(${DATA_FIELD}->>'a' as numeric)>=3)) and ((cast(${DATA_FIELD}->>'a' as numeric)<=5)) or (cast(${DATA_FIELD}->>'b' as numeric) in (2,3))) or ((cast(${DATA_FIELD}->>'b' as numeric) in (2,3))))`
+      `select '${DATA_FIELD}' from 'test' where (not ((((cast(${DATA_FIELD}->>'a' as numeric)=1))) and ((cast(${DATA_FIELD}->>'b' as numeric) in (2,3)))))`
+    )
+  })
+  test('that are composed of or doc filters that have multiple values, negated', () => {
+    const query = createQuery({
+      type: 'not',
+      value: {
+        type: 'or',
+        value: [
+          {
+            type: 'where',
+            value: {
+              a: { type: 'number', op: '=', value: 1 },
+              b: { type: 'number', op: 'in', value: [2, 3] },
+            },
+          },
+          {
+            type: 'where',
+            value: {
+              c: { type: 'number', op: '<=', value: 6 },
+              d: { type: 'number', op: 'null', value: true },
+            },
+          },
+        ],
+      },
+    })
+    expect(query).toEqual(
+      `select '${DATA_FIELD}' from 'test' where (not ((((cast(${DATA_FIELD}->>'a' as numeric)=1)) and (cast(${DATA_FIELD}->>'b' as numeric) in (2,3))) or (((cast(${DATA_FIELD}->>'c' as numeric)<=6)) and ((${DATA_FIELD}->>'d' is null)))))`
+    )
+  })
+  test('that are composed of and doc filters that have multiple values, negated', () => {
+    const query = createQuery({
+      type: 'not',
+      value: {
+        type: 'and',
+        value: [
+          {
+            type: 'where',
+            value: {
+              a: { type: 'number', op: '=', value: 1 },
+              b: { type: 'number', op: 'in', value: [2, 3] },
+            },
+          },
+          {
+            type: 'where',
+            value: {
+              c: { type: 'number', op: '<=', value: 6 },
+              d: { type: 'number', op: 'null', value: true },
+            },
+          },
+        ],
+      },
+    })
+    expect(query).toEqual(
+      `select '${DATA_FIELD}' from 'test' where (not ((((cast(${DATA_FIELD}->>'a' as numeric)=1)) and (cast(${DATA_FIELD}->>'b' as numeric) in (2,3))) and (((cast(${DATA_FIELD}->>'c' as numeric)<=6)) and ((${DATA_FIELD}->>'d' is null)))))`
     )
   })
 })

--- a/packages/core/src/indexing/__tests__/query-filter-converter.test.ts
+++ b/packages/core/src/indexing/__tests__/query-filter-converter.test.ts
@@ -19,7 +19,7 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: { type: 'integer', op: '=', value: 1 },
+        a: [{ type: 'integer', op: '=', value: 1 }],
       },
     })
 
@@ -31,7 +31,7 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: { type: 'number', op: '=', value: 1.2 },
+        a: [{ type: 'number', op: '=', value: 1.2 }],
       },
     })
 
@@ -43,7 +43,7 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: { type: 'string', op: 'in', value: ['a', 'b'] },
+        a: [{ type: 'string', op: 'in', value: ['a', 'b'] }],
       },
     })
 
@@ -55,7 +55,7 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: { type: 'integer', op: 'null', value: true },
+        a: [{ type: 'integer', op: 'null', value: true }],
       },
     })
 
@@ -67,7 +67,7 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: { type: 'number', op: 'null', value: false },
+        a: [{ type: 'number', op: 'null', value: false }],
       },
     })
 
@@ -79,7 +79,7 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: { type: 'string', op: '=', value: 'test_str' },
+        a: [{ type: 'string', op: '=', value: 'test_str' }],
       },
     })
 
@@ -91,21 +91,21 @@ describe('Should convert query filters', () => {
     const query = createQuery({
       type: 'where',
       value: {
-        a: { type: 'number', op: '=', value: 1 },
-        b: { type: 'number', op: 'in', value: [2, 3] },
+        a: [{ type: 'number', op: '=', value: 1 }],
+        b: [{ type: 'number', op: 'in', value: [2, 3] }],
       },
     })
     expect(query).toEqual(
       `select '${DATA_FIELD}' from 'test' where (((cast(${DATA_FIELD}->>'a' as numeric)=1)) and (cast(stream_content->>'b' as numeric) in (2,3)))`
     )
-    const query = createQuery({
+    const query2 = createQuery({
       type: 'where',
       value: {
-        b: { type: 'number', op: 'in', value: [2, 3] },
-        a: { type: 'number', op: '=', value: 1 },
+        b: [{ type: 'number', op: 'in', value: [2, 3] }],
+        a: [{ type: 'number', op: '=', value: 1 }],
       },
     })
-    expect(query).toEqual(
+    expect(query2).toEqual(
       `select '${DATA_FIELD}' from 'test' where ((cast(stream_content->>'b' as numeric) in (2,3)) and ((cast(${DATA_FIELD}->>'a' as numeric)=1)))`
     )
   })
@@ -116,13 +116,13 @@ describe('Should convert query filters', () => {
         {
           type: 'where',
           value: {
-            a: { type: 'number', op: '=', value: 1 },
+            a: [{ type: 'number', op: '=', value: 1 }],
           },
         },
         {
           type: 'where',
           value: {
-            b: { type: 'number', op: 'in', value: [2, 3] },
+            b: [{ type: 'number', op: 'in', value: [2, 3] }],
           },
         },
       ],
@@ -138,13 +138,13 @@ describe('Should convert query filters', () => {
         {
           type: 'where',
           value: {
-            a: { type: 'number', op: '=', value: 1 },
+            a: [{ type: 'number', op: '=', value: 1 }],
           },
         },
         {
           type: 'where',
           value: {
-            b: { type: 'number', op: 'in', value: [2, 3] },
+            b: [{ type: 'number', op: 'in', value: [2, 3] }],
           },
         },
       ],
@@ -162,13 +162,13 @@ describe('Should convert query filters', () => {
           {
             type: 'where',
             value: {
-              a: { type: 'number', op: '=', value: 1 },
+              a: [{ type: 'number', op: '=', value: 1 }],
             },
           },
           {
             type: 'where',
             value: {
-              b: { type: 'number', op: 'in', value: [2, 3] },
+              b: [{ type: 'number', op: 'in', value: [2, 3] }],
             },
           },
         ],
@@ -176,6 +176,32 @@ describe('Should convert query filters', () => {
     })
     expect(query).toEqual(
       `select '${DATA_FIELD}' from 'test' where ((not ((cast(${DATA_FIELD}->>'a' as numeric)=1))) or ((cast(stream_content->>'b' as numeric) not in (2,3))))`
+    )
+  })
+  test('STEPH', () => {
+    const query = createQuery({
+      type: 'or',
+      value: [
+        {
+          type: 'where',
+          value: {
+            a: [
+              { type: 'number', op: '>=', value: 3 },
+              { type: 'number', op: '<=', value: 5 },
+            ],
+            b: [{ type: 'number', op: 'in', value: [2, 3] }],
+          },
+        },
+        {
+          type: 'where',
+          value: {
+            b: [{ type: 'number', op: 'in', value: [2, 3] }],
+          },
+        },
+      ],
+    })
+    expect(query).toEqual(
+      `select '${DATA_FIELD}' from 'test' where ((((cast(${DATA_FIELD}->>'a' as numeric)>=3)) and ((cast(${DATA_FIELD}->>'a' as numeric)<=5)) or (cast(${DATA_FIELD}->>'b' as numeric) in (2,3))) or ((cast(${DATA_FIELD}->>'b' as numeric) in (2,3))))`
     )
   })
 })

--- a/packages/core/src/indexing/__tests__/query-filter-parser.test.ts
+++ b/packages/core/src/indexing/__tests__/query-filter-parser.test.ts
@@ -1,4 +1,3 @@
-import { jest } from '@jest/globals'
 import { parseQueryFilters } from '../query-filter-parser.js'
 
 describe('Should parse query filters', () => {
@@ -76,5 +75,234 @@ describe('Should parse query filters', () => {
         { type: 'where', value: { b: { type: 'string', op: '!=', value: '10' } } },
       ],
     })
+  })
+  test('that are composed of an or query', () => {
+    const parsed = parseQueryFilters({
+      or: [
+        {
+          where: {
+            a: { equalTo: 5 },
+          },
+        },
+        {
+          where: {
+            b: { notEqualTo: '10' },
+          },
+        },
+      ],
+    })
+    expect(parsed).toEqual({
+      type: 'or',
+      value: [
+        { type: 'where', value: { a: { type: 'number', op: '=', value: 5 } } },
+        { type: 'where', value: { b: { type: 'string', op: '!=', value: '10' } } },
+      ],
+    })
+  })
+  test('that are composed of a where query with multiple conditions per key', () => {
+    const parsed = parseQueryFilters({
+      where: {
+        a: { lessThan: 23, greaterThanOrEqualTo: 4 },
+      },
+    })
+    expect(parsed).toEqual({
+      type: 'and',
+      value: [
+        {
+          type: 'where',
+          value: {
+            a: { type: 'number', op: '>=', value: 4 },
+          },
+        },
+        {
+          type: 'where',
+          value: {
+            a: { type: 'number', op: '<', value: 23 },
+          },
+        },
+      ],
+    })
+  })
+  test('that are composed of a or query where with multiple condition/key pairs', () => {
+    const parsed = parseQueryFilters({
+      where: {
+        a: { equalTo: 5 },
+        b: { lessThanOrEqualTo: 22 },
+      },
+    })
+    expect(parsed).toEqual({
+      type: 'and',
+      value: [
+        {
+          type: 'where',
+          value: {
+            a: { type: 'number', op: '=', value: 5 },
+          },
+        },
+        {
+          type: 'where',
+          value: {
+            b: { type: 'number', op: '<=', value: 22 },
+          },
+        },
+      ],
+    })
+  })
+  test('that are composed of an or query containing where queries multiple condition/key pairs', () => {
+    const parsed = parseQueryFilters({
+      or: [
+        {
+          where: {
+            a: { equalTo: 5 },
+            b: { isNull: true },
+          },
+        },
+        {
+          where: {
+            c: { notEqualTo: '10' },
+          },
+        },
+      ],
+    })
+    expect(parsed).toEqual({
+      type: 'or',
+      value: [
+        {
+          type: 'and',
+          value: [
+            {
+              type: 'where',
+              value: {
+                a: { type: 'number', op: '=', value: 5 },
+              },
+            },
+            {
+              type: 'where',
+              value: {
+                b: { type: 'boolean', op: 'null', value: true },
+              },
+            },
+          ],
+        },
+        {
+          type: 'where',
+          value: {
+            c: { type: 'string', op: '!=', value: '10' },
+          },
+        },
+      ],
+    })
+  })
+  test('that are composed of an or query containing where queries multiple condition/key pairs, negated', () => {
+    const parsed = parseQueryFilters({
+      not: {
+        and: [
+          {
+            where: {
+              c: { notEqualTo: '10' },
+            },
+          },
+          {
+            where: {
+              a: { equalTo: 5 },
+              b: { isNull: true },
+            },
+          },
+        ],
+      },
+    })
+    expect(parsed).toEqual({
+      type: 'not',
+      value: {
+        type: 'and',
+        value: [
+          {
+            type: 'where',
+            value: {
+              c: { type: 'string', op: '!=', value: '10' },
+            },
+          },
+          {
+            type: 'and',
+            value: [
+              {
+                type: 'where',
+                value: {
+                  a: { type: 'number', op: '=', value: 5 },
+                },
+              },
+              {
+                type: 'where',
+                value: {
+                  b: { type: 'boolean', op: 'null', value: true },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+})
+
+describe('Should fail to parse queries', () => {
+  test('that are composed of a where query with multiple incompatible ops to combine', () => {
+    expect(() =>
+      parseQueryFilters({
+        where: {
+          a: { in: [5], greaterThan: 10 },
+        },
+      })
+    ).toThrow(/Can only combine value filters representing valid range boundaries/)
+  })
+  test('that are composed of a where query with too many ops to combine', () => {
+    expect(() =>
+      parseQueryFilters({
+        where: {
+          a: { notIn: [3], greaterThan: 2, lessThan: 11 },
+        },
+      })
+    ).toThrow(/Cannot combine more than 2 value filters/)
+  })
+  test('that provides an unknown query', () => {
+    expect(() =>
+      parseQueryFilters({
+        what: {
+          a: { notIn: [3], greaterThan: 2, lessThan: 11 },
+        },
+      } as any)
+    ).toThrow(/Invalid query/)
+  })
+  test('that provides an unknown op', () => {
+    expect(() =>
+      parseQueryFilters({
+        where: {
+          a: { cheese: [3] },
+        },
+      } as any)
+    ).toThrow(/Invalid op/)
+  })
+  test('has multiple filters at the same level', () => {
+    expect(() =>
+      parseQueryFilters({
+        and: [
+          {
+            where: {
+              a: { equalTo: 5 },
+            },
+          },
+          {
+            where: {
+              b: { notEqualTo: '10' },
+            },
+          },
+        ],
+        not: {
+          where: {
+            c: { equalTo: 2 },
+          },
+        },
+      })
+    ).toThrow(/Only one of where, and, or, and not can be used per query filter level/)
   })
 })

--- a/packages/core/src/indexing/query-filter-converter.ts
+++ b/packages/core/src/indexing/query-filter-converter.ts
@@ -45,14 +45,10 @@ function handleQuery(
   const opFunc = (bldr) => {
     if (first) {
       return bldr.where(func)
-    } else if (combinator) {
-      if (combinator == Combinator.Or) {
-        return bldr.orWhere(func)
-      } else {
-        return bldr.andWhere(func)
-      }
+    } else if (combinator && combinator == Combinator.Or) {
+      return bldr.orWhere(func)
     } else {
-      throw new Error('Combinator called without operand')
+      return bldr.andWhere(func)
     }
   }
   if (negated) {
@@ -114,13 +110,19 @@ function handleIn<T extends number | string>(
 }
 
 function handleWhereQuery(state: ConversionState<ObjectFilter>): ConvertedQueryFilter {
+  console.log(
+    '🚀 ~ file: query-filter-converter.ts:118 ~ handleWhereQuery ~ state:',
+    JSON.stringify(state, null, 3)
+  )
   let first = true
   let where = (bldr) => bldr
   const select = []
   for (const filterKey in state.filter) {
     select.push(filterKey)
     const value = state.filter[filterKey]
+    console.log('🚀 ~ file: query-filter-converter.ts:128 ~ handleWhereQuery ~ value:', value)
     const key = contentKey(filterKey)
+    console.log('🚀 ~ file: query-filter-converter.ts:130 ~ handleWhereQuery ~ key:', key)
 
     switch (value.op) {
       case 'null': {
@@ -223,6 +225,10 @@ function handleCombinator(state: ConversionState<QueryFilters>): ConvertedQueryF
 }
 
 function convert(state: ConversionState<QueryFilters>): ConvertedQueryFilter {
+  console.log(
+    '🚀 ~ file: query-filter-converter.ts:226 ~ convert ~ state:',
+    JSON.stringify(state, null, 3)
+  )
   switch (state.filter.type) {
     case 'where': {
       const filter = state.filter.value as ObjectFilter

--- a/packages/core/src/indexing/query-filter-parser.ts
+++ b/packages/core/src/indexing/query-filter-parser.ts
@@ -1,6 +1,7 @@
 import {
   QueryFilters as ApiQueryFilters,
   ObjectFilter as ApiObjectFilter,
+  NonEmptyArray,
 } from '@ceramicnetwork/common'
 
 export type NonBooleanValueFilterType = 'number' | 'string'
@@ -20,10 +21,12 @@ export type NonBooleanValueFilter<T extends number | string = number | string> =
 
 export type AllValueFilter = ValueFilter | NonBooleanValueFilter
 
+type ParsedObjectFilter = Record<string, NonEmptyArray<AllValueFilter>>
+
 /**
  * Mapping of object keys to value filter
  */
-export type ObjectFilter = Record<string, AllValueFilter[]>
+export type ObjectFilter = Record<string, AllValueFilter>
 
 /**
  * Advanced query filters on a document fields
@@ -58,20 +61,19 @@ function validateCombinedOps(ops: string[]): void {
   }
 
   if (ops.length > 2) {
-    throw Error('Cannot have more than one value filter')
+    throw new Error('Cannot combine more than 2 value filters')
   }
 
   ops.sort()
 
   if (!ops[0].startsWith('greaterThan') || !ops[1].startsWith('lessThan')) {
-    throw Error(
+    throw new Error(
       'Can only combine value filters representing valid range boundaries ex. greaterThan[orEqualto] and lessThan[orEqualTo]'
     )
   }
 }
 
-export function parseObjectFilter(filter: ApiObjectFilter): ObjectFilter {
-  // have entries be an array of values do validation ehre
+export function parseObjectFilter(filter: ApiObjectFilter): ParsedObjectFilter {
   const entries: Record<string, AllValueFilter[]> = {}
   const keys = Object.keys(filter)
   for (const key of keys) {
@@ -153,25 +155,50 @@ export function parseObjectFilter(filter: ApiObjectFilter): ObjectFilter {
           value: value,
         })
       } else {
-        throw new Error('what dis')
+        throw new Error(`Invalid op ${childKey}`)
       }
     }
   }
-  return entries
+  return entries as ParsedObjectFilter
 }
 
 export function parseQueryFilters(filter: ApiQueryFilters): QueryFilters {
   const keys = Object.keys(filter)
   if (keys.length > 1) {
-    throw Error('Only one of where, and, or, and not can be used per query filter level')
+    throw new Error('Only one of where, and, or, and not can be used per query filter level')
   }
 
   if ('where' in filter) {
     const value = parseObjectFilter(filter.where as ApiObjectFilter)
-    return {
-      type: 'where',
-      value,
+
+    // if there are multiple keys, combine them via "and"
+    const childWhereValues: Array<QueryFilters> = Object.entries(value).map(
+      ([childKey, childValue]) => {
+        // if there are multiple entries per key, combine them via "and"
+        if (childValue.length > 1) {
+          return {
+            type: 'and',
+            value: childValue.map((subChildValue) => ({
+              type: 'where',
+              value: { [childKey]: subChildValue },
+            })),
+          }
+        }
+        return {
+          type: 'where',
+          value: { [childKey]: childValue[0] },
+        }
+      }
+    )
+
+    if (childWhereValues.length > 1) {
+      return {
+        type: 'and',
+        value: childWhereValues,
+      }
     }
+
+    return childWhereValues[0]
   } else if ('and' in filter) {
     const value = filter.and.map(parseQueryFilters)
     return {
@@ -192,5 +219,5 @@ export function parseQueryFilters(filter: ApiQueryFilters): QueryFilters {
     }
   }
 
-  throw Error(`Invalid query filter provided: ${keys[0]}`)
+  throw new Error(`Invalid query: ${keys[0]}`)
 }

--- a/packages/stream-tests/src/__tests__/basic-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/basic-indexing.test.ts
@@ -86,17 +86,20 @@ const MODEL_WITH_RELATION_DEFINITION: ModelDefinition = {
   relations: { linkedDoc: { type: 'document', model: MODEL_STREAM_ID } },
 }
 
-const extractStreamStates = function (page: Page<StreamState>): Array<StreamState> {
+const extractStreamStates = function (page: Page<StreamState | null>): Array<StreamState | null> {
   return page.edges.map((edge) => edge.node)
 }
 
 const extractDocuments = function (
   ceramic: CeramicClient,
-  page: Page<StreamState>
+  page: Page<StreamState | null>
 ): Array<ModelInstanceDocument> {
-  return extractStreamStates(page).map((state) =>
-    ceramic.buildStreamFromState<ModelInstanceDocument>(state)
-  )
+  return extractStreamStates(page).map((state) => {
+    if (state === null) {
+      throw new Error('Null extracted stream state found')
+    }
+    return ceramic.buildStreamFromState<ModelInstanceDocument>(state)
+  })
 }
 
 enum DBEngine {
@@ -127,7 +130,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
   let midMetadata: ModelInstanceDocumentMetadataArgs
   let modelWithRelation: Model
   let midRelationMetadata: ModelInstanceDocumentMetadataArgs
-  let dbConnection: Knex = null
+  let dbConnection: Knex
 
   async function dropKnexTables() {
     await dbConnection.schema.dropTableIfExists(INDEXED_MODEL_CONFIG_TABLE_NAME)
@@ -188,7 +191,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
         break
       }
       case DBEngine.postgres:
-        dbURL = process.env.DATABASE_URL
+        dbURL = process.env.DATABASE_URL || ''
         dbConnection = knex({
           client: 'pg',
           connection: process.env.DATABASE_URL,
@@ -579,7 +582,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       expect(results.length).toEqual(1)
       expect(JSON.stringify(results[0].content)).toEqual(JSON.stringify(doc4.content))
     })
-    test('Can query a document with filter with multiple values', async () => {
+    test('Can query a document with a filter containing multiple key/values', async () => {
       await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
       await ModelInstanceDocument.create(ceramic, CONTENT1, midMetadata)
       await ModelInstanceDocument.create(ceramic, CONTENT3, midMetadata)
@@ -699,6 +702,150 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
           },
         })
       ).rejects.toThrow(/Can only combine value filters representing valid range boundaries/)
+    })
+    test('Can query multiple documents with negated or field', async () => {
+      const doc1 = await ModelInstanceDocument.create(ceramic, CONTENT1, midMetadata)
+      const doc2 = await ModelInstanceDocument.create(ceramic, CONTENT2, midMetadata)
+      const doc3 = await ModelInstanceDocument.create(ceramic, CONTENT3, midMetadata)
+      const doc4 = await ModelInstanceDocument.create(ceramic, CONTENT4, midMetadata)
+      const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
+      const doc6 = await ModelInstanceDocument.create(ceramic, CONTENT6, midMetadata)
+
+      const resultObj0 = await ceramic.index.query({
+        model: model.id,
+        last: 5,
+        queryFilters: {
+          not: {
+            or: [{ where: { myData: { equalTo: 3 } } }, { where: { myString: { equalTo: 'b' } } }],
+          },
+        },
+      })
+
+      const results = extractDocuments(ceramic, resultObj0)
+      expect(results.length).toEqual(2)
+      expect(JSON.stringify(results[0].content)).toEqual(JSON.stringify(doc1.content))
+      expect(JSON.stringify(results[1].content)).toEqual(JSON.stringify(doc5.content))
+    })
+
+    test('Can query multiple documents with negated and field', async () => {
+      const doc3 = await ModelInstanceDocument.create(ceramic, CONTENT3, midMetadata)
+      const doc4 = await ModelInstanceDocument.create(ceramic, CONTENT4, midMetadata)
+      const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
+      const doc6 = await ModelInstanceDocument.create(ceramic, CONTENT6, midMetadata)
+
+      const resultObj0 = await ceramic.index.query({
+        model: model.id,
+        last: 5,
+        queryFilters: {
+          not: {
+            and: [{ where: { myData: { equalTo: 3 } } }, { where: { myString: { equalTo: 'b' } } }],
+          },
+        },
+      })
+
+      const results = extractDocuments(ceramic, resultObj0)
+      for (const result of results) {
+        console.log(result.content)
+      }
+      expect(results.length).toEqual(3)
+      expect(JSON.stringify(results[0].content)).toEqual(JSON.stringify(doc4.content))
+      expect(JSON.stringify(results[1].content)).toEqual(JSON.stringify(doc5.content))
+      expect(JSON.stringify(results[2].content)).toEqual(JSON.stringify(doc6.content))
+    })
+    test('Can query multiple documents with multiple key values and valid boundaries, negated', async () => {
+      const doc1 = await ModelInstanceDocument.create(ceramic, CONTENT1, midMetadata)
+      const doc3 = await ModelInstanceDocument.create(ceramic, CONTENT3, midMetadata)
+      const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
+
+      const resultObj0 = await ceramic.index.query({
+        model: model.id,
+        last: 5,
+        queryFilters: {
+          not: {
+            where: {
+              myData: { in: [1, 3] },
+              myString: { equalTo: 'b' },
+            },
+          },
+        },
+      })
+
+      const results = extractDocuments(ceramic, resultObj0)
+      expect(results.length).toEqual(2)
+      expect(JSON.stringify(results[0].content)).toEqual(JSON.stringify(doc1.content))
+      expect(JSON.stringify(results[1].content)).toEqual(JSON.stringify(doc5.content))
+    })
+    test('Can query documents using a complex negated or filter', async () => {
+      const doc0 = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
+      const doc1 = await ModelInstanceDocument.create(ceramic, CONTENT1, midMetadata)
+      const doc2 = await ModelInstanceDocument.create(ceramic, CONTENT2, midMetadata)
+      const doc3 = await ModelInstanceDocument.create(ceramic, CONTENT3, midMetadata)
+      const doc4 = await ModelInstanceDocument.create(ceramic, CONTENT4, midMetadata)
+      const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
+      const doc6 = await ModelInstanceDocument.create(ceramic, CONTENT6, midMetadata)
+
+      const resultObj0 = await ceramic.index.query({
+        model: model.id,
+        last: 5,
+        queryFilters: {
+          or: [
+            {
+              not: {
+                where: {
+                  myData: { greaterThanOrEqualTo: 0, lessThan: 5 },
+                },
+              },
+            },
+            {
+              where: {
+                myData: { equalTo: 1 },
+                myString: { equalTo: 'a' },
+              },
+            },
+          ],
+        },
+      })
+
+      const results = extractDocuments(ceramic, resultObj0)
+      expect(results.length).toEqual(3)
+      expect(JSON.stringify(results[0].content)).toEqual(JSON.stringify(doc1.content))
+      expect(JSON.stringify(results[1].content)).toEqual(JSON.stringify(doc5.content))
+      expect(JSON.stringify(results[2].content)).toEqual(JSON.stringify(doc6.content))
+    })
+    test('Can query documents using a complex negated and filter', async () => {
+      const doc0 = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
+      const doc1 = await ModelInstanceDocument.create(ceramic, CONTENT1, midMetadata)
+      const doc2 = await ModelInstanceDocument.create(ceramic, CONTENT2, midMetadata)
+      const doc3 = await ModelInstanceDocument.create(ceramic, CONTENT3, midMetadata)
+      const doc4 = await ModelInstanceDocument.create(ceramic, CONTENT4, midMetadata)
+      const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
+      const doc6 = await ModelInstanceDocument.create(ceramic, CONTENT6, midMetadata)
+
+      const resultObj0 = await ceramic.index.query({
+        model: model.id,
+        last: 5,
+        queryFilters: {
+          and: [
+            {
+              not: {
+                where: {
+                  myData: { greaterThan: 4, lessThanOrEqualTo: 6 },
+                },
+              },
+            },
+            {
+              where: {
+                myString: { isNull: true },
+                myFloat: { equalTo: 1.0 },
+              },
+            },
+          ],
+        },
+      })
+
+      const results = extractDocuments(ceramic, resultObj0)
+      expect(results.length).toEqual(1)
+      expect(JSON.stringify(results[0].content)).toEqual(JSON.stringify(doc2.content))
     })
   })
 

--- a/packages/stream-tests/src/__tests__/basic-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/basic-indexing.test.ts
@@ -744,9 +744,6 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       })
 
       const results = extractDocuments(ceramic, resultObj0)
-      for (const result of results) {
-        console.log(result.content)
-      }
       expect(results.length).toEqual(3)
       expect(JSON.stringify(results[0].content)).toEqual(JSON.stringify(doc4.content))
       expect(JSON.stringify(results[1].content)).toEqual(JSON.stringify(doc5.content))


### PR DESCRIPTION
Added a bunch of tests
not(a & b)  and not a || b) fixed 
multiple keys/values with where filters

changed the approach if you looked at this branch before