### PR TITLE
chore: Make WitnessCAR optional again

### DIFF
--- a/packages/codecs/src/anchor.ts
+++ b/packages/codecs/src/anchor.ts
@@ -47,13 +47,13 @@ export const NotCompleteCASResponse = sparse(
 )
 export type NotCompleteCASResponse = TypeOf<typeof NotCompleteCASResponse>
 
-export const CompleteCASResponse = type(
+export const CompleteCASResponse = sparse(
   {
     ...NotCompleteCASResponse.props,
     status: literal(AnchorRequestStatusName.COMPLETED),
     // TODO CDB-2759 Drop this after enough Ceramic nodes can 100% rely on WitnessCAR
     anchorCommit: AnchorCommitPresentation,
-    witnessCar: uint8ArrayAsBase64.pipe(carAsUint8Array),
+    witnessCar: optional(uint8ArrayAsBase64.pipe(carAsUint8Array)),
   },
   'CompleteCASResponse'
 )

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -707,7 +707,7 @@ export class Repository {
   private async _handleAnchorCommit(
     state$: RunningState,
     tip: CID,
-    witnessCAR: CAR
+    witnessCAR: CAR | undefined
   ): Promise<void> {
     const anchorCommitCID = witnessCAR.roots[0]
     if (!anchorCommitCID) throw new Error(`No anchor commit CID as root`)
@@ -717,7 +717,9 @@ export class Repository {
       remainingRetries--
     ) {
       try {
-        await this.dispatcher.importCAR(witnessCAR)
+        if (witnessCAR) {
+          await this.dispatcher.importCAR(witnessCAR)
+        }
 
         const applied = await this._handleTip(state$, anchorCommitCID)
         if (applied) {


### PR DESCRIPTION
We still get requests for old anchors.