### PR TITLE
feat: Add StreamUpdater to handle applying incoming commits

### DIFF
--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -30,6 +30,7 @@ import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
 import { RepositoryInternals } from './repository-internals.js'
 import { StreamLoader } from '../stream-loading/stream-loader.js'
 import { OperationType } from './operation-type.js'
+import { StreamUpdater } from '../stream-loading/stream-updater.js'
 
 const CACHE_EVICTED_MEMORY = 'cache_eviction_memory'
 
@@ -44,6 +45,7 @@ export type RepositoryDependencies = {
   conflictResolution: ConflictResolution
   indexing: LocalIndexApi
   streamLoader: StreamLoader
+  streamUpdater: StreamUpdater
 }
 
 /**

--- a/packages/core/src/stream-loading/apply-tip-helper.ts
+++ b/packages/core/src/stream-loading/apply-tip-helper.ts
@@ -1,0 +1,35 @@
+import { LogSyncer } from './log-syncer.js'
+import { ApplyLogToStateOpts, StateManipulator } from './state-manipulator.js'
+import { AnchorTimestampExtractor } from './anchor-timestamp-extractor.js'
+import { StreamState, StreamUtils } from '@ceramicnetwork/common'
+import { CID } from 'multiformats/cid'
+
+/**
+ * Helper function for taking a StreamState and a tip CID and returning the new StreamState that
+ * results from applying that tip to the state.
+ * @param logSyncer
+ * @param anchorTimestampExtractor
+ * @param stateManipulator
+ * @param state
+ * @param tip
+ * @param opts
+ */
+export async function applyTipToState(
+  logSyncer: LogSyncer,
+  anchorTimestampExtractor: AnchorTimestampExtractor,
+  stateManipulator: StateManipulator,
+  state: StreamState,
+  tip: CID,
+  opts: ApplyLogToStateOpts
+): Promise<StreamState> {
+  const streamID = StreamUtils.streamIdFromState(state)
+  const logWithoutTimestamps = await logSyncer.syncLogUntilMatch(
+    streamID,
+    tip,
+    state.log.map((logEntry) => logEntry.cid)
+  )
+  const logWithTimestamps = await anchorTimestampExtractor.verifyAnchorAndApplyTimestamps(
+    logWithoutTimestamps
+  )
+  return stateManipulator.applyLogToState(state, logWithTimestamps, opts)
+}

--- a/packages/core/src/stream-loading/stream-updater.ts
+++ b/packages/core/src/stream-loading/stream-updater.ts
@@ -25,7 +25,10 @@ export class StreamUpdater {
   ) {}
 
   /**
-   *
+   * Applies a tip that was learned about via the p2p network (ie from pubsub, ReCon, HDS, etc) to
+   * the given StreamState.  Because it came from the network, we cannot trust that the tip is
+   * actually a valid tip for the stream.  If it is not, we just return the same StreamState
+   * unmodified.
    * @param state
    * @param tip
    */
@@ -44,6 +47,15 @@ export class StreamUpdater {
     )
   }
 
+  /**
+   * Apply a commit that came in from an active application request via the HTTP client. Because
+   * this write comes in from an active application session, we apply stricter rules to it and
+   * throw errors in cases that might indicate an application bug - for instance if the write
+   * is built on stale state in the client relative to what the server knows is the most current
+   * state for the Stream.
+   * @param state
+   * @param commit
+   */
   async applyCommitFromUser(state: StreamState, commit: CeramicCommit): Promise<StreamState> {
     const tip = await this.commitStorer.storeCommit(commit, StreamUtils.streamIdFromState(state))
 

--- a/packages/core/src/stream-loading/stream-updater.ts
+++ b/packages/core/src/stream-loading/stream-updater.ts
@@ -1,0 +1,63 @@
+import { LogSyncer } from './log-syncer.js'
+import { StateManipulator } from './state-manipulator.js'
+import { AnchorTimestampExtractor } from './anchor-timestamp-extractor.js'
+import { CeramicCommit, DiagnosticsLogger, StreamState, StreamUtils } from '@ceramicnetwork/common'
+import { StreamID } from '@ceramicnetwork/streamid'
+import { CID } from 'multiformats/cid'
+import { applyTipToState } from './apply-tip-helper.js'
+
+interface CommitStorer {
+  storeCommit(data: any, streamId?: StreamID): Promise<CID>
+}
+
+/**
+ * Class to contain all the logic for updating new commits to a stream.  It notably however does not
+ * manage the persistence of the state information, nor updating the cache or indexing. It is
+ * purely stateless.
+ */
+export class StreamUpdater {
+  constructor(
+    private readonly logger: DiagnosticsLogger,
+    private readonly commitStorer: CommitStorer,
+    private readonly logSyncer: LogSyncer,
+    private readonly anchorTimestampExtractor: AnchorTimestampExtractor,
+    private readonly stateManipulator: StateManipulator
+  ) {}
+
+  /**
+   *
+   * @param state
+   * @param tip
+   */
+  async applyTipFromNetwork(state: StreamState, tip: CID): Promise<StreamState> {
+    return applyTipToState(
+      this.logSyncer,
+      this.anchorTimestampExtractor,
+      this.stateManipulator,
+      state,
+      tip,
+      {
+        throwOnInvalidCommit: false,
+        throwIfStale: false,
+        throwOnConflict: false,
+      }
+    )
+  }
+
+  async applyCommitFromUser(state: StreamState, commit: CeramicCommit): Promise<StreamState> {
+    const tip = await this.commitStorer.storeCommit(commit, StreamUtils.streamIdFromState(state))
+
+    return applyTipToState(
+      this.logSyncer,
+      this.anchorTimestampExtractor,
+      this.stateManipulator,
+      state,
+      tip,
+      {
+        throwOnInvalidCommit: true,
+        throwIfStale: true,
+        throwOnConflict: true,
+      }
+    )
+  }
+}


### PR DESCRIPTION
Only the `StreamLoader` and `StreamUpdater` should be used by the `Repository`, all the components that make them up should be considered private implementation details (this will be enforced in CDB-2749).  The public methods of `StreamLoader` and `StreamUpdater` are the API presented to the `Repository` for handling all Stream operations.  In turn, nothing outside of the Repository should access the `StreamLoader` or `StreamUpdater` - the `Repository` should be the interface to all Stream operations performed by any other part of the codebase.  The Repository will be responsible for handling concurrency control (the loading and execution queues) as well as pinning, indexing, publishing tips to pubsub, etc.