### PR TITLE
chore(cli,common,http-client,indexing): remove legacy query fields

### DIFF
--- a/packages/cli/src/__tests__/index-api.test.ts
+++ b/packages/cli/src/__tests__/index-api.test.ts
@@ -75,7 +75,7 @@ test('count', async () => {
   const returnCount = Math.random()
   indexSpy.mockReturnValueOnce(Promise.resolve(returnCount))
   const query = {
-    model: modelStreamId,
+    models: [modelStreamId],
   }
   const result = await client.index.count(query)
   expect(result).toEqual(returnCount)
@@ -85,18 +85,18 @@ test('count', async () => {
 test('model in query', async () => {
   const indexSpy = jest.spyOn(daemon.ceramic.index, 'query')
   await client.index.query({
-    model: modelStreamId,
+    models: [modelStreamId],
     first: 100,
   })
   expect(indexSpy).toBeCalledWith({
     first: 100,
-    model: modelStreamId.toString(),
+    models: [modelStreamId.toString()],
   })
 })
 test('too much entries requested: forward pagination', async () => {
   await expect(
     client.index.query({
-      model: modelStreamId,
+      models: [modelStreamId],
       first: 20000,
     })
   ).rejects.toThrow(/Requested too many entries: 20000/)
@@ -104,7 +104,7 @@ test('too much entries requested: forward pagination', async () => {
 test('too much entries requested: forward pagination', async () => {
   await expect(
     client.index.query({
-      model: modelStreamId,
+      models: [modelStreamId],
       last: 20000,
     })
   ).rejects.toThrow(/Requested too many entries: 20000/)
@@ -113,13 +113,13 @@ test('model, account in query', async () => {
   const account = `did:key:${randomString(10)}`
   const indexSpy = jest.spyOn(daemon.ceramic.index, 'query')
   await client.index.query({
-    model: modelStreamId,
+    models: [modelStreamId],
     account: account,
     first: 100,
   })
   expect(indexSpy).toBeCalledWith({
     first: 100,
-    model: modelStreamId.toString(),
+    models: [modelStreamId.toString()],
     account: account,
   })
 })
@@ -154,7 +154,7 @@ test('serialize StreamState', async () => {
   }
   // It gets serialized
   const response = await client.index.query({
-    model: modelStreamId,
+    models: [modelStreamId],
     first: 100,
   })
   // const response = await fetchJson(query.toString())

--- a/packages/cli/src/daemon/__tests__/collection-query.test.ts
+++ b/packages/cli/src/daemon/__tests__/collection-query.test.ts
@@ -29,13 +29,13 @@ describe('parsePagination', () => {
 })
 
 describe('collectionQuery', () => {
-  const model = new StreamID(1, TestUtils.randomCID()).toString()
+  const models = [new StreamID(1, TestUtils.randomCID()).toString()]
   test('parse model', () => {
-    const parsed = collectionQuery({ first: 10, model })
-    expect(parsed).toEqual({ first: 10, model })
+    const parsed = collectionQuery({ first: 10, models })
+    expect(parsed).toEqual({ first: 10, models })
   })
   test('pass account', () => {
-    const parsed = collectionQuery({ first: 10, model, account: 'did:key:foo' })
-    expect(parsed).toEqual({ first: 10, model: model, account: 'did:key:foo' })
+    const parsed = collectionQuery({ first: 10, models, account: 'did:key:foo' })
+    expect(parsed).toEqual({ first: 10, models, account: 'did:key:foo' })
   })
 })

--- a/packages/cli/src/daemon/collection-queries.ts
+++ b/packages/cli/src/daemon/collection-queries.ts
@@ -69,10 +69,8 @@ export function collectionQuery(query: Record<string, any>): BaseQuery & Paginat
   try {
     const pagination = parsePagination(query)
     return {
-      model: query.model,
       models: query.models,
       account: query.account,
-      filter: query.filter,
       queryFilters: query.queryFilters,
       sorting: query.sorting,
       ...pagination,
@@ -84,10 +82,8 @@ export function collectionQuery(query: Record<string, any>): BaseQuery & Paginat
 
 export function countQuery(query: Record<string, any>): BaseQuery {
   return {
-    model: query.model,
     models: query.models,
     account: query.account,
-    filter: query.filter,
     queryFilters: query.queryFilters,
   }
 }

--- a/packages/common/src/index-api.ts
+++ b/packages/common/src/index-api.ts
@@ -109,19 +109,8 @@ export type Sorting = Record<string, SortOrder>
  * Base query to the index. Disregards pagination.
  */
 export type BaseQuery = {
-  /**
-   * @deprecated single model filter used by ComposeDB <= 0.5
-   */
-  model?: StreamID | string
-  /**
-   * TODO(v3): make "models" required when removing the "model" key
-   */
-  models?: Array<StreamID | string>
+  models: Array<StreamID | string>
   account?: string
-  /**
-   * @deprecated relation filters used by ComposeDB <= 0.4
-   */
-  filter?: Record<string, string>
   queryFilters?: QueryFilters
   sorting?: Sorting
 }

--- a/packages/http-client/src/utils.ts
+++ b/packages/http-client/src/utils.ts
@@ -32,7 +32,9 @@ export function serializeObjectToSearchParams(
 export function serializeObjectForHttpPost(query: Record<string, any>): Record<string, any> {
   const result = {}
   for (const [key, value] of Object.entries(query)) {
-    if (StreamID.isInstance(value)) {
+    if (Array.isArray(value)) {
+      result[key] = value.map((v) => (StreamID.isInstance(v) ? v.toString() : v))
+    } else if (StreamID.isInstance(value)) {
       result[key] = value.toString()
     } else {
       result[key] = value

--- a/packages/indexing/src/__tests__/database-index-api.test.ts
+++ b/packages/indexing/src/__tests__/database-index-api.test.ts
@@ -915,14 +915,14 @@ and indexname in (${expectedIndices});
         return { edges: [], pageInfo: { hasNextPage: false, hasPreviousPage: false } }
       })
       indexApi.insertionOrder.page = mockPage
-      await indexApi.page({ model: STREAM_ID_A, first: 100 })
+      await indexApi.page({ models: [STREAM_ID_A], first: 100 })
       expect(mockPage).toBeCalled()
     })
     test('throw if historical sync is not allowed', async () => {
       const indexApi = new PostgresIndexApi(FAUX_DB_CONNECTION, false, logger, Networks.INMEMORY)
       indexApi.setSyncQueryApi(new IncompleteQueryApi())
       indexApi.indexedModels = [{ streamID: StreamID.fromString(STREAM_ID_A) }]
-      await expect(indexApi.page({ model: STREAM_ID_A, first: 100 })).rejects.toThrow(
+      await expect(indexApi.page({ models: [STREAM_ID_A], first: 100 })).rejects.toThrow(
         IndexQueryNotAvailableError
       )
     })
@@ -947,11 +947,11 @@ and indexname in (${expectedIndices});
         await indexApi.indexStream(row)
       }
       // all
-      await expect(indexApi.count({ model: MODEL })).resolves.toEqual(rows.length)
+      await expect(indexApi.count({ models: [MODEL] })).resolves.toEqual(rows.length)
       // by account
       const account = 'did:key:blah'
       const expected = rows.filter((r) => r.controller === account).length
-      await expect(indexApi.count({ model: MODEL, account: account })).resolves.toEqual(expected)
+      await expect(indexApi.count({ models: [MODEL], account: account })).resolves.toEqual(expected)
     })
   })
 })
@@ -1696,14 +1696,14 @@ and name in (${expectedIndices})
         return { edges: [], pageInfo: { hasNextPage: false, hasPreviousPage: false } }
       })
       indexApi.insertionOrder.page = mockPage
-      await indexApi.page({ model: STREAM_ID_A, first: 100 })
+      await indexApi.page({ models: [STREAM_ID_A], first: 100 })
       expect(mockPage).toBeCalled()
     })
     test('throw if historical sync is not allowed', async () => {
       const indexApi = new SqliteIndexApi(FAUX_DB_CONNECTION, false, logger, Networks.INMEMORY)
       indexApi.setSyncQueryApi(new IncompleteQueryApi())
       indexApi.indexedModels = [{ streamID: StreamID.fromString(STREAM_ID_A) }]
-      await expect(indexApi.page({ model: STREAM_ID_A, first: 100 })).rejects.toThrow(
+      await expect(indexApi.page({ models: [STREAM_ID_A], first: 100 })).rejects.toThrow(
         IndexQueryNotAvailableError
       )
     })
@@ -1728,11 +1728,11 @@ and name in (${expectedIndices})
         await indexApi.indexStream(row)
       }
       // all
-      await expect(indexApi.count({ model: MODEL })).resolves.toEqual(rows.length)
+      await expect(indexApi.count({ models: [MODEL] })).resolves.toEqual(rows.length)
       // by account
       const account = 'did:key:blah'
       const expected = rows.filter((r) => r.controller === account).length
-      await expect(indexApi.count({ model: MODEL, account: account })).resolves.toEqual(expected)
+      await expect(indexApi.count({ models: [MODEL], account: account })).resolves.toEqual(expected)
     })
   })
 })

