### PR TITLE
chore: update multiformats

### DIFF
--- a/packages/3id-did-resolver/package.json
+++ b/packages/3id-did-resolver/package.json
@@ -45,7 +45,7 @@
     "@ceramicnetwork/streamid": "^3.2.0",
     "least-recent": "^1.0.3",
     "multiformats": "^13.0.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@ceramicnetwork/http-client": "^3.2.0",

--- a/packages/3id-did-resolver/package.json
+++ b/packages/3id-did-resolver/package.json
@@ -44,7 +44,7 @@
     "@ceramicnetwork/stream-tile": "^3.2.0",
     "@ceramicnetwork/streamid": "^3.2.0",
     "least-recent": "^1.0.3",
-    "multiformats": "^11.0.1",
+    "multiformats": "^13.0.0",
     "uint8arrays": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/anchor-listener/package.json
+++ b/packages/anchor-listener/package.json
@@ -38,7 +38,7 @@
     "@ceramicnetwork/common": "^3.2.0",
     "@ethersproject/abi": "^5.7.0",
     "@jest/globals": "^28.1.3",
-    "multiformats": "^11.0.1",
+    "multiformats": "^13.0.0",
     "uint8arrays": "^4.0.3"
   },
   "publishConfig": {

--- a/packages/anchor-listener/package.json
+++ b/packages/anchor-listener/package.json
@@ -39,7 +39,7 @@
     "@ethersproject/abi": "^5.7.0",
     "@jest/globals": "^28.1.3",
     "multiformats": "^13.0.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/anchor-utils/package.json
+++ b/packages/anchor-utils/package.json
@@ -33,7 +33,7 @@
     "@ceramicnetwork/common": "^3.2.0",
     "@ethersproject/abi": "^5.7.0",
     "multiformats": "^13.0.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@ceramicnetwork/streamid": "^3.2.0",

--- a/packages/anchor-utils/package.json
+++ b/packages/anchor-utils/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@ceramicnetwork/common": "^3.2.0",
     "@ethersproject/abi": "^5.7.0",
-    "multiformats": "^11.0.1",
+    "multiformats": "^13.0.0",
     "uint8arrays": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/blockchain-utils-linking/package.json
+++ b/packages/blockchain-utils-linking/package.json
@@ -43,7 +43,7 @@
     "@stablelib/sha256": "^1.0.1",
     "caip": "~1.1.0",
     "near-api-js": "^0.44.2",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@glif/filecoin-address": "1.1.0",

--- a/packages/blockchain-utils-validation/package.json
+++ b/packages/blockchain-utils-validation/package.json
@@ -50,7 +50,7 @@
     "@zondax/filecoin-signing-tools": "^0.18.2",
     "caip": "~1.1.0",
     "tweetnacl": "^1.0.3",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@glif/filecoin-address": "1.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -75,7 +75,7 @@
     "s3leveldown": "^2.2.2",
     "stream-to-array": "^2.3.0",
     "typedjson": "^1.8.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@ceramicnetwork/stream-model": "^2.2.0",

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -34,7 +34,7 @@
     "cartonne": "^2.1.1",
     "codeco": "^1.1.0",
     "dag-jose": "^4.0.0",
-    "multiformats": "^11.0.1",
+    "multiformats": "^13.0.0",
     "uint8arrays": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -35,7 +35,7 @@
     "codeco": "^1.1.0",
     "dag-jose": "^4.0.0",
     "multiformats": "^13.0.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "ts-essentials": "^9.3.2"

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -31,7 +31,7 @@
   "license": "(Apache-2.0 OR MIT)",
   "dependencies": {
     "@ceramicnetwork/streamid": "^3.2.0",
-    "cartonne": "^2.1.1",
+    "cartonne": "3.0.0",
     "codeco": "^1.1.0",
     "dag-jose": "^4.0.0",
     "multiformats": "^13.0.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -57,7 +57,7 @@
     "jet-logger": "1.2.2",
     "lodash.clonedeep": "^4.5.0",
     "logfmt": "^1.3.2",
-    "multiformats": "^11.0.1",
+    "multiformats": "^13.0.0",
     "rxjs": "^7.5.2",
     "uint8arrays": "^4.0.3"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -59,7 +59,7 @@
     "logfmt": "^1.3.2",
     "multiformats": "^13.0.0",
     "rxjs": "^7.5.2",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@types/lodash.clonedeep": "^4.5.6",

--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -94,7 +94,7 @@ export class StreamUtils {
     }
 
     if (StreamUtils.isSignedCommit(cloned)) {
-      cloned.link = toCID(cloned.link)
+      cloned.link = toCID(cloned.link.toString())
     }
 
     if (StreamUtils.isAnchorCommit(cloned)) {
@@ -261,7 +261,7 @@ export class StreamUtils {
     ipfs: IpfsApi
   ): Promise<CeramicCommit> {
     if (StreamUtils.isSignedCommit(commit)) {
-      const block = await ipfs.block.get(toCID((commit as DagJWS).link))
+      const block = await ipfs.block.get(toCID((commit as DagJWS).link.toString()))
       return {
         jws: commit as DagJWS,
         linkedBlock: block,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,7 +86,7 @@
     "level-ts": "^2.1.0",
     "lodash.clonedeep": "^4.5.0",
     "mapmoize": "^1.2.1",
-    "multiformats": "^11.0.1",
+    "multiformats": "^13.0.0",
     "p-queue": "7.3.0",
     "pg": "^8.7.3",
     "rxjs": "^7.5.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,7 +74,7 @@
     "ajv": "^8.8.2",
     "ajv-formats": "^2.1.1",
     "await-semaphore": "^0.1.3",
-    "cartonne": "^2.1.1",
+    "cartonne": "3.0.0",
     "codeco": "^1.1.0",
     "dag-jose": "^4.0.0",
     "dids": "^4.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,7 +91,7 @@
     "pg": "^8.7.3",
     "rxjs": "^7.5.2",
     "sqlite3": "^5.0.8",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@ceramicnetwork/3id-did-resolver": "^3.2.0",

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "dids": "^4.0.0",
     "key-did-resolver": "^3.0.0",
-    "multiformats": "^11.0.1"
+    "multiformats": "^13.0.0"
   },
   "gitHead": "56e646e82ee6e9cdb0b762bbbf77b8432edce367"
 }

--- a/packages/indexing/package.json
+++ b/packages/indexing/package.json
@@ -43,7 +43,7 @@
     "p-queue": "^7.4.0",
     "pg-boss": "^8.2.0",
     "rxjs": "^7.8.1",
-    "uint8arrays": "^4.0.6"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@ceramicnetwork/3id-did-resolver": "^3.2.0",

--- a/packages/indexing/package.json
+++ b/packages/indexing/package.json
@@ -39,7 +39,7 @@
     "@ethersproject/providers": "^5.5.1",
     "knex": "^2.5.1",
     "lodash.clonedeep": "^4.5.0",
-    "multiformats": "^12.1.0",
+    "multiformats": "^13.0.0",
     "p-queue": "^7.4.0",
     "pg-boss": "^8.2.0",
     "rxjs": "^7.8.1",

--- a/packages/pinning-aggregation/package.json
+++ b/packages/pinning-aggregation/package.json
@@ -40,7 +40,7 @@
     "@ceramicnetwork/pinning-ipfs-backend": "^3.2.0",
     "@ceramicnetwork/pinning-powergate-backend": "^3.2.0",
     "ipfs-core-types": "^0.14.0",
-    "multiformats": "^11.0.1"
+    "multiformats": "^13.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pinning-aggregation/package.json
+++ b/packages/pinning-aggregation/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@stablelib/sha256": "^1.0.1",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@ceramicnetwork/common": "^3.2.0",

--- a/packages/pinning-crust-backend/package.json
+++ b/packages/pinning-crust-backend/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@ceramicnetwork/common": "^3.2.0",
     "http-request-mock": "^1.8.17",
-    "multiformats": "^11.0.1"
+    "multiformats": "^13.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pinning-crust-backend/package.json
+++ b/packages/pinning-crust-backend/package.json
@@ -37,7 +37,7 @@
     "@polkadot/keyring": "^6.2.1",
     "@polkadot/types": "^4.6.2",
     "@stablelib/sha256": "^1.0.1",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@ceramicnetwork/common": "^3.2.0",

--- a/packages/pinning-ipfs-backend/package.json
+++ b/packages/pinning-ipfs-backend/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@ceramicnetwork/common": "^3.2.0",
     "ipfs-core-types": "^0.14.0",
-    "multiformats": "^11.0.1"
+    "multiformats": "^13.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pinning-ipfs-backend/package.json
+++ b/packages/pinning-ipfs-backend/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@stablelib/sha256": "^1.0.1",
     "ipfs-http-client": "^60.0.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@ceramicnetwork/common": "^3.2.0",

--- a/packages/pinning-powergate-backend/package.json
+++ b/packages/pinning-powergate-backend/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@stablelib/sha256": "^1.0.1",
     "@textile/powergate-client": "^4.1.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@ceramicnetwork/common": "^3.2.0",

--- a/packages/pinning-powergate-backend/package.json
+++ b/packages/pinning-powergate-backend/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@ceramicnetwork/common": "^3.2.0",
-    "multiformats": "^11.0.1"
+    "multiformats": "^13.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/stream-caip10-link-handler/package.json
+++ b/packages/stream-caip10-link-handler/package.json
@@ -48,7 +48,7 @@
     "@stablelib/sha256": "^1.0.1",
     "@types/lodash.clonedeep": "^4.5.6",
     "lodash.clonedeep": "^4.5.0",
-    "multiformats": "^11.0.1",
+    "multiformats": "^13.0.0",
     "uint8arrays": "^4.0.3"
   },
   "gitHead": "56e646e82ee6e9cdb0b762bbbf77b8432edce367"

--- a/packages/stream-caip10-link-handler/package.json
+++ b/packages/stream-caip10-link-handler/package.json
@@ -49,7 +49,7 @@
     "@types/lodash.clonedeep": "^4.5.6",
     "lodash.clonedeep": "^4.5.0",
     "multiformats": "^13.0.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "gitHead": "56e646e82ee6e9cdb0b762bbbf77b8432edce367"
 }

--- a/packages/stream-model-handler/package.json
+++ b/packages/stream-model-handler/package.json
@@ -63,7 +63,7 @@
     "fast-json-patch": "^3.1.0",
     "json-schema-typed": "^8.0.1",
     "key-did-resolver": "^3.0.0",
-    "multiformats": "^11.0.1"
+    "multiformats": "^13.0.0"
   },
   "gitHead": "56e646e82ee6e9cdb0b762bbbf77b8432edce367"
 }

