### PR TITLE
feat: Timeout fetching batches from the AnchorRequestStore

### DIFF
--- a/packages/core/src/anchor/processing-loop.ts
+++ b/packages/core/src/anchor/processing-loop.ts
@@ -107,11 +107,14 @@ export class ProcessingLoop<T> {
           isDone = next.done
           if (isDone) break
           const value = next.value
-          if (!value) continue
+          if (!value) {
+            this.#logger.debug(`No value received in ProcessingLoop, skipping this iteration`)
+            continue
+          }
           await Promise.race([this.handleValue(value), rejectOnAbortSignal])
         } while (!isDone)
         this.#whenComplete.resolve()
-        this.#logger.verbose(`ProcessingLoop complete`)
+        this.#logger.debug(`ProcessingLoop complete`)
       } catch (e) {
         this.#logger.err(`Error in ProcessingLoop: ${e}`)
         this.#whenComplete.reject(e)

--- a/packages/core/src/store/anchor-request-store.ts
+++ b/packages/core/src/store/anchor-request-store.ts
@@ -106,8 +106,9 @@ export class AnchorRequestStore extends ObjectStore<StreamID, AnchorRequestData>
     let numEntries = 0
     do {
       try {
+        let timeout
         const timeoutPromise = new Promise<null>((resolve) => {
-          setTimeout(() => {
+          timeout = setTimeout(() => {
             this.#logger.warn(`Timed out while waiting for AnchorRequestStore to fetch a batch`)
             resolve(null)
           }, this.#infiniteListBatchTimeoutMs)
@@ -119,6 +120,7 @@ export class AnchorRequestStore extends ObjectStore<StreamID, AnchorRequestData>
           gt: generateKey(gt),
         })
         const batch = await Promise.race([batchPromise, timeoutPromise])
+        clearTimeout(timeout)
         if (batch && batch.length > 0) {
           gt = StreamID.fromString(batch[batch.length - 1].key)
           for (const item of batch) {

--- a/packages/core/src/store/anchor-request-store.ts
+++ b/packages/core/src/store/anchor-request-store.ts
@@ -3,6 +3,9 @@ import { ObjectStore } from './object-store.js'
 import { CID } from 'multiformats/cid'
 import { DiagnosticsLogger, GenesisCommit, StreamUtils } from '@ceramicnetwork/common'
 
+// How long to wait for the store to return a batch from a find request.
+const DEFAULT_BATCH_TIMEOUT_MS = 60 * 1000 // 1 minute
+
 export type AnchorRequestData = {
   cid: CID
   timestamp: number
@@ -50,11 +53,15 @@ export function deserializeAnchorRequestData(serialized: any): AnchorRequestData
 export class AnchorRequestStore extends ObjectStore<StreamID, AnchorRequestData> {
   #shouldStop: boolean
   #logger: DiagnosticsLogger
+  // This timeout currently only applies to batches within the infiniteList() function
+  // TODO: Add a timeout to regular find() calls as well.
+  readonly #infiniteListBatchTimeoutMs: number
 
-  constructor(logger: DiagnosticsLogger) {
+  constructor(logger: DiagnosticsLogger, infiniteListBatchTimeoutMs = DEFAULT_BATCH_TIMEOUT_MS) {
     super(generateKey, serializeAnchorRequestData, deserializeAnchorRequestData)
     this.useCaseName = 'anchor-requests'
     this.#logger = logger
+    this.#infiniteListBatchTimeoutMs = infiniteListBatchTimeoutMs
   }
 
   exists(key: StreamID): Promise<boolean> {
@@ -64,6 +71,7 @@ export class AnchorRequestStore extends ObjectStore<StreamID, AnchorRequestData>
   async *list(batchSize = 1): AsyncIterable<Array<AnchorRequestStoreListResult>> {
     let gt: StreamID | undefined = undefined
     do {
+      // TODO: Add timeout to the query
       const batch = await this.store.find({
         limit: batchSize,
         useCaseName: this.useCaseName,
@@ -98,12 +106,20 @@ export class AnchorRequestStore extends ObjectStore<StreamID, AnchorRequestData>
     let numEntries = 0
     do {
       try {
-        const batch = await this.store.find({
+        const timeoutPromise = new Promise<null>((resolve) => {
+          setTimeout(() => {
+            this.#logger.warn(`Timed out while waiting for AnchorRequestStore to fetch a batch`)
+            resolve(null)
+          }, this.#infiniteListBatchTimeoutMs)
+        })
+
+        const batchPromise = this.store.find({
           limit: batchSize,
           useCaseName: this.useCaseName,
           gt: generateKey(gt),
         })
-        if (batch.length > 0) {
+        const batch = await Promise.race([batchPromise, timeoutPromise])
+        if (batch && batch.length > 0) {
           gt = StreamID.fromString(batch[batch.length - 1].key)
           for (const item of batch) {
             numEntries++


### PR DESCRIPTION
This is kind of me taking a stab in the dark because I still don't have any really good hypothesis for why the anchor polling keeps stopping.  But since the processing loop is serial, I had the thought that if the query from S3 hung for any reason, it would lock up the whole loop.  So this patch addresses that, as well as adding some increased logging to ProcessingLoop.