### PR TITLE
Update init dispatcher test

### DIFF
--- a/packages/core/src/__tests__/initialization.test.ts
+++ b/packages/core/src/__tests__/initialization.test.ts
@@ -80,6 +80,7 @@ describe('Ceramic integration', () => {
     const databaseConnectionString = new URL(`sqlite://${tmpDirectory}/ceramic.sqlite`)
     const [modules, params] = await Ceramic._processConfig(ipfs1, {
       networkName: Networks.INMEMORY,
+      stateStoreDirectory: tmpDirectory,
       indexing: { db: databaseConnectionString.href, models: [] },
     })
     const dispatcher = modules.dispatcher


### PR DESCRIPTION
## Description
The `init dispatch` test can only be run once, it fails if run a second time on the same machine. The code to create ipfs is using a temporary directory for the ipfs data storage, but the Ceramic node is using a consistent real directory for its data storage, for the purposes of the test, they should be both temporary.

Fix: Adding the `stateStoreDirectory` arg when creating the Ceramic node.

## How Has This Been Tested?

By running the unit tests more than once.

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

N/A
