### PR TITLE
fix: remove deprecated unsafe-perm npm flag

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -75,9 +75,7 @@ jobs:
           dagger do verify -p ${{ env.DAGGER_PLAN }}
       -
         name: Initialize and build code
-        run: |
-          npm set unsafe-perm true
-          npm ci && npm run build
+        run: npm ci && npm run build
       -
         name: Publish packages to NPM
         env:
@@ -156,9 +154,7 @@ jobs:
           dagger do verify -p ${{ env.DAGGER_PLAN }}
       -
         name: Initialize and build code
-        run: |
-          npm set unsafe-perm true
-          npm ci && npm run build
+        run: npm ci && npm run build
       -
         name: Publish packages to NPM
         env:
@@ -235,9 +231,7 @@ jobs:
           dagger do verify -p ${{ env.DAGGER_PLAN }}
       -
         name: Initialize and build code
-        run: |
-          npm set unsafe-perm true
-          npm ci && npm run build
+        run: npm ci && npm run build
       -
         name: Publish packages to NPM
         env:


### PR DESCRIPTION
I tried building without the flag and the installation worked correctly in a GitHub runner 🤷🏼  The flag is only supposed to apply during the install step anyway.

I can leave this PR open and perhaps the next RC/release you make, @stbrody, can be run from this branch so we can test the workflow before it goes in.