--- a/packages/stream-model-handler/package.json
+++ b/packages/stream-model-handler/package.json
@@ -48,7 +48,7 @@
     "json-ptr": "^3.1.1",
     "lodash.clonedeep": "^4.5.0",
     "lodash.ismatch": "^4.4.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@ceramicnetwork/3id-did-resolver": "^3.2.0",

--- a/packages/stream-model-instance-handler/package.json
+++ b/packages/stream-model-instance-handler/package.json
@@ -60,7 +60,7 @@
     "did-resolver": "^4.0.1",
     "dids": "^4.0.0",
     "key-did-resolver": "^3.0.0",
-    "multiformats": "^11.0.1"
+    "multiformats": "^13.0.0"
   },
   "gitHead": "56e646e82ee6e9cdb0b762bbbf77b8432edce367"
 }

--- a/packages/stream-model-instance-handler/package.json
+++ b/packages/stream-model-instance-handler/package.json
@@ -47,7 +47,7 @@
     "fast-json-patch": "^3.1.0",
     "least-recent": "^1.0.3",
     "lodash.clonedeep": "^4.5.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@ceramicnetwork/3id-did-resolver": "^3.2.0",

--- a/packages/stream-model-instance/package.json
+++ b/packages/stream-model-instance/package.json
@@ -44,7 +44,7 @@
     "@stablelib/random": "^1.0.1",
     "fast-json-patch": "^3.1.0",
     "object-sizeof": "^2.6.1",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "gitHead": "56e646e82ee6e9cdb0b762bbbf77b8432edce367"
 }

