### PR TITLE
chore: AnchorRequestCarBuilder

### DIFF
--- a/packages/core/src/anchor/anchor-request-car-builder.ts
+++ b/packages/core/src/anchor/anchor-request-car-builder.ts
@@ -1,0 +1,54 @@
+import type { Dispatcher } from '../dispatcher.js'
+import { CARFactory, type CAR } from 'cartonne'
+import * as DAG_JOSE from 'dag-jose'
+import type { StreamID } from '@ceramicnetwork/streamid'
+import type { CID } from 'multiformats/cid'
+import { StreamUtils } from '@ceramicnetwork/common'
+
+const CAR_FACTORY = new CARFactory()
+CAR_FACTORY.codecs.add(DAG_JOSE)
+
+export class AnchorRequestCarBuilder {
+  constructor(private readonly dispatcher: Dispatcher) {}
+
+  async build(streamId: StreamID, tip: CID): Promise<CAR> {
+    const car = CAR_FACTORY.build()
+
+    // Root block
+    const timestampISO = new Date().toISOString()
+    car.put(
+      {
+        timestamp: timestampISO,
+        streamId: streamId.bytes,
+        tip: tip,
+      },
+      { isRoot: true }
+    )
+
+    // Genesis block
+    const genesisCid = streamId.cid
+    car.blocks.put(await this.dispatcher.getIpfsBlock(genesisCid))
+
+    // Tip block
+    car.blocks.put(await this.dispatcher.getIpfsBlock(tip))
+
+    // Genesis Link Block
+    const genesisCommit = car.get(genesisCid)
+    if (StreamUtils.isSignedCommit(genesisCommit)) {
+      car.blocks.put(await this.dispatcher.getIpfsBlock(genesisCommit.link))
+    }
+
+    // Tip Link Block
+    const tipCommit = car.get(tip)
+    if (StreamUtils.isSignedCommit(tipCommit)) {
+      car.blocks.put(await this.dispatcher.getIpfsBlock(tipCommit.link))
+      // Tip CACAO Block
+      const tipCacaoCid = StreamUtils.getCacaoCidFromCommit(tipCommit)
+      if (tipCacaoCid) {
+        car.blocks.put(await this.dispatcher.getIpfsBlock(tipCacaoCid))
+      }
+    }
+
+    return car
+  }
+}

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -60,6 +60,7 @@ import {
 } from './initialization/anchoring.js'
 import { StreamUpdater } from './stream-loading/stream-updater.js'
 import type { AnchorService } from './anchor/anchor-service.js'
+import { AnchorRequestCarBuilder } from './anchor/anchor-request-car-builder.js'
 
 const DEFAULT_CACHE_LIMIT = 500 // number of streams stored in the cache
 const DEFAULT_QPS_LIMIT = 10 // Max number of pubsub query messages that can be published per second without rate limiting
@@ -140,6 +141,7 @@ export interface CeramicModules {
   repository: Repository
   shutdownSignal: ShutdownSignal
   providersCache: ProvidersCache
+  anchorRequestCarBuilder: AnchorRequestCarBuilder
 }
 
 /**
@@ -292,6 +294,7 @@ export class Ceramic implements CeramicApi {
       indexing: localIndex,
       streamLoader,
       streamUpdater,
+      anchorRequestCarBuilder: modules.anchorRequestCarBuilder,
     })
     this.syncApi = new SyncApi(
       {
@@ -380,6 +383,7 @@ export class Ceramic implements CeramicApi {
       !config.disablePeerDataSync,
       maxQueriesPerSecond
     )
+    const anchorRequestCarBuilder = new AnchorRequestCarBuilder(dispatcher)
     const pinStoreOptions = {
       pinningEndpoints: config.ipfsPinningEndpoints,
       pinningBackends: config.pinningBackends,
@@ -411,6 +415,7 @@ export class Ceramic implements CeramicApi {
       repository,
       shutdownSignal,
       providersCache,
+      anchorRequestCarBuilder,
     }
 
     return [modules, params]

--- a/packages/core/src/state-management/__tests__/state-manager.test.ts
+++ b/packages/core/src/state-management/__tests__/state-manager.test.ts
@@ -2,14 +2,16 @@ import { describe, expect, jest, test } from '@jest/globals'
 import type { Dispatcher } from '../../dispatcher.js'
 import type { AnchorRequestStore } from '../../store/anchor-request-store.js'
 import type { ExecutionQueue } from '../execution-queue.js'
-import type { AnchorService, DiagnosticsLogger } from '@ceramicnetwork/common'
+import type { DiagnosticsLogger } from '@ceramicnetwork/common'
 import type { ConflictResolution } from '../../conflict-resolution.js'
-import type { LocalIndexApi } from '../../indexing/local-index-api.js'
+import type { LocalIndexApi } from '@ceramicnetwork/indexing'
 import type { RepositoryInternals } from '../repository-internals.js'
+import type { AnchorService } from '../../anchor/anchor-service.js'
 import { TestUtils } from '@ceramicnetwork/common'
 import { StateManager } from '../state-manager.js'
 import { OperationType } from '../operation-type.js'
 import { RunningState } from '../running-state.js'
+import { AnchorRequestCarBuilder } from '../../anchor/anchor-request-car-builder.js'
 
 describe('applyWriteOpts', () => {
   const dispatcher = {} as unknown as Dispatcher
@@ -23,6 +25,7 @@ describe('applyWriteOpts', () => {
   const internals = {
     publishTip: publishTipFn,
   } as unknown as RepositoryInternals
+  const anchorRequestCarBuilder = new AnchorRequestCarBuilder(dispatcher)
   const stateManager = new StateManager(
     dispatcher,
     anchorRequestStore,
@@ -31,7 +34,8 @@ describe('applyWriteOpts', () => {
     conflictResolution,
     logger,
     localIndexApi,
-    internals
+    internals,
+    anchorRequestCarBuilder
   )
 
   test('publish on LOAD', async () => {

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -33,6 +33,7 @@ import { OperationType } from './operation-type.js'
 import { StreamUpdater } from '../stream-loading/stream-updater.js'
 import { CID } from 'multiformats/cid'
 import type { AnchorService } from '../anchor/anchor-service.js'
+import type { AnchorRequestCarBuilder } from '../anchor/anchor-request-car-builder.js'
 
 const CACHE_EVICTED_MEMORY = 'cache_eviction_memory'
 
@@ -48,6 +49,7 @@ export type RepositoryDependencies = {
   indexing: LocalIndexApi
   streamLoader: StreamLoader
   streamUpdater: StreamUpdater
+  anchorRequestCarBuilder: AnchorRequestCarBuilder
 }
 
 /**
@@ -194,7 +196,8 @@ export class Repository {
       deps.conflictResolution,
       this.logger,
       deps.indexing,
-      this._internals
+      this._internals,
+      deps.anchorRequestCarBuilder
     )
   }
 


### PR DESCRIPTION
Part of off-memory anchoring.

Move `StateManager. _buildAnchorRequestCARFile` to a class. This thing is needed in more than one place, and it is quite inconvenient to go through the hoops to call StateManager. Also, this functionality is not really a part of StateManager.