--- a/packages/indexing/src/database-index-api.ts
+++ b/packages/indexing/src/database-index-api.ts
@@ -322,21 +322,13 @@ export abstract class DatabaseIndexApi<DateType = Date | number> {
   abstract getCountFromResult(response: Array<Record<string, string | number>>): number
 
   async getQueryModels(query: BaseQuery): Promise<Set<string>> {
-    let ids: Array<StreamID | string> = []
-    // Use models array by default, but may not be provided by older clients
-    if (Array.isArray(query.models) && query.models.length !== 0) {
-      ids = query.models
-    } else if (query.model != null) {
-      // Fallback to single model
-      ids = [query.model]
-    } else {
-      // As neither the models or model values are required, it's possible no model is provided
-      throw new Error(`Missing "models" values to execute query`)
+    if (query.models.length === 0) {
+      throw new Error(`At least one model must be provided to execute query`)
     }
 
     // Collect all models implementing interfaces
     const models = new Set<string>()
-    for (const modelID of ids) {
+    for (const modelID of query.models) {
       const id = modelID.toString()
       const interfaceModels = this.#interfacesModels[id]
       if (interfaceModels == null) {

--- a/packages/stream-tests/src/__tests__/admin-api.test.ts
+++ b/packages/stream-tests/src/__tests__/admin-api.test.ts
@@ -113,7 +113,7 @@ describe('Admin API tests', () => {
       let indexedModels = await ceramic.admin.getIndexedModels()
       expect(indexedModels.length).toEqual(0)
 
-      await expect(ceramic.index.count({ model: model.id })).rejects.toThrow(
+      await expect(ceramic.index.count({ models: [model.id] })).rejects.toThrow(
         /is not indexed on this node/
       )
 
@@ -123,19 +123,19 @@ describe('Admin API tests', () => {
       expect(indexedModels.length).toEqual(1)
 
       // Doesn't know about the doc created before the model was indexed
-      await expect(ceramic.index.count({ model: model.id })).resolves.toEqual(0)
+      await expect(ceramic.index.count({ models: [model.id] })).resolves.toEqual(0)
       await ModelInstanceDocument.create(ceramic, CONTENT0, { model: model.id })
-      await expect(ceramic.index.count({ model: model.id })).resolves.toEqual(1)
+      await expect(ceramic.index.count({ models: [model.id] })).resolves.toEqual(1)
       // Discovers the first doc when it is updated
       ceramic.did = nonAdminDid // Set did back to the stream controller so it can be updated
       await doc1.replace(CONTENT1)
-      await expect(ceramic.index.count({ model: model.id })).resolves.toEqual(2)
+      await expect(ceramic.index.count({ models: [model.id] })).resolves.toEqual(2)
 
       // Now stop indexing the model
       ceramic.did = adminDid
       await ceramic.admin.stopIndexingModels([model.id])
 
-      await expect(ceramic.index.count({ model: model.id })).rejects.toThrow(
+      await expect(ceramic.index.count({ models: [model.id] })).rejects.toThrow(
         /is not indexed on this node/
       )
     })
@@ -150,7 +150,7 @@ describe('Admin API tests', () => {
       let indexedModels = await ceramic.admin.getIndexedModelData()
       expect(indexedModels.length).toEqual(0)
 
-      await expect(ceramic.index.count({ model: model.id })).rejects.toThrow(
+      await expect(ceramic.index.count({ models: [model.id] })).rejects.toThrow(
         /is not indexed on this node/
       )
 
@@ -165,19 +165,19 @@ describe('Admin API tests', () => {
       expect(indexedModels.length).toEqual(1)
 
       // Doesn't know about the doc created before the model was indexed
-      await expect(ceramic.index.count({ model: model.id })).resolves.toEqual(0)
+      await expect(ceramic.index.count({ models: [model.id] })).resolves.toEqual(0)
       await ModelInstanceDocument.create(ceramic, CONTENT0, { model: model.id })
-      await expect(ceramic.index.count({ model: model.id })).resolves.toEqual(1)
+      await expect(ceramic.index.count({ models: [model.id] })).resolves.toEqual(1)
       // Discovers the first doc when it is updated
       ceramic.did = nonAdminDid // Set did back to the stream controller so it can be updated
       await doc1.replace(CONTENT1)
-      await expect(ceramic.index.count({ model: model.id })).resolves.toEqual(2)
+      await expect(ceramic.index.count({ models: [model.id] })).resolves.toEqual(2)
 
       // Now stop indexing the model
       ceramic.did = adminDid
       await ceramic.admin.stopIndexingModels([model.id])
 
-      await expect(ceramic.index.count({ model: model.id })).rejects.toThrow(
+      await expect(ceramic.index.count({ models: [model.id] })).rejects.toThrow(
         /is not indexed on this node/
       )
     })

--- a/packages/stream-tests/src/__tests__/basic-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/basic-indexing.test.ts
@@ -292,7 +292,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       // Indexed streams should always get pinned, regardless of the 'pin' flag
       await expect(TestUtils.isPinned(ceramic, doc.id)).resolves.toBeTruthy()
 
-      const resultObj = await ceramic.index.query({ model: model.id, first: 100 })
+      const resultObj = await ceramic.index.query({ models: [model.id], first: 100 })
       const results = extractDocuments(ceramic, resultObj)
 
       expect(results.length).toEqual(1)
@@ -303,7 +303,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
 
     test("query a model that isn't indexed", async () => {
       await expect(
-        ceramic.index.query({ model: UNINDEXED_MODEL_STREAM_ID, first: 100 })
+        ceramic.index.query({ models: [UNINDEXED_MODEL_STREAM_ID], first: 100 })
       ).rejects.toThrow(/is not indexed on this node/)
     })
 
@@ -319,11 +319,11 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
     })
 
     test('basic count query', async () => {
-      await expect(ceramic.index.count({ model: model.id.toString() })).resolves.toEqual(0)
+      await expect(ceramic.index.count({ models: [model.id.toString()] })).resolves.toEqual(0)
       const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
-      await expect(ceramic.index.count({ model: model.id.toString() })).resolves.toEqual(1)
+      await expect(ceramic.index.count({ models: [model.id.toString()] })).resolves.toEqual(1)
       await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
-      await expect(ceramic.index.count({ model: model.id.toString() })).resolves.toEqual(2)
+      await expect(ceramic.index.count({ models: [model.id.toString()] })).resolves.toEqual(2)
 
       // Use a different model
       await ModelInstanceDocument.create(
@@ -332,15 +332,15 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
         midRelationMetadata
       )
       await expect(
-        ceramic.index.count({ model: modelWithRelation.id.toString() })
+        ceramic.index.count({ models: [modelWithRelation.id.toString()] })
       ).resolves.toEqual(1)
 
       // Creating a document in a different model doesn't affect the count
-      await expect(ceramic.index.count({ model: model.id.toString() })).resolves.toEqual(2)
+      await expect(ceramic.index.count({ models: [model.id.toString()] })).resolves.toEqual(2)
     })
 
     test("count query on a model that isn't indexed", async () => {
-      await expect(ceramic.index.count({ model: UNINDEXED_MODEL_STREAM_ID })).rejects.toThrow(
+      await expect(ceramic.index.count({ models: [UNINDEXED_MODEL_STREAM_ID] })).rejects.toThrow(
         /is not indexed on this node/
       )
     })
@@ -351,7 +351,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc2 = await ModelInstanceDocument.create(ceramic, CONTENT2, midMetadata)
       const doc3 = await ModelInstanceDocument.create(ceramic, CONTENT3, midMetadata)
 
-      const resultObj = await ceramic.index.query({ model: model.id, first: 100 })
+      const resultObj = await ceramic.index.query({ models: [model.id], first: 100 })
       const results = extractDocuments(ceramic, resultObj)
 
       expect(results.length).toEqual(3)
@@ -371,16 +371,16 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc4 = await ModelInstanceDocument.create(ceramic, CONTENT4, midMetadata)
       const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
 
-      const resultObj0 = await ceramic.index.query({ model: model.id, first: 2 })
+      const resultObj0 = await ceramic.index.query({ models: [model.id], first: 2 })
       expect(resultObj0.pageInfo.hasNextPage).toBeTruthy()
       const resultObj1 = await ceramic.index.query({
-        model: model.id,
+        models: [model.id],
         first: 2,
         after: resultObj0.pageInfo.endCursor,
       })
       expect(resultObj1.pageInfo.hasNextPage).toBeTruthy()
       const resultObj2 = await ceramic.index.query({
-        model: model.id,
+        models: [model.id],
         first: 2,
         after: resultObj1.pageInfo.endCursor,
       })
@@ -411,7 +411,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc2 = await ModelInstanceDocument.create(ceramic, CONTENT2, midMetadata)
       const doc3 = await ModelInstanceDocument.create(ceramic, CONTENT3, midMetadata)
 
-      const resultObj = await ceramic.index.query({ model: model.id, last: 100 })
+      const resultObj = await ceramic.index.query({ models: [model.id], last: 100 })
       const results = extractDocuments(ceramic, resultObj)
 
       // Using `last` doesn't change the order of documents returned within each page
@@ -432,16 +432,16 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc4 = await ModelInstanceDocument.create(ceramic, CONTENT4, midMetadata)
       const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
 
-      const resultObj0 = await ceramic.index.query({ model: model.id, last: 2 })
+      const resultObj0 = await ceramic.index.query({ models: [model.id], last: 2 })
       expect(resultObj0.pageInfo.hasPreviousPage).toBeTruthy()
       const resultObj1 = await ceramic.index.query({
-        model: model.id,
+        models: [model.id],
         last: 2,
         before: resultObj0.pageInfo.startCursor,
       })
       expect(resultObj1.pageInfo.hasPreviousPage).toBeTruthy()
       const resultObj2 = await ceramic.index.query({
-        model: model.id,
+        models: [model.id],
         last: 2,
         before: resultObj1.pageInfo.startCursor,
       })
@@ -478,7 +478,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
 
       const baseQuery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           where: { myData: { equalTo: 3 } },
         },
@@ -502,7 +502,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc4 = await ModelInstanceDocument.create(ceramic, CONTENT3, midMetadata)
 
       const baseQuery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           where: { myString: { isNull: false } },
         },
@@ -527,7 +527,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT4, midMetadata)
 
       const baseQuery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           where: { myString: { equalTo: 'b' } },
         },
@@ -552,7 +552,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT6, midMetadata)
 
       const baseQuery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           where: { myString: { in: ['a', 'c'] } },
         },
@@ -578,7 +578,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
 
       const baseQuery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           or: [{ where: { myData: { equalTo: 2 } } }, { where: { myData: { equalTo: 3 } } }],
         },
@@ -601,7 +601,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
 
       const baseQuery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           not: { where: { myData: { equalTo: 3 } } },
         },
@@ -629,7 +629,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
 
       const baseQuery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           where: { myData: { in: [3] } },
         },
@@ -654,7 +654,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
 
       const baseQuery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           where: { myFloat: { greaterThan: 1.2 } },
         },
@@ -679,7 +679,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
 
       const baseQuery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           where: { myFloat: { greaterThan: 1.0 } },
         },
@@ -704,7 +704,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT6, midMetadata)
 
       const resultObj0 = await ceramic.index.query({
-        model: model.id,
+        models: [model.id],
         last: 5,
         queryFilters: {
           where: {
@@ -718,7 +718,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       expect(JSON.stringify(results0[0].content)).toEqual(JSON.stringify(doc5.content))
 
       const countResults = await ceramic.index.count({
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           where: {
             myData: { equalTo: 6 },
@@ -737,7 +737,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
 
       await expect(
         ceramic.index.query({
-          model: model.id,
+          models: [model.id],
           last: 5,
           queryFilters: {
             where: {
@@ -756,7 +756,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
 
       await expect(
         ceramic.index.count({
-          model: model.id,
+          models: [model.id],
           queryFilters: {
             and: [
               {
@@ -778,7 +778,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT6, midMetadata)
 
       const baseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           where: {
             myString: { in: ['a', 'b'] },
@@ -807,7 +807,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
 
       await expect(
         ceramic.index.query({
-          model: model.id,
+          models: [model.id],
           last: 5,
           queryFilters: {
             where: {
@@ -820,7 +820,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
 
       await expect(
         ceramic.index.count({
-          model: model.id,
+          models: [model.id],
           queryFilters: {
             where: {
               myString: { in: ['a', 'b'] },
@@ -839,7 +839,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc6 = await ModelInstanceDocument.create(ceramic, CONTENT6, midMetadata)
 
       const baseQuery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           not: {
             or: [{ where: { myData: { equalTo: 3 } } }, { where: { myString: { equalTo: 'b' } } }],
@@ -867,7 +867,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc6 = await ModelInstanceDocument.create(ceramic, CONTENT6, midMetadata)
 
       const basequery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           not: {
             and: [{ where: { myData: { equalTo: 3 } } }, { where: { myString: { equalTo: 'b' } } }],
@@ -894,7 +894,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc5 = await ModelInstanceDocument.create(ceramic, CONTENT5, midMetadata)
 
       const baseQuery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           not: {
             where: {
@@ -927,7 +927,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc6 = await ModelInstanceDocument.create(ceramic, CONTENT6, midMetadata)
 
       const baseQuery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           or: [
             {
@@ -970,7 +970,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc6 = await ModelInstanceDocument.create(ceramic, CONTENT6, midMetadata)
 
       const baseQuery: BaseQuery = {
-        model: model.id,
+        models: [model.id],
         queryFilters: {
           and: [
             {
@@ -1010,7 +1010,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc2 = await ModelInstanceDocument.create(ceramic, CONTENT2, midMetadata)
 
       const resultObj = await ceramic.index.query({
-        model: model.id,
+        models: [model.id],
         sorting: { myData: 'ASC' },
         first: 100,
       })
@@ -1028,7 +1028,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc2 = await ModelInstanceDocument.create(ceramic, CONTENT2, midMetadata)
 
       const resultObj = await ceramic.index.query({
-        model: model.id,
+        models: [model.id],
         sorting: { myData: 'DESC' },
         first: 100,
       })
@@ -1046,7 +1046,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc2 = await ModelInstanceDocument.create(ceramic, CONTENT2, midMetadata)
 
       const resultObj = await ceramic.index.query({
-        model: model.id,
+        models: [model.id],
         sorting: { myData: 'ASC' },
         last: 100,
       })
@@ -1064,7 +1064,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const doc2 = await ModelInstanceDocument.create(ceramic, CONTENT2, midMetadata)
 
       const resultObj = await ceramic.index.query({
-        model: model.id,
+        models: [model.id],
         sorting: { myData: 'DESC' },
         last: 100,
       })
@@ -1086,7 +1086,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const [b1id, b2id] = [doc3.id.toString(), doc6.id.toString()].sort()
 
       const query = {
-        model: model.id,
+        models: [model.id],
         queryFilters: { where: { myString: { isNull: false } } },
         sorting: { myString: 'ASC' },
         first: 2,
@@ -1123,7 +1123,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const [b1id, b2id] = [doc3.id.toString(), doc6.id.toString()].sort()
 
       const query = {
-        model: model.id,
+        models: [model.id],
         queryFilters: { where: { myString: { isNull: false } } },
         sorting: { myString: 'DESC' },
         first: 2,
@@ -1160,7 +1160,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const [b1id, b2id] = [doc3.id.toString(), doc6.id.toString()].sort()
 
       const query = {
-        model: model.id,
+        models: [model.id],
         queryFilters: { where: { myString: { isNull: false } } },
         sorting: { myString: 'ASC' }, // Need to flip to DESC in query
         last: 2,
@@ -1197,7 +1197,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       const [b1id, b2id] = [doc3.id.toString(), doc6.id.toString()].sort()
 
       const query = {
-        model: model.id,
+        models: [model.id],
         queryFilters: { where: { myString: { isNull: false } } },
         sorting: { myString: 'DESC' },
         last: 2,
@@ -1251,9 +1251,9 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
         )
 
         let resultObj = await ceramic.index.query({
-          model: modelWithRelation.id,
+          models: [modelWithRelation.id],
           first: 100,
-          filter: { linkedDoc: referencedDoc0.id.toString() },
+          queryFilters: { where: { linkedDoc: { equalTo: referencedDoc0.id.toString() } } },
         })
         let results = extractDocuments(ceramic, resultObj)
         expect(results.length).toEqual(1)
@@ -1262,9 +1262,9 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
         expect(results[0].state).toEqual(doc0.state)
 
         resultObj = await ceramic.index.query({
-          model: modelWithRelation.id,
+          models: [modelWithRelation.id],
           first: 100,
-          filter: { linkedDoc: referencedDoc1.id.toString() },
+          queryFilters: { where: { linkedDoc: { equalTo: referencedDoc1.id.toString() } } },
         })
         results = extractDocuments(ceramic, resultObj)
         expect(results.length).toEqual(2)
@@ -1277,9 +1277,9 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
 
         // Now check with 'last' queries
         resultObj = await ceramic.index.query({
-          model: modelWithRelation.id,
+          models: [modelWithRelation.id],
           last: 100,
-          filter: { linkedDoc: referencedDoc0.id.toString() },
+          queryFilters: { where: { linkedDoc: { equalTo: referencedDoc0.id.toString() } } },
         })
         results = extractDocuments(ceramic, resultObj)
         expect(results.length).toEqual(1)
@@ -1288,9 +1288,9 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
         expect(results[0].state).toEqual(doc0.state)
 
         resultObj = await ceramic.index.query({
-          model: modelWithRelation.id,
+          models: [modelWithRelation.id],
           last: 100,
-          filter: { linkedDoc: referencedDoc1.id.toString() },
+          queryFilters: { where: { linkedDoc: { equalTo: referencedDoc1.id.toString() } } },
         })
         results = extractDocuments(ceramic, resultObj)
         expect(results.length).toEqual(2)
@@ -1343,19 +1343,19 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
 
         // Querying for a single relation should find two documents - one with each controller
         const resultObj0 = await ceramic.index.query({
-          model: modelWithRelation.id,
+          models: [modelWithRelation.id],
           first: 100,
-          filter: { linkedDoc: referencedDoc0.id.toString() },
+          queryFilters: { where: { linkedDoc: { equalTo: referencedDoc0.id.toString() } } },
         })
         const results0 = extractDocuments(ceramic, resultObj0)
         expect(results0.length).toEqual(2)
 
         // Querying for a single relation should find two documents - one with each controller
         const resultObj1 = await ceramic.index.query({
-          model: modelWithRelation.id,
+          models: [modelWithRelation.id],
           account: originalDid.id.toString(),
           first: 100,
-          filter: { linkedDoc: referencedDoc0.id.toString() },
+          queryFilters: { where: { linkedDoc: { equalTo: referencedDoc0.id.toString() } } },
         })
         const results1 = extractDocuments(ceramic, resultObj1)
         expect(results1.length).toEqual(1)
@@ -1369,7 +1369,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       async () => {
         const referencedDoc0 = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
         const referencedDoc1 = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
-        await expect(ceramic.index.count({ model: model.id.toString() })).resolves.toEqual(2)
+        await expect(ceramic.index.count({ models: [model.id.toString()] })).resolves.toEqual(2)
 
         // Create two docs with the original DID, referencing two different docs in the linked model
         const originalDid = ceramic.did
@@ -1380,7 +1380,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
         )
 
         await expect(
-          ceramic.index.count({ model: modelWithRelation.id.toString() })
+          ceramic.index.count({ models: [modelWithRelation.id.toString()] })
         ).resolves.toEqual(1)
 
         await ModelInstanceDocument.create(
@@ -1390,13 +1390,13 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
         )
 
         await expect(
-          ceramic.index.count({ model: modelWithRelation.id.toString() })
+          ceramic.index.count({ models: [modelWithRelation.id.toString()] })
         ).resolves.toEqual(2)
 
         await expect(
           ceramic.index.count({
-            model: modelWithRelation.id.toString(),
-            filter: { linkedDoc: referencedDoc0.id.toString() },
+            models: [modelWithRelation.id.toString()],
+            queryFilters: { where: { linkedDoc: { equalTo: referencedDoc0.id.toString() } } },
           })
         ).resolves.toEqual(1)
 
@@ -1414,7 +1414,7 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
         )
 
         await expect(
-          ceramic.index.count({ model: modelWithRelation.id.toString() })
+          ceramic.index.count({ models: [modelWithRelation.id.toString()] })
         ).resolves.toEqual(3)
 
         await ModelInstanceDocument.create(
@@ -1425,21 +1425,21 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
 
         // Count all docs in the model with the relation
         await expect(
-          ceramic.index.count({ model: modelWithRelation.id.toString() })
+          ceramic.index.count({ models: [modelWithRelation.id.toString()] })
         ).resolves.toEqual(4)
 
         // Count docs with a specific relation
         await expect(
           ceramic.index.count({
-            model: modelWithRelation.id.toString(),
-            filter: { linkedDoc: referencedDoc0.id.toString() },
+            models: [modelWithRelation.id.toString()],
+            queryFilters: { where: { linkedDoc: { equalTo: referencedDoc0.id.toString() } } },
           })
         ).resolves.toEqual(2)
 
         // count docs with a specific controller
         await expect(
           ceramic.index.count({
-            model: modelWithRelation.id.toString(),
+            models: [modelWithRelation.id.toString()],
             account: originalDid.id.toString(),
           })
         ).resolves.toEqual(2)
@@ -1447,9 +1447,9 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
         // count docs with a specific relation AND a specific controller
         await expect(
           ceramic.index.count({
-            model: modelWithRelation.id.toString(),
+            models: [modelWithRelation.id.toString()],
             account: originalDid.id.toString(),
-            filter: { linkedDoc: referencedDoc0.id.toString() },
+            queryFilters: { where: { linkedDoc: { equalTo: referencedDoc0.id.toString() } } },
           })
         ).resolves.toEqual(1)
       },
@@ -1472,12 +1472,12 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
       )
 
       await expect(
-        ceramic.index.count({ model: modelWithRelation.id.toString() })
+        ceramic.index.count({ models: [modelWithRelation.id.toString()] })
       ).resolves.toEqual(2)
       let resultObj = await ceramic.index.query({
-        model: modelWithRelation.id,
+        models: [modelWithRelation.id],
         first: 100,
-        filter: { linkedDoc: referencedDoc0.id.toString() },
+        queryFilters: { where: { linkedDoc: { equalTo: referencedDoc0.id.toString() } } },
       })
       let results = extractDocuments(ceramic, resultObj)
       expect(results.length).toEqual(1)
@@ -1498,12 +1498,12 @@ describe.each(envs)('Basic end-to-end indexing query test for $dbEngine', (env) 
         midRelationMetadata
       )
       await expect(
-        ceramic.index.count({ model: modelWithRelation.id.toString() })
+        ceramic.index.count({ models: [modelWithRelation.id.toString()] })
       ).resolves.toEqual(3)
       resultObj = await ceramic.index.query({
-        model: modelWithRelation.id,
+        models: [modelWithRelation.id],
         first: 100,
-        filter: { linkedDoc: referencedDoc0.id.toString() },
+        queryFilters: { where: { linkedDoc: { equalTo: referencedDoc0.id.toString() } } },
       })
       results = extractDocuments(ceramic, resultObj)
       expect(results.length).toEqual(1)

--- a/packages/stream-tests/src/__tests__/cross-node-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/cross-node-indexing.test.ts
@@ -184,11 +184,11 @@ describe.each(envs)(
       // TODO: Once we support subscriptions, use a subscription to wait for the stream to show up
       // in the index, instead of this polling-based approach
       await TestUtils.waitForConditionOrTimeout(async () => {
-        const count = await countResults(ceramic2, { model: model.id, first: 100 })
+        const count = await countResults(ceramic2, { models: [model.id], first: 100 })
         return count > 0
       })
 
-      let resultObj = await ceramic2.index.query({ model: model.id, first: 100 })
+      let resultObj = await ceramic2.index.query({ models: [model.id], first: 100 })
       let results = extractDocuments(ceramic2, resultObj)
 
       expect(results.length).toEqual(1)
@@ -205,11 +205,11 @@ describe.each(envs)(
       // TODO: Once we support subscriptions, use a subscription to wait for the stream to show up
       // in the index, instead of this polling-based approach.
       await TestUtils.waitForConditionOrTimeout(async () => {
-        const count = await countResults(ceramic2, { model: model.id, first: 100 })
+        const count = await countResults(ceramic2, { models: [model.id], first: 100 })
         return count > 1
       })
 
-      resultObj = await ceramic2.index.query({ model: model.id, first: 100 })
+      resultObj = await ceramic2.index.query({ models: [model.id], first: 100 })
       results = extractDocuments(ceramic2, resultObj)
 
       expect(results.length).toEqual(2)
@@ -231,7 +231,7 @@ describe.each(envs)(
       })
 
       // Since ceramic1 didn't publish the commit, ceramic2 won't know about it.
-      let resultObj = await ceramic2.index.query({ model: model.id, first: 100 })
+      let resultObj = await ceramic2.index.query({ models: [model.id], first: 100 })
       let results = extractDocuments(ceramic2, resultObj)
       expect(results.length).toEqual(0)
 
@@ -241,7 +241,7 @@ describe.each(envs)(
       // Indexed streams should always get pinned, regardless of the 'pin' flag
       await expect(TestUtils.isPinned(ceramic2, doc1.id)).toBeTruthy()
 
-      resultObj = await ceramic2.index.query({ model: model.id, first: 100 })
+      resultObj = await ceramic2.index.query({ models: [model.id], first: 100 })
       results = extractDocuments(ceramic2, resultObj)
       expect(results.length).toEqual(1)
       expect(results[0].id.toString()).toEqual(doc1.id.toString())

--- a/packages/stream-tests/src/__tests__/history-sync.test.ts
+++ b/packages/stream-tests/src/__tests__/history-sync.test.ts
@@ -208,7 +208,7 @@ const waitForMidsToBeIndexed = async (
   // in the index, instead of this polling-based approach.
   return TestUtils.waitForConditionOrTimeout(async () => {
     const results = await ceramic.index
-      .query({ model: MODEL_STREAM_ID, last: 100 })
+      .query({ models: [MODEL_STREAM_ID], last: 100 })
       .then((resultObj) => extractDocuments(ceramic, resultObj))
 
     return docs.every((doc) => {


### PR DESCRIPTION
Makes the `models` field required instead of having both `model` and `models` optional, and removes the `filters` field.