### PR TITLE
Bugfix/install rust ceramic follow redirect

### DIFF
--- a/ci-scripts/install-rust-ceramic.sh
+++ b/ci-scripts/install-rust-ceramic.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -ex
+
 REPO=3box/rust-ceramic/releases
 ARCH=x86_64
 OS=unknown-linux-gnu

--- a/ci-scripts/install-rust-ceramic.sh
+++ b/ci-scripts/install-rust-ceramic.sh
@@ -8,7 +8,7 @@ OS=unknown-linux-gnu
 TARGET=$ARCH-$OS
 
 NAME=ceramic-one
-VERSION=$(curl https://api.github.com/repos/$REPO/latest -s |  jq .name -r)
+VERSION=$(curl https://api.github.com/repos/$REPO/latest -sL |  jq .name -r)
 TAR_NAME=${NAME}_$TARGET.tar.gz
 DEB_NAME=${NAME}.deb
 OUTPUT_FILE=$NAME.tar.gz


### PR DESCRIPTION
## Description

The api request is returning a 301, which is not follow causing the VERSION to return `null` and the release download fails.

$ REPO=3box/rust-ceramic/releases curl https://api.github.com/repos/$REPO/latest -s
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/599309594/releases/latest",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}

## How Has This Been Tested?

Ran the command and inspected the output.

## PR checklist

Before submitting this PR, please make sure:

- [X] I have tagged the relevant reviewers and interested parties
- [X] I have updated the READMEs of affected packages
- [X] I have made corresponding changes to the documentation

