### PR TITLE
chore: Close connections on Ctrl+C

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -1004,6 +1004,7 @@ export class CeramicDaemon {
   async close(): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       if (!this.server) resolve()
+      this.server.closeAllConnections()
       this.server.close((err) => {
         if (err) {
           reject(err)


### PR DESCRIPTION
Now even if SSE feed is connected, the daemon could be closed.