### PR TITLE
fix: Update state store after applying update

### DIFF
--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -533,7 +533,7 @@ export class Repository {
       if (next) {
         state$.next(next)
         await this._updateStateIfPinned(state$)
-        this.logger.imp(`Stream ${state$.id} successfully updated to tip ${cid}`)
+        this.logger.verbose(`Stream ${state$.id} successfully updated to tip ${cid}`)
         return true
       } else {
         return false

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -741,7 +741,9 @@ export class Repository {
             // If we failed to apply the commit at least once, then it's worth logging when
             // we are able to do so successfully on the retry.
             this.logger.imp(
-              `Successfully applied anchor commit ${anchorCommitCID} for stream ${state$.id}`
+              `Successfully applied anchor commit ${anchorCommitCID} for stream ${
+                state$.id
+              } after ${APPLY_ANCHOR_COMMIT_ATTEMPTS - remainingRetries} attempts`
             )
           } else {
             this.logger.verbose(

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -717,13 +717,15 @@ export class Repository {
     const streamId = StreamUtils.streamIdFromState(state$.state)
     const anchorCommitCID = witnessCAR.roots[0]
     if (!anchorCommitCID) throw new Error(`No anchor commit CID as root`)
+
+    this.logger.verbose(`Handling anchor commit for ${streamId} with CID ${anchorCommitCID}`)
+
     for (
       let remainingRetries = APPLY_ANCHOR_COMMIT_ATTEMPTS - 1;
       remainingRetries >= 0;
       remainingRetries--
     ) {
       try {
-        this.logger.verbose(`Handling anchor commit for ${streamId}`)
         if (witnessCAR) {
           await this.dispatcher.importCAR(witnessCAR)
           this.logger.verbose(`successfully imported CAR file for ${streamId}`)


### PR DESCRIPTION
This is the bug that causes anchored updates to be lost after a node restart.  It was introduced in https://github.com/ceramicnetwork/js-ceramic/commit/62bc7cbdef356e32768282d09c1c96409142b16a, almost 2 months ago.