### PR TITLE
feat: Add shouldIndex metadata flag

### DIFF
--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@ceramicnetwork/base-test-utils": "^1.2.0-rc.0",
-    "ts-essentials": "^9.3.2"
+    "ts-essentials": "^9.4.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -28,6 +28,7 @@ export interface CommitHeader {
   model?: Uint8Array // StreamID encoded as byte array
   schema?: string // deprecated
   tags?: Array<string> // deprecated
+  shouldIndex?: boolean // ModelInstanceDocument indexing
 
   [index: string]: any // allow support for future changes
 }
@@ -45,7 +46,7 @@ export type GenesisCommit = {
 
 export interface RawCommit {
   id: CID
-  header?: CommitHeader
+  header?: Partial<CommitHeader>
   data: any
   prev: CID
 }
@@ -79,6 +80,7 @@ export interface StreamMetadata {
   schema?: string // deprecated
   tags?: Array<string> // deprecated
   forbidControllerChange?: boolean // deprecated, only used by TileDocument
+  shouldIndex?: boolean // ModelInstanceDocument indexing
   [index: string]: any // allow arbitrary properties
 }
 

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -971,6 +971,7 @@ export class Repository {
       tip: state$.tip,
       lastAnchor: lastAnchor,
       firstAnchor: firstAnchor,
+      shouldIndex: state$.value.metadata.shouldIndex,
     }
 
     await this.index.indexStream(streamContent)

--- a/packages/indexing/src/database-index-api.ts
+++ b/packages/indexing/src/database-index-api.ts
@@ -210,7 +210,7 @@ export abstract class DatabaseIndexApi<DateType = Date | number> {
   /**
    * This method inserts the stream if it is not present in the index, updates
    * the 'content' if the stream already exists in the index, or deletes the
-   * stream from the index if the 'index' arg is set to false.
+   * stream from the index if the 'shouldIndex' arg is set to false.
    * @param indexingArgs
    */
   async indexStream(

--- a/packages/indexing/src/database-index-api.ts
+++ b/packages/indexing/src/database-index-api.ts
@@ -32,6 +32,7 @@ export interface IndexStreamArgs {
   readonly tip: CID
   readonly lastAnchor: Date | null
   readonly firstAnchor: Date | null
+  readonly shouldIndex?: boolean
 }
 
 /**
@@ -207,14 +208,21 @@ export abstract class DatabaseIndexApi<DateType = Date | number> {
   }
 
   /**
-   * This method inserts the stream if it is not present in the index, or updates
-   * the 'content' if the stream already exists in the index.
+   * This method inserts the stream if it is not present in the index, updates
+   * the 'content' if the stream already exists in the index, or deletes the
+   * stream from the index if the 'index' arg is set to false.
    * @param indexingArgs
    */
   async indexStream(
     indexingArgs: IndexStreamArgs & { createdAt?: Date; updatedAt?: Date }
   ): Promise<void> {
     const tableName = asTableName(indexingArgs.model)
+    if (indexingArgs.shouldIndex === false) {
+      await this.dbConnection(tableName)
+        .where('stream_id', indexingArgs.streamID.toString())
+        .delete()
+      return
+    }
     const indexedData = this.getIndexedData(indexingArgs) as Record<string, unknown>
     const relations = this.modelRelations.get(indexingArgs.model.toString()) ?? []
     for (const relation of relations) {

--- a/packages/indexing/src/local-index-api.ts
+++ b/packages/indexing/src/local-index-api.ts
@@ -159,7 +159,7 @@ export class LocalIndexApi implements IndexApi {
     return this.databaseIndexApi?.getIndexedModels() ?? []
   }
 
-  async convertModelDataToIndexModelsArgs(
+  convertModelDataToIndexModelsArgs(
     modelsNoLongerIndexed: Array<ModelData>,
     modelData: ModelData,
     loading: LoadingInterfaceImplements = {}
@@ -167,9 +167,9 @@ export class LocalIndexApi implements IndexApi {
     const modelStreamId = modelData.streamID
     this.logger.imp(`Starting indexing for Model ${modelStreamId.toString()}`)
 
-    const modelNoLongerIndexed = modelsNoLongerIndexed.some(function (oldIdx) {
-      return oldIdx.streamID.equals(modelStreamId)
-    })
+    const modelNoLongerIndexed = modelsNoLongerIndexed.some((oldIdx) =>
+      oldIdx.streamID.equals(modelStreamId)
+    )
     // TODO(CDB-2297): Handle a model's historical sync after re-indexing
     if (modelNoLongerIndexed) {
       throw new Error(
@@ -177,7 +177,7 @@ export class LocalIndexApi implements IndexApi {
       )
     }
 
-    return await _getIndexModelArgs(this.reader, modelData, loading)
+    return _getIndexModelArgs(this.reader, modelData, loading)
   }
 
   async indexModels(models: Array<ModelData>): Promise<void> {
@@ -185,9 +185,9 @@ export class LocalIndexApi implements IndexApi {
     const loading = {}
 
     const indexModelsArgs = await Promise.all(
-      models.map(async (idx) => {
-        return await this.convertModelDataToIndexModelsArgs(modelsNoLongerIndexed, idx, loading)
-      })
+      models.map((idx) =>
+        this.convertModelDataToIndexModelsArgs(modelsNoLongerIndexed, idx, loading)
+      )
     )
 
     await this.databaseIndexApi?.indexModels(indexModelsArgs)

--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -1117,7 +1117,7 @@ describe('ModelInstanceDocumentHandler', () => {
       envelope: signedCommit.jws,
     }
     await expect(handler.applyCommit(signedCommitData, context, state)).rejects.toThrow(
-      `Unsupported metadata changes for ModelInstanceDocument Stream ${doc.id}: controllers. Only the index argument can be changed.`
+      `Unsupported metadata changes for ModelInstanceDocument Stream ${doc.id}: controllers. Only the shouldIndex argument can be changed.`
     )
   })
 

--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -1117,7 +1117,7 @@ describe('ModelInstanceDocumentHandler', () => {
       envelope: signedCommit.jws,
     }
     await expect(handler.applyCommit(signedCommitData, context, state)).rejects.toThrow(
-      /Updating metadata for ModelInstanceDocument Streams is not allowed/
+      `Unsupported metadata changes for ModelInstanceDocument Stream ${doc.id}: controllers. Only the index argument can be changed.`
     )
   })
 

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -172,8 +172,8 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
           )}. Only the shouldIndex argument can be changed.`
         )
       }
-      if (shouldIndex !== null) {
-        state.metadata.shouldIndex = shouldIndex ?? false
+      if (shouldIndex != null) {
+        state.metadata.shouldIndex = shouldIndex
       }
     }
 

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -163,11 +163,18 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     )
 
     if (payload.header) {
-      throw new Error(
-        `Updating metadata for ModelInstanceDocument Streams is not allowed.  Tried to change metadata for Stream ${streamId} from ${JSON.stringify(
-          state.metadata
-        )} to ${JSON.stringify(payload.header)}\``
-      )
+      const { shouldIndex, ...others } = payload.header
+      const otherKeys = Object.keys(others)
+      if (otherKeys.length) {
+        throw new Error(
+          `Unsupported metadata changes for ModelInstanceDocument Stream ${streamId}: ${otherKeys.join(
+            ','
+          )}. Only the index argument can be changed.`
+        )
+      }
+      if (shouldIndex != null) {
+        state.metadata.shouldIndex = shouldIndex
+      }
     }
 
     const oldContent = state.content ?? {}
@@ -240,11 +247,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
 
     validateContentLength(content)
 
-    await this._schemaValidator.validateSchema(
-      content,
-      model.content.schema,
-      model.commitId.toString()
-    )
+    this._schemaValidator.validateSchema(content, model.content.schema, model.commitId.toString())
 
     // Now validate the relations
     await this._validateRelationsContent(ceramic, model, content)

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -172,8 +172,8 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
           )}. Only the index argument can be changed.`
         )
       }
-      if (shouldIndex != null) {
-        state.metadata.shouldIndex = shouldIndex
+      if (shouldIndex !== null) {
+        state.metadata.shouldIndex = shouldIndex ?? false
       }
     }
 

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -169,7 +169,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
         throw new Error(
           `Unsupported metadata changes for ModelInstanceDocument Stream ${streamId}: ${otherKeys.join(
             ','
-          )}. Only the index argument can be changed.`
+          )}. Only the shouldIndex argument can be changed.`
         )
       }
       if (shouldIndex !== null) {

--- a/packages/stream-model-instance-handler/src/schema-utils.ts
+++ b/packages/stream-model-instance-handler/src/schema-utils.ts
@@ -27,7 +27,11 @@ export class SchemaValidation {
     this.validators = new LRUCache(AJV_CACHE_SIZE)
   }
 
-  public validateSchema(content: Record<string, any>, schema: SchemaObject, schemaId: string) {
+  public validateSchema(
+    content: Record<string, any>,
+    schema: SchemaObject,
+    schemaId: string
+  ): void {
     let validator = this.validators.get(schemaId)
     if (!validator) {
       validator = buildAjv()

--- a/packages/stream-model-instance/src/model-instance-document.ts
+++ b/packages/stream-model-instance/src/model-instance-document.ts
@@ -6,7 +6,7 @@ import sizeof from 'object-sizeof'
 import {
   CreateOpts,
   LoadOpts,
-  UpdateOpts,
+  UpdateOpts as CommonUpdateOpts,
   Stream,
   StreamConstructor,
   StreamStatic,
@@ -17,12 +17,17 @@ import {
   SignedCommitContainer,
   CeramicSigner,
   GenesisHeader,
+  CommitHeader,
   StreamWriter,
   StreamReader,
   IntoSigner,
 } from '@ceramicnetwork/common'
 import { CommitID, StreamID, StreamRef } from '@ceramicnetwork/streamid'
 import { fromString } from 'uint8arrays'
+
+export interface UpdateOpts extends CommonUpdateOpts {
+  shouldIndex?: boolean
+}
 
 /**
  * Arguments used to generate the metadata for Model Instance Documents
@@ -48,6 +53,12 @@ export interface ModelInstanceDocumentMetadataArgs {
    * ModelInstanceDocuments whose Model has an accountRelation of 'SINGLE'.
    */
   deterministic?: boolean
+
+  /**
+   * Whether the stream should be stored by indexers or not. When undefined, indexers could
+   * index the stream if wanted.
+   */
+  shouldIndex?: boolean
 }
 
 /**
@@ -68,6 +79,11 @@ export interface ModelInstanceDocumentMetadata {
    * Unique bytes
    */
   unique?: Uint8Array
+
+  /**
+   * Whether the stream should be indexed or not.
+   */
+  shouldIndex?: boolean
 }
 
 const DEFAULT_CREATE_OPTS = {
@@ -107,7 +123,12 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
 
   get metadata(): ModelInstanceDocumentMetadata {
     const metadata = this.state$.value.metadata
-    return { controller: metadata.controllers[0], model: metadata.model, unique: metadata.unique }
+    return {
+      controller: metadata.controllers[0],
+      model: metadata.model,
+      unique: metadata.unique,
+      shouldIndex: metadata.shouldIndex,
+    }
   }
 
   /**
@@ -218,18 +239,20 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
    * @param opts - Additional options
    */
   async replace(content: T | null, opts: UpdateOpts = {}): Promise<void> {
-    opts = { ...DEFAULT_UPDATE_OPTS, ...opts }
+    const { shouldIndex, ...options } = { ...DEFAULT_UPDATE_OPTS, ...opts }
     validateContentLength(content)
-    const signer: CeramicSigner = opts.asDID
-      ? CeramicSigner.fromDID(opts.asDID)
-      : opts.signer || this.api.signer
-    const updateCommit = await ModelInstanceDocument.makeUpdateCommit(
-      signer,
-      this.commitId,
-      this.content,
-      content
-    )
-    const updated = await this.api.applyCommit(this.id, updateCommit, opts)
+    const signer: CeramicSigner = options.asDID
+      ? CeramicSigner.fromDID(options.asDID)
+      : options.signer || this.api.signer
+    let header: Partial<CommitHeader> | undefined = undefined
+    if (shouldIndex != null) {
+      header = {
+        shouldIndex: shouldIndex,
+      }
+    }
+    const rawCommit = this._makeRawCommitA(content, header)
+    const updateCommit = await signer.createDagJWS(rawCommit)
+    const updated = await this.api.applyCommit(this.id, updateCommit, options)
     this.state$.next(updated.state)
   }
 
@@ -240,10 +263,11 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
    * @param opts - Additional options
    */
   async patch(jsonPatch: Operation[], opts: UpdateOpts = {}): Promise<void> {
-    opts = { ...DEFAULT_UPDATE_OPTS, ...opts }
-    const signer: CeramicSigner = opts.asDID
-      ? CeramicSigner.fromDID(opts.asDID)
-      : opts.signer || this.api.signer
+    const { shouldIndex, ...options } = { ...DEFAULT_UPDATE_OPTS, ...opts }
+
+    const signer: CeramicSigner = options.asDID
+      ? CeramicSigner.fromDID(options.asDID)
+      : options.signer || this.api.signer
     jsonPatch.forEach((patch) => {
       switch (patch.op) {
         case 'add': {
@@ -264,9 +288,24 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
       prev: this.tip,
       id: this.id.cid,
     }
+    // Null check is necessary to avoid `undefined` value that can't be encoded with IPLD
+    if (shouldIndex != null) {
+      rawCommit.header = {
+        shouldIndex: shouldIndex,
+      }
+    }
     const commit = await signer.createDagJWS(rawCommit)
-    const updated = await this.api.applyCommit(this.id, commit, opts)
+    const updated = await this.api.applyCommit(this.id, commit, options)
     this.state$.next(updated.state)
+  }
+
+  /**
+   * Set the index metadata field for the stream
+   * @param shouldIndex - Whether the stream should be indexed or not
+   * @param opts - Additional options
+   */
+  shouldIndex(shouldIndex: boolean, opts: CommonUpdateOpts = {}): Promise<void> {
+    return this.replace(this.content, { ...opts, shouldIndex: false })
   }
 
   /**
@@ -303,19 +342,34 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
   }
 
   /**
+   * Helper function for _makeCommit() to allow unit tests to update the commit before it is signed.
+   * @param newContent
+   * @param header - Optional header
+   */
+  private _makeRawCommitA(newContent: T | null, header?: Partial<CommitHeader>): RawCommit {
+    return ModelInstanceDocument._makeRawCommit(this.commitId, this.content, newContent, header)
+  }
+
+  /**
    * Helper function for makeUpdateCommit() to allow unit tests to update the commit before it is signed.
    */
   private static _makeRawCommit<T>(
     prev: CommitID,
     oldContent: T | null,
-    newContent: T | null
+    newContent: T | null,
+    header?: Partial<CommitHeader>
   ): RawCommit {
     const patch = jsonpatch.compare(oldContent ?? {}, newContent ?? {})
-    return {
+    const rawCommit: RawCommit = {
       data: patch,
       prev: prev.commit,
       id: prev.baseID.cid,
     }
+    // Null check is necessary to avoid `undefined` value that can't be encoded with IPLD
+    if (header != null) {
+      rawCommit.header = header
+    }
+    return rawCommit
   }
 
   /**

--- a/packages/stream-model-instance/src/model-instance-document.ts
+++ b/packages/stream-model-instance/src/model-instance-document.ts
@@ -310,7 +310,7 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
    * @param opts - Additional options
    */
   shouldIndex(shouldIndex: boolean, opts: CommonUpdateOpts = {}): Promise<void> {
-    return this.replace(this.content, { ...opts, shouldIndex: shouldIndex })
+    return this.patch([], { ...opts, shouldIndex: shouldIndex })
   }
 
   /**

--- a/packages/stream-model-instance/src/model-instance-document.ts
+++ b/packages/stream-model-instance/src/model-instance-document.ts
@@ -305,7 +305,7 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
    * @param opts - Additional options
    */
   shouldIndex(shouldIndex: boolean, opts: CommonUpdateOpts = {}): Promise<void> {
-    return this.replace(this.content, { ...opts, shouldIndex: false })
+    return this.replace(this.content, { ...opts, shouldIndex: shouldIndex })
   }
 
   /**

--- a/packages/stream-model-instance/src/model-instance-document.ts
+++ b/packages/stream-model-instance/src/model-instance-document.ts
@@ -250,7 +250,12 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
         shouldIndex: shouldIndex,
       }
     }
-    const rawCommit = this._makeRawCommitA(content, header)
+    const rawCommit = ModelInstanceDocument._makeRawCommit(
+      this.commitId,
+      this.content,
+      content,
+      header
+    )
     const updateCommit = await signer.createDagJWS(rawCommit)
     const updated = await this.api.applyCommit(this.id, updateCommit, options)
     this.state$.next(updated.state)
@@ -339,15 +344,6 @@ export class ModelInstanceDocument<T = Record<string, any>> extends Stream {
   ): Promise<CeramicCommit> {
     const commit = ModelInstanceDocument._makeRawCommit(prev, oldContent, newContent)
     return signer.createDagJWS(commit)
-  }
-
-  /**
-   * Helper function for _makeCommit() to allow unit tests to update the commit before it is signed.
-   * @param newContent
-   * @param header - Optional header
-   */
-  private _makeRawCommitA(newContent: T | null, header?: Partial<CommitHeader>): RawCommit {
-    return ModelInstanceDocument._makeRawCommit(this.commitId, this.content, newContent, header)
   }
 
   /**

--- a/packages/stream-tests/package.json
+++ b/packages/stream-tests/package.json
@@ -48,6 +48,7 @@
     "merge-options": "^3.0.4",
     "pkh-did-resolver": "^1.2.0",
     "tmp-promise": "^3.0.3",
+    "ts-essentials": "^9.4.1",
     "uint8arrays": "^5.0.1"
   },
   "gitHead": "34eeee25597b0a60def72906c26d3afd6230aaf1"

--- a/packages/stream-tests/src/__tests__/caip10/tezos.test.ts
+++ b/packages/stream-tests/src/__tests__/caip10/tezos.test.ts
@@ -1,17 +1,18 @@
 import { jest } from '@jest/globals'
 import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
-import { CeramicApi, IpfsApi } from '@ceramicnetwork/common'
+import { IpfsApi } from '@ceramicnetwork/common'
 import { clearDid, happyPath, wrongProof } from './caip-flows.js'
 import { TezosAuthProvider, TezosProvider } from '@ceramicnetwork/blockchain-utils-linking'
 import { InMemorySigner } from '@taquito/signer'
 import HttpRequestMock from 'http-request-mock'
+import type { Ceramic } from '@ceramicnetwork/core'
 
 const privateKey = 'p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1'
 
 let provider: TezosProvider
 let publicKey: string
 
-let ceramic: CeramicApi
+let ceramic: Ceramic
 let ipfs: IpfsApi
 
 const mocker = HttpRequestMock.setupForUnitTest('fetch')

--- a/packages/stream-tests/src/__tests__/model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/model-instance-document.test.ts
@@ -1,4 +1,4 @@
-import { jest } from '@jest/globals'
+import { jest, test, expect, beforeAll, afterAll, describe } from '@jest/globals'
 import getPort from 'get-port'
 import { AnchorStatus, CommitType, IpfsApi } from '@ceramicnetwork/common'
 import { Utils as CoreUtils } from '@ceramicnetwork/core'
@@ -321,6 +321,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
     await expect(
       ModelInstanceDocument.single(ceramic, {
         ...midSingleMetadata,
+        // @ts-expect-error
         controller: { invalid: 'object' },
       })
     ).rejects.toThrow(/Attempting to create a ModelInstanceDocument with an invalid DID string/)
@@ -386,6 +387,21 @@ describe('ModelInstanceDocument API http-client tests', () => {
     const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
     await expect(TestUtils.isPinned(ceramic.admin, doc.id)).resolves.toBeTruthy()
     await expect(TestUtils.isPinned(ceramic.admin, model.id)).resolves.toBeTruthy()
+  })
+
+  test('unindex and reindex', async () => {
+    const indexApi = core.index
+    const count = () => indexApi.count({ models: [model.id] })
+    const start = await count()
+    // Index as usual
+    const document = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
+    await expect(count()).resolves.toEqual(start + 1)
+    // Unindex
+    await document.shouldIndex(false)
+    await expect(count()).resolves.toEqual(start)
+    // Reindex
+    await document.shouldIndex(true)
+    await expect(count()).resolves.toEqual(start + 1)
   })
 })
 

--- a/packages/stream-tests/src/create-ceramic.ts
+++ b/packages/stream-tests/src/create-ceramic.ts
@@ -1,12 +1,13 @@
 import mergeOpts from 'merge-options'
-import { CeramicConfig, Ceramic } from '@ceramicnetwork/core'
-import { IpfsApi } from '@ceramicnetwork/common'
+import { Ceramic, type CeramicConfig } from '@ceramicnetwork/core'
+import type { IpfsApi } from '@ceramicnetwork/common'
 import tmp from 'tmp-promise'
 import { createDid } from './create_did.js'
+import type { DeepPartial } from 'ts-essentials'
 
 export async function createCeramic(
   ipfs: IpfsApi,
-  config: CeramicConfig & { seed?: string } = {},
+  config: DeepPartial<CeramicConfig & { seed?: string }> = {},
   providersCache?
 ): Promise<Ceramic> {
   const stateStoreDirectory = await tmp.tmpName()


### PR DESCRIPTION
Replaces #3109 due to merge conflicts.

- `shouldIndex` still remains as it was previously agreed on.
- `shouldIndex` is part of opts still: this makes the most sense from DX and release management perspective.