### PR TITLE
Feature/cat 2857 images missing in js cermic developer documents

### DIFF
--- a/docs-src/architecture/overview.md
+++ b/docs-src/architecture/overview.md
@@ -6,7 +6,7 @@ This document provides a basic overview of how js-ceramic is implemented. It goe
 
 CeramicApi is an interface that both CeramicCore and CeramicHttpClient implements. It provides all the methods needed by a developer to build on top of Ceramic. An instance of CeramicApi allows only one user to be set at a time, using the [DID](https://github.com/ceramicnetwork/js-did) interface. The main methods that this interface provides are `createDocument`, and `loadDocument` which both return *Stream* instances.
 
-![CeramicApi](media://ceramic-api.png)
+![CeramicApi](media/ceramic-api.png)
 
 **CeramicCore** is the implementation of the core protocol and can be run both in nodejs as well as in browser environments. It verifies every document that it loads locally and does all network communication over libp2p.
 
@@ -16,7 +16,7 @@ CeramicApi is an interface that both CeramicCore and CeramicHttpClient implement
 
 The DID provider ([EIP2844](https://eips.ethereum.org/EIPS/eip-2844)) is the interface used to communicate between the *CeramicApi* and wallets. This interface can be implemented by any DID method and provides an agnostic way to sign and decrypt data based on DIDs. Each CeramicApi instance can have one DID provider associated with it at any given time (see [section below](#http-client-and-daemon) for how to have multiple users associated with one ceramic node). This abstraction allows for separation between the wallet and the application that uses ceramic since the DID provider is a json-rpc interface that can be used over a wide variety of transports.
 
-![did-provider](media://wallets.png)
+![did-provider](media/wallets.png)
 
 For example, in the figure above there is a wallet instance that is being run within 3ID connect, which is an iframe. A web application can communicate with the 3ID Connect iframe using the *postMessage* api which is used to pass json-rpc messages between the wallet and the application. CeramicApi and IdentityWallet can of course also be used together within the same process.
 
@@ -24,6 +24,6 @@ For example, in the figure above there is a wallet instance that is being run wi
 
 As mentioned above both CeramicCore and CeramicHttpClient implements the CeramicApi abstraction. In practice the CeramicHttpClient needs to talk to a CeramicCore node to actually read and write to the network. In order to facilitate this the CeramicDaemon implements an http api which the client can consume. The daemon is wrapped together with CeramicCore in the CeramicCli package, which provides a basic command line interface for interacting with Ceramic.
 
-![http-clients](media://http-clients.png)
+![http-clients](media/http-clients.png)
 
 As can be observed in the figure above multiple http clients can interact with the same daemon. This allows for multiple users on different machines to rely on the same http daemon while only authorizing their own DID to have write access. The daemon doesn't really have to care about which users are authenticated since it only reads from, and passes signed updates along to the CeramicCore instance.

--- a/docs-src/architecture/overview.md
+++ b/docs-src/architecture/overview.md
@@ -6,7 +6,7 @@ This document provides a basic overview of how js-ceramic is implemented. It goe
 
 CeramicApi is an interface that both CeramicCore and CeramicHttpClient implements. It provides all the methods needed by a developer to build on top of Ceramic. An instance of CeramicApi allows only one user to be set at a time, using the [DID](https://github.com/ceramicnetwork/js-did) interface. The main methods that this interface provides are `createDocument`, and `loadDocument` which both return *Stream* instances.
 
-![CeramicApi](media/ceramic-api.png)
+![CeramicApi](../media/ceramic-api.png)
 
 **CeramicCore** is the implementation of the core protocol and can be run both in nodejs as well as in browser environments. It verifies every document that it loads locally and does all network communication over libp2p.
 
@@ -16,7 +16,7 @@ CeramicApi is an interface that both CeramicCore and CeramicHttpClient implement
 
 The DID provider ([EIP2844](https://eips.ethereum.org/EIPS/eip-2844)) is the interface used to communicate between the *CeramicApi* and wallets. This interface can be implemented by any DID method and provides an agnostic way to sign and decrypt data based on DIDs. Each CeramicApi instance can have one DID provider associated with it at any given time (see [section below](#http-client-and-daemon) for how to have multiple users associated with one ceramic node). This abstraction allows for separation between the wallet and the application that uses ceramic since the DID provider is a json-rpc interface that can be used over a wide variety of transports.
 
-![did-provider](media/wallets.png)
+![did-provider](../media/wallets.png)
 
 For example, in the figure above there is a wallet instance that is being run within 3ID connect, which is an iframe. A web application can communicate with the 3ID Connect iframe using the *postMessage* api which is used to pass json-rpc messages between the wallet and the application. CeramicApi and IdentityWallet can of course also be used together within the same process.
 
@@ -24,6 +24,6 @@ For example, in the figure above there is a wallet instance that is being run wi
 
 As mentioned above both CeramicCore and CeramicHttpClient implements the CeramicApi abstraction. In practice the CeramicHttpClient needs to talk to a CeramicCore node to actually read and write to the network. In order to facilitate this the CeramicDaemon implements an http api which the client can consume. The daemon is wrapped together with CeramicCore in the CeramicCli package, which provides a basic command line interface for interacting with Ceramic.
 
-![http-clients](media/http-clients.png)
+![http-clients](../media/http-clients.png)
 
 As can be observed in the figure above multiple http clients can interact with the same daemon. This allows for multiple users on different machines to rely on the same http daemon while only authorizing their own DID to have write access. The daemon doesn't really have to care about which users are authenticated since it only reads from, and passes signed updates along to the CeramicCore instance.

--- a/docs-src/architecture/state-management.md
+++ b/docs-src/architecture/state-management.md
@@ -20,7 +20,7 @@ Disposition:
 
 Let us see what happens when 4α starts. As per Node.js execution model, processing is event-based. After IO/event is emitted, Node.js executes all the code non-interrupted until it stumbles upon wait for the next IO/event. Ceramic tasks are heavily IO based, so it would be fair to assume here, that at some point task 1α starts to wait for IO, for example, for IPFS retrieval. At that point Node.js starts handing the next event which in our case is task 4α.
 
-![Execution Queue](media://state-management/execution-queue.png)
+![Execution Queue](media/state-management/execution-queue.png)
 
 When task 4α starts, the cache exceeds the limit, so it evicts the oldest document 1. Yet, it does not pause the task 1α. It still runs. This rises two questions.
 
@@ -48,7 +48,7 @@ So, at any time, we are sure we start subscription with the latest available sta
 
 As part of state refactor effort we have decided to maintain a certain semantics for how Stream updates state. After created, Stream maintains just the state it was initialized with. It only updates state after being manually changed or when subscribed. In the latter case, the state gets continuously updated. If looked from the inside, one could notice a Stream relies on `RunningStateLike` instance to maintain the state. One could see `RunningStateLike` as either an [Observable](https://rxjs.dev/guide/observable) of DocState with an access to the current value, or as [BehaviorSubject](https://rxjs.dev/guide/subject#behaviorsubject) with some additional getters. The reason for this, is we want to avoid explicit memory management in Stream instances. Anyway `RunningStateLike` is a kind of [Subject](https://rxjs.dev/guide/subject), that has to be explicitly closed, and as one could see from sections above managing document state life cycle is complicated. Ceramic instance performs that closing behavior when the CeramicAPI instance itself is closed, and that frees a developer from closing every Stream manually. However, the more open and subscribed Stream instances there, the more memory is used, as having lots of subscribed Stream instances can cause the in-memory cache to grow behind the configured max cache size.
 
-![Relationship between doctype and state](media://state-management/doctype-and-state.png)
+![Relationship between doctype and state](media/state-management/doctype-and-state.png)
 
 ## Components
 
@@ -64,7 +64,7 @@ Repository shepherds a list of document states, be they running or sleeping. In 
 
 We also have `StateLink`  implementing `RunningStateLike`. Its initial state is set on construction time. It can be updated, and update only changes local state. It can be subscribed to, and this actually triggers subscription to another upstream Observable (returned from `Repository#updates$` in production case). This way we achieve behavior outlined in Subscriptions section, while maintaining single responsibility for the entity. `StateLink` maintains state local to Stream. The upstream observable handles Repository-specific logic.
 
-![Running State Hierarchy](media://state-management/running-state-hierarchy.png)
+![Running State Hierarchy](media/state-management/running-state-hierarchy.png)
 
 ### Repository
 

--- a/docs-src/architecture/state-management.md
+++ b/docs-src/architecture/state-management.md
@@ -20,7 +20,7 @@ Disposition:
 
 Let us see what happens when 4α starts. As per Node.js execution model, processing is event-based. After IO/event is emitted, Node.js executes all the code non-interrupted until it stumbles upon wait for the next IO/event. Ceramic tasks are heavily IO based, so it would be fair to assume here, that at some point task 1α starts to wait for IO, for example, for IPFS retrieval. At that point Node.js starts handing the next event which in our case is task 4α.
 
-![Execution Queue](media/state-management/execution-queue.png)
+![Execution Queue](../media/state-management/execution-queue.png)
 
 When task 4α starts, the cache exceeds the limit, so it evicts the oldest document 1. Yet, it does not pause the task 1α. It still runs. This rises two questions.
 
@@ -48,7 +48,7 @@ So, at any time, we are sure we start subscription with the latest available sta
 
 As part of state refactor effort we have decided to maintain a certain semantics for how Stream updates state. After created, Stream maintains just the state it was initialized with. It only updates state after being manually changed or when subscribed. In the latter case, the state gets continuously updated. If looked from the inside, one could notice a Stream relies on `RunningStateLike` instance to maintain the state. One could see `RunningStateLike` as either an [Observable](https://rxjs.dev/guide/observable) of DocState with an access to the current value, or as [BehaviorSubject](https://rxjs.dev/guide/subject#behaviorsubject) with some additional getters. The reason for this, is we want to avoid explicit memory management in Stream instances. Anyway `RunningStateLike` is a kind of [Subject](https://rxjs.dev/guide/subject), that has to be explicitly closed, and as one could see from sections above managing document state life cycle is complicated. Ceramic instance performs that closing behavior when the CeramicAPI instance itself is closed, and that frees a developer from closing every Stream manually. However, the more open and subscribed Stream instances there, the more memory is used, as having lots of subscribed Stream instances can cause the in-memory cache to grow behind the configured max cache size.
 
-![Relationship between doctype and state](media/state-management/doctype-and-state.png)
+![Relationship between doctype and state](../media/state-management/doctype-and-state.png)
 
 ## Components
 
@@ -64,7 +64,7 @@ Repository shepherds a list of document states, be they running or sleeping. In 
 
 We also have `StateLink`  implementing `RunningStateLike`. Its initial state is set on construction time. It can be updated, and update only changes local state. It can be subscribed to, and this actually triggers subscription to another upstream Observable (returned from `Repository#updates$` in production case). This way we achieve behavior outlined in Subscriptions section, while maintaining single responsibility for the entity. `StateLink` maintains state local to Stream. The upstream observable handles Repository-specific logic.
 
-![Running State Hierarchy](media/state-management/running-state-hierarchy.png)
+![Running State Hierarchy](../media/state-management/running-state-hierarchy.png)
 
 ### Repository
 


### PR DESCRIPTION
## Description

Correcting image paths in developer docs to make images upload. (link to doc: https://github.com/ceramicnetwork/js-ceramic/blob/develop/docs-src/architecture/overview.md)

## How Has This Been Tested?
Test Case 1 : Go to js-ceramic/blob/develop/docs-src/architecture/overview.md and verify the page has proper images in the documents.
[
<img width="1044" alt="Screenshot 2023-11-14 at 4 04 33 PM" src="https://github.com/ceramicnetwork/js-ceramic/assets/25499838/12aabb02-e437-4855-9b41-780638c6bb8b">
](url)

Test Case 2 : Go to js-ceramic/docs-src/architecture/state-management.md and verify the page has proper images in the documents.

<img width="1440" alt="Screenshot 2023-11-14 at 4 12 00 PM" src="https://github.com/ceramicnetwork/js-ceramic/assets/25499838/423b7456-4fc3-41e4-b6b3-2b5f6273d6f3">

Result : Images are visible in the docs-src section now, screenshots are presented as proof.

## PR checklist

Before submitting this PR, please make sure:

- [ Yes] I have tagged the relevant reviewers and interested parties
- [ Not needed] I have updated the READMEs of affected packages
- [ Not needed] I have made corresponding changes to the documentation

## References:
 None
