### PR TITLE
fix: initialize s3 state store after setting up did

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -337,16 +337,6 @@ export class CeramicDaemon {
     )
 
     const ceramic = new Ceramic(modules, params)
-    if (opts.stateStore?.mode == StateStoreMode.S3) {
-      const s3Store = new S3Store(
-        params.networkOptions.name,
-        opts.stateStore?.s3Bucket,
-        opts.stateStore?.s3Endpoint
-      )
-
-      await ceramic.repository.injectKeyValueStore(s3Store)
-    }
-
     let didOptions: DIDOptions = { resolver: makeResolvers(ceramic) }
     let provider: DIDProvider
 
@@ -371,6 +361,18 @@ export class CeramicDaemon {
       )
     }
     ceramic.did = did
+
+    // This needs to happen after the DID is set up so that any stream operations have a valid DID to use
+    if (opts.stateStore?.mode == StateStoreMode.S3) {
+      const s3Store = new S3Store(
+        params.networkOptions.name,
+        opts.stateStore?.s3Bucket,
+        opts.stateStore?.s3Endpoint
+      )
+
+      await ceramic.repository.injectKeyValueStore(s3Store)
+    }
+
     await ceramic._init(true)
 
     const daemon = new CeramicDaemon(ceramic, opts)


### PR DESCRIPTION
The S3 state store was being initialized before the Ceramic DID was set up. Normally, this worked fine but if the state store path was changed and indexed model streams previously accessible were no longer available in the store, the node would attempt to load them from the network. Without the DID set up correctly, this would cause the startup process to fail.