### PR TITLE
chore: don't log key not found errors

### DIFF
--- a/packages/core/src/store/level-db-store.ts
+++ b/packages/core/src/store/level-db-store.ts
@@ -105,10 +105,11 @@ export class LevelDbStore implements IKVStore {
       return await store.get(key)
     } catch (err) {
       const msg = `Error fetching key ${key} from leveldb state store: ${err}`
-      this.logger.warn(msg)
       if (err.notFound) {
+        // Key not found errors are common and expected, it's too verbose to log them every time.
         throw new NotFoundError(msg)
       } else {
+        this.logger.warn(msg)
         throw new Error(msg)
       }
     }


### PR DESCRIPTION
This logging was added recently in https://github.com/ceramicnetwork/js-ceramic/commit/bc46534a162af4c8ce1fac6b812ecb8bca3e0ba2, but it's too verbose for key not found errors, which happen often