### PR TITLE
fix(core): Use the anchor proofs chain id to verify the anchor proof

### DIFF
--- a/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-validator.ts
@@ -214,7 +214,8 @@ export class EthereumAnchorValidator implements AnchorValidator {
       throw new Error(`The root CID ${anchorProof.root} is not in the transaction`)
     }
 
-    if (txResponse.blockNumber <= BLOCK_THRESHHOLDS[this._chainId]) {
+    // we use the anchor proof chain id instead of the this._chainId, as this._chainId is not set if the ceramic node is being used in readOnly mode
+    if (txResponse.blockNumber <= BLOCK_THRESHHOLDS[anchorProof.chainId]) {
       return block.timestamp
     }
 
@@ -222,7 +223,7 @@ export class EthereumAnchorValidator implements AnchorValidator {
     if (anchorProof.txType !== V1_PROOF_TYPE) {
       throw new Error(
         `Any anchor proofs created after block ${
-          BLOCK_THRESHHOLDS[this._chainId]
+          BLOCK_THRESHHOLDS[anchorProof.chainId]
         } must include the txType field. Anchor txn blockNumber: ${txResponse.blockNumber}`
       )
     }


### PR DESCRIPTION
## Description

Previously: In readOnly mode cannot load streams fully. Logs show the following error
```
[2024-01-17T22:22:25.350Z] WARNING: 'Error when validating anchor commit: Error: Any anchor proofs created after block undefined must include the txType field. Anchor txn blockNumber: 15325737'
[2024-01-17T22:22:25.352Z] WARNING: 'Error when validating anchor commit: Error: Any anchor proofs created after block undefined must include the txType field. Anchor txn blockNumber: 15325737'
[2024-01-17T22:22:25.354Z] WARNING: 'Error when validating anchor commit: Error: Any anchor proofs created after block undefined must include the txType field. Anchor txn blockNumber: 15325737'
```

Now: In readOnly mode can load streams fully. No errors in logs 

## How Has This Been Tested?

Run in readOnly mode. Successfully load streams fully (should have same state as a non read only node)