--- a/packages/stream-model/package.json
+++ b/packages/stream-model/package.json
@@ -47,7 +47,7 @@
     "codeco": "^1.1.0",
     "fast-json-patch": "^3.1.0",
     "json-schema-typed": "^8.0.1",
-    "multiformats": "^11.0.1",
+    "multiformats": "^13.0.0",
     "uint8arrays": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/stream-model/package.json
+++ b/packages/stream-model/package.json
@@ -48,7 +48,7 @@
     "fast-json-patch": "^3.1.0",
     "json-schema-typed": "^8.0.1",
     "multiformats": "^13.0.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "json-schema-typed": "^8.0.1"

--- a/packages/stream-tests/package.json
+++ b/packages/stream-tests/package.json
@@ -46,7 +46,7 @@
     "merge-options": "^3.0.4",
     "pkh-did-resolver": "^1.2.0",
     "tmp-promise": "^3.0.3",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "gitHead": "34eeee25597b0a60def72906c26d3afd6230aaf1"
 }

--- a/packages/stream-tile-handler/package.json
+++ b/packages/stream-tile-handler/package.json
@@ -58,7 +58,7 @@
     "did-resolver": "^4.0.1",
     "dids": "^4.0.0",
     "key-did-resolver": "^3.0.0",
-    "multiformats": "^11.0.1"
+    "multiformats": "^13.0.0"
   },
   "gitHead": "56e646e82ee6e9cdb0b762bbbf77b8432edce367"
 }

