### PR TITLE
DO NOT MERGE - dont apply any anchor commits

### DIFF
--- a/packages/core/src/anchor/anchor-processing-loop.ts
+++ b/packages/core/src/anchor/anchor-processing-loop.ts
@@ -50,7 +50,7 @@ export class AnchorProcessingLoop {
    * Start looping.
    */
   start(): void {
-    this.#loop.start()
+    // this.#loop.start()
   }
 
   /**

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -420,30 +420,30 @@ export class Dispatcher {
    * Handles one message from the pubsub topic.
    */
   async handleMessage(message: PubsubMessage): Promise<void> {
-    try {
-      switch (message.typ) {
-        case MsgType.UPDATE:
-          await this._handleUpdateMessage(message)
-          break
-        case MsgType.QUERY:
-          await this._handleQueryMessage(message)
-          break
-        case MsgType.RESPONSE:
-          await this._handleResponseMessage(message)
-          break
-        case MsgType.KEEPALIVE:
-          break
-        default:
-          throw new UnreachableCaseError(message, `Unsupported message type`)
-      }
-    } catch (e) {
-      // TODO: Combine these two log statements into one line so that they can't get split up in the
-      // log output.
-      this._logger.err(
-        `Error while processing ${messageTypeToString(message.typ)} message from pubsub: ${e}`
-      )
-      this._logger.err(e) // Log stack trace
-    }
+    // try {
+    //   switch (message.typ) {
+    //     case MsgType.UPDATE:
+    //       await this._handleUpdateMessage(message)
+    //       break
+    //     case MsgType.QUERY:
+    //       await this._handleQueryMessage(message)
+    //       break
+    //     case MsgType.RESPONSE:
+    //       await this._handleResponseMessage(message)
+    //       break
+    //     case MsgType.KEEPALIVE:
+    //       break
+    //     default:
+    //       throw new UnreachableCaseError(message, `Unsupported message type`)
+    //   }
+    // } catch (e) {
+    //   // TODO: Combine these two log statements into one line so that they can't get split up in the
+    //   // log output.
+    //   this._logger.err(
+    //     `Error while processing ${messageTypeToString(message.typ)} message from pubsub: ${e}`
+    //   )
+    //   this._logger.err(e) // Log stack trace
+    // }
   }
 
   /**


### PR DESCRIPTION
This is a quick hack to prevent us from ever applying anchors. We want this so that we can build up a backlog of commits that are anchored on the CAS but still unanchored on the local Ceramic node and still contained within the AnchorRequestStore.  We accomplish this by turning off the two ways the node can learn about anchor commits: the loop that polls the CAS directly, and pubsub.  Note that disabling pubsub entirely means the node won't be able to sync data to/from other Ceramic nodes, but that shouldn't matter for the purposes of the test we want to use it for.