### PR TITLE
chore: Log connected peers at startup

### DIFF
--- a/packages/ipfs-topology/src/ipfs-topology.ts
+++ b/packages/ipfs-topology/src/ipfs-topology.ts
@@ -80,7 +80,7 @@ export class IpfsTopology {
     this.logger.debug(`Connected to peers: ${connectedPeers.join(',')}`)
 
     this.intervalId = setInterval(async () => {
-      this.logger.debug(`Performing periodic reconnection to bootstrap peers`)
+      this.logger.debug(`Performing periodic reconnection to bootstrap peers for network ${this.ceramicNetwork}`)
       await this.forceConnection()
     }, this.period)
   }

--- a/packages/ipfs-topology/src/ipfs-topology.ts
+++ b/packages/ipfs-topology/src/ipfs-topology.ts
@@ -68,14 +68,19 @@ export class IpfsTopology {
   ) {}
 
   async forceConnection(): Promise<void> {
-    this.logger.debug(`Performing periodic reconnection to bootstrap peers`)
     const bootstrapList: Multiaddr[] = BOOTSTRAP_LIST(this.ceramicNetwork as Networks) || []
     await this._forceBootstrapConnection(this.ipfs, bootstrapList)
   }
 
   async start() {
+    this.logger.imp(`Connecting to bootstrap peers for network ${this.ceramicNetwork}`)
+
     await this.forceConnection()
+    const connectedPeers = (await this.ipfs.swarm.peers()).map((peer) => peer.addr.toString())
+    this.logger.debug(`Connected to peers: ${connectedPeers.join(',')}`)
+
     this.intervalId = setInterval(async () => {
+      this.logger.debug(`Performing periodic reconnection to bootstrap peers`)
       await this.forceConnection()
     }, this.period)
   }


### PR DESCRIPTION
Only logs at debug log level, but that's what we use on our nodes in our tests and infra so should help us debug failures.