### PR TITLE
chore(core): cat 2855 add lint rule to detect promises that never get awaited on core

### DIFF
--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -4,7 +4,7 @@
   "plugins": ["@typescript-eslint", "import"],
   // required for no-floating -promises lint rule
   "parserOptions": {
-    "project": "tsconfig.json" 
+    "project": "tsconfig.linter.json" 
   },
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -2,12 +2,17 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "import"],
+  // required for no-floating -promises lint rule
+  "parserOptions": {
+    "project": "tsconfig.json" 
+  },
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
-    "import/default": "off"
+    "import/default": "off",
+    "@typescript-eslint/no-floating-promises": "error"
   },
   "settings": {
     "import/parsers": {

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -11,7 +11,13 @@ import {
 import tmp from 'tmp-promise'
 import type { Ceramic } from '../ceramic.js'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
-import { AnchorStatus, IpfsApi, StreamUtils, TestUtils } from '@ceramicnetwork/common'
+import {
+  AnchorStatus,
+  IpfsApi,
+  StreamUtils,
+  TestUtils,
+  LoggerProvider,
+} from '@ceramicnetwork/common'
 import { CommitID, StreamID } from '@ceramicnetwork/streamid'
 import cloneDeep from 'lodash.clonedeep'
 import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
@@ -96,6 +102,7 @@ describe('Ceramic API', () => {
   describe('API', () => {
     let ceramic: Ceramic
     let tmpFolder: tmp.DirectoryResult
+    const logger = new LoggerProvider().getDiagnosticsLogger()
 
     beforeEach(async () => {
       ModelInstanceDocument.MAX_DOCUMENT_SIZE = 16_000_000
@@ -108,7 +115,7 @@ describe('Ceramic API', () => {
     afterEach(async () => {
       await ceramic.close()
       await tmpFolder.cleanup().catch((error) => {
-        console.error('Error while cleaning up tmpFolder:', error)
+        logger.err('Error while cleaning up tmpFolder:' + error.message)
       })
     })
 

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -107,7 +107,9 @@ describe('Ceramic API', () => {
 
     afterEach(async () => {
       await ceramic.close()
-      tmpFolder.cleanup()
+      await tmpFolder.cleanup().catch((error) => {
+        console.error('Error while cleaning up tmpFolder:', error)
+      })
     })
 
     it('can load the previous stream commit', async () => {

--- a/packages/core/src/__tests__/ceramic-pinning.test.ts
+++ b/packages/core/src/__tests__/ceramic-pinning.test.ts
@@ -299,12 +299,12 @@ describe('Ceramic stream pinning', () => {
 
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
     // pin:true flag will be ignored
-    TileDocument.load(ceramic, stream.id, { sync: SyncOptions.NEVER_SYNC, pin: true })
+    await TileDocument.load(ceramic, stream.id, { sync: SyncOptions.NEVER_SYNC, pin: true })
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeFalsy()
     await ceramic.admin.pin.add(stream.id)
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeTruthy()
     // pin:false flag will be ignored
-    TileDocument.load(ceramic, stream.id, { sync: SyncOptions.NEVER_SYNC, pin: false })
+    await TileDocument.load(ceramic, stream.id, { sync: SyncOptions.NEVER_SYNC, pin: false })
     await expect(TestUtils.isPinned(ceramic, stream.id)).resolves.toBeTruthy()
 
     await ceramic.close()

--- a/packages/core/src/__tests__/ceramic-query-response.test.ts
+++ b/packages/core/src/__tests__/ceramic-query-response.test.ts
@@ -175,7 +175,7 @@ describe('Response to pubsub queries handling', () => {
         await receiveMessage(asIpfsMessage(response))
       }
     }
-    publishResponses() // don't await for publishing to complete, let the responses happen in the background
+    void publishResponses() // don't await for publishing to complete, let the responses happen in the background
 
     await syncCompletionPromise
     const timeAfterSync = new Date()

--- a/packages/core/src/__tests__/shutdown-signal.test.ts
+++ b/packages/core/src/__tests__/shutdown-signal.test.ts
@@ -6,13 +6,9 @@ const fn = (abortSignal: AbortSignal) => {
     abortSignal.addEventListener('abort', () => {
       reject(new Error(`aborted after run`))
     })
-    new Promise((resolve1) => setTimeout(resolve1, 500))
-      .then(() => {
-        resolve('ok')
-      })
-      .catch((error) => {
-        reject(error)
-      })
+    setTimeout(() => {
+      resolve('ok')
+    }, 500)
   })
 }
 

--- a/packages/core/src/__tests__/shutdown-signal.test.ts
+++ b/packages/core/src/__tests__/shutdown-signal.test.ts
@@ -6,7 +6,13 @@ const fn = (abortSignal: AbortSignal) => {
     abortSignal.addEventListener('abort', () => {
       reject(new Error(`aborted after run`))
     })
-    new Promise((resolve1) => setTimeout(resolve1, 500)).then(() => resolve('ok'))
+    new Promise((resolve1) => setTimeout(resolve1, 500))
+      .then(() => {
+        resolve('ok')
+      })
+      .catch((error) => {
+        reject(error)
+      })
   })
 }
 

--- a/packages/core/src/state-management/__tests__/anchor-resuming-service.test.ts
+++ b/packages/core/src/state-management/__tests__/anchor-resuming-service.test.ts
@@ -102,7 +102,7 @@ describe('resumeRunningStatesFromAnchorRequestStore(...) method', () => {
       // All streams except one has only one commit. The stream with two commits has not requested an anchor for the 2nd commit. Therefore we
       // we only need to anchor the first commit of each stream.
       // @ts-ignore { cid: , streamID: } is not an instance of Candidate class (which shouldn't be exported, if necessary)
-      newAnchoringService._process({ cid: state$.state.log[0].cid, streamId: state$.id })
+      await newAnchoringService._process({ cid: state$.state.log[0].cid, streamId: state$.id })
     })
 
     // Use the ceramic instance with anchorOnRequest === true to resume anchors

--- a/packages/core/src/state-management/__tests__/anchor-resuming-service.test.ts
+++ b/packages/core/src/state-management/__tests__/anchor-resuming-service.test.ts
@@ -102,7 +102,7 @@ describe('resumeRunningStatesFromAnchorRequestStore(...) method', () => {
       // All streams except one has only one commit. The stream with two commits has not requested an anchor for the 2nd commit. Therefore we
       // we only need to anchor the first commit of each stream.
       // @ts-ignore { cid: , streamID: } is not an instance of Candidate class (which shouldn't be exported, if necessary)
-      await newAnchoringService._process({ cid: state$.state.log[0].cid, streamId: state$.id })
+      void newAnchoringService._process({ cid: state$.state.log[0].cid, streamId: state$.id })
     })
 
     // Use the ceramic instance with anchorOnRequest === true to resume anchors

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -996,7 +996,7 @@ export class Repository {
           })
         })
         .catch((error) => {
-          this.logger.err(`An error occurred in updates$ for StreamID ${id}: ${error.message}`)
+          this.logger.err(`An error occurred in updates$ for StreamID ${id}: ${error}`)
         })
     })
   }

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -997,6 +997,8 @@ export class Repository {
         })
         .catch((error) => {
           this.logger.err(`An error occurred in updates$ for StreamID ${id}: ${error}`)
+          // propogate the error to the subscriber
+          subscriber.error(error)
         })
     })
   }

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -985,15 +985,19 @@ export class Repository {
   updates$(init: StreamState): Observable<StreamState> {
     return new Observable<StreamState>((subscriber) => {
       const id = new StreamID(init.type, init.log[0].cid)
-      this.fromMemoryOrStore(id).then((found) => {
-        const state$ = found || new RunningState(init, false)
-        this.inmemory.endure(id.toString(), state$)
-        state$.subscribe(subscriber).add(() => {
-          if (state$.observers.length === 0) {
-            this.inmemory.free(id.toString())
-          }
+      this.fromMemoryOrStore(id)
+        .then((found) => {
+          const state$ = found || new RunningState(init, false)
+          this.inmemory.endure(id.toString(), state$)
+          state$.subscribe(subscriber).add(() => {
+            if (state$.observers.length === 0) {
+              this.inmemory.free(id.toString())
+            }
+          })
         })
-      })
+        .catch((error) => {
+          this.logger.err(`An error occurred in updates$ for StreamID ${id}: ${error.message}`)
+        })
     })
   }
 

--- a/packages/core/src/stream-loading/__tests__/tip-fetcher.test.ts
+++ b/packages/core/src/stream-loading/__tests__/tip-fetcher.test.ts
@@ -44,7 +44,9 @@ describe('TipFetcher test', () => {
       if (message.typ == MsgType.QUERY && message.stream.equals(streamID)) {
         const tipMap = new Map().set(streamID.toString(), tip)
         const response: PubsubMessage = { typ: MsgType.RESPONSE, id: message.id, tips: tipMap }
-        ipfs2.pubsub.publish(TOPIC, serialize(response))
+        ipfs2.pubsub.publish(TOPIC, serialize(response)).catch((error) => {
+          console.log(error.message)
+        })
       }
     })
 

--- a/packages/core/src/stream-loading/__tests__/tip-fetcher.test.ts
+++ b/packages/core/src/stream-loading/__tests__/tip-fetcher.test.ts
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals'
 import { Dispatcher } from '../../dispatcher.js'
 import { createIPFS, swarmConnect } from '@ceramicnetwork/ipfs-daemon'
 import { createDispatcher } from '../../__tests__/create-dispatcher.js'
-import { IpfsApi, TestUtils, LoggerProvider } from '@ceramicnetwork/common'
+import { IpfsApi, TestUtils } from '@ceramicnetwork/common'
 import { deserialize, MsgType, PubsubMessage, serialize } from '../../pubsub/pubsub-message.js'
 import type { SignedMessage } from '@libp2p/interface-pubsub'
 import { TipFetcher } from '../tip-fetcher.js'
@@ -20,7 +20,6 @@ describe('TipFetcher test', () => {
     ipfsClient = await createIPFS()
 
     dispatcher = await createDispatcher(ipfsClient, TOPIC)
-    const logger = new LoggerProvider().getDiagnosticsLogger()
   })
 
   afterAll(async () => {
@@ -34,7 +33,6 @@ describe('TipFetcher test', () => {
   })
 
   test('basic tip fetch', async () => {
-    const logger = new LoggerProvider().getDiagnosticsLogger()
     const streamID = TestUtils.randomStreamID()
     const tip = TestUtils.randomCID()
 
@@ -47,9 +45,8 @@ describe('TipFetcher test', () => {
         const tipMap = new Map().set(streamID.toString(), tip)
         const response: PubsubMessage = { typ: MsgType.RESPONSE, id: message.id, tips: tipMap }
         ipfs2.pubsub.publish(TOPIC, serialize(response)).catch((error) => {
-          logger.err(
-            'Error occurred in the "basic tip fetch" test while publishing to ipfs' + error.message
-          )
+          // we want the test to fail if an error occurs thus we are rethrowing the error
+          throw error
         })
       }
     })

--- a/packages/core/src/stream-loading/__tests__/tip-fetcher.test.ts
+++ b/packages/core/src/stream-loading/__tests__/tip-fetcher.test.ts
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals'
 import { Dispatcher } from '../../dispatcher.js'
 import { createIPFS, swarmConnect } from '@ceramicnetwork/ipfs-daemon'
 import { createDispatcher } from '../../__tests__/create-dispatcher.js'
-import { IpfsApi, TestUtils } from '@ceramicnetwork/common'
+import { IpfsApi, TestUtils, LoggerProvider } from '@ceramicnetwork/common'
 import { deserialize, MsgType, PubsubMessage, serialize } from '../../pubsub/pubsub-message.js'
 import type { SignedMessage } from '@libp2p/interface-pubsub'
 import { TipFetcher } from '../tip-fetcher.js'
@@ -20,6 +20,7 @@ describe('TipFetcher test', () => {
     ipfsClient = await createIPFS()
 
     dispatcher = await createDispatcher(ipfsClient, TOPIC)
+    const logger = new LoggerProvider().getDiagnosticsLogger()
   })
 
   afterAll(async () => {
@@ -33,6 +34,7 @@ describe('TipFetcher test', () => {
   })
 
   test('basic tip fetch', async () => {
+    const logger = new LoggerProvider().getDiagnosticsLogger()
     const streamID = TestUtils.randomStreamID()
     const tip = TestUtils.randomCID()
 
@@ -45,7 +47,7 @@ describe('TipFetcher test', () => {
         const tipMap = new Map().set(streamID.toString(), tip)
         const response: PubsubMessage = { typ: MsgType.RESPONSE, id: message.id, tips: tipMap }
         ipfs2.pubsub.publish(TOPIC, serialize(response)).catch((error) => {
-          console.log(error.message)
+          logger.err('Error occurred in the "basic tip fetch" test while publishing to ipfs' + error.message);
         })
       }
     })

--- a/packages/core/src/stream-loading/__tests__/tip-fetcher.test.ts
+++ b/packages/core/src/stream-loading/__tests__/tip-fetcher.test.ts
@@ -44,10 +44,7 @@ describe('TipFetcher test', () => {
       if (message.typ == MsgType.QUERY && message.stream.equals(streamID)) {
         const tipMap = new Map().set(streamID.toString(), tip)
         const response: PubsubMessage = { typ: MsgType.RESPONSE, id: message.id, tips: tipMap }
-        ipfs2.pubsub.publish(TOPIC, serialize(response)).catch((error) => {
-          // we want the test to fail if an error occurs thus we are rethrowing the error
-          throw error
-        })
+        void ipfs2.pubsub.publish(TOPIC, serialize(response))
       }
     })
 

--- a/packages/core/src/stream-loading/__tests__/tip-fetcher.test.ts
+++ b/packages/core/src/stream-loading/__tests__/tip-fetcher.test.ts
@@ -47,7 +47,9 @@ describe('TipFetcher test', () => {
         const tipMap = new Map().set(streamID.toString(), tip)
         const response: PubsubMessage = { typ: MsgType.RESPONSE, id: message.id, tips: tipMap }
         ipfs2.pubsub.publish(TOPIC, serialize(response)).catch((error) => {
-          logger.err('Error occurred in the "basic tip fetch" test while publishing to ipfs' + error.message);
+          logger.err(
+            'Error occurred in the "basic tip fetch" test while publishing to ipfs' + error.message
+          )
         })
       }
     })

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "include": ["./src/**/*"]
+  // override exclude imported above as we want lint rules to be applied to mocks and test files as well
+  "exclude": ["node_modules", "coverage", "src/*.spec.ts"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,6 +4,5 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  // override exclude imported above as we want lint rules to be applied to mocks and test files as well
-  "exclude": ["node_modules", "coverage", "src/*.spec.ts"]
+  "include": ["./src/**/*"]
 }

--- a/packages/core/tsconfig.linter.json
+++ b/packages/core/tsconfig.linter.json
@@ -1,0 +1,5 @@
+
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["node_modules", "coverage", "src/*.spec.ts"]
+}

--- a/packages/ipfs-topology/src/ipfs-topology.ts
+++ b/packages/ipfs-topology/src/ipfs-topology.ts
@@ -79,7 +79,9 @@ export class IpfsTopology {
     this.logger.debug(`Connected to peers: ${connectedPeers.join(',')}`)
 
     this.intervalId = setInterval(async () => {
-      this.logger.debug(`Performing periodic reconnection to bootstrap peers for network ${this.ceramicNetwork}`)
+      this.logger.debug(
+        `Performing periodic reconnection to bootstrap peers for network ${this.ceramicNetwork}`
+      )
       await this.forceConnection()
     }, this.period)
   }


### PR DESCRIPTION
## Description

This PR introduces an ESLint rule in the js-ceramic codebase to prevent floating promises in the core package. Floating promises occur when the outcome of a promise is not explicitly managed. To address this, we apply one of three strategies:

1) Handling Positive and Negative Outcomes: This involves adding a .catch() to manage errors when promises fail.
2) Using void Keyword: This is used when the result of the promise is intentionally ignored.
3) Silencing the Linter: This is a last resort and should be used sparingly.


## How Has This Been Tested?

To ensure the effectiveness of this rule, the following test was conducted:

Test 1: Executed npm lint to confirm no errors related to @typescript-eslint/no-floating-promises.

- Test 1 : ran npm lint, ensured no errors regarding to the rule @typescript-eslint/no-floating-promises

## PR checklist

Before submitting this PR, please make sure:

- [ Yes] I have tagged the relevant reviewers and interested parties
- [ Not Needed] I have updated the READMEs of affected packages
- [ Not required] I have made corresponding changes to the documentation

## References:
https://typescript-eslint.io/rules/no-floating-promises/ : rule for no floating promises.
