### PR TITLE
fix: use lerna conventional-prerelease for nightlies

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -306,7 +306,7 @@ jobs:
         name: Initialize and build code
         run: npm ci && npm run build
       -
-        # These step explicitly do not push the release commit so the specified nightly branch will not be impacted
+        # These steps explicitly do not push the release commit, so the specified nightly branch will not be impacted.
         name: Publish all packages to NPM
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -317,6 +317,8 @@ jobs:
           # and we want to publish nightly packages for the new versions. If this fails, presumably because some
           # packages have not changed since the last release, we'll try to publish only the packages that did change.
           npm run publish:nightly -- --force-publish --yes
+          # If we reached here then the publish succeeded and we can exit the workflow
+          exit 0
         continue-on-error: true
       -
         # Now reset the branch and try to publish only the packages that have changed since the last release

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "publish:release-candidate-followup": "npx lerna publish --dist-tag next --preid rc --no-verify-access --conventional-prerelease",
     "publish:release": "npx lerna publish --dist-tag latest --create-release github --no-verify-access --conventional-graduate bump minor",
     "publish:hotfix": "npx lerna publish --dist-tag latest --no-verify-access --conventional-graduate bump patch",
-    "publish:nightly": "npx lerna publish --dist-tag nightly --no-verify-access --no-push --canary prerelease --preid nightly",
+    "publish:nightly": "npx lerna publish --dist-tag nightly --no-verify-access --conventional-prerelease --preid nightly --no-push",
     "format": "npx prettier --write 'packages/**/src/**/*{.ts,.tsx,.js}'",
     "lint": "npx lerna run lint && npx prettier --check packages/**/src/**/*.ts",
     "clean": "npm run clean:deps && npm run clean:coverage && npm run clean:build-artifacts",


### PR DESCRIPTION
`--canary` mode appears to have a bug where it won't update internal dependencies on publish. e.g. If package A (`v1`) and B (`v1`) are published and A refers internally to B, then canary mode will publish A => `v1.1-nightly.0` and B => `v1.1-nightly.0` but A will continue to refer to B => `v1` internally.