### PR TITLE
chore(core): Add logging when creating new leveldb store

### DIFF
--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -1001,6 +1001,7 @@ export class Repository {
       stream.complete()
     })
     await this.#deps.pinStore.close()
+    await this.#deps.anchorRequestStore.close()
     await this.index.close()
   }
 }

--- a/packages/core/src/store/anchor-request-store.ts
+++ b/packages/core/src/store/anchor-request-store.ts
@@ -72,4 +72,8 @@ export class AnchorRequestStore extends ObjectStore<StreamID, AnchorRequestData>
       }
     } while (true)
   }
+
+  async close(): Promise<void> {
+    await this.store.close(this.useCaseName)
+  }
 }


### PR DESCRIPTION
## Description

* Noticed that the anchor request store wasn't being closed, its a no op for this store, but can be for other types of stores.
* This is not a solution but can provide better insight into whats happening with little impact. I have a solution on deck, but I'm not too fond of it as the packages it needs are "deprecated". 
* Should we be upgrading our level packages (level-ts uses deprecated level packages) 

## How Has This Been Tested?

Unit tests are running
