### PR TITLE
chore: drop signature verification for in-memory-anchor-service

### DIFF
--- a/packages/core/src/__tests__/caip10-link.test.ts
+++ b/packages/core/src/__tests__/caip10-link.test.ts
@@ -62,7 +62,6 @@ describe('Ceramic API', () => {
       ceramic = await createCeramic(ipfs, {
         stateStoreDirectory: tmpFolder.path,
         anchorOnRequest: false,
-        verifySignatures: false,
       })
       authProvider = { createLink: jest.fn() }
     })


### PR DESCRIPTION
We do not use it anywhere, and it does not conform to what real CAS does.