### PR TITLE
fix: load model should work under postgres

### DIFF
--- a/packages/stream-model-instance/src/model-instance-document.ts
+++ b/packages/stream-model-instance/src/model-instance-document.ts
@@ -37,8 +37,8 @@ export interface ModelInstanceDocumentMetadataArgs {
   model: StreamID
 
   /**
-  * An optional string used to identify the context of the ModelInstanceDocument.
-  */
+   * An optional string used to identify the context of the ModelInstanceDocument.
+   */
   context?: StreamID
 
   /**

--- a/packages/stream-tests/src/__tests__/model.test.ts
+++ b/packages/stream-tests/src/__tests__/model.test.ts
@@ -16,6 +16,54 @@ const MODEL_DEFINITION: ModelDefinition = {
   accountRelation: { type: 'list' },
 }
 
+const INDEXED_MODEL_DEFINITION: ModelDefinition = {
+  name: 'myIndexedModel',
+  version: '1.0',
+  accountRelation: { type: 'list' },
+  schema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      myData: {
+        type: 'integer',
+        maximum: 10000,
+        minimum: 0,
+      },
+      myStringData: {
+        type: 'string',
+        maximum: 100,
+        minimum: 0,
+      },
+    },
+    required: ['myData'],
+  },
+}
+
+const SINGLE_INDEXED_MODEL_DEFINITION: ModelDefinition = {
+  name: 'myIndexedModel',
+  version: '1.0',
+  accountRelation: { type: 'single' },
+  schema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      myData: {
+        type: 'integer',
+        maximum: 10000,
+        minimum: 0,
+      },
+      myStringData: {
+        type: 'string',
+        maximum: 100,
+        minimum: 0,
+      },
+    },
+    required: ['myData'],
+  },
+}
+
 // The model above will always result in this StreamID when created with the fixed did:key
 // controller used by the test.
 const MODEL_STREAM_ID = 'kjzl6hvfrbw6c5ykyyjq0v80od0nhdimprq7j2pccg1l100ktiiqcc01ddka716'
@@ -38,20 +86,35 @@ describe('Model API http-client tests', () => {
 
   beforeAll(async () => {
     ipfs = await createIPFS()
+  })
+
+  beforeEach(async () => {
     core = await createCeramic(ipfs)
 
     const port = await getPort()
     const apiUrl = 'http://localhost:' + port
-    daemon = new CeramicDaemon(core, DaemonConfig.fromObject({ 'http-api': { port }, node: {} }))
+    daemon = new CeramicDaemon(
+      core,
+      DaemonConfig.fromObject({
+        'http-api': {
+          port,
+          'admin-dids': [core.did.id.toString()],
+        },
+        node: {},
+      })
+    )
     await daemon.listen()
     ceramic = new CeramicClient(apiUrl)
     ceramic.did = core.did
   }, 12000)
 
-  afterAll(async () => {
+  afterEach(async () => {
     await ceramic.close()
     await daemon.close()
     await core.close()
+  })
+
+  afterAll(async () => {
     await ipfs.stop()
   })
 
@@ -69,6 +132,413 @@ describe('Model API http-client tests', () => {
     expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
     expect(model.id.toString()).toEqual(MODEL_STREAM_ID)
+  })
+
+  describe('model indexing', () => {
+    test('Create and index valid model', async () => {
+      const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+      expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+      expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+      expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+      expect(model.state.log.length).toEqual(1)
+      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+      await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: model.id,
+          },
+        ])
+      ).resolves.not.toThrow()
+    })
+
+    test('Create, index, and load valid model', async () => {
+      const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+      expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+      expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+      expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+      expect(model.state.log.length).toEqual(1)
+      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+      await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: model.id,
+          },
+        ])
+      ).resolves.not.toThrow()
+
+      await expect(Model.load(ceramic, model.id)).resolves.not.toThrow()
+    })
+
+    test('Create and index a model with custom indices', async () => {
+      const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+      expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+      expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+      expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+      expect(model.state.log.length).toEqual(1)
+      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+      await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: model.id,
+            indices: [
+              {
+                fields: [{ path: ['myData'] }],
+              },
+            ],
+          },
+        ])
+      ).resolves.not.toThrow()
+    })
+
+    test('Create and index a model with custom indices that is not pinned', async () => {
+      const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+      expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+      expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+      expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+      expect(model.state.log.length).toEqual(1)
+      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: model.id,
+            indices: [
+              {
+                fields: [{ path: ['myData'] }],
+              },
+            ],
+          },
+        ])
+      ).resolves.not.toThrow()
+    })
+
+    test('Create, index, and load valid model with custom indices', async () => {
+      const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+      expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+      expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+      expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+      expect(model.state.log.length).toEqual(1)
+      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+      await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: model.id,
+            indices: [
+              {
+                fields: [{ path: ['myData'] }],
+              },
+            ],
+          },
+        ])
+      ).resolves.not.toThrow()
+
+      await expect(Model.load(ceramic, model.id)).resolves.not.toThrow()
+    })
+
+    test('Create, index, load and index valid model with custom indices on create', async () => {
+      const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+      expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+      expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+      expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+      expect(model.state.log.length).toEqual(1)
+      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+      await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: model.id,
+            indices: [
+              {
+                fields: [{ path: ['myData'] }],
+              },
+            ],
+          },
+        ])
+      ).resolves.not.toThrow()
+
+      const loadedModel = await Model.load(ceramic, model.id)
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: loadedModel.id,
+          },
+        ])
+      ).resolves.not.toThrow()
+    })
+
+    test('Create, index, load and not index valid model with custom indices on load', async () => {
+      const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+      expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+      expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+      expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+      expect(model.state.log.length).toEqual(1)
+      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+      await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: model.id,
+          },
+        ])
+      ).resolves.not.toThrow()
+
+      const loadedModel = await Model.load(ceramic, model.id)
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: loadedModel.id,
+            indices: [
+              {
+                fields: [{ path: ['myData'] }],
+              },
+            ],
+          },
+        ])
+      ).rejects.toThrow(/Schema verification failed/)
+    })
+
+    test('Create, index, load and index valid model with less custom indices on load', async () => {
+      const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+      expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+      expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+      expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+      expect(model.state.log.length).toEqual(1)
+      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+      await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: model.id,
+            indices: [
+              {
+                fields: [{ path: ['myData'] }],
+              },
+              {
+                fields: [{ path: ['myString'] }],
+              },
+            ],
+          },
+        ])
+      ).resolves.not.toThrow()
+
+      const loadedModel = await Model.load(ceramic, model.id)
+
+      //TODO: this should throw
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: loadedModel.id,
+            indices: [
+              {
+                fields: [{ path: ['myData'] }],
+              },
+            ],
+          },
+        ])
+      ).resolves.not.toThrow()
+    })
+
+    test('Create, index, load and index valid model with different custom indices on load', async () => {
+      const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+      expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+      expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+      expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+      expect(model.state.log.length).toEqual(1)
+      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+      await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: model.id,
+            indices: [
+              {
+                fields: [{ path: ['myData'] }],
+              },
+              {
+                fields: [{ path: ['myString'] }],
+              },
+            ],
+          },
+        ])
+      ).resolves.not.toThrow()
+
+      const loadedModel = await Model.load(ceramic, model.id)
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: loadedModel.id,
+            indices: [
+              {
+                fields: [{ path: ['myString'] }],
+              },
+              {
+                fields: [{ path: ['myData'] }],
+              },
+            ],
+          },
+        ])
+      ).resolves.not.toThrow()
+    })
+
+    test('Create, index, load and index valid model with different custom indices on load', async () => {
+      const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+      expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+      expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+      expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+      expect(model.state.log.length).toEqual(1)
+      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+      await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: model.id,
+            indices: [
+              {
+                fields: [{ path: ['myData'] }],
+              },
+            ],
+          },
+        ])
+      ).resolves.not.toThrow()
+
+      const loadedModel = await Model.load(ceramic, model.id)
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: loadedModel.id,
+            indices: [
+              {
+                fields: [{ path: ['myString'] }],
+              },
+            ],
+          },
+        ])
+      ).rejects.toThrow(/Schema verification failed/)
+    })
+
+    test('Create and index valid single model', async () => {
+      const model = await Model.create(ceramic, SINGLE_INDEXED_MODEL_DEFINITION)
+
+      expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+      expect(model.content).toEqual(SINGLE_INDEXED_MODEL_DEFINITION)
+      expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+      expect(model.state.log.length).toEqual(1)
+      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+      await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: model.id,
+          },
+        ])
+      ).resolves.not.toThrow()
+    })
+
+    test('Create and index valid single model with indices', async () => {
+      const model = await Model.create(ceramic, SINGLE_INDEXED_MODEL_DEFINITION)
+
+      expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+      expect(model.content).toEqual(SINGLE_INDEXED_MODEL_DEFINITION)
+      expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+      expect(model.state.log.length).toEqual(1)
+      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+      await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: model.id,
+            indices: [
+              {
+                fields: [{ path: ['myData'] }],
+              },
+            ],
+          },
+        ])
+      ).resolves.not.toThrow()
+    })
+
+    test('Create, index, and load valid single model', async () => {
+      const model = await Model.create(ceramic, SINGLE_INDEXED_MODEL_DEFINITION)
+
+      expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+      expect(model.content).toEqual(SINGLE_INDEXED_MODEL_DEFINITION)
+      expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+      expect(model.state.log.length).toEqual(1)
+      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+      await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: model.id,
+          },
+        ])
+      ).resolves.not.toThrow()
+
+      const loadedModel = await Model.load(ceramic, model.id)
+
+      await expect(
+        ceramic.admin.startIndexingModelData([
+          {
+            streamID: loadedModel.id,
+          },
+        ])
+      ).resolves.not.toThrow()
+    })
   })
 
   test('Create valid model with relation', async () => {

--- a/packages/stream-tests/src/__tests__/model.test.ts
+++ b/packages/stream-tests/src/__tests__/model.test.ts
@@ -326,7 +326,7 @@ describe('Model API http-client tests', () => {
             ],
           },
         ])
-      ).rejects.toThrow(/Schema verification failed/)
+      ).resolves.not.toThrow()
     })
 
     test('Create, index, load and index valid model with less custom indices on load', async () => {
@@ -459,7 +459,7 @@ describe('Model API http-client tests', () => {
             ],
           },
         ])
-      ).rejects.toThrow(/Schema verification failed/)
+      ).resolves.not.toThrow()
     })
 
     test('Create and index valid single model', async () => {

--- a/packages/stream-tests/src/__tests__/pg-model-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/pg-model-indexing.test.ts
@@ -1,0 +1,491 @@
+import { jest } from '@jest/globals'
+import { AnchorStatus, CommitType, IpfsApi } from '@ceramicnetwork/common'
+import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
+import { Model, ModelDefinition } from '@ceramicnetwork/stream-model'
+import { createCeramic } from '../create-ceramic.js'
+import { Ceramic } from '@ceramicnetwork/core'
+import pgSetup from '@databases/pg-test/jest/globalSetup'
+import pgTeardown from '@databases/pg-test/jest/globalTeardown'
+
+const INDEXED_MODEL_DEFINITION: ModelDefinition = {
+  name: 'myIndexedModel',
+  version: '1.0',
+  accountRelation: { type: 'list' },
+  schema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      myData: {
+        type: 'integer',
+        maximum: 10000,
+        minimum: 0,
+      },
+      myStringData: {
+        type: 'string',
+        maximum: 100,
+        minimum: 0,
+      },
+    },
+    required: ['myData'],
+  },
+}
+
+const SINGLE_INDEXED_MODEL_DEFINITION: ModelDefinition = {
+  name: 'myIndexedModel',
+  version: '1.0',
+  accountRelation: { type: 'single' },
+  schema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      myData: {
+        type: 'integer',
+        maximum: 10000,
+        minimum: 0,
+      },
+      myStringData: {
+        type: 'string',
+        maximum: 100,
+        minimum: 0,
+      },
+    },
+    required: ['myData'],
+  },
+}
+
+describe('Postgres Model indexing tests', () => {
+  jest.setTimeout(1000 * 30)
+
+  let ipfs: IpfsApi
+  let ceramic: Ceramic
+
+  beforeEach(async () => {
+    await pgSetup()
+    const dbURL = process.env.DATABASE_URL || ''
+
+    ipfs = await createIPFS()
+
+    ceramic = await createCeramic(ipfs, {
+      indexing: {
+        db: dbURL,
+        allowQueriesBeforeHistoricalSync: true,
+        enableHistoricalSync: false,
+        disableComposedb: false,
+      },
+    })
+  }, 12000)
+
+  afterEach(async () => {
+    await ceramic.close()
+    await ipfs.stop()
+
+    await pgTeardown()
+  })
+
+  test('Create and index valid model', async () => {
+    const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+    expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+    expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+    expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+    expect(model.state.log.length).toEqual(1)
+    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+        },
+      ])
+    ).resolves.not.toThrow()
+  })
+
+  test('Create, index, and load valid model', async () => {
+    const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+    expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+    expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+    expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+    expect(model.state.log.length).toEqual(1)
+    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+        },
+      ])
+    ).resolves.not.toThrow()
+
+    await expect(Model.load(ceramic, model.id)).resolves.not.toThrow()
+  })
+
+  test('Create and index a model with custom indices', async () => {
+    const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+    expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+    expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+    expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+    expect(model.state.log.length).toEqual(1)
+    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+          indices: [
+            {
+              fields: [{ path: ['myData'] }],
+            },
+          ],
+        },
+      ])
+    ).resolves.not.toThrow()
+  })
+
+  test('Create and index a model with custom indices that is not pinned', async () => {
+    const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+    expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+    expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+    expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+    expect(model.state.log.length).toEqual(1)
+    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+          indices: [
+            {
+              fields: [{ path: ['myData'] }],
+            },
+          ],
+        },
+      ])
+    ).resolves.not.toThrow()
+  })
+
+  test('Create, index, and load valid model with custom indices', async () => {
+    const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+    expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+    expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+    expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+    expect(model.state.log.length).toEqual(1)
+    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+          indices: [
+            {
+              fields: [{ path: ['myData'] }],
+            },
+          ],
+        },
+      ])
+    ).resolves.not.toThrow()
+
+    await expect(Model.load(ceramic, model.id)).resolves.not.toThrow()
+  })
+
+  test('Create, index, load and index valid model with custom indices on create', async () => {
+    const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+    expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+    expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+    expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+    expect(model.state.log.length).toEqual(1)
+    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+          indices: [
+            {
+              fields: [{ path: ['myData'] }],
+            },
+          ],
+        },
+      ])
+    ).resolves.not.toThrow()
+
+    const loadedModel = await Model.load(ceramic, model.id)
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: loadedModel.id,
+        },
+      ])
+    ).resolves.not.toThrow()
+  })
+
+  test('Create, index, load and not index valid model with custom indices on load', async () => {
+    const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+    expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+    expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+    expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+    expect(model.state.log.length).toEqual(1)
+    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+        },
+      ])
+    ).resolves.not.toThrow()
+
+    const loadedModel = await Model.load(ceramic, model.id)
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: loadedModel.id,
+          indices: [
+            {
+              fields: [{ path: ['myData'] }],
+            },
+          ],
+        },
+      ])
+    ).resolves.not.toThrow()
+  })
+
+  test('Create, index, load and index valid model with less custom indices on load', async () => {
+    const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+    expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+    expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+    expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+    expect(model.state.log.length).toEqual(1)
+    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+          indices: [
+            {
+              fields: [{ path: ['myData'] }],
+            },
+            {
+              fields: [{ path: ['myString'] }],
+            },
+          ],
+        },
+      ])
+    ).resolves.not.toThrow()
+
+    const loadedModel = await Model.load(ceramic, model.id)
+
+    //TODO: this should throw
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: loadedModel.id,
+          indices: [
+            {
+              fields: [{ path: ['myData'] }],
+            },
+          ],
+        },
+      ])
+    ).resolves.not.toThrow()
+  })
+
+  test('Create, index, load and index valid model with different custom indices on load', async () => {
+    const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+    expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+    expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+    expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+    expect(model.state.log.length).toEqual(1)
+    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+          indices: [
+            {
+              fields: [{ path: ['myData'] }],
+            },
+            {
+              fields: [{ path: ['myString'] }],
+            },
+          ],
+        },
+      ])
+    ).resolves.not.toThrow()
+
+    const loadedModel = await Model.load(ceramic, model.id)
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: loadedModel.id,
+          indices: [
+            {
+              fields: [{ path: ['myString'] }],
+            },
+            {
+              fields: [{ path: ['myData'] }],
+            },
+          ],
+        },
+      ])
+    ).resolves.not.toThrow()
+  })
+
+  test('Create, index, load and index valid model with different custom indices on load', async () => {
+    const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
+
+    expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+    expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
+    expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+    expect(model.state.log.length).toEqual(1)
+    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+          indices: [
+            {
+              fields: [{ path: ['myData'] }],
+            },
+          ],
+        },
+      ])
+    ).resolves.not.toThrow()
+
+    const loadedModel = await Model.load(ceramic, model.id)
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: loadedModel.id,
+          indices: [
+            {
+              fields: [{ path: ['myString'] }],
+            },
+          ],
+        },
+      ])
+    ).resolves.not.toThrow()
+  })
+
+  test('Create and index valid single model', async () => {
+    const model = await Model.create(ceramic, SINGLE_INDEXED_MODEL_DEFINITION)
+
+    expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+    expect(model.content).toEqual(SINGLE_INDEXED_MODEL_DEFINITION)
+    expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+    expect(model.state.log.length).toEqual(1)
+    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+        },
+      ])
+    ).resolves.not.toThrow()
+  })
+
+  test('Create and index valid single model with indices', async () => {
+    const model = await Model.create(ceramic, SINGLE_INDEXED_MODEL_DEFINITION)
+
+    expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+    expect(model.content).toEqual(SINGLE_INDEXED_MODEL_DEFINITION)
+    expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+    expect(model.state.log.length).toEqual(1)
+    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+          indices: [
+            {
+              fields: [{ path: ['myData'] }],
+            },
+          ],
+        },
+      ])
+    ).resolves.not.toThrow()
+  })
+
+  test('Create, index, and load valid single model', async () => {
+    const model = await Model.create(ceramic, SINGLE_INDEXED_MODEL_DEFINITION)
+
+    expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
+    expect(model.content).toEqual(SINGLE_INDEXED_MODEL_DEFINITION)
+    expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
+    expect(model.state.log.length).toEqual(1)
+    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: model.id,
+        },
+      ])
+    ).resolves.not.toThrow()
+
+    const loadedModel = await Model.load(ceramic, model.id)
+
+    await expect(
+      ceramic.admin.startIndexingModelData([
+        {
+          streamID: loadedModel.id,
+        },
+      ])
+    ).resolves.not.toThrow()
+  })
+})


### PR DESCRIPTION
Postgres was not preserving casing on field names, so index validation was
failing on MID table creation. Added additional test file to verify PG
behavior.

Addresses WS2-2960 and WS2-2937