### PR TITLE
fix: Use envelope not payload when building StreamID for applying genesis commits

### DIFF
--- a/packages/stream-model-handler/src/model-handler.ts
+++ b/packages/stream-model-handler/src/model-handler.ts
@@ -106,7 +106,7 @@ export class ModelHandler implements StreamHandler<Model> {
       throw new Error('Exactly one controller must be specified')
     }
 
-    const streamId = await StreamID.fromGenesis('model', commitData.commit)
+    const streamId = new StreamID(Model.STREAM_TYPE_ID, commitData.cid)
     const { controllers, model } = payload.header
     const controller = controllers[0]
     const modelStreamID = StreamID.fromBytes(model)

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -86,7 +86,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     const { controllers, model } = payload.header
     const controller = controllers[0]
     const modelStreamID = StreamID.fromBytes(model)
-    const streamId = await StreamID.fromGenesis('MID', commitData.commit)
+    const streamId = new StreamID(ModelInstanceDocument.STREAM_TYPE_ID, commitData.cid)
     const metadata = { controllers: [controller], model: modelStreamID }
 
     if (!(payload.header.controllers && payload.header.controllers.length === 1)) {

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -86,7 +86,7 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
     const payload = commitData.commit
     const isSigned = StreamUtils.isSignedCommitData(commitData)
     if (isSigned) {
-      const streamId = await StreamID.fromGenesis('tile', commitData.commit)
+      const streamId = new StreamID(TileDocument.STREAM_TYPE_ID, commitData.cid)
       const { controllers } = payload.header
       await SignatureUtils.verifyCommitSignature(commitData, did, controllers[0], null, streamId)
     } else if (payload.data) {


### PR DESCRIPTION
This mostly manifests as logging the wrong StreamID.
In theory, the StreamID we pass to `SignatureUtils.verifyCommitSignature` can matter, because it's possible to issue a CACAO that is authorized only to write to a specific StreamID.  This definitely matters for updates.  But this PR only changes code for applying genesisCommits.  It's pretty hard to create a CACAO that will let you only create a specific stream with a specific StreamID, because you usually don't know the StreamID until after the Stream is created.  So practically speaking its very hard for this to ever be an actual issue.  In theory if you were using a deterministic stream you could predict the StreamID before creating it and then issue a CACAO that allows someone to create it.  But that's a pretty niche and unlikely use case.  Also, while CACAOs in theory can be specified to grant access to only a single StreamID, I don't think the did-session library actually exposes this very easily (it mostly exposes granting access to specific models).  So it's extremely unlikely this bug has actually affected any real users.