### PR TITLE
fix: Make AnchorRequestStore processing loop more robust

### DIFF
--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -134,6 +134,7 @@ export class EthereumAnchorService implements AnchorService {
   }
 
   async close(): Promise<void> {
+    this.#logger.debug(`Closing EthereumAnchorService`)
     await this.#cas.close()
     await this.#store.close()
     await this.#loop.stop()

--- a/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
+++ b/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
@@ -129,7 +129,7 @@ describe('LevelDB-backed AnchorRequestStore state store', () => {
   beforeEach(async () => {
     tmpFolder = await tmp.dir({ unsafeCleanup: true })
     levelStore = new LevelDbStore(logger, tmpFolder.path, 'fakeNetwork')
-    anchorRequestStore = new AnchorRequestStore()
+    anchorRequestStore = new AnchorRequestStore(logger)
     await anchorRequestStore.open(levelStore)
 
     // add a small delay after creating the leveldb instance before trying to use it.


### PR DESCRIPTION
Adds logs and exception handling.  Also increases restart delay from 100ms to 1 second to avoid hammering S3 too often.