### PR TITLE
fix: event id can parse hex string

### DIFF
--- a/packages/streamid/package.json
+++ b/packages/streamid/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@ipld/dag-cbor": "^7.0.0",
     "@stablelib/sha256": "^1.0.1",
-    "cborg": "^1.10.2",
+    "cborg": "^4.0.8",
     "mapmoize": "^1.2.1",
     "multiformats": "^13.0.0",
     "uint8arrays": "^5.0.1",

--- a/packages/streamid/src/__tests__/event-id.test.ts
+++ b/packages/streamid/src/__tests__/event-id.test.ts
@@ -103,10 +103,19 @@ describe('Event Id: ', () => {
     })
   })
 
-  test('create from string', () => {
+  test('create from string base36', () => {
     const eventid = EventID.fromString(eventID)
     const hexstring = base16.encode(eventid.bytes)
     expect(hexstring).toEqual(eventIDHex)
+  })
+
+  test('create from string base16', () => {
+    const eventid = EventID.fromString(
+      'fce0105808080801030ad4f6bd83602fedeb6cb4af0e69eeb846a17bb000185011220dcf202d667ea626adf6c875cac16413b7b5b99bc2541ef2e555a21df846a17bb'
+    )
+    expect(eventid.toString()).toEqual(
+      'k1a0mdi2ck1hmrcz3nbz5ev4g6110umvg1tostfmi6xfiijkm60tnji8taxrvn7269hw5274u0m506q82qhexm3j0hazrejuaf6jyx8b'
+    )
   })
 
   test('create from bytes', () => {


### PR DESCRIPTION
We can possible receive hex strings from the recon api. We made assumptions about the even height byte length that we should not have. 