### PR TITLE
Revert "feat(3id-did-resolver, anchor-listener, anchor-utils, blockchain-utils-linking, blockchain-utils-validation, cli, codecs, common, core, http-client, indexing, ipfs-daemon, ipfs-topology, job-queue, logger, pinning-aggregation, pinning-crust-backend, pinning-ipfs-backend, pinning-powergate-backend, stream-caip10-link, stream-caip10-link-handler, stream-handler-common, stream-model, stream-model-handler, stream-model-instance, stream-model-instance-handler, stream-tests, stream-tile, stream-tile-handler, streamid): upgrade to node 20 and add engine"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
           name: Install rust-ceramic
           command: sudo bash ci-scripts/install-rust-ceramic.sh
       - node/install:
-          node-version: '20'
+          node-version: '16'
       - node/install-packages
       - run: npm run build
       - run: npm run lint

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -35,7 +35,7 @@ jobs:
         name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 20
+          node-version: 16
       -
         name: Checkout main branch
         uses: actions/checkout@v3
@@ -118,7 +118,7 @@ jobs:
         name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 20
+          node-version: 16
       -
         name: Checkout rc branch
         uses: actions/checkout@v3
@@ -200,7 +200,7 @@ jobs:
         name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 20
+          node-version: 16
       -
         name: Branch check
         if: ${{ inputs.branch == '' }}

--- a/Dockerfile.daemon
+++ b/Dockerfile.daemon
@@ -1,6 +1,6 @@
-FROM node:20 as ceramic
+FROM node:16 as ceramic
 
-RUN apt-get update && apt-get install -y netcat-traditional gettext-base jq
+RUN apt-get update && apt-get install -y netcat gettext-base jq
 
 COPY ci-scripts/install-rust-ceramic.sh ./
 

--- a/docs-dev/DEVELOPMENT_LOCAL.md
+++ b/docs-dev/DEVELOPMENT_LOCAL.md
@@ -24,7 +24,7 @@ __*Note*__ that using `--network dev-unstable` will cause your node connecting t
 
 ## PRE-REQUISITES
 
-* Node `20`
+* Node `v16`
 * npm `v8`
 
 ### macOS specific (11.x+)

--- a/packages/3id-did-resolver/babel.config.json
+++ b/packages/3id-did-resolver/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/anchor-listener/babel.config.json
+++ b/packages/anchor-listener/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/anchor-utils/babel.config.json
+++ b/packages/anchor-utils/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/blockchain-utils-linking/babel.config.json
+++ b/packages/blockchain-utils-linking/babel.config.json
@@ -1,4 +1,4 @@
 {
-  "presets": [["@babel/preset-env", { "targets": { "node": "20" } }], "@babel/preset-typescript"],
+  "presets": [["@babel/preset-env", { "targets": { "node": "16" } }], "@babel/preset-typescript"],
   "plugins": [["@babel/plugin-proposal-decorators", { "legacy": true }]]
 }

--- a/packages/blockchain-utils-validation/babel.config.json
+++ b/packages/blockchain-utils-validation/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/cli/babel.config.json
+++ b/packages/cli/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,9 +2,6 @@
   "name": "@ceramicnetwork/cli",
   "version": "2.43.0-rc.0",
   "description": "Typescript implementation of the Ceramic CLI",
-  "engines": {
-    "node": ">=20.8"
-  },
   "keywords": [
     "Ceramic",
     "DID",

--- a/packages/codecs/babel.config.json
+++ b/packages/codecs/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/common/babel.config.json
+++ b/packages/common/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/core/babel.config.json
+++ b/packages/core/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,9 +2,6 @@
   "name": "@ceramicnetwork/core",
   "version": "2.45.0-rc.0",
   "description": "Typescript implementation of the Ceramic protocol",
-  "engines": {
-    "node": ">=20.8"
-  },
   "keywords": [
     "Ceramic",
     "DID",

--- a/packages/http-client/babel.config.json
+++ b/packages/http-client/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": [["@babel/preset-env", { "targets": { "node": "20" } }], "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "16" } }], "@babel/preset-typescript"]
 }

--- a/packages/indexing/babel.config.json
+++ b/packages/indexing/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/ipfs-daemon/babel.config.json
+++ b/packages/ipfs-daemon/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": [["@babel/preset-env", { "targets": { "node": "20" } }], "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "16" } }], "@babel/preset-typescript"]
 }

--- a/packages/ipfs-topology/babel.config.json
+++ b/packages/ipfs-topology/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": [["@babel/preset-env", { "targets": { "node": "20" } }], "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "16" } }], "@babel/preset-typescript"]
 }

--- a/packages/job-queue/babel.config.json
+++ b/packages/job-queue/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/logger/babel.config.json
+++ b/packages/logger/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/pinning-aggregation/babel.config.json
+++ b/packages/pinning-aggregation/babel.config.json
@@ -1,4 +1,4 @@
 {
-  "presets": [["@babel/preset-env", { "targets": { "node": "20" } }], "@babel/preset-typescript"],
+  "presets": [["@babel/preset-env", { "targets": { "node": "16" } }], "@babel/preset-typescript"],
   "plugins": [["@babel/plugin-proposal-decorators", { "legacy": true }]]
 }

--- a/packages/pinning-crust-backend/babel.config.json
+++ b/packages/pinning-crust-backend/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/pinning-ipfs-backend/babel.config.json
+++ b/packages/pinning-ipfs-backend/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": [["@babel/preset-env", { "targets": { "node": "20" } }], "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "16" } }], "@babel/preset-typescript"]
 }

--- a/packages/pinning-powergate-backend/babel.config.json
+++ b/packages/pinning-powergate-backend/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": [["@babel/preset-env", { "targets": { "node": "20" } }], "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "16" } }], "@babel/preset-typescript"]
 }

--- a/packages/stream-caip10-link-handler/babel.config.json
+++ b/packages/stream-caip10-link-handler/babel.config.json
@@ -1,4 +1,4 @@
 {
-  "presets": [["@babel/preset-env", { "targets": { "node": "20" } }], "@babel/preset-typescript"],
+  "presets": [["@babel/preset-env", { "targets": { "node": "16" } }], "@babel/preset-typescript"],
   "plugins": [["@babel/plugin-proposal-decorators", { "legacy": true }]]
 }

--- a/packages/stream-caip10-link/babel.config.json
+++ b/packages/stream-caip10-link/babel.config.json
@@ -1,4 +1,4 @@
 {
-  "presets": [["@babel/preset-env", { "targets": { "node": "20" } }], "@babel/preset-typescript"],
+  "presets": [["@babel/preset-env", { "targets": { "node": "16" } }], "@babel/preset-typescript"],
   "plugins": [["@babel/plugin-proposal-decorators", { "legacy": true }]]
 }

--- a/packages/stream-handler-common/babel.config.json
+++ b/packages/stream-handler-common/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/stream-model-handler/babel.config.json
+++ b/packages/stream-model-handler/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/stream-model-instance-handler/babel.config.json
+++ b/packages/stream-model-instance-handler/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/stream-model/babel.config.json
+++ b/packages/stream-model/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/stream-tile-handler/babel.config.json
+++ b/packages/stream-tile-handler/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],

--- a/packages/streamid/babel.config.json
+++ b/packages/streamid/babel.config.json
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "20"
+          "node": "16"
         }
       }
     ],


### PR DESCRIPTION
Reverts ceramicnetwork/js-ceramic#3003