### PR TITLE
Fix Uint8Array inputs for concatenation calls

### DIFF
--- a/packages/streamid/package.json
+++ b/packages/streamid/package.json
@@ -35,7 +35,7 @@
     "cborg": "^1.10.2",
     "mapmoize": "^1.2.1",
     "multiformats": "^11.0.1",
-    "uint8arrays": "^4.0.3",
+    "uint8arrays": "^4.0.9",
     "varint": "^6.0.0"
   },
   "publishConfig": {

--- a/packages/streamid/src/commit-id.ts
+++ b/packages/streamid/src/commit-id.ts
@@ -180,8 +180,8 @@ export class CommitID implements StreamRef {
    */
   @Memoize()
   get bytes(): Uint8Array {
-    const codec = varint.encode(STREAMID_CODEC)
-    const type = varint.encode(this.type)
+    const codec = new Uint8Array(varint.encode(STREAMID_CODEC))
+    const type = new Uint8Array(varint.encode(this.type))
 
     const commitBytes = this.#commit?.bytes || new Uint8Array([0])
     return uint8ArrayConcat([codec, type, this.cid.bytes, commitBytes])

--- a/packages/streamid/src/event-id.ts
+++ b/packages/streamid/src/event-id.ts
@@ -98,9 +98,9 @@ export class EventID {
    */
   @Memoize()
   get bytes(): Uint8Array {
-    const streamCodec = varint.encode(STREAMID_CODEC)
-    const eventIDCodec = varint.encode(EVENT_ID_CODEC)
-    const networkID = varint.encode(this._networkID)
+    const streamCodec = new Uint8Array(varint.encode(STREAMID_CODEC))
+    const eventIDCodec = new Uint8Array(varint.encode(EVENT_ID_CODEC))
+    const networkID = new Uint8Array(varint.encode(this._networkID))
     const eventHeight = cbor.encode(this._eventHeight)
     const event = this._event.bytes
     return u8a.concat([

--- a/packages/streamid/src/stream-id.ts
+++ b/packages/streamid/src/stream-id.ts
@@ -173,8 +173,8 @@ export class StreamID implements StreamRef {
    */
   @Memoize()
   get bytes(): Uint8Array {
-    const codec = varint.encode(STREAMID_CODEC)
-    const type = varint.encode(this.type)
+    const codec = new Uint8Array(varint.encode(STREAMID_CODEC))
+    const type = new Uint8Array(varint.encode(this.type))
 
     return uint8ArrayConcat([codec, type, this.cid.bytes])
   }


### PR DESCRIPTION
This should be a fix for https://forum.ceramic.network/t/from-discord-user-elcharitas-please-help-i-am-running-a-local-ceramic-node-and-i-keep-getting-this-error/1374/15

If I understand the issue correctly, [`uint8arrays` v4.0.9 released 3 days ago](https://github.com/achingbrain/uint8arrays/releases/tag/v4.0.9) is more strict in the input values it accepts for `concat()`, it only accepts `Uint8Array` and no longer plain `Array` that can be generated by using `varint.encode()`, so this PR ensures these are explicitly cast.