### PR TITLE
chore: Extract inmemory validator

### DIFF
--- a/packages/core/src/anchor/memory/in-memory-anchor-service.ts
+++ b/packages/core/src/anchor/memory/in-memory-anchor-service.ts
@@ -6,12 +6,12 @@ import type { AnchorProof, AnchorCommit, AnchorEvent } from '@ceramicnetwork/com
 import type { Dispatcher } from '../../dispatcher.js'
 import type { Ceramic } from '../../ceramic.js'
 import type { StreamID } from '@ceramicnetwork/streamid'
-import { LRUCache } from 'least-recent'
 import { CARFactory, type CAR } from 'cartonne'
 import * as DAG_JOSE from 'dag-jose'
 import { AnchorRequestCarFileReader } from '../anchor-request-car-file-reader.js'
 import { AnchorRequestStatusName } from '@ceramicnetwork/codecs'
 import type { AnchorService, AnchorValidator } from '../anchor-service.js'
+import { InMemoryAnchorValidator, TRANSACTION_CACHE } from './in-memory-anchor-validator.js'
 
 const CHAIN_ID = 'inmemory:12345'
 const V1_PROOF_TYPE = 'f(bytes32)'
@@ -34,7 +34,6 @@ type InMemoryAnchorConfig = {
 // multiple InMemoryAnchorServices are being used simultaneously in the same process (usually by
 // tests that use multiple Ceramic nodes), they can share the set of recent transactions and thus
 // can successfully validate each others transactions.
-const txnCache: LRUCache<string, number> = new LRUCache(100)
 const carFactory = new CARFactory()
 carFactory.codecs.add(DAG_JOSE)
 
@@ -57,7 +56,7 @@ function groupCandidatesByStreamId(candidates: Candidate[]): Record<string, Cand
 /**
  * In-memory anchor service - used locally, not meant to be used in production code
  */
-export class InMemoryAnchorService implements AnchorService, AnchorValidator {
+export class InMemoryAnchorService implements AnchorService {
   #ceramic: Ceramic
   #dispatcher: Dispatcher
 
@@ -84,7 +83,7 @@ export class InMemoryAnchorService implements AnchorService, AnchorValidator {
     // Remember the most recent AnchorEvent for each anchor request
     this.#events.subscribe((asr) => this.#anchors.set(asr.cid.toString(), asr))
     this.events = this.#events
-    this.validator = this
+    this.validator = new InMemoryAnchorValidator(CHAIN_ID)
   }
 
   async init(): Promise<void> {
@@ -278,7 +277,7 @@ export class InMemoryAnchorService implements AnchorService, AnchorValidator {
       //TODO (NET-1657): Update the InMemoryAnchorService to mirror the behavior of the contract-based anchoring system
       txType: V1_PROOF_TYPE,
     }
-    txnCache.set(txHashCid.toString(), timestamp)
+    TRANSACTION_CACHE.set(txHashCid.toString(), timestamp)
     const proof = await this.#dispatcher.storeCommit(proofData)
     const commit = { proof, path: '', prev: leaf.cid, id: leaf.streamId.cid }
     const cid = await this._publishAnchorCommit(leaf.streamId, commit)
@@ -296,18 +295,6 @@ export class InMemoryAnchorService implements AnchorService, AnchorValidator {
       })
       clearTimeout(handle)
     }, this.#anchorDelay)
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async validateChainInclusion(proof: AnchorProof): Promise<number> {
-    const txHashString = proof.txHash.toString()
-    if (!txnCache.has(txHashString)) {
-      throw new Error(
-        `Txn ${proof.txHash.toString()} was not recently anchored by the InMemoryAnchorService`
-      )
-    }
-
-    return txnCache.get(txHashString)
   }
 
   async close(): Promise<void> {

--- a/packages/core/src/anchor/memory/in-memory-anchor-validator.ts
+++ b/packages/core/src/anchor/memory/in-memory-anchor-validator.ts
@@ -1,0 +1,39 @@
+import type { AnchorValidator } from '../anchor-service.js'
+import type { AnchorProof } from '@ceramicnetwork/common'
+import type { CID } from 'multiformats'
+import { LRUCache } from 'least-recent'
+
+// Caches recent anchor txn hashes and the timestamp when they were anchored
+// This is intentionally global and not a member of InMemoryAnchorService. This is so that when
+// multiple InMemoryAnchorServices are being used simultaneously in the same process (usually by
+// tests that use multiple Ceramic nodes), they can share the set of recent transactions and thus
+// can successfully validate each others transactions.
+export const TRANSACTION_CACHE = new LRUCache<string, number>(100)
+
+class NotAnchoredError extends Error {
+  constructor(txHash: CID) {
+    super(`Txn ${txHash} was not recently anchored by the InMemoryAnchorService`)
+  }
+}
+
+export class InMemoryAnchorValidator implements AnchorValidator {
+  readonly chainId: string
+  readonly ethereumRpcEndpoint = null
+
+  constructor(chainId: string) {
+    this.chainId = chainId
+  }
+
+  async init(): Promise<void> {
+    // Do Nothing
+  }
+
+  async validateChainInclusion(anchorProof: AnchorProof): Promise<number> {
+    const key = anchorProof.txHash.toString()
+    const found = TRANSACTION_CACHE.get(key)
+    if (!found) {
+      throw new NotAnchoredError(anchorProof.txHash)
+    }
+    return found
+  }
+}

--- a/packages/core/src/stream-loading/__tests__/stream-loader.test.ts
+++ b/packages/core/src/stream-loading/__tests__/stream-loader.test.ts
@@ -20,7 +20,6 @@ import { HandlersMap } from '../../handlers-map.js'
 import { StreamLoader } from '../stream-loader.js'
 import { TipFetcher } from '../tip-fetcher.js'
 import { AnchorTimestampExtractor } from '../anchor-timestamp-extractor.js'
-import { InMemoryAnchorService } from '../../anchor/memory/in-memory-anchor-service.js'
 import { CommitID, StreamID } from '@ceramicnetwork/streamid'
 import cloneDeep from 'lodash.clonedeep'
 import { CID } from 'multiformats/cid'
@@ -76,7 +75,7 @@ describe('StreamLoader querying against real Ceramic node', () => {
     const anchorTimestampExtractor = new AnchorTimestampExtractor(
       logger,
       dispatcher,
-      ceramic.anchorService as InMemoryAnchorService
+      ceramic.anchorService.validator
     )
     const handlers = new HandlersMap(logger)
     const stateManipulator = new StateManipulator(
@@ -336,7 +335,7 @@ describe('StreamLoader querying against mocked pubsub responses', () => {
     const anchorTimestampExtractor = new AnchorTimestampExtractor(
       logger,
       dispatcher,
-      ceramic.anchorService as InMemoryAnchorService
+      ceramic.anchorService.validator
     )
     const handlers = new HandlersMap(logger)
     const stateManipulator = new StateManipulator(


### PR DESCRIPTION
...due to a difference for what `init` expects on the inmemory anchor service and the inmemory validator.

Previously `InMemoryAnchorService` implemented `AnchorValidator` interface. The PR extracts `InMemoryAnchorValidator` class to free `InMemoryAnchorService` from validator responsibility, and make unconvoluted `init`.

Positive side-effect: InMemoryAnchorService is more inline with EthereumAnchorService.

That's part of off-memory anchoring PR unbundling.