### PR TITLE
chore: log size of AnchorRequestStore periodically

### DIFF
--- a/packages/cli/src/__tests__/ceramic-error.test.ts
+++ b/packages/cli/src/__tests__/ceramic-error.test.ts
@@ -54,6 +54,7 @@ beforeAll(async () => {
   })
 
   const ceramicConfig = makeCeramicConfig(daemonConfig)
+  ceramicConfig.enableAnchorPollingLoop = false
   core = await Ceramic.create(ipfs, ceramicConfig)
   daemon = new CeramicDaemon(core, daemonConfig)
   await daemon.listen()

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -24,7 +24,9 @@ import { RemoteCAS } from './remote-cas.js'
 import { doNotWait } from '../../ancillary/do-not-wait.js'
 import { NamedTaskQueue } from '../../state-management/named-task-queue.js'
 
-const BATCH_SIZE = 10
+// BATCH_SIZE controls the number of keys fetched from the AnchorRequestStore at once.
+// It does not affect the parallelism/concurrency of actually processing the entries in those batches.
+const BATCH_SIZE = 1000
 
 /**
  * Ethereum anchor service that stores root CIDs on Ethereum blockchain

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -250,7 +250,7 @@ export class Ceramic implements CeramicApi {
       dispatcher: this.dispatcher,
       pinStore: pinStore,
       keyValueStore: this._levelStore,
-      anchorRequestStore: new AnchorRequestStore(),
+      anchorRequestStore: new AnchorRequestStore(this._logger),
       context: this.context,
       handlers: this._streamHandlers,
       anchorService: modules.anchorService,


### PR DESCRIPTION
We have been using this log line (https://github.com/ceramicnetwork/js-ceramic/blob/7f334b119e267483aa04324f17c2620e363bcd6f/packages/core/src/state-management/anchor-resuming-service.ts#L72) to keep track of the size of the AnchorRequestStore.  Now that that line was removed in the off-memory-anchoring commit, this is to put back some way to keep track of the size of the store and ensure it isn't growing unbounded.