### PR TITLE
chore: Add more context to errors from leveldb

### DIFF
--- a/packages/core/src/__tests__/create-dispatcher.ts
+++ b/packages/core/src/__tests__/create-dispatcher.ts
@@ -10,11 +10,12 @@ import { TaskQueue } from '../ancillary/task-queue.js'
 
 export async function createDispatcher(ipfs: IpfsApi, pubsubTopic: string): Promise<Dispatcher> {
   const loggerProvider = new LoggerProvider()
+  const logger = loggerProvider.getDiagnosticsLogger()
   const levelPath = await tmp.tmpName()
-  const levelStore = new LevelDbStore(levelPath, 'test')
-  const stateStore = new StreamStateStore(loggerProvider.getDiagnosticsLogger())
+  const levelStore = new LevelDbStore(logger, levelPath, 'test')
+  const stateStore = new StreamStateStore(logger)
   await stateStore.open(levelStore)
-  const repository = new Repository(100, 100, loggerProvider.getDiagnosticsLogger())
+  const repository = new Repository(100, 100, logger)
   const pinStore = {
     stateStore,
   } as unknown as PinStore
@@ -25,7 +26,7 @@ export async function createDispatcher(ipfs: IpfsApi, pubsubTopic: string): Prom
     ipfs,
     pubsubTopic,
     repository,
-    loggerProvider.getDiagnosticsLogger(),
+    logger,
     loggerProvider.makeServiceLogger('pubsub'),
     shutdownSignal,
     true,

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -222,6 +222,7 @@ export class Ceramic implements CeramicApi {
     this._startTime = new Date()
 
     this._levelStore = new LevelDbStore(
+      this._logger,
       params.stateStoreDirectory ?? DEFAULT_STATE_STORE_DIRECTORY,
       this._networkOptions.name
     )

--- a/packages/core/src/store/__tests__/level-store.test.ts
+++ b/packages/core/src/store/__tests__/level-store.test.ts
@@ -1,6 +1,6 @@
 import tmp from 'tmp-promise'
 import { LevelDbStore } from '../level-db-store.js'
-import { TestUtils } from '@ceramicnetwork/common'
+import { LoggerProvider, TestUtils } from '@ceramicnetwork/common'
 
 describe('LevelStore', () => {
   let tmpFolder: any
@@ -8,7 +8,11 @@ describe('LevelStore', () => {
 
   beforeEach(async () => {
     tmpFolder = await tmp.dir({ unsafeCleanup: true })
-    levelStore = new LevelDbStore(tmpFolder.path, 'fakeNetwork')
+    levelStore = new LevelDbStore(
+      new LoggerProvider().getDiagnosticsLogger(),
+      tmpFolder.path,
+      'fakeNetwork'
+    )
 
     // add a small delay after creating the leveldb instance before trying to use it.
     await TestUtils.delay(100)

--- a/packages/core/src/store/__tests__/state-store-integration.test.ts
+++ b/packages/core/src/store/__tests__/state-store-integration.test.ts
@@ -8,6 +8,7 @@ import {
   SignatureStatus,
   TestUtils,
   LoggerProvider,
+  DiagnosticsLogger,
 } from '@ceramicnetwork/common'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { PinStore } from '../pin-store.js'
@@ -38,6 +39,7 @@ const repository = {
 
 describe('Level data store', () => {
   let store: PinStore
+  let logger: DiagnosticsLogger
 
   const streamId = new StreamID('tile', FAKE_CID)
   const streamState: StreamState = {
@@ -50,6 +52,7 @@ describe('Level data store', () => {
   }
 
   beforeEach(async () => {
+    logger = new LoggerProvider().getDiagnosticsLogger()
     const levelPath = (await tmp.dir({ unsafeCleanup: true })).path
     const storeFactory = new PinStoreFactory(
       ipfs,
@@ -58,9 +61,9 @@ describe('Level data store', () => {
       {
         pinningEndpoints: ['ipfs+context'],
       },
-      new LoggerProvider().getDiagnosticsLogger()
+      logger
     )
-    const levelStore = new LevelDbStore(levelPath, 'inmemory')
+    const levelStore = new LevelDbStore(logger, levelPath, 'inmemory')
     store = storeFactory.createPinStore()
     await store.open(levelStore)
   })
@@ -143,7 +146,7 @@ describe('Level data store', () => {
 
   it('pins in different networks', async () => {
     const levelPath = (await tmp.dir({ unsafeCleanup: true })).path
-    const localLevelStore = new LevelDbStore(levelPath, 'local')
+    const localLevelStore = new LevelDbStore(logger, levelPath, 'local')
     const storeFactoryLocal = new PinStoreFactory(
       ipfs,
       new IPLDRecordsCache(10),
@@ -162,7 +165,7 @@ describe('Level data store', () => {
     await localStore.close()
 
     // Now create a net pin store for a different ceramic network
-    const inmemoryLevelStore = new LevelDbStore(levelPath, 'inmemory')
+    const inmemoryLevelStore = new LevelDbStore(logger, levelPath, 'inmemory')
     const storeFactoryInMemory = new PinStoreFactory(
       ipfs,
       new IPLDRecordsCache(10),

--- a/packages/core/src/store/level-db-store.ts
+++ b/packages/core/src/store/level-db-store.ts
@@ -19,6 +19,10 @@ const LevelC = (levelTs as any).default as unknown as typeof Level
 
 const DEFAULT_LEVELDB_STORE_USE_CASE_NAME = 'default'
 
+class NotFoundError extends Error {
+  readonly notFound = true
+}
+
 class LevelDBStoreMap {
   readonly #storeRoot
   readonly networkName
@@ -100,8 +104,13 @@ export class LevelDbStore implements IKVStore {
     try {
       return await store.get(key)
     } catch (err) {
-      this.logger.warn(`Error fetching key ${key} from leveldb state store: ${err}`)
-      throw err
+      const msg = `Error fetching key ${key} from leveldb state store: ${err}`
+      this.logger.warn(msg)
+      if (err.notFound) {
+        throw new NotFoundError(msg)
+      } else {
+        throw new Error(msg)
+      }
     }
   }
 

--- a/packages/core/src/store/level-db-store.ts
+++ b/packages/core/src/store/level-db-store.ts
@@ -3,7 +3,7 @@ import type Level from 'level-ts'
 import { IKVStore, IKVStoreFindResult, StoreSearchParams } from './ikv-store.js'
 import path from 'path'
 import * as fs from 'fs'
-import { Networks } from '@ceramicnetwork/common'
+import { DiagnosticsLogger, Networks } from '@ceramicnetwork/common'
 
 // When Node.js imports a CJS module from ESM, it considers whole contents of `module.exports` as ESM default export.
 // 'level-ts' is a CommomJS module, which exports Level constructor as `exports.default`.
@@ -71,7 +71,7 @@ class LevelDBStoreMap {
 export class LevelDbStore implements IKVStore {
   readonly #storeMap: LevelDBStoreMap
 
-  constructor(storeRoot: string, networkName: string) {
+  constructor(readonly logger: DiagnosticsLogger, storeRoot: string, networkName: string) {
     this.#storeMap = new LevelDBStoreMap(storeRoot, networkName)
   }
 
@@ -86,12 +86,24 @@ export class LevelDbStore implements IKVStore {
 
   async del(key: string, useCaseName?: string): Promise<void> {
     const store = await this.#storeMap.get(useCaseName)
-    return await store.del(key)
+    try {
+      return await store.del(key)
+    } catch (err) {
+      const msg = `Error deleting key ${key} from leveldb state store: ${err}`
+      this.logger.warn(msg)
+      throw new Error(msg)
+    }
   }
 
   async get(key: string, useCaseName?: string): Promise<any> {
     const store = await this.#storeMap.get(useCaseName)
-    return await store.get(key)
+    try {
+      return await store.get(key)
+    } catch (err) {
+      const msg = `Error fetching key ${key} from leveldb state store: ${err}`
+      this.logger.warn(msg)
+      throw new Error(msg)
+    }
   }
 
   async isEmpty(params?: StoreSearchParams): Promise<boolean> {
@@ -100,9 +112,9 @@ export class LevelDbStore implements IKVStore {
   }
 
   async exists(key: string, useCaseName?: string): Promise<boolean> {
-    const store = await this.#storeMap.get(useCaseName)
     try {
-      return typeof (await store.get(key)) === 'string'
+      const val = await this.get(key)
+      return typeof val === 'string'
     } catch (e) {
       if (/Key not found in database/.test(e.toString())) {
         return false
@@ -137,6 +149,12 @@ export class LevelDbStore implements IKVStore {
 
   async put(key: string, value: any, useCaseName?: string): Promise<void> {
     const store = await this.#storeMap.get(useCaseName)
-    return await store.put(key, value)
+    try {
+      await store.put(key, value)
+    } catch (err) {
+      const msg = `Error storing key ${key} to leveldb state store: ${err}`
+      this.logger.warn(msg)
+      throw new Error(msg)
+    }
   }
 }

--- a/packages/core/src/store/level-db-store.ts
+++ b/packages/core/src/store/level-db-store.ts
@@ -112,7 +112,7 @@ export class LevelDbStore implements IKVStore {
 
   async exists(key: string, useCaseName?: string): Promise<boolean> {
     try {
-      const val = await this.get(key)
+      const val = await this.get(key, useCaseName)
       return typeof val === 'string'
     } catch (e) {
       if (/Key not found in database/.test(e.toString())) {

--- a/packages/core/src/store/level-db-store.ts
+++ b/packages/core/src/store/level-db-store.ts
@@ -100,9 +100,8 @@ export class LevelDbStore implements IKVStore {
     try {
       return await store.get(key)
     } catch (err) {
-      const msg = `Error fetching key ${key} from leveldb state store: ${err}`
-      this.logger.warn(msg)
-      throw new Error(msg)
+      this.logger.warn(`Error fetching key ${key} from leveldb state store: ${err}`)
+      throw err
     }
   }
 


### PR DESCRIPTION
Trying to get more information about what's happening in this flaky test failure: https://app.circleci.com/pipelines/github/ceramicnetwork/js-ceramic/11815/workflows/bb4e8a7d-0df8-42b7-a88a-9c1500ed8570/jobs/15545