### PR TITLE
no console es lint rule added to pkgs with minimal/no changes

### DIFF
--- a/packages/3id-did-resolver/.eslintrc.json
+++ b/packages/3id-did-resolver/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/anchor-listener/.eslintrc.json
+++ b/packages/anchor-listener/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/anchor-utils/.eslintrc.json
+++ b/packages/anchor-utils/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/anchor-utils/src/merkle/__tests__/merkle-proof.test.ts
+++ b/packages/anchor-utils/src/merkle/__tests__/merkle-proof.test.ts
@@ -66,7 +66,7 @@ describe('Merkle tree proofs tests', () => {
       const hashedProof = uint8arrays.toString(hashProof(leaf, proof), 'hex')
       if (hashedProof !== root) {
         const lettersProof = lettersTree.getProof(i)
-        // tslint:disable-next-line:no-console
+        // eslint-disable-next-line no-console        
         console.log(
           'The resulting hash of your proof is wrong. \n' +
             `We were expecting: ${root} \n` +

--- a/packages/blockchain-utils-validation/.eslintrc.json
+++ b/packages/blockchain-utils-validation/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/codecs/.eslintrc.json
+++ b/packages/codecs/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -7,7 +7,8 @@
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
-    "import/default": "off"
+    "import/default": "off",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/http-client/.eslintrc.json
+++ b/packages/http-client/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/http-client/src/dummy-pin-api.ts
+++ b/packages/http-client/src/dummy-pin-api.ts
@@ -1,8 +1,10 @@
-import { PinApi, PublishOpts } from '@ceramicnetwork/common'
+import { PinApi, PublishOpts, LoggerProvider } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
 
+const logger = new LoggerProvider().getDiagnosticsLogger()
+
 function warn(operation: string) {
-  console.warn(
+  logger.warn(
     `You are using the ceramic.pin.${operation} API which has been removed and is now a no-op.  This operation will not have any affect.  If you want to change the pin state of streams please use the new ceramic.admin.pin API which requires a DID that has been granted admin access on the Ceramic node.`
   )
 }

--- a/packages/indexing/.eslintrc.json
+++ b/packages/indexing/.eslintrc.json
@@ -7,7 +7,8 @@
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
-    "import/default": "off"
+    "import/default": "off",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/ipfs-daemon/.eslintrc.json
+++ b/packages/ipfs-daemon/.eslintrc.json
@@ -7,7 +7,8 @@
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
-    "import/default": "off"
+    "import/default": "off",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/ipfs-daemon/src/bin/ipfs-daemon.ts
+++ b/packages/ipfs-daemon/src/bin/ipfs-daemon.ts
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
 
 import { IpfsDaemon } from '../ipfs-daemon.js'
+import { LoggerProvider } from '@ceramicnetwork/common'
+
+const logger = new LoggerProvider().getDiagnosticsLogger()
 
 process.on('uncaughtException', (err) => {
-  console.log(err) // just log for now
+  logger.err(err)
 })
 
 IpfsDaemon.create()
   .then((ipfs) => ipfs.start())
-  .catch((e) => console.error(e))
+  .catch((e) => logger.err(e))

--- a/packages/ipfs-topology/.eslintrc.json
+++ b/packages/ipfs-topology/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/job-queue/.eslintrc.json
+++ b/packages/job-queue/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/pinning-aggregation/.eslintrc.json
+++ b/packages/pinning-aggregation/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error"
   },
   "settings": {
     "import/parsers": {

--- a/packages/pinning-crust-backend/.eslintrc.json
+++ b/packages/pinning-crust-backend/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/pinning-crust-backend/src/index.ts
+++ b/packages/pinning-crust-backend/src/index.ts
@@ -9,9 +9,13 @@ import { KeyringPair } from '@polkadot/keyring/types'
 import { DispatchError } from '@polkadot/types/interfaces'
 import { ITuple } from '@polkadot/types/types'
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types'
+import { LoggerProvider } from '@ceramicnetwork/common'
 
 // Encoder
 const textEncoder = new TextEncoder()
+
+// Logger
+const logger = new LoggerProvider().getDiagnosticsLogger()
 
 // Errors
 export class EmptySeedError extends Error {
@@ -177,7 +181,7 @@ export class CrustPinningBackend implements PinningBackend {
   async sendTx(tx: SubmittableExtrinsic, krp: KeyringPair): Promise<void> {
     return new Promise((resolve, reject) => {
       tx.signAndSend(krp, ({ events = [], status }) => {
-        console.log(`  ↪ 💸 [tx]: Transaction status: ${status.type}, nonce: ${tx.nonce}`)
+        logger.imp(`  ↪ 💸 [tx]: Transaction status: ${status.type}, nonce: ${tx.nonce}`)
 
         if (status.isInvalid || status.isDropped || status.isUsurped) {
           reject(new Error(`${status.type} transaction.`))
@@ -189,12 +193,12 @@ export class CrustPinningBackend implements PinningBackend {
           events.forEach(({ event: { data, method, section } }) => {
             if (section === 'system' && method === 'ExtrinsicFailed') {
               const [dispatchError] = data as unknown as ITuple<[DispatchError]>
-              console.log(
+              logger.err(
                 `  ↪ 💸 ❌ [tx]: Send transaction(${tx.type}) failed with ${dispatchError.type}.`
               )
               reject(new TxError(tx.type, dispatchError.type))
             } else if (method === 'ExtrinsicSuccess') {
-              console.log(`  ↪ 💸 ✅ [tx]: Send transaction(${tx.type}) success.`)
+              logger.imp(`  ↪ 💸 ✅ [tx]: Send transaction(${tx.type}) success.`)
               resolve()
             }
           })

--- a/packages/pinning-ipfs-backend/.eslintrc.json
+++ b/packages/pinning-ipfs-backend/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/pinning-powergate-backend/.eslintrc.json
+++ b/packages/pinning-powergate-backend/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/stream-caip10-link-handler/.eslintrc.json
+++ b/packages/stream-caip10-link-handler/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/stream-caip10-link/.eslintrc.json
+++ b/packages/stream-caip10-link/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/stream-handler-common/.eslintrc.json
+++ b/packages/stream-handler-common/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/stream-model-handler/.eslintrc.json
+++ b/packages/stream-model-handler/.eslintrc.json
@@ -7,7 +7,8 @@
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
-    "import/default": "off"
+    "import/default": "off",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/stream-model-instance-handler/.eslintrc.json
+++ b/packages/stream-model-instance-handler/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/stream-model-instance/.eslintrc.json
+++ b/packages/stream-model-instance/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/stream-model/.eslintrc.json
+++ b/packages/stream-model/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/stream-tests/.eslintrc.json
+++ b/packages/stream-tests/.eslintrc.json
@@ -7,7 +7,8 @@
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
-    "import/default": "off"
+    "import/default": "off",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/stream-tile-handler/.eslintrc.json
+++ b/packages/stream-tile-handler/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {

--- a/packages/stream-tile/.eslintrc.json
+++ b/packages/stream-tile/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error"
   },
   "settings": {
     "import/parsers": {

--- a/packages/streamid/.eslintrc.json
+++ b/packages/streamid/.eslintrc.json
@@ -12,7 +12,8 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "import/no-unresolved": "error",
     "import/default": "off",
-    "@typescript-eslint/no-floating-promises": "error"
+    "@typescript-eslint/no-floating-promises": "error",
+    "no-console": "error" 
   },
   "settings": {
     "import/parsers": {


### PR DESCRIPTION
## Description

es-lint rule for no direct access to console added. This will deny direct access to console from the code.
This PR includes packages in js-ceramic codebase that required minimal changes. 
PRs for this are broken down into 3 PRS : 
1) PR with minimal code changes - packages where direct console access was minimal. (This PR)
2) PR for CLI - wip
3) PR for common, strem-tests, blockchain-utils-linking, logging - wip
## How Has This Been Tested?

Ran npm run lint on the packages where this rule has been added and corrected code that was not following the standard.

## PR checklist

Before submitting this PR, please make sure:

- [ Yes ] I have tagged the relevant reviewers and interested parties
- [ Not required] I have updated the READMEs of affected packages
- [ Not required] I have made corresponding changes to the documentation

## References:

https://eslint.org/docs/latest/rules/no-console -- es lint rule for denying direct access to console