### PR TITLE
fix: register new running state

### DIFF
--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -942,6 +942,9 @@ export class Repository {
       this.fromMemoryOrStore(id)
         .then((found) => {
           const state$ = found || new RunningState(init, false)
+          if (!found) {
+            this._registerRunningState(state$)
+          }
           this.inmemory.endure(id.toString(), state$)
           state$.subscribe(subscriber).add(() => {
             if (state$.observers.length === 0) {


### PR DESCRIPTION
## Description

If we hit the case here where the state isn't found in the cache or state store, but then we wind up creating a new RunningState object here, we don't ever call _registerRunningState on it.
