### PR TITLE
feat(common, core, indexing, ipfs-toplogy): Remove ELP network

### DIFF
--- a/packages/common/src/networks.ts
+++ b/packages/common/src/networks.ts
@@ -1,6 +1,5 @@
 export enum Networks {
   MAINNET = 'mainnet',
-  ELP = 'elp', // early launch program
   TESTNET_CLAY = 'testnet-clay',
   DEV_UNSTABLE = 'dev-unstable',
   LOCAL = 'local',

--- a/packages/core/src/initialization/__tests__/anchoring.test.ts
+++ b/packages/core/src/initialization/__tests__/anchoring.test.ts
@@ -26,10 +26,9 @@ describe('makeAnchorServiceUrl', () => {
   })
   test('throw on custom CAS on mainnet', () => {
     expect(() => makeAnchorServiceUrl(CUSTOM_URL, Networks.MAINNET)).toThrow(CustomMainnetCasError)
-    expect(() => makeAnchorServiceUrl(CUSTOM_URL, Networks.ELP)).toThrow(CustomMainnetCasError)
     const casInternal = 'https://cas-internal.3boxlabs.com'
     expect(makeAnchorServiceUrl(casInternal, Networks.MAINNET)).toEqual(casInternal)
     const casDirect = 'https://cas-direct.3boxlabs.com'
-    expect(makeAnchorServiceUrl(casDirect, Networks.ELP)).toEqual(casDirect)
+    expect(makeAnchorServiceUrl(casDirect, Networks.MAINNET)).toEqual(casDirect)
   })
 })

