### PR TITLE
feat: make the feed codecs more robust

### DIFF
--- a/packages/codecs/src/feed.ts
+++ b/packages/codecs/src/feed.ts
@@ -1,5 +1,5 @@
 import { type Context, Type, type } from 'codeco'
-import { commitIdAsString } from './stream.js'
+import { commitIdAsString, StreamMetadata } from './stream.js'
 
 export const JsonAsString = new Type<unknown, string, string>(
   'JSON-as-string',
@@ -11,9 +11,11 @@ export const JsonAsString = new Type<unknown, string, string>(
       return context.failure()
     }
   },
-  (commitID) => JSON.stringify(commitID)
+  (data) => JSON.stringify(data)
 )
 
 export const AggregationDocument = type({
   commitId: commitIdAsString,
+  content: JsonAsString,
+  metadata: StreamMetadata,
 })

--- a/packages/codecs/src/stream.ts
+++ b/packages/codecs/src/stream.ts
@@ -71,7 +71,7 @@ export const commitIdAsString = new Type<CommitID, string, string>(
 /**
  * codeco for StreamMetadata
  */
-export const StreamMetadata = type({
+export const StreamMetadata = sparse({
   controllers: array(string),
   model: optional(streamIdAsString),
   context: optional(streamIdAsString),

--- a/packages/codecs/src/stream.ts
+++ b/packages/codecs/src/stream.ts
@@ -1,5 +1,5 @@
 import { CommitID, StreamID } from '@ceramicnetwork/streamid'
-import { type Context, Type, refinement, string } from 'codeco'
+import { type Context, Type, refinement, string, type, array, optional, boolean } from 'codeco'
 
 /**
  * Verify if `input` is a StreamID string.
@@ -67,3 +67,16 @@ export const commitIdAsString = new Type<CommitID, string, string>(
   },
   (commitId) => commitId.toString()
 )
+
+/**
+ * codeco for StreamMetadata
+ */
+export const StreamMetadata = type({
+  controllers: array(string),
+  model: optional(streamIdAsString),
+  context: optional(streamIdAsString),
+  family: optional(string),
+  schema: optional(string),
+  tags: optional(array(string)),
+  forbidControllerChange: optional(boolean),
+})

--- a/packages/codecs/src/stream.ts
+++ b/packages/codecs/src/stream.ts
@@ -1,5 +1,5 @@
 import { CommitID, StreamID } from '@ceramicnetwork/streamid'
-import { type Context, Type, refinement, string, type, array, optional, boolean } from 'codeco'
+import { type Context, Type, refinement, string, sparse, array, optional, boolean } from 'codeco'
 
 /**
  * Verify if `input` is a StreamID string.


### PR DESCRIPTION
## Description
The current codec would misbehave for `metadata.model` field, as it is Uint8Array encoded. Also, if we do decode on the current codec, only commitId field is available. This PR introduces a StreamMetadata codec and a more complete AggregationDocument codec.

This change doesn't require a different usage to the current implementation.