### PR TITLE
fix: Fix calculation on number of eth blocks in 24 hours

### DIFF
--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -279,6 +279,7 @@ export class Ceramic implements CeramicApi {
     const pinApi = new LocalPinApi(this.repository, this._logger)
     this.repository.index.setSyncQueryApi(this.syncApi)
     this.admin = new LocalAdminApi(
+      this._logger,
       localIndex,
       this.syncApi,
       this.nodeStatus.bind(this),

--- a/packages/stream-tests/src/__tests__/history-sync.test.ts
+++ b/packages/stream-tests/src/__tests__/history-sync.test.ts
@@ -17,8 +17,6 @@ import {
   STATE_TABLE_NAME,
 } from '@ceramicnetwork/indexing'
 import { Ceramic } from '@ceramicnetwork/core'
-// import { NUMBER_OF_BLOCKS_BEFORE_TX_TO_START_SYNC } from '../../local-admin-api.js'
-// import { IProvidersCache } from '../../providers-cache.js'
 
 import { Model, ModelDefinition } from '@ceramicnetwork/stream-model'
 import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'


### PR DESCRIPTION
A minor follow-up to https://github.com/ceramicnetwork/js-ceramic/pull/2881

Also adds a few log messages