--- a/packages/core/src/initialization/anchoring.ts
+++ b/packages/core/src/initialization/anchoring.ts
@@ -10,7 +10,6 @@ import type { AnchorService } from '../anchor/anchor-service.js'
 
 export const DEFAULT_ANCHOR_SERVICE_URLS = {
   [Networks.MAINNET]: 'https://cas.3boxlabs.com',
-  [Networks.ELP]: 'https://cas.3boxlabs.com',
   [Networks.TESTNET_CLAY]: 'https://cas-clay.3boxlabs.com',
   [Networks.DEV_UNSTABLE]: 'https://cas-qa.3boxlabs.com',
   [Networks.LOCAL]: 'http://localhost:8081',
@@ -18,7 +17,6 @@ export const DEFAULT_ANCHOR_SERVICE_URLS = {
 
 const SUPPORTED_CHAINS_BY_NETWORK = {
   [Networks.MAINNET]: ['eip155:1'], // Ethereum mainnet
-  [Networks.ELP]: ['eip155:1'], // Ethereum mainnet
   [Networks.TESTNET_CLAY]: ['eip155:3', 'eip155:4', 'eip155:100'], // Ethereum Ropsten, Rinkeby, Gnosis Chain
   [Networks.DEV_UNSTABLE]: ['eip155:3', 'eip155:4', 'eip155:5'], // Ethereum Ropsten, Rinkeby, Goerli
   [Networks.LOCAL]: ['eip155:1337'], // Ganache
@@ -53,7 +51,6 @@ const MAINNET_CAS_URLS = [
   'https://cas-internal.3boxlabs.com',
   'https://cas-direct.3boxlabs.com',
   DEFAULT_ANCHOR_SERVICE_URLS[Networks.MAINNET],
-  DEFAULT_ANCHOR_SERVICE_URLS[Networks.ELP],
 ]
 export function makeAnchorServiceUrl(fromConfig: string | undefined, network: Networks): string {
   const casUrl = fromConfig?.replace(TRAILING_SLASH, '') || DEFAULT_ANCHOR_SERVICE_URLS[network]
@@ -64,7 +61,7 @@ export function makeAnchorServiceUrl(fromConfig: string | undefined, network: Ne
 }
 
 function isMainnet(network: Networks): boolean {
-  return network == Networks.MAINNET || network == Networks.ELP
+  return network == Networks.MAINNET
 }
 
 /**

--- a/packages/core/src/initialization/network-options.ts
+++ b/packages/core/src/initialization/network-options.ts
@@ -5,7 +5,6 @@ const DEFAULT_NETWORK = Networks.INMEMORY
 
 const TOPIC_BY_NETWORK = {
   [Networks.MAINNET]: '/ceramic/mainnet',
-  [Networks.ELP]: '/ceramic/mainnet',
   [Networks.TESTNET_CLAY]: '/ceramic/testnet-clay',
   [Networks.DEV_UNSTABLE]: '/ceramic/dev-unstable',
   // Default to a random pub/sub topic so that local deployments are isolated from each other

--- a/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
+++ b/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
@@ -21,6 +21,7 @@ import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
 import { createCeramic } from '../../__tests__/create-ceramic.js'
 import first from 'it-first'
 import all from 'it-all'
+import { OLD_ELP_DEFAULT_LOCATION } from '../level-db-store.js'
 
 const MODEL_CONTENT_1: ModelDefinition = {
   name: 'MyModel 1',
@@ -245,7 +246,7 @@ describe('LevelDB-backed AnchorRequestStore state store', () => {
   })
 
   test('switch from ELP to Mainnet preserves data', async () => {
-    const elpLevelStore = new LevelDbStore(logger, tmpFolder.path, Networks.ELP)
+    const elpLevelStore = new LevelDbStore(logger, tmpFolder.path, OLD_ELP_DEFAULT_LOCATION)
     await anchorRequestStore.open(elpLevelStore)
 
     const anchorRequestData: AnchorRequestData = {
@@ -268,8 +269,8 @@ describe('LevelDB-backed AnchorRequestStore state store', () => {
   })
 
   test('switch from Clay to Mainnet does not preserve data', async () => {
-    const elpLevelStore = new LevelDbStore(logger, tmpFolder.path, Networks.TESTNET_CLAY)
-    await anchorRequestStore.open(elpLevelStore)
+    const testnetLevelStore = new LevelDbStore(logger, tmpFolder.path, Networks.TESTNET_CLAY)
+    await anchorRequestStore.open(testnetLevelStore)
 
     const anchorRequestData: AnchorRequestData = {
       cid: TestUtils.randomCID(),

--- a/packages/core/src/store/__tests__/level-state-store.test.ts
+++ b/packages/core/src/store/__tests__/level-state-store.test.ts
@@ -9,7 +9,7 @@ import {
   Networks,
   DiagnosticsLogger,
 } from '@ceramicnetwork/common'
-import { LevelDbStore } from '../level-db-store.js'
+import { LevelDbStore, OLD_ELP_DEFAULT_LOCATION } from '../level-db-store.js'
 import { StreamStateStore } from '../stream-state-store.js'
 
 class FakeType extends Stream {
@@ -170,7 +170,7 @@ describe('LevelDB-backed StateStore network change tests', () => {
   })
 
   test('switch from ELP to Mainnet preserves data', async () => {
-    const elpLevelStore = new LevelDbStore(logger, tmpFolder.path, Networks.ELP)
+    const elpLevelStore = new LevelDbStore(logger, tmpFolder.path, OLD_ELP_DEFAULT_LOCATION)
     await stateStore.open(elpLevelStore)
 
     const state = TestUtils.makeStreamState()

--- a/packages/core/src/store/level-db-store.ts
+++ b/packages/core/src/store/level-db-store.ts
@@ -18,6 +18,8 @@ import { DiagnosticsLogger, Networks } from '@ceramicnetwork/common'
 const LevelC = (levelTs as any).default as unknown as typeof Level
 
 const DEFAULT_LEVELDB_STORE_USE_CASE_NAME = 'default'
+// When ELP existed ELP and Mainnet shared data by utilizing the elp location
+export const OLD_ELP_DEFAULT_LOCATION = 'elp'
 
 class NotFoundError extends Error {
   readonly notFound = true
@@ -48,14 +50,15 @@ class LevelDBStoreMap {
   }
 
   private getDefaultLocation(): string {
-    // We want ELP and Mainnet to share data
-    return this.networkName === Networks.MAINNET ? Networks.ELP : this.networkName
+    return this.networkName === Networks.MAINNET ? OLD_ELP_DEFAULT_LOCATION : this.networkName
   }
 
   private getFullLocation(useCaseName = DEFAULT_LEVELDB_STORE_USE_CASE_NAME): string {
     if (useCaseName === DEFAULT_LEVELDB_STORE_USE_CASE_NAME) {
+      console.log('1', this.getDefaultLocation())
       return this.getDefaultLocation()
     } else {
+      console.log('2', `${this.getDefaultLocation()}-${useCaseName}`)
       return `${this.getDefaultLocation()}-${useCaseName}`
     }
   }

--- a/packages/core/src/store/level-db-store.ts
+++ b/packages/core/src/store/level-db-store.ts
@@ -18,7 +18,8 @@ import { DiagnosticsLogger, Networks } from '@ceramicnetwork/common'
 const LevelC = (levelTs as any).default as unknown as typeof Level
 
 const DEFAULT_LEVELDB_STORE_USE_CASE_NAME = 'default'
-// When ELP existed ELP and Mainnet shared data by utilizing the elp location
+// When ELP existed ELP and Mainnet both utilized the elp location because they shared data.
+// In order to not lose the data stored there we will continue to do use the elp location for mainnet.
 export const OLD_ELP_DEFAULT_LOCATION = 'elp'
 
 class NotFoundError extends Error {

--- a/packages/core/src/store/level-db-store.ts
+++ b/packages/core/src/store/level-db-store.ts
@@ -55,10 +55,8 @@ class LevelDBStoreMap {
 
   private getFullLocation(useCaseName = DEFAULT_LEVELDB_STORE_USE_CASE_NAME): string {
     if (useCaseName === DEFAULT_LEVELDB_STORE_USE_CASE_NAME) {
-      console.log('1', this.getDefaultLocation())
       return this.getDefaultLocation()
     } else {
-      console.log('2', `${this.getDefaultLocation()}-${useCaseName}`)
       return `${this.getDefaultLocation()}-${useCaseName}`
     }
   }

--- a/packages/core/src/store/stream-state-store.ts
+++ b/packages/core/src/store/stream-state-store.ts
@@ -48,18 +48,6 @@ export class StreamStateStore extends ObjectStore<StreamID, StreamState> {
   }
 
   async open(store: IKVStore): Promise<void> {
-    if (store.networkName == Networks.MAINNET || store.networkName == Networks.ELP) {
-      // If using "mainnet", check for data under an 'elp' directory first. This is because older
-      // versions of Ceramic only supported an 'elp' network as an alias for mainnet and stored
-      // state store data under 'elp' instead of 'mainnet' by mistake, and we don't want to lose
-      // that data if it exists.
-      const hasPinnedStreams = !(await store.isEmpty())
-      if (hasPinnedStreams) {
-        this.#logger.verbose(
-          `Detected existing state store data under 'elp' directory. Continuing to use 'elp' directory to store state store data`
-        )
-      }
-    }
     return super.open(store)
   }
 

--- a/packages/indexing/src/migrations/1-create-model-table.ts
+++ b/packages/indexing/src/migrations/1-create-model-table.ts
@@ -108,8 +108,7 @@ export function defaultIndices(tableName: string): TableIndices {
  */
 export function getDefaultCDBDatabaseConfig(networkName: string): { [key: string]: any } {
   switch (networkName) {
-    case 'mainnet':
-    case 'elp': {
+    case 'mainnet': {
       return {
         enable_historical_sync: true,
         allow_queries_before_historical_sync: true,

--- a/packages/ipfs-topology/src/ipfs-topology.ts
+++ b/packages/ipfs-topology/src/ipfs-topology.ts
@@ -8,7 +8,6 @@ import { Multiaddr, multiaddr } from '@multiformats/multiaddr'
 const BOOTSTRAP_LIST = (ceramicNetwork: Networks): Array<Multiaddr> | null => {
   switch (ceramicNetwork) {
     case Networks.MAINNET:
-    case Networks.ELP:
       return [
         multiaddr(
           '/dns4/go-ipfs-ceramic-private-mainnet-external.3boxlabs.com/tcp/4011/ws/p2p/QmXALVsXZwPWTUbsT8G6VVzzgTJaAWRUD7FWL5f7d5ubAL'


### PR DESCRIPTION
Note that mainnet used "elp" as the default location for the stores. I'm keeping that for mainnet as we have never used "mainnet" as the default location. 