### PR TITLE
fix: Don't attempt to close Ceramic if it never finished initializing

### DIFF
--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -485,7 +485,7 @@ export class Ceramic implements StreamReaderWriter, StreamStateLoader {
 
       await this._startupChecks()
     } catch (err) {
-      await this.close()
+      this._logger.err(err)
       throw err
     }
   }


### PR DESCRIPTION
Otherwise we can get a different error while trying to close half-initialized state, and wind up masking whatever the actual real error was that caused initialization to fail in the first place.