### PR TITLE
chore: Move load functionality out of RepositoryInternals

### DIFF
--- a/packages/core/src/__tests__/ceramic.test.ts
+++ b/packages/core/src/__tests__/ceramic.test.ts
@@ -325,11 +325,11 @@ describe('Ceramic integration', () => {
 
         const repository1 = ceramic1.repository
         const addSpy1 = jest.spyOn(repository1._internals, 'add')
-        const loadSpy1 = jest.spyOn(repository1._internals, 'load')
+        const loadSpy1 = jest.spyOn(repository1, 'load')
 
         const repository2 = ceramic2.repository
         const addSpy2 = jest.spyOn(repository2._internals, 'add')
-        const loadSpy2 = jest.spyOn(repository2._internals, 'load')
+        const loadSpy2 = jest.spyOn(repository2, 'load')
 
         const stream1 = await TileDocument.create<any>(ceramic1, { test: 456 }, null, {
           publish: false,
@@ -373,11 +373,11 @@ describe('Ceramic integration', () => {
 
         const repository1 = ceramic1.repository
         const addSpy1 = jest.spyOn(repository1._internals, 'add')
-        const loadSpy1 = jest.spyOn(repository1._internals, 'load')
+        const loadSpy1 = jest.spyOn(repository1, 'load')
 
         const repository2 = ceramic2.repository
         const addSpy2 = jest.spyOn(repository2._internals, 'add')
-        const loadSpy2 = jest.spyOn(repository2._internals, 'load')
+        const loadSpy2 = jest.spyOn(repository2, 'load')
 
         const stream1 = await TileDocument.create<any>(ceramic1, { test: 456 })
         expect(loadSpy1).toBeCalledTimes(1)

--- a/packages/core/src/state-management/__tests__/repository.test.ts
+++ b/packages/core/src/state-management/__tests__/repository.test.ts
@@ -57,9 +57,9 @@ afterEach(async () => {
 describe('#load', () => {
   test('from memory', async () => {
     const stream1 = await TileDocument.create(ceramic, { foo: 'bar' })
-    const fromMemorySpy = jest.spyOn(repository._loadHelpers, '_fromMemory')
-    const fromStateStoreSpy = jest.spyOn(repository._loadHelpers, '_fromStreamStateStore')
-    const fromNetworkSpy = jest.spyOn(repository._loadHelpers, '_genesisFromNetwork')
+    const fromMemorySpy = jest.spyOn(repository, '_fromMemory')
+    const fromStateStoreSpy = jest.spyOn(repository, '_fromStreamStateStore')
+    const fromNetworkSpy = jest.spyOn(repository, '_genesisFromNetwork')
     const stream2 = await repository.load(stream1.id, { syncTimeoutSeconds: 0 })
     expect(StreamUtils.serializeState(stream1.state)).toEqual(
       StreamUtils.serializeState(stream2.state)
@@ -70,10 +70,10 @@ describe('#load', () => {
   })
 
   test('from state store', async () => {
-    const fromMemorySpy = jest.spyOn(repository._loadHelpers, '_fromMemory')
-    const fromStateStoreSpy = jest.spyOn(repository._loadHelpers, '_fromStreamStateStore')
-    const fromNetworkSpy = jest.spyOn(repository._loadHelpers, '_genesisFromNetwork')
-    const syncSpy = jest.spyOn(repository._loadHelpers, '_sync')
+    const fromMemorySpy = jest.spyOn(repository, '_fromMemory')
+    const fromStateStoreSpy = jest.spyOn(repository, '_fromStreamStateStore')
+    const fromNetworkSpy = jest.spyOn(repository, '_genesisFromNetwork')
+    const syncSpy = jest.spyOn(repository, '_sync')
 
     const stream1 = await TileDocument.create(ceramic, { foo: 'bar' }, null, { anchor: false })
     await ceramic.admin.pin.add(stream1.id)
@@ -123,10 +123,10 @@ describe('#load', () => {
     } as unknown as StreamState
     const runningState = new RunningState(streamState, true)
 
-    const fromMemorySpy = jest.spyOn(repository._loadHelpers, '_fromMemory')
-    const fromStateStoreSpy = jest.spyOn(repository._loadHelpers, '_fromStreamStateStore')
-    const fromNetworkSpy = jest.spyOn(repository._loadHelpers, '_genesisFromNetwork')
-    const syncSpy = jest.spyOn(repository._loadHelpers, '_sync')
+    const fromMemorySpy = jest.spyOn(repository, '_fromMemory')
+    const fromStateStoreSpy = jest.spyOn(repository, '_fromStreamStateStore')
+    const fromNetworkSpy = jest.spyOn(repository, '_genesisFromNetwork')
+    const syncSpy = jest.spyOn(repository, '_sync')
 
     fromMemorySpy.mockReturnValueOnce(null)
     fromMemorySpy.mockReturnValueOnce(null)
@@ -159,8 +159,8 @@ describe('#load', () => {
     const genesisCommit = await TileDocument.makeGenesis(ceramic, { foo: 'bar' }, null)
     const genesisCid = await ceramic.dispatcher.storeCommit(genesisCommit)
     const streamId = new StreamID('tile', genesisCid)
-    const syncSpy = jest.spyOn(repository._loadHelpers, '_sync')
-    const loadFromNetworkSpy = jest.spyOn(repository._loadHelpers, '_loadStreamFromNetwork')
+    const syncSpy = jest.spyOn(repository, '_sync')
+    const loadFromNetworkSpy = jest.spyOn(repository, '_loadStreamFromNetwork')
 
     const stream1 = await repository.load(streamId, { syncTimeoutSeconds: 0 })
     expect(stream1.state.content).toEqual(content)
@@ -518,9 +518,9 @@ describe('#load', () => {
         })
         await stream1.update({ a: 2 }, null, { anchor: false })
 
-        const fromMemory = jest.spyOn(repository._loadHelpers, '_fromMemory')
+        const fromMemory = jest.spyOn(repository, '_fromMemory')
         fromMemory.mockReturnValueOnce(undefined)
-        const fromStateStore = jest.spyOn(repository._loadHelpers, '_fromStreamStateStore')
+        const fromStateStore = jest.spyOn(repository, '_fromStreamStateStore')
         const fromNetwork = jest.spyOn(repository.streamLoader, 'resyncStream')
         const saveFromStreamStateHolder = jest.spyOn(
           repository.pinStore.stateStore,
@@ -548,8 +548,8 @@ describe('#load', () => {
         })
         await stream1.update({ a: 2 }, null, { anchor: false })
 
-        const fromMemory = jest.spyOn(repository._loadHelpers, '_fromMemory')
-        const fromStateStore = jest.spyOn(repository._loadHelpers, '_fromStreamStateStore')
+        const fromMemory = jest.spyOn(repository, '_fromMemory')
+        const fromStateStore = jest.spyOn(repository, '_fromStreamStateStore')
         const fromNetwork = jest.spyOn(repository.streamLoader, 'resyncStream')
         const saveFromStreamStateHolder = jest.spyOn(
           repository.pinStore.stateStore,

--- a/packages/core/src/state-management/__tests__/repository.test.ts
+++ b/packages/core/src/state-management/__tests__/repository.test.ts
@@ -57,9 +57,9 @@ afterEach(async () => {
 describe('#load', () => {
   test('from memory', async () => {
     const stream1 = await TileDocument.create(ceramic, { foo: 'bar' })
-    const fromMemorySpy = jest.spyOn(repository._internals as any, '_fromMemory')
-    const fromStateStoreSpy = jest.spyOn(repository._internals as any, 'fromStreamStateStore')
-    const fromNetworkSpy = jest.spyOn(repository._internals as any, '_genesisFromNetwork')
+    const fromMemorySpy = jest.spyOn(repository._loadHelpers, '_fromMemory')
+    const fromStateStoreSpy = jest.spyOn(repository._loadHelpers, '_fromStreamStateStore')
+    const fromNetworkSpy = jest.spyOn(repository._loadHelpers, '_genesisFromNetwork')
     const stream2 = await repository.load(stream1.id, { syncTimeoutSeconds: 0 })
     expect(StreamUtils.serializeState(stream1.state)).toEqual(
       StreamUtils.serializeState(stream2.state)
@@ -70,10 +70,10 @@ describe('#load', () => {
   })
 
   test('from state store', async () => {
-    const fromMemorySpy = jest.spyOn(repository._internals as any, '_fromMemory')
-    const fromStateStoreSpy = jest.spyOn(repository._internals as any, 'fromStreamStateStore')
-    const fromNetworkSpy = jest.spyOn(repository._internals as any, '_genesisFromNetwork')
-    const syncSpy = jest.spyOn(repository._internals, '_sync')
+    const fromMemorySpy = jest.spyOn(repository._loadHelpers, '_fromMemory')
+    const fromStateStoreSpy = jest.spyOn(repository._loadHelpers, '_fromStreamStateStore')
+    const fromNetworkSpy = jest.spyOn(repository._loadHelpers, '_genesisFromNetwork')
+    const syncSpy = jest.spyOn(repository._loadHelpers, '_sync')
 
     const stream1 = await TileDocument.create(ceramic, { foo: 'bar' }, null, { anchor: false })
     await ceramic.admin.pin.add(stream1.id)
@@ -107,7 +107,7 @@ describe('#load', () => {
 
   test('Sync pinned stream first time loaded from state store', async () => {
     const content = { foo: 'bar' }
-    const genesisCommit = await TileDocument.makeGenesis(ceramic, { foo: 'bar' })
+    const genesisCommit = await TileDocument.makeGenesis(ceramic, { foo: 'bar' }, null)
     const genesisCid = await ceramic.dispatcher.storeCommit(genesisCommit)
     const streamId = new StreamID('tile', genesisCid)
     const streamState = {
@@ -123,15 +123,15 @@ describe('#load', () => {
     } as unknown as StreamState
     const runningState = new RunningState(streamState, true)
 
-    const fromMemorySpy = jest.spyOn(repository._internals as any, '_fromMemory')
-    const fromStateStoreSpy = jest.spyOn(repository._internals as any, 'fromStreamStateStore')
-    const fromNetworkSpy = jest.spyOn(repository._internals as any, '_genesisFromNetwork')
-    const syncSpy = jest.spyOn(repository._internals, '_sync')
+    const fromMemorySpy = jest.spyOn(repository._loadHelpers, '_fromMemory')
+    const fromStateStoreSpy = jest.spyOn(repository._loadHelpers, '_fromStreamStateStore')
+    const fromNetworkSpy = jest.spyOn(repository._loadHelpers, '_genesisFromNetwork')
+    const syncSpy = jest.spyOn(repository._loadHelpers, '_sync')
 
     fromMemorySpy.mockReturnValueOnce(null)
     fromMemorySpy.mockReturnValueOnce(null)
-    fromStateStoreSpy.mockReturnValueOnce(runningState)
-    fromStateStoreSpy.mockReturnValueOnce(runningState)
+    fromStateStoreSpy.mockReturnValueOnce(Promise.resolve(runningState))
+    fromStateStoreSpy.mockReturnValueOnce(Promise.resolve(runningState))
 
     const stream1 = await repository.load(streamId, { syncTimeoutSeconds: 0 })
     expect(stream1.state.content).toEqual(content)
@@ -156,11 +156,11 @@ describe('#load', () => {
 
   test('Pinning a stream prevents it from needing to be synced', async () => {
     const content = { foo: 'bar' }
-    const genesisCommit = await TileDocument.makeGenesis(ceramic, { foo: 'bar' })
+    const genesisCommit = await TileDocument.makeGenesis(ceramic, { foo: 'bar' }, null)
     const genesisCid = await ceramic.dispatcher.storeCommit(genesisCommit)
     const streamId = new StreamID('tile', genesisCid)
-    const syncSpy = jest.spyOn(repository._internals, '_sync')
-    const loadFromNetworkSpy = jest.spyOn(repository._internals, '_loadStreamFromNetwork')
+    const syncSpy = jest.spyOn(repository._loadHelpers, '_sync')
+    const loadFromNetworkSpy = jest.spyOn(repository._loadHelpers, '_loadStreamFromNetwork')
 
     const stream1 = await repository.load(streamId, { syncTimeoutSeconds: 0 })
     expect(stream1.state.content).toEqual(content)
@@ -204,7 +204,7 @@ describe('#load', () => {
 
     // Now remove the stream from both the cache and the syncedPinnedStreams set
     repository.inmemory.delete(streamId.toString())
-    repository._internals.markUnpinned(streamId)
+    repository.markUnpinned(streamId)
 
     const stream5 = await repository.load(streamId, { syncTimeoutSeconds: 0 })
     expect(StreamUtils.serializeState(stream5.state)).toEqual(
@@ -518,10 +518,10 @@ describe('#load', () => {
         })
         await stream1.update({ a: 2 }, null, { anchor: false })
 
-        const fromMemory = jest.spyOn(repository._internals as any, '_fromMemory')
+        const fromMemory = jest.spyOn(repository._loadHelpers, '_fromMemory')
         fromMemory.mockReturnValueOnce(undefined)
-        const fromStateStore = jest.spyOn(repository._internals as any, 'fromStreamStateStore')
-        const fromNetwork = jest.spyOn(repository.streamLoader as any, 'resyncStream')
+        const fromStateStore = jest.spyOn(repository._loadHelpers, '_fromStreamStateStore')
+        const fromNetwork = jest.spyOn(repository.streamLoader, 'resyncStream')
         const saveFromStreamStateHolder = jest.spyOn(
           repository.pinStore.stateStore,
           'saveFromStreamStateHolder'
@@ -548,9 +548,9 @@ describe('#load', () => {
         })
         await stream1.update({ a: 2 }, null, { anchor: false })
 
-        const fromMemory = jest.spyOn(repository._internals as any, '_fromMemory')
-        const fromStateStore = jest.spyOn(repository._internals as any, 'fromStreamStateStore')
-        const fromNetwork = jest.spyOn(repository.streamLoader as any, 'resyncStream')
+        const fromMemory = jest.spyOn(repository._loadHelpers, '_fromMemory')
+        const fromStateStore = jest.spyOn(repository._loadHelpers, '_fromStreamStateStore')
+        const fromNetwork = jest.spyOn(repository.streamLoader, 'resyncStream')
         const saveFromStreamStateHolder = jest.spyOn(
           repository.pinStore.stateStore,
           'saveFromStreamStateHolder'

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -116,155 +116,6 @@ export class Repository {
   _internals: RepositoryInternals
 
   /**
-   * A collection of private helper functions used by the stream loading code
-   * @private
-   */
-  readonly _loadHelpers = new (class {
-    constructor(readonly parentRepository: Repository) {}
-
-    _fromMemory(streamId: StreamID): RunningState | undefined {
-      const state = this.parentRepository.inmemory.get(streamId.toString())
-      if (state) {
-        Metrics.count(CACHE_HIT_MEMORY, 1)
-      }
-      return state
-    }
-
-    async _fromStreamStateStore(streamId: StreamID): Promise<RunningState | undefined> {
-      const streamState = await this.parentRepository.pinStore.stateStore.load(streamId)
-      if (streamState) {
-        Metrics.count(CACHE_HIT_LOCAL, 1)
-        const runningState = new RunningState(streamState, true)
-        this.parentRepository._internals.add(runningState)
-        const storedRequest = await this.parentRepository.anchorRequestStore.load(streamId)
-        if (storedRequest !== null && this.parentRepository.anchorService) {
-          this.parentRepository._internals.confirmAnchorResponse(runningState, storedRequest.cid)
-        }
-        return runningState
-      } else {
-        return undefined
-      }
-    }
-
-    /**
-     * Return a stream, either from cache or re-constructed from state store, but will not load from the network.
-     * Adds the stream to cache.
-     */
-    async _fromMemoryOrStore(streamId: StreamID): Promise<RunningState | undefined> {
-      const fromMemory = this._fromMemory(streamId)
-      if (fromMemory) return fromMemory
-      return this._fromStreamStateStore(streamId)
-    }
-
-    /**
-     * Helper function for loading the state for a stream from either the in-memory cache
-     * or the state store, while also returning information about whether or not the state needs
-     * to be synced.
-     * WARNING: This should only be called from within a thread in the loadingQ!!!
-     *
-     * @param streamId
-     * @returns a tuple whose first element is the state that was loaded, and whose second element
-     *   is a boolean representing whether we believe that state should be the most update-to-date
-     *   state for that stream, or whether it could be behind the current tip and needs to be synced.
-     */
-    async _fromMemoryOrStoreWithSyncStatus(
-      streamId: StreamID
-    ): Promise<[RunningState | null, boolean]> {
-      let stream = this._fromMemory(streamId)
-      if (stream) {
-        return [stream, true]
-      }
-
-      stream = await this._fromStreamStateStore(streamId)
-      if (stream) {
-        return [stream, this.parentRepository.wasPinnedStreamSynced(streamId)]
-      }
-      return [null, false]
-    }
-
-    /**
-     * Loads a stream that the node has never seen before from the network for the first time.
-     *
-     * @param streamId
-     * @param syncTimeoutSeconds - How much time do we wait for a response from the network.
-     */
-    async _loadStreamFromNetwork(
-      streamId: StreamID,
-      syncTimeoutSeconds: number
-    ): Promise<RunningState> {
-      const state = await this.parentRepository.streamLoader.loadStream(
-        streamId,
-        syncTimeoutSeconds
-      )
-      Metrics.count(STREAM_SYNC, 1)
-      const newState$ = new RunningState(state, false)
-      this.parentRepository._internals.add(newState$)
-      return newState$
-    }
-
-    async _genesisFromNetwork(streamId: StreamID): Promise<RunningState> {
-      const state = await this.parentRepository.streamLoader.loadGenesisState(streamId)
-      Metrics.count(CACHE_HIT_REMOTE, 1)
-
-      const state$ = new RunningState(state, false)
-      this.parentRepository._internals.add(state$)
-      this.parentRepository.logger.verbose(
-        `Genesis commit for stream ${streamId.toString()} successfully loaded`
-      )
-      return state$
-    }
-
-    /**
-     * Takes a stream state that might not contain the complete log (and might in fact contain only the
-     * genesis commit) and kicks off the process to load and apply the most recent Tip to it.
-     *
-     * @param state$ - Current stream state.
-     * @param syncTimeoutSeconds - How much time do we wait for a response from the network.
-     */
-    async _sync(state$: RunningState, syncTimeoutSeconds: number): Promise<void> {
-      const syncedState = await this.parentRepository.streamLoader.syncStream(
-        state$.state,
-        syncTimeoutSeconds
-      )
-      state$.next(syncedState)
-      Metrics.count(STREAM_SYNC, 1)
-    }
-
-    /**
-     * When SYNC_ALWAYS is provided, we want to reapply and re-validate
-     * the stream state.  We effectively throw out our locally stored state
-     * as it's possible that the commits that were used to construct that
-     * state are no longer valid (for example if the CACAOs used to author them
-     * have expired since they were first applied to the cached state object).
-     * But if we were the only node on the network that knew about the most recent tip,
-     * we don't want to totally forget about that, so we make sure to apply the previously
-     * known about tip so that it can still be considered alongside whatever tip we learn
-     * about from the network.
-     * @param streamId
-     * @param syncTimeoutSeconds
-     * @param existingState$
-     */
-    async _resyncStreamFromNetwork(
-      streamId: StreamID,
-      syncTimeoutSeconds: number,
-      existingState$: RunningState | null
-    ): Promise<RunningState> {
-      const resyncedState = existingState$
-        ? await this.parentRepository.streamLoader.resyncStream(
-            streamId,
-            existingState$.tip,
-            syncTimeoutSeconds
-          )
-        : await this.parentRepository.streamLoader.loadStream(streamId, syncTimeoutSeconds)
-
-      Metrics.count(STREAM_SYNC, 1)
-      const newState$ = new RunningState(resyncedState, false)
-      this.parentRepository._internals.add(newState$)
-      return newState$
-    }
-  })(this)
-
-  /**
    * @param cacheLimit - Maximum number of streams to store in memory cache.
    * @param logger - Where we put diagnostics messages.
    * @param concurrencyLimit - Maximum number of concurrently running tasks on the streams.
@@ -360,23 +211,19 @@ export class Repository {
     const opts = { ...DEFAULT_LOAD_OPTS, ...loadOptions }
 
     const [state$, synced] = await this.loadingQ.forStream(streamId).run(async () => {
-      const [existingState$, alreadySynced] =
-        await this._loadHelpers._fromMemoryOrStoreWithSyncStatus(streamId)
+      const [existingState$, alreadySynced] = await this._fromMemoryOrStoreWithSyncStatus(streamId)
 
       switch (opts.sync) {
         case SyncOptions.PREFER_CACHE:
         case SyncOptions.SYNC_ON_ERROR: {
           if (!existingState$) {
-            return [
-              await this._loadHelpers._loadStreamFromNetwork(streamId, opts.syncTimeoutSeconds),
-              true,
-            ]
+            return [await this._loadStreamFromNetwork(streamId, opts.syncTimeoutSeconds), true]
           }
 
           if (alreadySynced) {
             return [existingState$, alreadySynced]
           } else {
-            await this._loadHelpers._sync(existingState$, opts.syncTimeoutSeconds)
+            await this._sync(existingState$, opts.syncTimeoutSeconds)
             return [existingState$, true]
           }
         }
@@ -385,15 +232,11 @@ export class Repository {
             return [existingState$, alreadySynced]
           }
           // TODO(CDB-2761): Throw an error if stream isn't found in cache or state store.
-          return [await this._loadHelpers._genesisFromNetwork(streamId), false]
+          return [await this._genesisFromNetwork(streamId), false]
         }
         case SyncOptions.SYNC_ALWAYS: {
           return [
-            await this._loadHelpers._resyncStreamFromNetwork(
-              streamId,
-              opts.syncTimeoutSeconds,
-              existingState$
-            ),
+            await this._resyncStreamFromNetwork(streamId, opts.syncTimeoutSeconds, existingState$),
             true,
           ]
         }
@@ -413,6 +256,135 @@ export class Repository {
     }
 
     return state$
+  }
+
+  _fromMemory(streamId: StreamID): RunningState | undefined {
+    const state = this.inmemory.get(streamId.toString())
+    if (state) {
+      Metrics.count(CACHE_HIT_MEMORY, 1)
+    }
+    return state
+  }
+
+  async _fromStreamStateStore(streamId: StreamID): Promise<RunningState | undefined> {
+    const streamState = await this.pinStore.stateStore.load(streamId)
+    if (streamState) {
+      Metrics.count(CACHE_HIT_LOCAL, 1)
+      const runningState = new RunningState(streamState, true)
+      this._internals.add(runningState)
+      const storedRequest = await this.anchorRequestStore.load(streamId)
+      if (storedRequest !== null && this.anchorService) {
+        this._internals.confirmAnchorResponse(runningState, storedRequest.cid)
+      }
+      return runningState
+    } else {
+      return undefined
+    }
+  }
+
+  /**
+   * Return a stream, either from cache or re-constructed from state store, but will not load from the network.
+   * Adds the stream to cache.
+   */
+  async _fromMemoryOrStore(streamId: StreamID): Promise<RunningState | undefined> {
+    const fromMemory = this._fromMemory(streamId)
+    if (fromMemory) return fromMemory
+    return this._fromStreamStateStore(streamId)
+  }
+
+  /**
+   * Helper function for loading the state for a stream from either the in-memory cache
+   * or the state store, while also returning information about whether or not the state needs
+   * to be synced.
+   * WARNING: This should only be called from within a thread in the loadingQ!!!
+   *
+   * @param streamId
+   * @returns a tuple whose first element is the state that was loaded, and whose second element
+   *   is a boolean representing whether we believe that state should be the most update-to-date
+   *   state for that stream, or whether it could be behind the current tip and needs to be synced.
+   */
+  async _fromMemoryOrStoreWithSyncStatus(
+    streamId: StreamID
+  ): Promise<[RunningState | null, boolean]> {
+    let stream = this._fromMemory(streamId)
+    if (stream) {
+      return [stream, true]
+    }
+
+    stream = await this._fromStreamStateStore(streamId)
+    if (stream) {
+      return [stream, this.wasPinnedStreamSynced(streamId)]
+    }
+    return [null, false]
+  }
+
+  /**
+   * Loads a stream that the node has never seen before from the network for the first time.
+   *
+   * @param streamId
+   * @param syncTimeoutSeconds - How much time do we wait for a response from the network.
+   */
+  async _loadStreamFromNetwork(
+    streamId: StreamID,
+    syncTimeoutSeconds: number
+  ): Promise<RunningState> {
+    const state = await this.streamLoader.loadStream(streamId, syncTimeoutSeconds)
+    Metrics.count(STREAM_SYNC, 1)
+    const newState$ = new RunningState(state, false)
+    this._internals.add(newState$)
+    return newState$
+  }
+
+  async _genesisFromNetwork(streamId: StreamID): Promise<RunningState> {
+    const state = await this.streamLoader.loadGenesisState(streamId)
+    Metrics.count(CACHE_HIT_REMOTE, 1)
+
+    const state$ = new RunningState(state, false)
+    this._internals.add(state$)
+    this.logger.verbose(`Genesis commit for stream ${streamId.toString()} successfully loaded`)
+    return state$
+  }
+
+  /**
+   * Takes a stream state that might not contain the complete log (and might in fact contain only the
+   * genesis commit) and kicks off the process to load and apply the most recent Tip to it.
+   *
+   * @param state$ - Current stream state.
+   * @param syncTimeoutSeconds - How much time do we wait for a response from the network.
+   */
+  async _sync(state$: RunningState, syncTimeoutSeconds: number): Promise<void> {
+    const syncedState = await this.streamLoader.syncStream(state$.state, syncTimeoutSeconds)
+    state$.next(syncedState)
+    Metrics.count(STREAM_SYNC, 1)
+  }
+
+  /**
+   * When SYNC_ALWAYS is provided, we want to reapply and re-validate
+   * the stream state.  We effectively throw out our locally stored state
+   * as it's possible that the commits that were used to construct that
+   * state are no longer valid (for example if the CACAOs used to author them
+   * have expired since they were first applied to the cached state object).
+   * But if we were the only node on the network that knew about the most recent tip,
+   * we don't want to totally forget about that, so we make sure to apply the previously
+   * known about tip so that it can still be considered alongside whatever tip we learn
+   * about from the network.
+   * @param streamId
+   * @param syncTimeoutSeconds
+   * @param existingState$
+   */
+  async _resyncStreamFromNetwork(
+    streamId: StreamID,
+    syncTimeoutSeconds: number,
+    existingState$: RunningState | null
+  ): Promise<RunningState> {
+    const resyncedState = existingState$
+      ? await this.streamLoader.resyncStream(streamId, existingState$.tip, syncTimeoutSeconds)
+      : await this.streamLoader.loadStream(streamId, syncTimeoutSeconds)
+
+    Metrics.count(STREAM_SYNC, 1)
+    const newState$ = new RunningState(resyncedState, false)
+    this._internals.add(newState$)
+    return newState$
   }
 
   /**
@@ -504,7 +476,7 @@ export class Repository {
    * @param model - Model Stream ID
    */
   async handleUpdate(streamId: StreamID, tip: CID, model?: StreamID): Promise<void> {
-    let state$ = await this._loadHelpers._fromMemoryOrStore(streamId)
+    let state$ = await this._fromMemoryOrStore(streamId)
     const shouldIndex = model && this.index.shouldIndexStream(model)
     if (!shouldIndex && !state$) {
       // stream isn't pinned or indexed, nothing to do
@@ -625,7 +597,7 @@ export class Repository {
    * Adds the stream to cache.
    */
   async fromMemoryOrStore(streamId: StreamID): Promise<RunningState | undefined> {
-    return await this._loadHelpers._fromMemoryOrStore(streamId)
+    return await this._fromMemoryOrStore(streamId)
   }
 
   /**

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -12,6 +12,8 @@ import {
   PublishOpts,
   StreamState,
   StreamUtils,
+  SyncOptions,
+  UnreachableCaseError,
   UpdateOpts,
 } from '@ceramicnetwork/common'
 import type { LocalIndexApi } from '@ceramicnetwork/indexing'
@@ -34,7 +36,13 @@ import { CID } from 'multiformats/cid'
 import type { AnchorService } from '../anchor/anchor-service.js'
 import type { AnchorRequestCarBuilder } from '../anchor/anchor-request-car-builder.js'
 
+const DEFAULT_LOAD_OPTS = { sync: SyncOptions.PREFER_CACHE, syncTimeoutSeconds: 3 }
+
 const CACHE_EVICTED_MEMORY = 'cache_eviction_memory'
+const CACHE_HIT_LOCAL = 'cache_hit_local'
+const CACHE_HIT_MEMORY = 'cache_hit_memory'
+const CACHE_HIT_REMOTE = 'cache_hit_remote'
+const STREAM_SYNC = 'stream_sync'
 
 export type RepositoryDependencies = {
   dispatcher: Dispatcher
@@ -95,9 +103,166 @@ export class Repository {
   #deps: RepositoryDependencies
 
   /**
+   * Keeps track of every pinned StreamID that has had its state 'synced' (i.e. a query was sent to
+   * pubsub requesting the current tip for that stream) since the start of this process. This set
+   * only grows over time, in line with how many pinned streams get queried.
+   * @private
+   */
+  #syncedPinnedStreams: Set<string> = new Set()
+
+  /**
    * Internal APIs
    */
   _internals: RepositoryInternals
+
+  /**
+   * A collection of private helper functions used by the stream loading code
+   * @private
+   */
+  readonly _loadHelpers = new (class {
+    constructor(readonly parentRepository: Repository) {}
+
+    _fromMemory(streamId: StreamID): RunningState | undefined {
+      const state = this.parentRepository.inmemory.get(streamId.toString())
+      if (state) {
+        Metrics.count(CACHE_HIT_MEMORY, 1)
+      }
+      return state
+    }
+
+    async _fromStreamStateStore(streamId: StreamID): Promise<RunningState | undefined> {
+      const streamState = await this.parentRepository.pinStore.stateStore.load(streamId)
+      if (streamState) {
+        Metrics.count(CACHE_HIT_LOCAL, 1)
+        const runningState = new RunningState(streamState, true)
+        this.parentRepository._internals.add(runningState)
+        const storedRequest = await this.parentRepository.anchorRequestStore.load(streamId)
+        if (storedRequest !== null && this.parentRepository.anchorService) {
+          this.parentRepository._internals.confirmAnchorResponse(runningState, storedRequest.cid)
+        }
+        return runningState
+      } else {
+        return undefined
+      }
+    }
+
+    /**
+     * Return a stream, either from cache or re-constructed from state store, but will not load from the network.
+     * Adds the stream to cache.
+     */
+    async _fromMemoryOrStore(streamId: StreamID): Promise<RunningState | undefined> {
+      const fromMemory = this._fromMemory(streamId)
+      if (fromMemory) return fromMemory
+      return this._fromStreamStateStore(streamId)
+    }
+
+    /**
+     * Helper function for loading the state for a stream from either the in-memory cache
+     * or the state store, while also returning information about whether or not the state needs
+     * to be synced.
+     * WARNING: This should only be called from within a thread in the loadingQ!!!
+     *
+     * @param streamId
+     * @returns a tuple whose first element is the state that was loaded, and whose second element
+     *   is a boolean representing whether we believe that state should be the most update-to-date
+     *   state for that stream, or whether it could be behind the current tip and needs to be synced.
+     */
+    async _fromMemoryOrStoreWithSyncStatus(
+      streamId: StreamID
+    ): Promise<[RunningState | null, boolean]> {
+      let stream = this._fromMemory(streamId)
+      if (stream) {
+        return [stream, true]
+      }
+
+      stream = await this._fromStreamStateStore(streamId)
+      if (stream) {
+        return [stream, this.parentRepository.wasPinnedStreamSynced(streamId)]
+      }
+      return [null, false]
+    }
+
+    /**
+     * Loads a stream that the node has never seen before from the network for the first time.
+     *
+     * @param streamId
+     * @param syncTimeoutSeconds - How much time do we wait for a response from the network.
+     */
+    async _loadStreamFromNetwork(
+      streamId: StreamID,
+      syncTimeoutSeconds: number
+    ): Promise<RunningState> {
+      const state = await this.parentRepository.streamLoader.loadStream(
+        streamId,
+        syncTimeoutSeconds
+      )
+      Metrics.count(STREAM_SYNC, 1)
+      const newState$ = new RunningState(state, false)
+      this.parentRepository._internals.add(newState$)
+      return newState$
+    }
+
+    async _genesisFromNetwork(streamId: StreamID): Promise<RunningState> {
+      const state = await this.parentRepository.streamLoader.loadGenesisState(streamId)
+      Metrics.count(CACHE_HIT_REMOTE, 1)
+
+      const state$ = new RunningState(state, false)
+      this.parentRepository._internals.add(state$)
+      this.parentRepository.logger.verbose(
+        `Genesis commit for stream ${streamId.toString()} successfully loaded`
+      )
+      return state$
+    }
+
+    /**
+     * Takes a stream state that might not contain the complete log (and might in fact contain only the
+     * genesis commit) and kicks off the process to load and apply the most recent Tip to it.
+     *
+     * @param state$ - Current stream state.
+     * @param syncTimeoutSeconds - How much time do we wait for a response from the network.
+     */
+    async _sync(state$: RunningState, syncTimeoutSeconds: number): Promise<void> {
+      const syncedState = await this.parentRepository.streamLoader.syncStream(
+        state$.state,
+        syncTimeoutSeconds
+      )
+      state$.next(syncedState)
+      Metrics.count(STREAM_SYNC, 1)
+    }
+
+    /**
+     * When SYNC_ALWAYS is provided, we want to reapply and re-validate
+     * the stream state.  We effectively throw out our locally stored state
+     * as it's possible that the commits that were used to construct that
+     * state are no longer valid (for example if the CACAOs used to author them
+     * have expired since they were first applied to the cached state object).
+     * But if we were the only node on the network that knew about the most recent tip,
+     * we don't want to totally forget about that, so we make sure to apply the previously
+     * known about tip so that it can still be considered alongside whatever tip we learn
+     * about from the network.
+     * @param streamId
+     * @param syncTimeoutSeconds
+     * @param existingState$
+     */
+    async _resyncStreamFromNetwork(
+      streamId: StreamID,
+      syncTimeoutSeconds: number,
+      existingState$: RunningState | null
+    ): Promise<RunningState> {
+      const resyncedState = existingState$
+        ? await this.parentRepository.streamLoader.resyncStream(
+            streamId,
+            existingState$.tip,
+            syncTimeoutSeconds
+          )
+        : await this.parentRepository.streamLoader.loadStream(streamId, syncTimeoutSeconds)
+
+      Metrics.count(STREAM_SYNC, 1)
+      const newState$ = new RunningState(resyncedState, false)
+      this.parentRepository._internals.add(newState$)
+      return newState$
+    }
+  })(this)
 
   /**
    * @param cacheLimit - Maximum number of streams to store in memory cache.
@@ -191,8 +356,63 @@ export class Repository {
    * Starts by checking if the stream state is present in the in-memory cache, if not then
    * checks the state store, and finally loads the stream from pubsub.
    */
-  async load(streamId: StreamID, opts: LoadOpts & InternalOpts): Promise<RunningState> {
-    return await this._internals.load(streamId, opts)
+  async load(streamId: StreamID, loadOptions: LoadOpts & InternalOpts = {}): Promise<RunningState> {
+    const opts = { ...DEFAULT_LOAD_OPTS, ...loadOptions }
+
+    const [state$, synced] = await this.loadingQ.forStream(streamId).run(async () => {
+      const [existingState$, alreadySynced] =
+        await this._loadHelpers._fromMemoryOrStoreWithSyncStatus(streamId)
+
+      switch (opts.sync) {
+        case SyncOptions.PREFER_CACHE:
+        case SyncOptions.SYNC_ON_ERROR: {
+          if (!existingState$) {
+            return [
+              await this._loadHelpers._loadStreamFromNetwork(streamId, opts.syncTimeoutSeconds),
+              true,
+            ]
+          }
+
+          if (alreadySynced) {
+            return [existingState$, alreadySynced]
+          } else {
+            await this._loadHelpers._sync(existingState$, opts.syncTimeoutSeconds)
+            return [existingState$, true]
+          }
+        }
+        case SyncOptions.NEVER_SYNC: {
+          if (existingState$) {
+            return [existingState$, alreadySynced]
+          }
+          // TODO(CDB-2761): Throw an error if stream isn't found in cache or state store.
+          return [await this._loadHelpers._genesisFromNetwork(streamId), false]
+        }
+        case SyncOptions.SYNC_ALWAYS: {
+          return [
+            await this._loadHelpers._resyncStreamFromNetwork(
+              streamId,
+              opts.syncTimeoutSeconds,
+              existingState$
+            ),
+            true,
+          ]
+        }
+        default:
+          throw new UnreachableCaseError(opts.sync, 'Invalid sync option')
+      }
+    })
+
+    if (!opts.skipCacaoExpirationChecks) {
+      StreamUtils.checkForCacaoExpiration(state$.state)
+    }
+
+    // TODO(WS1-1269): No need to update state if we loaded from the cache or state store
+    await this._internals._updateStateIfPinned(state$)
+    if (synced && state$.isPinned) {
+      this.markPinnedAndSynced(state$.id)
+    }
+
+    return state$
   }
 
   /**
@@ -256,7 +476,7 @@ export class Repository {
   ): Promise<RunningState> {
     this.logger.verbose(`Repository apply commit to stream ${streamId.toString()}`)
 
-    const state$ = await this._internals.load(streamId, opts)
+    const state$ = await this.load(streamId, opts)
     this.logger.verbose(`Repository loaded state for stream ${streamId.toString()}`)
 
     return this.executionQ.forStream(streamId).run(async () => {
@@ -284,7 +504,7 @@ export class Repository {
    * @param model - Model Stream ID
    */
   async handleUpdate(streamId: StreamID, tip: CID, model?: StreamID): Promise<void> {
-    let state$ = await this._internals.fromMemoryOrStore(streamId)
+    let state$ = await this._loadHelpers._fromMemoryOrStore(streamId)
     const shouldIndex = model && this.index.shouldIndexStream(model)
     if (!shouldIndex && !state$) {
       // stream isn't pinned or indexed, nothing to do
@@ -292,7 +512,7 @@ export class Repository {
     }
 
     if (!state$) {
-      state$ = await this._internals.load(streamId)
+      state$ = await this.load(streamId)
     }
     this.executionQ.forStream(streamId).add(async () => {
       await this._internals.handleTip(state$, tip)
@@ -335,8 +555,8 @@ export class Repository {
    * @private
    */
   async applyWriteOpts(state$: RunningState, opts: CreateOpts | UpdateOpts, opType: OperationType) {
-    const anchor = (opts as any).anchor
-    const publish = (opts as any).publish
+    const anchor = opts.anchor
+    const publish = opts.publish
     if (anchor) {
       await this.anchor(state$, opts)
     }
@@ -405,7 +625,7 @@ export class Repository {
    * Adds the stream to cache.
    */
   async fromMemoryOrStore(streamId: StreamID): Promise<RunningState | undefined> {
-    return await this._internals.fromMemoryOrStore(streamId)
+    return await this._loadHelpers._fromMemoryOrStore(streamId)
   }
 
   /**
@@ -444,12 +664,27 @@ export class Repository {
       this._internals.publishTip(state$)
     }
 
-    this._internals.markUnpinned(state$.id)
+    this.markUnpinned(state$.id)
     return this.#deps.pinStore.rm(state$)
   }
 
   markPinnedAndSynced(streamId: StreamID): void {
-    this._internals.markPinnedAndSynced(streamId)
+    this.#syncedPinnedStreams.add(streamId.toString())
+  }
+
+  markUnpinned(streamId: StreamID): void {
+    this.#syncedPinnedStreams.delete(streamId.toString())
+  }
+
+  /**
+   * Returns whether the given StreamID corresponds to a pinned stream that has been synced at least
+   * once during the lifetime of this process. As long as it's been synced once, it's guaranteed to
+   * be up to date since we keep streams in the state store up to date when we hear pubsub messages
+   * about updates to them.
+   * @param streamId
+   */
+  wasPinnedStreamSynced(streamId: StreamID): boolean {
+    return this.#syncedPinnedStreams.has(streamId.toString())
   }
 
   /**


### PR DESCRIPTION
Builds on https://github.com/ceramicnetwork/js-ceramic/pull/2985

Step one of killing RepositoryInternals