### PR TITLE
Check if ELP bucket exists for S3 state store

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -22,7 +22,6 @@ import { StreamID } from '@ceramicnetwork/streamid'
 import * as ThreeIdResolver from '@ceramicnetwork/3id-did-resolver'
 import * as KeyDidResolver from 'key-did-resolver'
 import * as PkhDidResolver from 'pkh-did-resolver'
-import AWSSDK from 'aws-sdk'
 
 import { DID, DIDOptions, DIDProvider } from 'dids'
 import cors from 'cors'
@@ -369,6 +368,7 @@ export class CeramicDaemon {
         opts.stateStore?.s3Bucket,
         opts.stateStore?.s3Endpoint
       )
+
       await ceramic.repository.injectKeyValueStore(s3Store)
     }
 

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -365,32 +365,11 @@ export class CeramicDaemon {
 
     // This needs to happen after the DID is set up so that any stream operations have a valid DID to use
     if (opts.stateStore?.mode == StateStoreMode.S3) {
-      let networkName = params.networkOptions.name
-
-      // Check if ELP bucket is used
-      if (networkName === Networks.MAINNET) {
-        const s3 = new AWSSDK.S3()
-        const storeRoot = opts.stateStore?.s3Bucket
-          ? `${opts.stateStore?.s3Bucket}/ceramic/elp`
-          : 'ceramic/elp'
-        try {
-          await s3.headBucket({ Bucket: storeRoot }).promise()
-          // Bucket exists and needs to be used
-          console.warn(
-            `S3 bucket found with ELP location, using it instead of default mainnet location for state store`
-          )
-          networkName = 'elp' as Networks
-        } catch (error) {
-          // Ignore error
-        }
-      }
-
       const s3Store = new S3Store(
-        networkName,
+        params.networkOptions.name,
         opts.stateStore?.s3Bucket,
         opts.stateStore?.s3Endpoint
       )
-
       await ceramic.repository.injectKeyValueStore(s3Store)
     }
 

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -365,6 +365,7 @@ export class CeramicDaemon {
     if (opts.stateStore?.mode == StateStoreMode.S3) {
       const s3Store = new S3Store(
         params.networkOptions.name,
+        diagnosticsLogger,
         opts.stateStore?.s3Bucket,
         opts.stateStore?.s3Endpoint
       )

--- a/packages/cli/src/s3-store.ts
+++ b/packages/cli/src/s3-store.ts
@@ -1,3 +1,4 @@
+import { Networks } from '@ceramicnetwork/common'
 import { IKVStore, IKVStoreFindResult, StoreSearchParams } from '@ceramicnetwork/core'
 import LevelUp from 'levelup'
 import S3LevelDOWN from 's3leveldown'
@@ -66,7 +67,9 @@ class S3StoreMap {
 }
 
 export class S3Store implements IKVStore {
-  readonly #storeMap: S3StoreMap
+  readonly #bucketName: string
+  readonly #customEndpoint?: string
+  #storeMap: S3StoreMap
 
   readonly #loadingLimit = new PQueue({
     intervalCap: MAX_LOAD_RPS,
@@ -75,11 +78,31 @@ export class S3Store implements IKVStore {
   })
 
   constructor(networkName: string, bucketName: string, customEndpoint?: string) {
+    this.#bucketName = bucketName
+    this.#customEndpoint = customEndpoint
     this.#storeMap = new S3StoreMap(networkName, bucketName, customEndpoint)
   }
 
   get networkName(): string {
     return this.#storeMap.networkName
+  }
+
+  async init(): Promise<void> {
+    // Check if ELP bucket is used
+    if (this.networkName === Networks.MAINNET) {
+      const s3 = new AWSSDK.S3()
+      try {
+        await s3.headBucket({ Bucket: `${this.#bucketName}/ceramic/elp` }).promise()
+        // Bucket exists and needs to be used
+        console.warn(
+          `S3 bucket found with ELP location, using it instead of default mainnet location for state store`
+        )
+        // Re-create store map with 'elp' network name
+        this.#storeMap = new S3StoreMap('elp' as Networks, this.#bucketName, this.#customEndpoint)
+      } catch (error) {
+        // Ignore bucket not found or other error from S3
+      }
+    }
   }
 
   async close(useCaseName?: string): Promise<void> {

--- a/packages/cli/src/s3-store.ts
+++ b/packages/cli/src/s3-store.ts
@@ -98,16 +98,16 @@ export class S3Store implements IKVStore {
     // Check if ELP bucket is used
     if (this.networkName === Networks.MAINNET) {
       const s3 = new AWSSDK.S3()
-      try {
-        await s3.headBucket({ Bucket: `${this.#bucketName}/ceramic/elp` }).promise()
-        // Bucket exists and needs to be used
+      const res = await s3
+        .listObjectsV2({ Bucket: this.#bucketName, Prefix: 'ceramic/elp', MaxKeys: 1 })
+        .promise()
+      if (res.Contents?.length) {
+        // state store exists and needs to be used
         this.#diagnosticsLogger.warn(
           `S3 bucket found with ELP location, using it instead of default mainnet location for state store`
         )
         // Re-create store map with 'elp' network name
         this.#storeMap = new S3StoreMap('elp' as Networks, this.#bucketName, this.#customEndpoint)
-      } catch (error) {
-        // Ignore bucket not found or other error from S3
       }
     }
   }

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -157,6 +157,7 @@ export class Repository {
   }
 
   async init(): Promise<void> {
+    await this.#deps.keyValueStore.init()
     await this.pinStore.open(this.#deps.keyValueStore)
     await this.anchorRequestStore.open(this.#deps.keyValueStore)
     await this.index.init()

--- a/packages/core/src/store/ikv-store.ts
+++ b/packages/core/src/store/ikv-store.ts
@@ -11,7 +11,7 @@ export type IKVStoreFindResult = {
 
 export interface IKVStore {
   networkName: string
-
+  init(): Promise<void>
   close(useCaseName?: string): Promise<void>
   isEmpty(params?: StoreSearchParams): Promise<boolean>
   findKeys(params?: StoreSearchParams): Promise<Array<string>>

--- a/packages/core/src/store/level-db-store.ts
+++ b/packages/core/src/store/level-db-store.ts
@@ -105,7 +105,10 @@ export class LevelDbStore implements IKVStore {
     return this.#storeMap.networkName
   }
 
-  async init(): Promise<void> {}
+  async init(): Promise<void> {
+    // do nothing
+    return
+  }
 
   close(useCaseName?: string): Promise<void> {
     // do nothing

--- a/packages/core/src/store/level-db-store.ts
+++ b/packages/core/src/store/level-db-store.ts
@@ -70,7 +70,8 @@ class LevelDBStoreMap {
     // Check if store exists at legacy ELP location
     if (this.networkName === Networks.MAINNET) {
       const elpLocation = this.getStoreLocation(useCaseName, OLD_ELP_DEFAULT_LOCATION)
-      if (fs.existsSync(elpLocation)) {
+      const storePath = path.join(this.#storeRoot, elpLocation)
+      if (fs.existsSync(storePath)) {
         console.warn(
           `LevelDB store ${useCaseName} found with ELP location, using it instead of default mainnet location`
         )


### PR DESCRIPTION
From my understanding of the ticket this is the kind of logic required, though I'm wondering about the following:
- Is the `storeRoot` path logic correct?
  - If the `s3Bucket` option is not provided, is there a default value?  
  - Is `elp` the right name for the network?
- Is the `storeRoot` value the right one to provide for the S3 `Bucket` check? 
- Is the `S3Store` internal logic OK if I replace the network name by `elp` or are there other changes needed there?
- Is there any way to test the behavior in unit tests or manually locally?

Thanks!