--- a/packages/stream-tile-handler/package.json
+++ b/packages/stream-tile-handler/package.json
@@ -47,7 +47,7 @@
     "fast-json-patch": "^3.1.0",
     "least-recent": "^1.0.3",
     "lodash.clonedeep": "^4.5.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "devDependencies": {
     "@ceramicnetwork/3id-did-resolver": "^3.2.0",

--- a/packages/stream-tile/package.json
+++ b/packages/stream-tile/package.json
@@ -45,7 +45,7 @@
     "dids": "^4.0.0",
     "fast-json-patch": "^3.1.0",
     "lodash.clonedeep": "^4.5.0",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^5.0.1"
   },
   "gitHead": "56e646e82ee6e9cdb0b762bbbf77b8432edce367"
 }

--- a/packages/streamid/package.json
+++ b/packages/streamid/package.json
@@ -35,7 +35,7 @@
     "cborg": "^1.10.2",
     "mapmoize": "^1.2.1",
     "multiformats": "^13.0.0",
-    "uint8arrays": "^4.0.9",
+    "uint8arrays": "^5.0.1",
     "varint": "^6.0.0"
   },
   "publishConfig": {

--- a/packages/streamid/package.json
+++ b/packages/streamid/package.json
@@ -34,7 +34,7 @@
     "@stablelib/sha256": "^1.0.1",
     "cborg": "^1.10.2",
     "mapmoize": "^1.2.1",
-    "multiformats": "^11.0.1",
+    "multiformats": "^13.0.0",
     "uint8arrays": "^4.0.9",
     "varint": "^6.0.0"
   },


### PR DESCRIPTION
## Description
The CI test for this repository seem to be due to some sort of update to the way CIDs are serialized, the solution is to upgrade some libraries
- upgrades `multiformats` library
- upgrades `uint8arrays` library
