### PR TITLE
feat: Add static method for updating a MID without access to the StreamState

### DIFF
--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -623,9 +623,23 @@ describe('ModelInstanceDocumentHandler', () => {
     const state$ = TestUtils.runningState(state)
     const doc = new ModelInstanceDocument(state$, context)
 
-    await expect(doc._makeCommit({} as CeramicApi, CONTENT1)).rejects.toThrow(/No DID/)
+    await expect(
+      ModelInstanceDocument.makeUpdateCommit(
+        {} as CeramicApi,
+        doc.id,
+        doc.tip,
+        doc.content,
+        CONTENT1
+      )
+    ).rejects.toThrow(/No DID/)
 
-    const commit = (await doc._makeCommit(context.api, CONTENT1)) as SignedCommitContainer
+    const commit = (await ModelInstanceDocument.makeUpdateCommit(
+      context.api,
+      doc.id,
+      doc.tip,
+      doc.content,
+      CONTENT1
+    )) as SignedCommitContainer
     const patch = jsonpatch.compare(CONTENT0, CONTENT1)
     const expectedCommit = { data: patch, prev: FAKE_CID_1, id: FAKE_CID_1 }
     await checkSignedCommitMatchesExpectations(did, commit, expectedCommit)
@@ -654,7 +668,13 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const state$ = TestUtils.runningState(state)
     const doc = new ModelInstanceDocument(state$, context)
-    const signedCommit = (await doc._makeCommit(context.api, CONTENT1)) as SignedCommitContainer
+    const signedCommit = (await ModelInstanceDocument.makeUpdateCommit(
+      context.api,
+      doc.id,
+      doc.tip,
+      doc.content,
+      CONTENT1
+    )) as SignedCommitContainer
 
     await context.ipfs.dag.put(signedCommit, FAKE_CID_2)
 
@@ -697,7 +717,13 @@ describe('ModelInstanceDocumentHandler', () => {
     // make a first update
     const state$ = TestUtils.runningState(genesisState)
     let doc = new ModelInstanceDocument(state$, context)
-    const signedCommit1 = (await doc._makeCommit(context.api, CONTENT1)) as SignedCommitContainer
+    const signedCommit1 = (await ModelInstanceDocument.makeUpdateCommit(
+      context.api,
+      doc.id,
+      doc.tip,
+      doc.content,
+      CONTENT1
+    )) as SignedCommitContainer
 
     await context.ipfs.dag.put(signedCommit1, FAKE_CID_2)
     const sPayload1 = dagCBOR.decode(signedCommit1.linkedBlock)
@@ -714,7 +740,13 @@ describe('ModelInstanceDocumentHandler', () => {
     // make a second update on top of the first
     const state1$ = TestUtils.runningState(state1)
     doc = new ModelInstanceDocument(state1$, context)
-    const signedCommit2 = (await doc._makeCommit(context.api, CONTENT2)) as SignedCommitContainer
+    const signedCommit2 = (await ModelInstanceDocument.makeUpdateCommit(
+      context.api,
+      doc.id,
+      doc.tip,
+      doc.content,
+      CONTENT2
+    )) as SignedCommitContainer
 
     await context.ipfs.dag.put(signedCommit2, FAKE_CID_3)
     const sPayload2 = dagCBOR.decode(signedCommit2.linkedBlock)
@@ -787,7 +819,13 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const state$ = TestUtils.runningState(state)
     const doc = new ModelInstanceDocument(state$, context)
-    const signedCommit = (await doc._makeCommit(context.api, {})) as SignedCommitContainer
+    const signedCommit = (await ModelInstanceDocument.makeUpdateCommit(
+      context.api,
+      doc.id,
+      doc.tip,
+      doc.content,
+      {}
+    )) as SignedCommitContainer
 
     await context.ipfs.dag.put(signedCommit, FAKE_CID_2)
 
@@ -857,7 +895,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const state$ = TestUtils.runningState(state)
     const doc = new ModelInstanceDocument(state$, context)
-    const rawCommit = doc._makeRawCommit(CONTENT1)
+    const rawCommit = ModelInstanceDocument._makeRawCommit(doc.id, doc.tip, doc.content, CONTENT1)
     const newDid = 'did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7zzzz'
     rawCommit.header = { controllers: [newDid] }
     const signedCommit = await ModelInstanceDocument._signDagJWS(context.api, rawCommit)
@@ -902,7 +940,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const state$ = TestUtils.runningState(state)
     const doc = new ModelInstanceDocument(state$, context)
-    const rawCommit = doc._makeRawCommit(CONTENT1)
+    const rawCommit = ModelInstanceDocument._makeRawCommit(doc.id, doc.tip, doc.content, CONTENT1)
     rawCommit.prev = FAKE_CID_3
     const signedCommit = await ModelInstanceDocument._signDagJWS(context.api, rawCommit)
 
@@ -946,7 +984,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const state$ = TestUtils.runningState(state)
     const doc = new ModelInstanceDocument(state$, context)
-    const rawCommit = doc._makeRawCommit(CONTENT1)
+    const rawCommit = ModelInstanceDocument._makeRawCommit(doc.id, doc.tip, doc.content, CONTENT1)
     rawCommit.id = FAKE_CID_3
     const signedCommit = await ModelInstanceDocument._signDagJWS(context.api, rawCommit)
 
@@ -990,7 +1028,13 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const state$ = TestUtils.runningState(state)
     const doc = new ModelInstanceDocument(state$, context)
-    const signedCommit = (await doc._makeCommit(context.api, CONTENT1)) as SignedCommitContainer
+    const signedCommit = (await ModelInstanceDocument.makeUpdateCommit(
+      context.api,
+      doc.id,
+      doc.tip,
+      doc.content,
+      CONTENT1
+    )) as SignedCommitContainer
 
     await context.ipfs.dag.put(signedCommit, FAKE_CID_2)
 
@@ -1052,8 +1096,11 @@ describe('ModelInstanceDocumentHandler', () => {
     // make update with old key
     const state$ = TestUtils.runningState(state)
     const doc = new ModelInstanceDocument(state$, context)
-    const signedCommit = (await doc._makeCommit(
+    const signedCommit = (await ModelInstanceDocument.makeUpdateCommit(
       signerUsingOldKey,
+      doc.id,
+      doc.tip,
+      doc.content,
       CONTENT1
     )) as SignedCommitContainer
 

--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -624,19 +624,12 @@ describe('ModelInstanceDocumentHandler', () => {
     const doc = new ModelInstanceDocument(state$, context)
 
     await expect(
-      ModelInstanceDocument.makeUpdateCommit(
-        {} as CeramicApi,
-        doc.id,
-        doc.tip,
-        doc.content,
-        CONTENT1
-      )
+      ModelInstanceDocument.makeUpdateCommit({} as CeramicApi, doc.commitId, doc.content, CONTENT1)
     ).rejects.toThrow(/No DID/)
 
     const commit = (await ModelInstanceDocument.makeUpdateCommit(
       context.api,
-      doc.id,
-      doc.tip,
+      doc.commitId,
       doc.content,
       CONTENT1
     )) as SignedCommitContainer
@@ -670,8 +663,7 @@ describe('ModelInstanceDocumentHandler', () => {
     const doc = new ModelInstanceDocument(state$, context)
     const signedCommit = (await ModelInstanceDocument.makeUpdateCommit(
       context.api,
-      doc.id,
-      doc.tip,
+      doc.commitId,
       doc.content,
       CONTENT1
     )) as SignedCommitContainer
@@ -719,8 +711,7 @@ describe('ModelInstanceDocumentHandler', () => {
     let doc = new ModelInstanceDocument(state$, context)
     const signedCommit1 = (await ModelInstanceDocument.makeUpdateCommit(
       context.api,
-      doc.id,
-      doc.tip,
+      doc.commitId,
       doc.content,
       CONTENT1
     )) as SignedCommitContainer
@@ -742,8 +733,7 @@ describe('ModelInstanceDocumentHandler', () => {
     doc = new ModelInstanceDocument(state1$, context)
     const signedCommit2 = (await ModelInstanceDocument.makeUpdateCommit(
       context.api,
-      doc.id,
-      doc.tip,
+      doc.commitId,
       doc.content,
       CONTENT2
     )) as SignedCommitContainer
@@ -821,8 +811,7 @@ describe('ModelInstanceDocumentHandler', () => {
     const doc = new ModelInstanceDocument(state$, context)
     const signedCommit = (await ModelInstanceDocument.makeUpdateCommit(
       context.api,
-      doc.id,
-      doc.tip,
+      doc.commitId,
       doc.content,
       {}
     )) as SignedCommitContainer
@@ -895,7 +884,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const state$ = TestUtils.runningState(state)
     const doc = new ModelInstanceDocument(state$, context)
-    const rawCommit = ModelInstanceDocument._makeRawCommit(doc.id, doc.tip, doc.content, CONTENT1)
+    const rawCommit = ModelInstanceDocument._makeRawCommit(doc.commitId, doc.content, CONTENT1)
     const newDid = 'did:3:k2t6wyfsu4pg0t2n4j8ms3s33xsgqjhtto04mvq8w5a2v5xo48idyz38l7zzzz'
     rawCommit.header = { controllers: [newDid] }
     const signedCommit = await ModelInstanceDocument._signDagJWS(context.api, rawCommit)
@@ -940,7 +929,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const state$ = TestUtils.runningState(state)
     const doc = new ModelInstanceDocument(state$, context)
-    const rawCommit = ModelInstanceDocument._makeRawCommit(doc.id, doc.tip, doc.content, CONTENT1)
+    const rawCommit = ModelInstanceDocument._makeRawCommit(doc.commitId, doc.content, CONTENT1)
     rawCommit.prev = FAKE_CID_3
     const signedCommit = await ModelInstanceDocument._signDagJWS(context.api, rawCommit)
 
@@ -984,7 +973,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const state$ = TestUtils.runningState(state)
     const doc = new ModelInstanceDocument(state$, context)
-    const rawCommit = ModelInstanceDocument._makeRawCommit(doc.id, doc.tip, doc.content, CONTENT1)
+    const rawCommit = ModelInstanceDocument._makeRawCommit(doc.commitId, doc.content, CONTENT1)
     rawCommit.id = FAKE_CID_3
     const signedCommit = await ModelInstanceDocument._signDagJWS(context.api, rawCommit)
 
@@ -1030,8 +1019,7 @@ describe('ModelInstanceDocumentHandler', () => {
     const doc = new ModelInstanceDocument(state$, context)
     const signedCommit = (await ModelInstanceDocument.makeUpdateCommit(
       context.api,
-      doc.id,
-      doc.tip,
+      doc.commitId,
       doc.content,
       CONTENT1
     )) as SignedCommitContainer
@@ -1098,8 +1086,7 @@ describe('ModelInstanceDocumentHandler', () => {
     const doc = new ModelInstanceDocument(state$, context)
     const signedCommit = (await ModelInstanceDocument.makeUpdateCommit(
       signerUsingOldKey,
-      doc.id,
-      doc.tip,
+      doc.commitId,
       doc.content,
       CONTENT1
     )) as SignedCommitContainer

--- a/packages/stream-model-instance/src/model-instance-document.ts
+++ b/packages/stream-model-instance/src/model-instance-document.ts
@@ -253,36 +253,29 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
    * Make a commit to update the document.  Can be applied using the applyCommit method on the
    * Ceramic client.
    * @param signer - Object containing the DID making (and signing) the commit.
-   * @param streamId - The StreamID of the Stream to update.
-   * @param prev - The current tip of the Stream that the update should be applied on top of.
+   * @param prev - The CommitID of the current tip of the Stream that the update should be applied on top of.
    * @param oldContent - The current content of the Stream.
    * @param newContent - The new content to update the Stream with.
    */
   static makeUpdateCommit<T>(
     signer: CeramicSigner,
-    streamId: StreamID,
-    prev: CID,
+    prev: CommitID,
     oldContent: T,
     newContent: T | null
   ): Promise<CeramicCommit> {
-    const commit = ModelInstanceDocument._makeRawCommit(streamId, prev, oldContent, newContent)
+    const commit = ModelInstanceDocument._makeRawCommit(prev, oldContent, newContent)
     return ModelInstanceDocument._signDagJWS(signer, commit)
   }
 
   /**
    * Helper function for makeUpdateCommit() to allow unit tests to update the commit before it is signed.
    */
-  private static _makeRawCommit<T>(
-    streamId: StreamID,
-    prev: CID,
-    oldContent: T,
-    newContent: T | null
-  ): RawCommit {
+  private static _makeRawCommit<T>(prev: CommitID, oldContent: T, newContent: T | null): RawCommit {
     const patch = jsonpatch.compare(oldContent, newContent || {})
     return {
       data: patch,
-      prev,
-      id: streamId.cid,
+      prev: prev.commit,
+      id: prev.baseID.cid,
     }
   }
 

--- a/packages/stream-model-instance/src/model-instance-document.ts
+++ b/packages/stream-model-instance/src/model-instance-document.ts
@@ -192,8 +192,7 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
     const signer: CeramicSigner = opts.asDID ? { did: opts.asDID } : this.api
     const updateCommit = await ModelInstanceDocument.makeUpdateCommit(
       signer,
-      this.id,
-      this.tip,
+      this.commitId,
       this.content,
       content
     )

--- a/packages/stream-model-instance/src/model-instance-document.ts
+++ b/packages/stream-model-instance/src/model-instance-document.ts
@@ -270,7 +270,7 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
   }
 
   /**
-   * Helper function for _makeCommit() to allow unit tests to update the commit before it is signed.
+   * Helper function for makeUpdateCommit() to allow unit tests to update the commit before it is signed.
    */
   private static _makeRawCommit<T>(
     streamId: StreamID,


### PR DESCRIPTION
This will be useful to users of the Firehose who won't have access to the StreamState object but might still want to be able to issue updates to documents that they are maintaining via the Firehose.