### PR TITLE
fix(ci): update rust-ceramic repo path

### DIFF
--- a/ci-scripts/install-rust-ceramic.sh
+++ b/ci-scripts/install-rust-ceramic.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-REPO=3box/rust-ceramic/releases
+REPO=ceramicnetwork/rust-ceramic/releases
 ARCH=x86_64
 OS=unknown-linux-gnu
 TARGET=$ARCH-$OS
@@ -20,4 +20,4 @@ echo "Extracting "$OUTPUT_FILE
 tar -xvf $OUTPUT_FILE
 rm $OUTPUT_FILE
 
-DEBIAN_FRONTEND=noninteractive dpkg -i $DEB_NAME 
+DEBIAN_FRONTEND=noninteractive dpkg -i $DEB_NAME


### PR DESCRIPTION
Update the `rust-ceramic` release path to point to the [new location](https://github.com/ceramicnetwork/rust-ceramic).