### PR TITLE
fix: broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 > **Project status**: **Access  the Ceramic mainnet. 🚀** <br/>
 > With the launch of [ComposeDB Beta](https://blog.ceramic.network/composedb-is-live-on-ceramic-mainnet/), it is now much easier to access Ceramic mainnet for building applications.
-> Developers can now onboard their node to Ceramic mainnet in under 5 minutes without needing to contact any community members. Check out [this guide](https://composedb.js.org/docs/0.5.x/guides/composedb-server/access-mainnet)
+> Developers can now onboard their node to Ceramic mainnet in under 5 minutes without needing to contact any community members. Check out [this guide](https://developers.ceramic.network/docs/composedb/guides/composedb-server/access-mainnet)
 > to learn more.
 
 

--- a/docs-dev/QUICKSTART.md
+++ b/docs-dev/QUICKSTART.md
@@ -25,7 +25,7 @@ The default configuration file is located at
 
 For more information about the configuration options see [Server Configurations](https://developers.ceramic.network/docs/composedb/guides/composedb-server/server-configurations)
 
-For an example how to run in the cloud using Digital Ocean and Kubernetes see [Running in the Cloud](https://developers.ceramic.network/docs/composedb/guides/composedb-server/running-in-the-cloud) or refer to the [SimpleDeploy](SimpleDeploy) example ansible scripts.
+For an example how to run in the cloud using Digital Ocean and Kubernetes see [Running in the Cloud](https://developers.ceramic.network/docs/composedb/guides/composedb-server/running-in-the-cloud) or refer to the [SimpleDeploy](https://github.com/ceramicstudio/simpledeploy) example ansible scripts.
 
 ## Develop on Ceramic using ComposeDB
 

--- a/docs-dev/QUICKSTART.md
+++ b/docs-dev/QUICKSTART.md
@@ -23,9 +23,9 @@ The default configuration file is located at
 
 `$HOME/.ceramic/daemon.config.json`
 
-For more information about the configuration options see [Server Configurations](https://composedb.js.org/docs/0.5.x/guides/composedb-server/server-configurations)
+For more information about the configuration options see [Server Configurations](https://developers.ceramic.network/docs/composedb/guides/composedb-server/server-configurations)
 
-For an example how to run in the cloud using Digital Ocean and Kubernetes see [Running in the Cloud](https://composedb.js.org/docs/0.5.x/guides/composedb-server/running-in-the-cloud) or refer to the [SimpleDeploy](SimpleDeploy) example ansible scripts.
+For an example how to run in the cloud using Digital Ocean and Kubernetes see [Running in the Cloud](https://developers.ceramic.network/docs/composedb/guides/composedb-server/running-in-the-cloud) or refer to the [SimpleDeploy](SimpleDeploy) example ansible scripts.
 
 ## Develop on Ceramic using ComposeDB
 

--- a/packages/core/src/anchor/auth/did-anchor-service-auth.ts
+++ b/packages/core/src/anchor/auth/did-anchor-service-auth.ts
@@ -52,7 +52,7 @@ export class DIDAnchorServiceAuth implements AnchorServiceAuth {
         throw new Error(
           `You are not authorized to use the anchoring service found at: ${
             this.#anchorServiceUrl
-          }. Are you using the correct anchoring service url? If so please ensure that you have access to 3Box Labs’ Ceramic Anchor Service by following the steps found here: https://composedb.js.org/docs/0.4.x/guides/composedb-server/access-mainnet`
+          }. Are you using the correct anchoring service url? If so please ensure that you have access to 3Box Labs’ Ceramic Anchor Service by following the steps found here: https://developers.ceramic.network/docs/composedb/guides/composedb-server/access-mainnet`
         )
       }
       throw err


### PR DESCRIPTION
Fixed a broken link

## Description

There is a broken link to a guide for accessing mainnet with an existing node, so I found what seems to be the correct article in the latest documentation and swapped the link.

## How Has This Been Tested?

- [x] Clicked on the link from the preview to make sure it resolves properly

