### PR TITLE
chore: Rewrite tests of how sync waits for responses

### DIFF
--- a/packages/core/src/__tests__/ceramic-query-response.test.ts
+++ b/packages/core/src/__tests__/ceramic-query-response.test.ts
@@ -1,0 +1,190 @@
+import { jest, expect, describe, test, afterEach, beforeEach } from '@jest/globals'
+import { type IpfsApi, TestUtils } from '@ceramicnetwork/common'
+import { TileDocument } from '@ceramicnetwork/stream-tile'
+import { StreamID } from '@ceramicnetwork/streamid'
+import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
+import { createCeramic } from './create-ceramic.js'
+import { MsgType, PubsubMessage, QueryMessage, ResponseMessage } from '../pubsub/pubsub-message.js'
+import { MAX_RESPONSE_INTERVAL } from '../pubsub/message-bus.js'
+import { CID } from 'multiformats/cid'
+import { asIpfsMessage } from '../pubsub/__tests__/as-ipfs-message.js'
+import { Ceramic } from '../ceramic.js'
+
+const LONG_SYNC_TIME = 60 * 1000
+
+function makeResponse(streamID: StreamID, queryId: string, cid: CID): ResponseMessage {
+  const tipMap = new Map().set(streamID.toString(), cid)
+  const response = { typ: MsgType.RESPONSE as const, id: queryId, tips: tipMap }
+  return response
+}
+
+/**
+ * Intercepts the function that publishes messages to pubsub and returns the first query message
+ * published (while still passing it on to pubsub as normal).
+ * @param ceramic
+ * @param streamID
+ */
+function getQueryPublishedPromise(
+  ceramic: Ceramic,
+  streamID: StreamID,
+  originalPubsubPublish
+): Promise<QueryMessage> {
+  const pubsubPublishSpy = jest.spyOn(ceramic.dispatcher.messageBus.pubsub, 'next')
+  return new Promise((resolve) => {
+    pubsubPublishSpy.mockImplementation((message: PubsubMessage) => {
+      if (message.typ == MsgType.QUERY && message.stream.equals(streamID)) {
+        resolve(message)
+      }
+      return originalPubsubPublish(message)
+    })
+  })
+}
+
+describe('Response to pubsub queries handling', () => {
+  jest.setTimeout(30 * 1000)
+
+  let ceramicIpfs: IpfsApi
+  let ceramic: Ceramic
+
+  let receiveMessage
+  let handleUpdateSpy
+  let originalPubsubPublish
+
+  const cids: Array<CID> = []
+  let streamID: StreamID
+
+  beforeAll(async () => {
+    ceramicIpfs = await createIPFS()
+
+    // Intercept the function passed to ipfs on pubsub subscription so that we can publish new
+    // messages directly
+    const originalPubsubSubscribe = ceramicIpfs.pubsub.subscribe.bind(ceramicIpfs.pubsub)
+    const pubsubSubscribeSpy = jest.spyOn(ceramicIpfs.pubsub, 'subscribe')
+    pubsubSubscribeSpy.mockImplementation(async (topic, onMessageCallback, opts) => {
+      receiveMessage = onMessageCallback
+      return originalPubsubSubscribe(topic, onMessageCallback, opts)
+    })
+
+    ceramic = await createCeramic(ceramicIpfs)
+
+    handleUpdateSpy = jest.spyOn(ceramic.repository, 'handleUpdate')
+    originalPubsubPublish = ceramic.dispatcher.messageBus.pubsub.next.bind(
+      ceramic.dispatcher.messageBus.pubsub
+    )
+
+    // Make sure we have some random valid CIDs to respond to pubsub queries with
+    for (let i = 0; i < 10; i++) {
+      const commit = await TileDocument.makeGenesis(ceramic, { foo: i }, null)
+      const cid = await ceramic.dispatcher.storeCommit(commit)
+      cids.push(cid)
+    }
+  })
+
+  beforeEach(async () => {
+    const genesisCommit = await TileDocument.makeGenesis(ceramic, { foo: 'bar' }, null)
+    const genesisCID = await ceramic.dispatcher.storeCommit(genesisCommit)
+    streamID = new StreamID(0, genesisCID)
+  })
+
+  afterAll(async () => {
+    await ceramic.close()
+    await ceramicIpfs.stop()
+  })
+
+  afterEach(async () => {
+    handleUpdateSpy.mockReset()
+  })
+
+  test('sync returns after the only response', async () => {
+    const queryPublished = getQueryPublishedPromise(ceramic, streamID, originalPubsubPublish)
+
+    const timeBeforeSync = new Date()
+    const syncCompletionPromise = ceramic.loadStream(streamID, {
+      syncTimeoutSeconds: LONG_SYNC_TIME / 1000,
+    })
+
+    const queryMessage = await queryPublished
+
+    const timeBeforeResponding = MAX_RESPONSE_INTERVAL / 2
+    await TestUtils.delay(timeBeforeResponding)
+    const response = makeResponse(streamID, queryMessage.id, cids[0])
+    await receiveMessage(asIpfsMessage(response))
+
+    await syncCompletionPromise
+    const timeAfterSync = new Date()
+    const syncDuration = timeAfterSync.getTime() - timeBeforeSync.getTime()
+
+    expect(syncDuration).toBeGreaterThan(timeBeforeResponding)
+    expect(syncDuration).toBeLessThan(LONG_SYNC_TIME)
+
+    expect(handleUpdateSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('sync continues delaying for multiple responses close together', async () => {
+    const queryPublished = getQueryPublishedPromise(ceramic, streamID, originalPubsubPublish)
+
+    const timeBeforeSync = new Date()
+    const syncCompletionPromise = ceramic.loadStream(streamID, {
+      syncTimeoutSeconds: LONG_SYNC_TIME / 1000,
+    })
+
+    const queryMessage = await queryPublished
+
+    const timeBetweenResponses = MAX_RESPONSE_INTERVAL / 2
+    const numResponses = 10
+    for (let i = 0; i < numResponses; i++) {
+      await TestUtils.delay(timeBetweenResponses)
+      const response = makeResponse(streamID, queryMessage.id, cids[i])
+      await receiveMessage(asIpfsMessage(response))
+    }
+
+    await syncCompletionPromise
+    const timeAfterSync = new Date()
+    const syncDuration = timeAfterSync.getTime() - timeBeforeSync.getTime()
+
+    expect(syncDuration).toBeGreaterThan(timeBetweenResponses * numResponses)
+    expect(syncDuration).toBeLessThan(LONG_SYNC_TIME)
+
+    expect(handleUpdateSpy).toHaveBeenCalledTimes(numResponses)
+  })
+
+  test('sync stops delaying once responses are far enough apart', async () => {
+    const timeBetweenInitialResponses = MAX_RESPONSE_INTERVAL / 2
+    const timeBetweenLaterResponses = MAX_RESPONSE_INTERVAL * 5
+    const numInitialResponses = 5
+    const numLaterResponses = 5
+
+    const queryPublished = getQueryPublishedPromise(ceramic, streamID, originalPubsubPublish)
+
+    const timeBeforeSync = new Date()
+    const syncCompletionPromise = ceramic.loadStream(streamID, {
+      syncTimeoutSeconds: LONG_SYNC_TIME / 1000,
+    })
+
+    const queryMessage = await queryPublished
+
+    const publishResponses = async function () {
+      for (let i = 0; i < numInitialResponses; i++) {
+        await TestUtils.delay(timeBetweenInitialResponses)
+        const response = makeResponse(streamID, queryMessage.id, cids[i])
+        await receiveMessage(asIpfsMessage(response))
+      }
+      for (let i = 0; i < numLaterResponses; i++) {
+        await TestUtils.delay(timeBetweenLaterResponses)
+        const response = makeResponse(streamID, queryMessage.id, cids[i + numInitialResponses])
+        await receiveMessage(asIpfsMessage(response))
+      }
+    }
+    publishResponses() // don't await for publishing to complete, let the responses happen in the background
+
+    await syncCompletionPromise
+    const timeAfterSync = new Date()
+    const syncDuration = timeAfterSync.getTime() - timeBeforeSync.getTime()
+
+    expect(syncDuration).toBeGreaterThan(timeBetweenInitialResponses * numInitialResponses)
+    expect(syncDuration).toBeLessThan(timeBetweenLaterResponses * numLaterResponses)
+    expect(syncDuration).toBeLessThan(LONG_SYNC_TIME)
+
+    expect(handleUpdateSpy).toHaveBeenCalledTimes(numInitialResponses)
+  })
+})

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -10,26 +10,18 @@ import {
 } from '@jest/globals'
 import {
   AnchorStatus,
-  CommitType,
   IpfsApi,
   SignatureStatus,
   Stream,
   TestUtils,
   AnchorCommit,
 } from '@ceramicnetwork/common'
-import { CID } from 'multiformats/cid'
-import { decode as decodeMultiHash } from 'multiformats/hashes/digest'
-import { RunningState } from '../state-management/running-state.js'
 import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
 import { createCeramic } from './create-ceramic.js'
 import { Ceramic } from '../ceramic.js'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
-import * as uint8arrays from 'uint8arrays'
-import * as sha256 from '@stablelib/sha256'
 import { StreamID } from '@ceramicnetwork/streamid'
-import { from, Subject, timer, firstValueFrom } from 'rxjs'
-import { concatMap, map } from 'rxjs/operators'
-import { MAX_RESPONSE_INTERVAL } from '../pubsub/message-bus.js'
+import { Subject, firstValueFrom } from 'rxjs'
 import { InMemoryAnchorService } from '../anchor/memory/in-memory-anchor-service.js'
 import { whenSubscriptionDone } from './when-subscription-done.util.js'
 import { CASResponse, AnchorRequestStatusName } from '@ceramicnetwork/codecs'
@@ -203,120 +195,6 @@ describe('anchor', () => {
         publish: true,
       })
       expect(publishTip).toHaveBeenCalledWith(stream1.id, stream1.tip, undefined)
-    })
-
-    describe('sync', () => {
-      let originalCeramic: Ceramic
-
-      beforeEach(() => {
-        originalCeramic = ceramic
-      })
-
-      afterEach(() => {
-        ceramic = originalCeramic
-      })
-
-      const FAKE_STREAM_ID = StreamID.fromString(
-        'kjzl6cwe1jw147dvq16zluojmraqvwdmbh61dx9e0c59i344lcrsgqfohexp60s'
-      )
-      function digest(input: string) {
-        return uint8arrays.toString(sha256.hash(uint8arrays.fromString(input)), 'base16')
-      }
-      function hash(data: string): CID {
-        return CID.create(1, 0x12, decodeMultiHash(Buffer.from('1220' + digest(data), 'hex')))
-      }
-
-      function responseTips(amount: number) {
-        const times = Array.from({ length: amount }).map((_, index) => index)
-        return times.map((n) => hash(n.toString()))
-      }
-
-      test('handle first received', async () => {
-        const internals = ceramic.repository._internals
-        const response = responseTips(1)
-        ceramic.dispatcher.messageBus.queryNetwork = () => from(response)
-        const fakeHandleTip = jest.fn(() =>
-          Promise.resolve()
-        ) as unknown as typeof internals.handleTip
-        internals.handleTip = fakeHandleTip
-        const state$ = {
-          id: FAKE_STREAM_ID,
-          value: {
-            log: [{ type: CommitType.GENESIS, cid: FAKE_STREAM_ID }],
-          },
-        } as unknown as RunningState
-        await internals.sync(state$, 1000)
-        expect(fakeHandleTip).toHaveBeenCalledWith(state$, response[0])
-      })
-      test('handle all received', async () => {
-        const internals = ceramic.repository._internals
-        const amount = 10
-        const response = responseTips(amount)
-        ceramic.dispatcher.messageBus.queryNetwork = () => from(response)
-        const fakeHandleTip = jest.fn(() =>
-          Promise.resolve()
-        ) as unknown as typeof internals.handleTip
-        internals.handleTip = fakeHandleTip
-        const state$ = {
-          id: FAKE_STREAM_ID,
-          value: {
-            log: [{ type: CommitType.GENESIS, cid: FAKE_STREAM_ID }],
-          },
-        } as unknown as RunningState
-        await internals.sync(state$, 1000)
-        response.forEach((r) => {
-          expect(fakeHandleTip).toHaveBeenCalledWith(state$, r)
-        })
-      })
-      test('not handle delayed', async () => {
-        const internals = ceramic.repository._internals
-        const amount = 10
-        const response = responseTips(amount)
-        ceramic.dispatcher.messageBus.queryNetwork = () =>
-          from(response).pipe(
-            concatMap(async (value, index) => {
-              await new Promise((resolve) =>
-                setTimeout(resolve, index * MAX_RESPONSE_INTERVAL * 0.3)
-              )
-              return value
-            })
-          )
-        const fakeHandleTip = jest.fn(() =>
-          Promise.resolve()
-        ) as unknown as typeof internals.handleTip
-        internals.handleTip = fakeHandleTip
-        const state$ = {
-          id: FAKE_STREAM_ID,
-          value: {
-            log: [{ type: CommitType.GENESIS, cid: FAKE_STREAM_ID }],
-          },
-        } as unknown as RunningState
-        await internals.sync(state$, 1000)
-        expect(fakeHandleTip).toBeCalledTimes(5)
-        response.slice(0, 5).forEach((r) => {
-          expect(fakeHandleTip).toHaveBeenCalledWith(state$, r)
-        })
-        response.slice(6, 10).forEach((r) => {
-          expect(fakeHandleTip).not.toHaveBeenCalledWith(state$, r)
-        })
-      })
-      test('stop after timeout', async () => {
-        const internals = ceramic.repository._internals
-        ceramic.dispatcher.messageBus.queryNetwork = () =>
-          timer(0, MAX_RESPONSE_INTERVAL * 0.5).pipe(map((n) => hash(n.toString())))
-        const fakeHandleTip = jest.fn(() =>
-          Promise.resolve()
-        ) as unknown as typeof internals.handleTip
-        internals.handleTip = fakeHandleTip
-        const state$ = {
-          id: FAKE_STREAM_ID,
-          value: {
-            log: [{ type: CommitType.GENESIS, cid: FAKE_STREAM_ID }],
-          },
-        } as unknown as RunningState
-        await internals.sync(state$, MAX_RESPONSE_INTERVAL * 10)
-        expect(fakeHandleTip).toBeCalledTimes(20)
-      })
     })
   })
 


### PR DESCRIPTION
The implementation of how streams get synced during loadStream is about to change a lot, so these tests as-written in `state-manager.test.ts` won't work anymore.  They're testing functionality we want to preserve though, so I want to make sure we don't lose that test coverage, so I re-wrote them to happen at a higher level.