### PR TITLE
chore(indexing, ipfs-daemon, stream-model-handler, stream-tests) : cat added no-floating promise linter to pkgs and fixed errors related

### DIFF
--- a/packages/indexing/.eslintrc.json
+++ b/packages/indexing/.eslintrc.json
@@ -2,12 +2,17 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "import"],
+    // required for no-floating -promises lint rule
+    "parserOptions": {
+      "project": "tsconfig.linter.json" 
+    },
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
-    "import/default": "off"
+    "import/default": "off",
+    "@typescript-eslint/no-floating-promises": "error"
   },
   "settings": {
     "import/parsers": {

--- a/packages/indexing/src/history-sync/sync-api.ts
+++ b/packages/indexing/src/history-sync/sync-api.ts
@@ -306,7 +306,7 @@ export class SyncApi implements ISyncApi {
     const job =
       type === HISTORY_SYNC_JOB ? createHistorySyncJob(data) : createContinuousSyncJob(data)
 
-    this.jobQueue.addJob(job)
+    await this.jobQueue.addJob(job)
   }
 
   /**

--- a/packages/indexing/src/insertion-order.ts
+++ b/packages/indexing/src/insertion-order.ts
@@ -258,6 +258,7 @@ export class InsertionOrder {
     if (cursor.type === 'timestamp') {
       // Paginate using the `created_at` field when no custom field ordering is provided
       builder = builder.where((qb) => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         qb.where('created_at', isReverseOrder ? '<' : '>', cursor.value) // strict next value
           .orWhere('created_at', '=', cursor.value) // or current value
           .andWhere('stream_id', '>', cursor.id) // with stream ID tie-breaker
@@ -268,6 +269,7 @@ export class InsertionOrder {
         const field = contentKey(key)
         const sign = getComparisonSign(sorting[key], isReverseOrder)
         builder = builder.where((qb) => {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
           qb.whereRaw(`${field} ${sign} ?`, [value]) // strict next value
             .orWhereRaw(`${field} = ?`, [value]) // or current value
             .andWhere('stream_id', '>', cursor.id) // with stream ID tie-breaker

--- a/packages/indexing/src/query-filter-converter.ts
+++ b/packages/indexing/src/query-filter-converter.ts
@@ -98,6 +98,7 @@ function handleIn<T extends number | string>(
       op = ` not${op}`
     }
     const raw = bldr.client.raw(`cast(${key} as ${cast})${op}(${arrValue})`)
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     bldr.whereRaw(raw)
   }
   if (first) {

--- a/packages/indexing/tsconfig.linter.json
+++ b/packages/indexing/tsconfig.linter.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["node_modules", "coverage", "src/*.spec.ts"]
+}

--- a/packages/ipfs-daemon/.eslintrc.json
+++ b/packages/ipfs-daemon/.eslintrc.json
@@ -2,12 +2,17 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "import"],
+  // required for no-floating -promises lint rule
+  "parserOptions": {
+    "project": "tsconfig.linter.json" 
+  },
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
-    "import/default": "off"
+    "import/default": "off",
+    "@typescript-eslint/no-floating-promises": "error"
   },
   "settings": {
     "import/parsers": {

--- a/packages/ipfs-daemon/src/rust-ipfs.ts
+++ b/packages/ipfs-daemon/src/rust-ipfs.ts
@@ -48,7 +48,7 @@ class BinaryRunningIpfs implements RunningIpfs {
   async shutdown(logger?: DiagnosticsLogger): Promise<void> {
     try {
       this.proc.kill()
-      this.dir.cleanup()
+      await this.dir.cleanup()
     } catch (e) {
       if (logger) {
         logger.err(`Failed to shutdown binary Rust IPFS: ${e}`)

--- a/packages/ipfs-daemon/tsconfig.linter.json
+++ b/packages/ipfs-daemon/tsconfig.linter.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["node_modules", "coverage", "src/*.spec.ts"]
+}

--- a/packages/stream-model-handler/.eslintrc.json
+++ b/packages/stream-model-handler/.eslintrc.json
@@ -2,12 +2,17 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "import"],
+  // required for no-floating -promises lint rule
+  "parserOptions": {
+    "project": "tsconfig.linter.json" 
+  },
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
-    "import/default": "off"
+    "import/default": "off",
+    "@typescript-eslint/no-floating-promises": "error"
   },
   "settings": {
     "import/parsers": {

--- a/packages/stream-model-handler/src/__tests__/schema-utils.test.ts
+++ b/packages/stream-model-handler/src/__tests__/schema-utils.test.ts
@@ -36,7 +36,7 @@ describe('SchemaValidation', () => {
   })
 
   it('validates correct 2020-12 schema', async () => {
-    expect(
+    await expect(
       schemaValidator.validateSchema(VALID_JSON_SCHEMA_2020_12_NO_ADDITIONAL_PROPS)
     ).resolves.not.toThrow()
   })
@@ -46,9 +46,9 @@ describe('SchemaValidation', () => {
       ...VALID_JSON_SCHEMA_2020_12_NO_ADDITIONAL_PROPS,
       additionalProperties: true,
     }
-    expect(schemaValidator.validateSchema(validSchemaAllowingAdditionalProps)).rejects.toThrow(
-      'All objects in schema need to have additional properties disabled'
-    )
+    await expect(
+      schemaValidator.validateSchema(validSchemaAllowingAdditionalProps)
+    ).rejects.toThrow('All objects in schema need to have additional properties disabled')
   })
 
   it('throws for correct 2020-12 schema with `additionalProperties === <allowed_property_type>` enabled on top-level', async () => {
@@ -57,7 +57,7 @@ describe('SchemaValidation', () => {
       additionalProperties: { type: 'string' },
     }
 
-    expect(
+    await expect(
       schemaValidator.validateSchema(validSchemaAllowingAdditionalStringProps)
     ).rejects.toThrow('All objects in schema need to have additional properties disabled')
   })
@@ -73,13 +73,13 @@ describe('SchemaValidation', () => {
       },
     }
 
-    expect(
+    await expect(
       schemaValidator.validateSchema(validSchemaAllowingAdditionalPropsInEmbeddedObj)
     ).rejects.toThrow('All objects in schema need to have additional properties disabled')
   })
 
   it('throws for an incorrect 2020-12 schema', async () => {
-    expect(
+    await expect(
       schemaValidator.validateSchema({
         $schema: 'https://json-schema.org/draft/2020-12/schema',
         type: 'object',

--- a/packages/stream-model-handler/tsconfig.linter.json
+++ b/packages/stream-model-handler/tsconfig.linter.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["node_modules", "coverage", "src/*.spec.ts"]
+}

--- a/packages/stream-tests/.eslintrc.json
+++ b/packages/stream-tests/.eslintrc.json
@@ -2,12 +2,17 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "import"],
+  // required for no-floating -promises lint rule
+  "parserOptions": {
+    "project": "tsconfig.linter.json" 
+  },
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
-    "import/default": "off"
+    "import/default": "off",
+    "@typescript-eslint/no-floating-promises": "error"
   },
   "settings": {
     "import/parsers": {

--- a/packages/stream-tests/src/__tests__/caip10/near.test.ts
+++ b/packages/stream-tests/src/__tests__/caip10/near.test.ts
@@ -11,7 +11,7 @@ const chainRef = 'testnet'
 const accountName = 'crustykitty.testnet'
 const keyPair = nearApiJs.utils.KeyPair.fromString(privateKey)
 const keyStore = new nearApiJs.keyStores.InMemoryKeyStore()
-keyStore.setKey(chainRef, accountName, keyPair)
+await keyStore.setKey(chainRef, accountName, keyPair)
 const config = {
   keyStore, // instance of InMemoryKeyStore
   networkId: 'testnet',

--- a/packages/stream-tests/src/__tests__/invalid_tip.test.ts
+++ b/packages/stream-tests/src/__tests__/invalid_tip.test.ts
@@ -62,7 +62,10 @@ describe('Test loading a stream when pubsub replies with an invalid tip', () => 
       if (message.typ == MsgType.QUERY && message.stream.equals(streamID)) {
         const tipMap = new Map().set(streamID.toString(), nonExistentTip)
         const response = { typ: MsgType.RESPONSE, id: message.id, tips: tipMap }
-        ipfs2.pubsub.publish(ceramic.pubsubTopic, serialize(response))
+        ipfs2.pubsub.publish(ceramic.pubsubTopic, serialize(response)).catch((error) => {
+          // we want the test to fail if an error occurs thus we are rethrowing the error
+          throw error
+        })
       }
     })
 
@@ -94,7 +97,10 @@ describe('Test loading a stream when pubsub replies with an invalid tip', () => 
       if (message.typ == MsgType.QUERY && message.stream.equals(streamID)) {
         const tipMap = new Map().set(streamID.toString(), garbageTip)
         const response = { typ: MsgType.RESPONSE, id: message.id, tips: tipMap }
-        ipfs2.pubsub.publish(ceramic.pubsubTopic, serialize(response))
+        ipfs2.pubsub.publish(ceramic.pubsubTopic, serialize(response)).catch((error) => {
+          // we want the test to fail if an error occurs thus we are rethrowing the error
+          throw error
+        })
       }
     })
 
@@ -128,7 +134,10 @@ describe('Test loading a stream when pubsub replies with an invalid tip', () => 
       if (message.typ == MsgType.QUERY && message.stream.equals(streamID)) {
         const tipMap = new Map().set(streamID.toString(), otherStream.tip)
         const response = { typ: MsgType.RESPONSE, id: message.id, tips: tipMap }
-        ipfs2.pubsub.publish(ceramic.pubsubTopic, serialize(response))
+        ipfs2.pubsub.publish(ceramic.pubsubTopic, serialize(response)).catch((error) => {
+          // we want the test to fail if an error occurs thus we are rethrowing the error
+          throw error
+        })
       }
     })
 

--- a/packages/stream-tests/tsconfig.linter.json
+++ b/packages/stream-tests/tsconfig.linter.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["node_modules", "coverage", "src/*.spec.ts"]
+}


### PR DESCRIPTION
## Description

This PR introduces an ESLint rule in the js-ceramic codebase to prevent floating promises in the core package. Floating promises occur when the outcome of a promise is not explicitly managed. Packages touched are indexing, ipfs-daemon, stream-model-handler and stream-tests
To address this, we apply one of three strategies:

Handling Positive and Negative Outcomes: This involves adding a .catch() to manage errors when promises fail.
Using void Keyword: This is used when the result of the promise is intentionally ignored.
Silencing the Linter: This is a last resort and should be used sparingly. This is used when the linter is highlighting code that we do not think should be highlighted

This PR is an extension of : https://github.com/ceramicnetwork/js-ceramic/pull/3049

## How Has This Been Tested?

To ensure the effectiveness of this rule, the following test was conducted:

Test 1: Executed npm lint to confirm no errors related to @typescript-eslint/no-floating-promises.

## PR checklist

Before submitting this PR, please make sure:

- [Yes ] I have tagged the relevant reviewers and interested parties
- [ Not needed] I have updated the READMEs of affected packages
- [ Not needed] I have made corresponding changes to the documentation

## References:

https://typescript-eslint.io/rules/no-floating-promises/ : rule for no floating promises.
For ignoring lint rules for Knex query builder code : https://github.com/knex/knex/blob/6243f6cbd5421c9db046979b60fe8661b523581f/lib/query/querybuilder.js#L545

