### PR TITLE
feat: change all commitType name and values

### DIFF
--- a/packages/3id-did-resolver/src/index.ts
+++ b/packages/3id-did-resolver/src/index.ts
@@ -22,7 +22,7 @@ import * as u8a from 'uint8arrays'
 import { StreamID, CommitID } from '@ceramicnetwork/streamid'
 import { CID } from 'multiformats/cid'
 import { errorRepresentation, withResolutionError } from './error-representation.js'
-import { CommitType, type Stream } from '@ceramicnetwork/common'
+import { EventType, type Stream } from '@ceramicnetwork/common'
 
 const DID_LD_JSON = 'application/did+ld+json'
 const DID_JSON = 'application/did+json'
@@ -92,7 +92,7 @@ function lastAnchorOrGenesisEntry(log: NonEmptyArray<LogEntry>): LogEntry {
   // Look for last anchor
   for (let index = log.length - 1; index >= 0; index--) {
     const entry = log[index]!
-    if (entry.type === CommitType.ANCHOR) {
+    if (entry.type === EventType.TIME) {
       return entry
     }
   }

--- a/packages/cli/src/__tests__/index-api.test.ts
+++ b/packages/cli/src/__tests__/index-api.test.ts
@@ -4,7 +4,7 @@ import tmp from 'tmp-promise'
 import { Ceramic } from '@ceramicnetwork/core'
 import { CeramicClient } from '@ceramicnetwork/http-client'
 import { randomString } from '@stablelib/random'
-import { CommitType, IpfsApi, StreamState } from '@ceramicnetwork/common'
+import { EventType, IpfsApi, StreamState } from '@ceramicnetwork/common'
 import { CeramicDaemon } from '../ceramic-daemon.js'
 import { makeCeramicCore } from './make-ceramic-core.js'
 import { makeCeramicDaemon } from './make-ceramic-daemon.js'
@@ -133,7 +133,7 @@ test('serialize StreamState', async () => {
     type: 0,
     log: [
       {
-        type: CommitType.GENESIS,
+        type: eventType.INIT,
         cid: TestUtils.randomCID(),
       },
     ],

--- a/packages/codecs/src/feed.ts
+++ b/packages/codecs/src/feed.ts
@@ -1,5 +1,5 @@
 import { type Context, Type, type } from 'codeco'
-import { commitIdAsString, CommitTypeAsNumber, StreamMetadata } from './stream.js'
+import { commitIdAsString, EventTypeAsNumber, StreamMetadata } from './stream.js'
 
 export const JsonAsString = new Type<unknown, string, string>(
   'JSON-as-string',
@@ -18,5 +18,5 @@ export const AggregationDocument = type({
   commitId: commitIdAsString,
   content: JsonAsString,
   metadata: StreamMetadata,
-  eventType: CommitTypeAsNumber,
+  eventType: EventTypeAsNumber,
 })

--- a/packages/codecs/src/stream.ts
+++ b/packages/codecs/src/stream.ts
@@ -1,5 +1,5 @@
 import { CommitID, StreamID } from '@ceramicnetwork/streamid'
-import { CommitType } from '@ceramicnetwork/common'
+import { EventType } from '@ceramicnetwork/common'
 import { type Context, Type, refinement, string, sparse, array, optional, boolean } from 'codeco'
 import { enumCodec } from './enum.js'
 
@@ -83,4 +83,4 @@ export const StreamMetadata = sparse({
   forbidControllerChange: optional(boolean),
 })
 
-export const CommitTypeAsNumber = enumCodec<CommitType>('CommitType', CommitType)
+export const EventTypeAsNumber = enumCodec<EventType>('EventType', EventType)

--- a/packages/common-test-utils/src/index.ts
+++ b/packages/common-test-utils/src/index.ts
@@ -5,7 +5,7 @@ import type { StreamState, Stream } from '@ceramicnetwork/common'
 import {
   AdminApi,
   AnchorStatus,
-  CommitType,
+  EventType,
   RunningStateLike,
   SignatureStatus,
   StreamUtils,
@@ -120,7 +120,7 @@ export class CommonTestUtils {
       anchorStatus: AnchorStatus.NOT_REQUESTED,
       log: [
         {
-          type: CommitType.GENESIS,
+          type: EventType.INIT,
           cid,
         },
       ],

--- a/packages/common/src/__tests__/stream-state-subject.test.ts
+++ b/packages/common/src/__tests__/stream-state-subject.test.ts
@@ -1,6 +1,6 @@
 import { CID } from 'multiformats/cid'
 import { StreamStateSubject } from '../stream-state-subject.js'
-import { CommitType, StreamState } from '../stream.js'
+import { EventType, StreamState } from '../stream.js'
 
 const FAKE_CID_1 = CID.parse('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
 const FAKE_CID2 = CID.parse('bafybeig6xv5nwphfmvcnektpnojts44jqcuam7bmye2pb54adnrtccjlsu')
@@ -10,7 +10,7 @@ test('emit on distinct changes', async () => {
     type: 0,
     log: [
       {
-        type: CommitType.GENESIS,
+        type: eventType.INIT,
         cid: FAKE_CID_1,
       },
     ],
@@ -20,7 +20,7 @@ test('emit on distinct changes', async () => {
     log: [
       ...initial.log,
       {
-        type: CommitType.SIGNED,
+        type: EventType.DATA,
         cid: FAKE_CID2,
       },
     ],

--- a/packages/common/src/__tests__/stream-utils.test.ts
+++ b/packages/common/src/__tests__/stream-utils.test.ts
@@ -1,5 +1,5 @@
 import { CID } from 'multiformats/cid'
-import { AnchorStatus, CommitType, RawCommit, SignatureStatus, StreamState } from '../stream.js'
+import { AnchorStatus, EventType, RawCommit, SignatureStatus, StreamState } from '../stream.js'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { StreamUtils } from '../utils/stream-utils.js'
 
@@ -16,7 +16,7 @@ test('StreamState serialization round trip', async () => {
     metadata: { controllers: [FAKE_DID], model: FAKE_STREAM_ID },
     signature: SignatureStatus.GENESIS,
     anchorStatus: AnchorStatus.NOT_REQUESTED,
-    log: [{ cid: FAKE_CID, type: CommitType.GENESIS }],
+    log: [{ cid: FAKE_CID, type: eventType.INIT }],
   }
 
   const serialized = StreamUtils.serializeState(state)

--- a/packages/common/src/stream.ts
+++ b/packages/common/src/stream.ts
@@ -90,10 +90,10 @@ export interface StreamNext {
   metadata?: StreamMetadata
 }
 
-export enum CommitType {
-  GENESIS,
-  SIGNED,
-  ANCHOR,
+export enum EventType {
+  INIT,
+  DATA,
+  TIME,
 }
 
 /**
@@ -104,7 +104,7 @@ export interface LogEntry {
   cid: CID
 
   // Type of the commit (e.g. genesis, signed, anchor)
-  type: CommitType
+  type: EventType
 
   // Timestamp (in seconds) of when this commit was anchored (if available)
   timestamp?: number
@@ -248,7 +248,7 @@ export abstract class Stream extends Observable<StreamState> implements StreamSt
    */
   get anchorCommitIds(): Array<CommitID> {
     return this.state$.value.log
-      .filter(({ type }) => type === CommitType.ANCHOR)
+      .filter(({ type }) => type === EventType.TIME)
       .map(({ cid }) => CommitID.make(this.id, cid))
   }
 

--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -7,7 +7,7 @@ import {
   AnchorStatus,
   CeramicCommit,
   CommitData,
-  CommitType,
+  EventType,
   LogEntry,
   RawCommit,
   SignedCommit,
@@ -329,10 +329,10 @@ export class StreamUtils {
     return commitData && commitData.proof !== undefined
   }
 
-  static commitDataToLogEntry(commitData: CommitData, commitType: CommitType): LogEntry {
+  static commitDataToLogEntry(commitData: CommitData, eventType: EventType): LogEntry {
     const logEntry: LogEntry = {
       cid: commitData.cid,
-      type: commitType,
+      type: eventType,
     }
     if (commitData?.capability?.p?.exp) {
       logEntry.expirationTime = Math.floor(Date.parse(commitData.capability.p.exp) / 1000)

--- a/packages/core/src/__tests__/ceramic-feed.test.ts
+++ b/packages/core/src/__tests__/ceramic-feed.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, test, beforeAll, afterAll } from '@jest/globals'
-import { CommitType, type IpfsApi } from '@ceramicnetwork/common'
+import { EventType, type IpfsApi } from '@ceramicnetwork/common'
 import { Utils as CoreUtils } from '@ceramicnetwork/core'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { createIPFS, swarmConnect } from '@ceramicnetwork/ipfs-daemon'
@@ -49,8 +49,8 @@ describe('Ceramic feed', () => {
     expect(feed[0].metadata).toStrictEqual(feed[1].metadata)
     expect(feed[0].content).toStrictEqual({ hello: original })
     expect(feed[1].content).toStrictEqual({ hello: updated })
-    expect(feed[0].eventType).toBe(CommitType.GENESIS)
-    expect(feed[1].eventType).toBe(CommitType.SIGNED)
+    expect(feed[0].eventType).toBe(eventType.INIT)
+    expect(feed[1].eventType).toBe(EventType.DATA)
   })
 
   test('add entry after loading pinned stream/pubsub', async () => {
@@ -76,11 +76,11 @@ describe('Ceramic feed', () => {
     await TestUtils.delay(500)
 
     expect(feed1.length).toEqual(2) // create + update
-    expect(feed1[0].eventType).toBe(CommitType.GENESIS)
-    expect(feed1[1].eventType).toBe(CommitType.SIGNED)
+    expect(feed1[0].eventType).toBe(eventType.INIT)
+    expect(feed1[1].eventType).toBe(EventType.DATA)
     expect(feed2.length).toEqual(2) //load + pubsub update
-    expect(feed2[0].eventType).toBe(CommitType.GENESIS)
-    expect(feed2[1].eventType).toBe(CommitType.SIGNED)
+    expect(feed2[0].eventType).toBe(eventType.INIT)
+    expect(feed2[1].eventType).toBe(EventType.DATA)
     expect(feed2[0].content.test).toBe(content.test)
     expect(feed2[0].commitId).toStrictEqual(feed1[0].commitId)
     // test pubsub propagating the update from stream1 being inside the feed
@@ -114,7 +114,7 @@ describe('Ceramic feed', () => {
     expect(feed[0].content).toEqual(model.state.content)
     expect(feed[0].metadata).toEqual(model.state.metadata)
     expect(feed[0].commitId).toEqual(model.commitId)
-    expect(feed[0].eventType).toBe(CommitType.GENESIS)
+    expect(feed[0].eventType).toBe(eventType.INIT)
     s1.unsubscribe()
   })
 
@@ -137,8 +137,8 @@ describe('Ceramic feed', () => {
     expect(feed[0].content).toEqual(feed[1].content)
     expect(feed[0].metadata).toEqual(feed[1].metadata)
     expect(feed[0].commitId.equals(feed[1].commitId)).toEqual(false)
-    expect(feed[0].eventType).toBe(CommitType.GENESIS)
-    expect(feed[1].eventType).toBe(CommitType.ANCHOR)
+    expect(feed[0].eventType).toBe(eventType.INIT)
+    expect(feed[1].eventType).toBe(EventType.TIME)
     s.unsubscribe()
   })
 })

--- a/packages/core/src/__tests__/dispatcher-mock-ipfs.test.ts
+++ b/packages/core/src/__tests__/dispatcher-mock-ipfs.test.ts
@@ -2,7 +2,7 @@ import { expect, jest, it, test, describe, beforeEach, afterEach } from '@jest/g
 import { Dispatcher } from '../dispatcher.js'
 import { CID } from 'multiformats/cid'
 import { StreamID } from '@ceramicnetwork/streamid'
-import { CommitType, StreamState, IpfsApi } from '@ceramicnetwork/common'
+import { EventType, StreamState, IpfsApi } from '@ceramicnetwork/common'
 import { CommonTestUtils as TestUtils } from '@ceramicnetwork/common-test-utils'
 import { serialize, MsgType } from '../pubsub/pubsub-message.js'
 import { Repository } from '../state-management/repository.js'
@@ -215,7 +215,7 @@ describe('Dispatcher with mock ipfs', () => {
       log: [
         {
           cid: FAKE_STREAM_ID.cid,
-          type: CommitType.GENESIS,
+          type: eventType.INIT,
         },
       ],
     } as unknown as StreamState
@@ -243,7 +243,7 @@ describe('Dispatcher with mock ipfs', () => {
       ...initialState,
       log: initialState.log.concat({
         cid: FAKE_CID,
-        type: CommitType.SIGNED,
+        type: EventType.DATA,
       }),
     } as unknown as StreamState
     const stream2 = await register(continuationState)
@@ -280,7 +280,7 @@ describe('Dispatcher with mock ipfs', () => {
       log: [
         {
           cid: FAKE_STREAM_ID.cid,
-          type: CommitType.GENESIS,
+          type: eventType.INIT,
         },
       ],
     } as unknown as StreamState

--- a/packages/core/src/__tests__/local-pin-api.test.ts
+++ b/packages/core/src/__tests__/local-pin-api.test.ts
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals'
 import { LocalPinApi } from '../local-pin-api.js'
 import { StreamID } from '@ceramicnetwork/streamid'
 import * as random from '@stablelib/random'
-import { CommitType, StreamState, LoggerProvider, SyncOptions } from '@ceramicnetwork/common'
+import { EventType, StreamState, LoggerProvider, SyncOptions } from '@ceramicnetwork/common'
 import { Repository } from '../state-management/repository.js'
 import { CID } from 'multiformats/cid'
 import { RunningState } from '../state-management/running-state.js'
@@ -14,7 +14,7 @@ const FAKE_CID = CID.parse('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnr
 
 const streamState = {
   type: 0,
-  log: [{ cid: FAKE_CID, type: CommitType.GENESIS }],
+  log: [{ cid: FAKE_CID, type: eventType.INIT }],
 } as unknown as StreamState
 const state$ = new RunningState(streamState, true)
 const repository = {

--- a/packages/core/src/feed.ts
+++ b/packages/core/src/feed.ts
@@ -1,4 +1,4 @@
-import { CommitType, StreamMetadata, StreamState } from '@ceramicnetwork/common'
+import { EventType, StreamMetadata, StreamState } from '@ceramicnetwork/common'
 import { Subject, type Observable } from 'rxjs'
 import { CommitID } from '@ceramicnetwork/streamid'
 import { StreamUtils } from '@ceramicnetwork/common'
@@ -8,7 +8,7 @@ export class FeedDocument {
     readonly commitId: CommitID,
     readonly content: any,
     readonly metadata: StreamMetadata,
-    readonly eventType: CommitType
+    readonly eventType: EventType
   ) {}
 
   static fromStreamState(streamState: StreamState): FeedDocument {

--- a/packages/core/src/state-management/__tests__/repository.test.ts
+++ b/packages/core/src/state-management/__tests__/repository.test.ts
@@ -11,7 +11,7 @@ import {
 import {
   AnchorEvent,
   AnchorStatus,
-  CommitType,
+  EventType,
   IpfsApi,
   SignatureStatus,
   StreamState,
@@ -128,7 +128,7 @@ describe('#load', () => {
       type: TileDocument.STREAM_TYPE_ID,
       log: [
         {
-          type: CommitType.GENESIS,
+          type: eventType.INIT,
           cid: genesisCid,
         },
       ],
@@ -779,7 +779,7 @@ describe('_registerRunningState', () => {
         log: [
           {
             cid: TestUtils.randomCID(),
-            type: CommitType.GENESIS,
+            type: eventType.INIT,
           },
         ],
         signature: 3,

--- a/packages/core/src/state-management/__tests__/running-state.test.ts
+++ b/packages/core/src/state-management/__tests__/running-state.test.ts
@@ -1,5 +1,5 @@
 import { CID } from 'multiformats/cid'
-import { CommitType, StreamState } from '@ceramicnetwork/common'
+import { EventType, StreamState } from '@ceramicnetwork/common'
 import { RunningState } from '../running-state.js'
 
 const FAKE_CID1 = CID.parse('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu')
@@ -9,7 +9,7 @@ const initial = {
   type: 0,
   log: [
     {
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       cid: FAKE_CID1,
     },
   ],
@@ -19,7 +19,7 @@ const second = {
   log: [
     ...initial.log,
     {
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       cid: FAKE_CID2,
     },
   ],

--- a/packages/core/src/state-management/__tests__/state-link.test.ts
+++ b/packages/core/src/state-management/__tests__/state-link.test.ts
@@ -1,5 +1,5 @@
 import { CID } from 'multiformats/cid'
-import { CommitType, StreamState } from '@ceramicnetwork/common'
+import { EventType, StreamState } from '@ceramicnetwork/common'
 import { StateLink } from '../state-link.js'
 import { Observable } from 'rxjs'
 
@@ -11,7 +11,7 @@ test('emit on distinct changes', async () => {
     type: 0,
     log: [
       {
-        type: CommitType.GENESIS,
+        type: eventType.INIT,
         cid: FAKE_CID_1,
       },
     ],
@@ -21,7 +21,7 @@ test('emit on distinct changes', async () => {
     log: [
       ...initial.log,
       {
-        type: CommitType.SIGNED,
+        type: EventType.DATA,
         cid: FAKE_CID2,
       },
     ],

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -3,7 +3,7 @@ import {
   AnchorEvent,
   AnchorOpts,
   AnchorStatus,
-  CommitType,
+  EventType,
   CreateOpts,
   DiagnosticsLogger,
   LoadOpts,
@@ -72,7 +72,7 @@ function shouldIndex(state$: RunningState, index: LocalIndexApi): boolean {
 function commitAtTime(state: StreamState, timestamp: number): CommitID {
   let commitCid: CID = state.log[0].cid
   for (const entry of state.log) {
-    if (entry.type === CommitType.ANCHOR) {
+    if (entry.type === EventType.TIME) {
       if (entry.timestamp <= timestamp) {
         commitCid = entry.cid
       } else {
@@ -961,7 +961,7 @@ export class Repository {
     // TODO(NET-1614) Test that the timestamps are correctly passed to the Index API.
     const lastAnchor = asDate(StreamUtils.anchorTimestampFromState(state$.value))
     const firstAnchor = asDate(
-      state$.value.log.find((log) => log.type == CommitType.ANCHOR)?.timestamp
+      state$.value.log.find((log) => log.type == EventType.TIME)?.timestamp
     )
     const streamContent = {
       model: state$.value.metadata.model,

--- a/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
+++ b/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
@@ -2,7 +2,7 @@ import { Model, ModelDefinition } from '@ceramicnetwork/stream-model'
 import { LevelDbStore } from '../level-db-store.js'
 import {
   CeramicApi,
-  CommitType,
+  EventType,
   DiagnosticsLogger,
   GenesisCommit,
   IpfsApi,
@@ -102,7 +102,7 @@ describe('LevelDB-backed AnchorRequestStore state store', () => {
     streamId: StreamID
   ): Promise<GenesisCommit> {
     const commit = await Utils.getCommitData(ceramic.dispatcher, streamId.cid, streamId)
-    expect(commit.type).toEqual(CommitType.GENESIS)
+    expect(commit.type).toEqual(eventType.INIT)
     return commit.commit as GenesisCommit
   }
 

--- a/packages/core/src/store/__tests__/pin-store.test.ts
+++ b/packages/core/src/store/__tests__/pin-store.test.ts
@@ -7,7 +7,7 @@ import {
   Stream,
   PinningBackend,
   StreamState,
-  CommitType,
+  EventType,
   JSONToBase64Url,
   StreamUtils,
 } from '@ceramicnetwork/common'
@@ -66,7 +66,7 @@ const state: StreamState = {
   signature: SignatureStatus.GENESIS,
   anchorStatus: AnchorStatus.NOT_REQUESTED,
   log: [
-    { cid: CID.parse('QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D'), type: CommitType.GENESIS },
+    { cid: CID.parse('QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D'), type: eventType.INIT },
   ],
 }
 

--- a/packages/core/src/store/__tests__/state-store-integration.test.ts
+++ b/packages/core/src/store/__tests__/state-store-integration.test.ts
@@ -2,7 +2,7 @@ import { jest, expect, it, beforeEach, describe, test } from '@jest/globals'
 import tmp from 'tmp-promise'
 import {
   AnchorStatus,
-  CommitType,
+  EventType,
   StreamState,
   IpfsApi,
   SignatureStatus,
@@ -48,7 +48,7 @@ describe('Level data store', () => {
     metadata: { controllers: ['foo'] },
     signature: SignatureStatus.GENESIS,
     anchorStatus: AnchorStatus.NOT_REQUESTED,
-    log: [{ cid: FAKE_CID, type: CommitType.GENESIS }],
+    log: [{ cid: FAKE_CID, type: eventType.INIT }],
   }
 
   beforeEach(async () => {
@@ -79,7 +79,7 @@ describe('Level data store', () => {
   it('pins not anchored stream correctly with IPFS pinning', async () => {
     const state: StreamState = {
       ...streamState,
-      log: [{ cid: FAKE_CID, type: CommitType.GENESIS }],
+      log: [{ cid: FAKE_CID, type: eventType.INIT }],
     }
     await expect(store.stateStore.load(streamId)).resolves.toBeNull()
     const pinSpy = jest.spyOn(store.pinning, 'pin')

--- a/packages/core/src/stream-loading/__tests__/state-manipulator.test.ts
+++ b/packages/core/src/stream-loading/__tests__/state-manipulator.test.ts
@@ -6,7 +6,7 @@ import {
   AnchorStatus,
   AppliableStreamLog,
   CommitData,
-  CommitType,
+  EventType,
   IpfsApi,
   LogEntry,
   LoggerProvider,
@@ -390,12 +390,12 @@ describe('StateManipulator test', () => {
 
       test('Neither log is anchored, same log lengths', async () => {
         const log1: Array<LogEntry> = [
-          { cid: cids[1], type: CommitType.SIGNED },
-          { cid: cids[2], type: CommitType.SIGNED },
+          { cid: cids[1], type: EventType.DATA },
+          { cid: cids[2], type: EventType.DATA },
         ]
         const log2: Array<LogEntry> = [
-          { cid: cids[4], type: CommitType.SIGNED },
-          { cid: cids[0], type: CommitType.SIGNED },
+          { cid: cids[4], type: EventType.DATA },
+          { cid: cids[0], type: EventType.DATA },
         ]
 
         // When neither log is anchored and log lengths are the same we should pick the log whose last entry has the
@@ -406,13 +406,13 @@ describe('StateManipulator test', () => {
 
       test('Neither log is anchored, different log lengths', async () => {
         const log1: Array<LogEntry> = [
-          { cid: cids[1], type: CommitType.SIGNED },
-          { cid: cids[2], type: CommitType.SIGNED },
-          { cid: cids[3], type: CommitType.SIGNED },
+          { cid: cids[1], type: EventType.DATA },
+          { cid: cids[2], type: EventType.DATA },
+          { cid: cids[3], type: EventType.DATA },
         ]
         const log2: Array<LogEntry> = [
-          { cid: cids[4], type: CommitType.SIGNED },
-          { cid: cids[0], type: CommitType.SIGNED },
+          { cid: cids[4], type: EventType.DATA },
+          { cid: cids[0], type: EventType.DATA },
         ]
 
         // When neither log is anchored and log lengths are different we should pick the log with
@@ -422,8 +422,8 @@ describe('StateManipulator test', () => {
       })
 
       test('One log anchored before the other', async () => {
-        const log1: Array<LogEntry> = [{ cid: cids[1], type: CommitType.SIGNED }]
-        const log2: Array<LogEntry> = [{ cid: cids[2], type: CommitType.ANCHOR }]
+        const log1: Array<LogEntry> = [{ cid: cids[1], type: EventType.DATA }]
+        const log2: Array<LogEntry> = [{ cid: cids[2], type: EventType.TIME }]
 
         // When only one of the logs has been anchored, we pick the anchored one
         expect(stateManipulator._pickLogToAccept(log1, log2)).toEqual(log2)
@@ -435,12 +435,12 @@ describe('StateManipulator test', () => {
         const earlierTime = now - 10000
         const laterTime = now - 5000
         const log1: Array<LogEntry> = [
-          { cid: cids[0], type: CommitType.SIGNED, timestamp: laterTime },
-          { cid: cids[1], type: CommitType.ANCHOR, timestamp: laterTime },
+          { cid: cids[0], type: EventType.DATA, timestamp: laterTime },
+          { cid: cids[1], type: EventType.TIME, timestamp: laterTime },
         ]
         const log2: Array<LogEntry> = [
-          { cid: cids[2], type: CommitType.SIGNED, timestamp: earlierTime },
-          { cid: cids[3], type: CommitType.ANCHOR, timestamp: earlierTime },
+          { cid: cids[2], type: EventType.DATA, timestamp: earlierTime },
+          { cid: cids[3], type: EventType.TIME, timestamp: earlierTime },
         ]
 
         // When both logs are anchored, take the one anchored in the earlier block.
@@ -451,13 +451,13 @@ describe('StateManipulator test', () => {
       test('Both logs anchored in same block blocks - different log lengths', async () => {
         const timestamp = new Date().getTime()
         const log1: Array<LogEntry> = [
-          { cid: cids[1], type: CommitType.SIGNED, timestamp },
-          { cid: cids[2], type: CommitType.SIGNED, timestamp },
-          { cid: cids[3], type: CommitType.ANCHOR, timestamp },
+          { cid: cids[1], type: EventType.DATA, timestamp },
+          { cid: cids[2], type: EventType.DATA, timestamp },
+          { cid: cids[3], type: EventType.TIME, timestamp },
         ]
         const log2: Array<LogEntry> = [
-          { cid: cids[4], type: CommitType.SIGNED, timestamp },
-          { cid: cids[0], type: CommitType.ANCHOR, timestamp },
+          { cid: cids[4], type: EventType.DATA, timestamp },
+          { cid: cids[0], type: EventType.TIME, timestamp },
         ]
 
         // When anchored in the same block, and with different log lengths, we should choose the one
@@ -471,15 +471,15 @@ describe('StateManipulator test', () => {
         const earlierTime = now - 10000
         const laterTime = now - 5000
         const log1: Array<LogEntry> = [
-          { cid: cids[1], type: CommitType.SIGNED, timestamp: earlierTime },
-          { cid: cids[2], type: CommitType.SIGNED, timestamp: earlierTime },
-          { cid: cids[3], type: CommitType.ANCHOR, timestamp: earlierTime },
+          { cid: cids[1], type: EventType.DATA, timestamp: earlierTime },
+          { cid: cids[2], type: EventType.DATA, timestamp: earlierTime },
+          { cid: cids[3], type: EventType.TIME, timestamp: earlierTime },
         ]
         const log2: Array<LogEntry> = [
-          { cid: cids[4], type: CommitType.SIGNED, timestamp: earlierTime },
-          { cid: cids[0], type: CommitType.ANCHOR, timestamp: earlierTime },
-          { cid: cids[5], type: CommitType.SIGNED, timestamp: laterTime },
-          { cid: cids[6], type: CommitType.ANCHOR, timestamp: laterTime },
+          { cid: cids[4], type: EventType.DATA, timestamp: earlierTime },
+          { cid: cids[0], type: EventType.TIME, timestamp: earlierTime },
+          { cid: cids[5], type: EventType.DATA, timestamp: laterTime },
+          { cid: cids[6], type: EventType.TIME, timestamp: laterTime },
         ]
 
         // When first anchor is in the same block, break tie only with log length until first anchor,
@@ -491,12 +491,12 @@ describe('StateManipulator test', () => {
       test('Both logs anchored in the same block with the same log lengths', async () => {
         const timestamp = new Date().getTime()
         const log1: Array<LogEntry> = [
-          { cid: cids[1], type: CommitType.SIGNED, timestamp },
-          { cid: cids[2], type: CommitType.ANCHOR, timestamp },
+          { cid: cids[1], type: EventType.DATA, timestamp },
+          { cid: cids[2], type: EventType.TIME, timestamp },
         ]
         const log2: Array<LogEntry> = [
-          { cid: cids[4], type: CommitType.SIGNED, timestamp },
-          { cid: cids[0], type: CommitType.ANCHOR, timestamp },
+          { cid: cids[4], type: EventType.DATA, timestamp },
+          { cid: cids[0], type: EventType.TIME, timestamp },
         ]
 
         // When anchored in the same block, and with same log lengths, we should use

--- a/packages/core/src/stream-loading/anchor-timestamp-extractor.ts
+++ b/packages/core/src/stream-loading/anchor-timestamp-extractor.ts
@@ -4,7 +4,7 @@ import type {
   DiagnosticsLogger,
   UnappliableStreamLog,
 } from '@ceramicnetwork/common'
-import { CommitType } from '@ceramicnetwork/common'
+import { EventType } from '@ceramicnetwork/common'
 import type { CID } from 'multiformats/cid'
 import type { AnchorValidator } from '../anchor/anchor-service.js'
 
@@ -71,7 +71,7 @@ export class AnchorTimestampExtractor {
     let timestamp = null
     for (let i = log.commits.length - 1; i >= 0; i--) {
       const commitData = log.commits[i]
-      if (commitData.type == CommitType.ANCHOR) {
+      if (commitData.type == EventType.TIME) {
         try {
           timestamp = await this.verifyAnchorCommit(commitData)
         } catch (err) {

--- a/packages/core/src/stream-loading/state-manipulator.ts
+++ b/packages/core/src/stream-loading/state-manipulator.ts
@@ -1,6 +1,6 @@
 import {
   AppliableStreamLog,
-  CommitType,
+  EventType,
   DiagnosticsLogger,
   LogEntry,
   Stream,
@@ -130,7 +130,7 @@ export class StateManipulator {
   ): AppliableStreamLog {
     let timestamp = null
     for (let i = dest.commits.length - 1; i >= 0; i--) {
-      if (copyTimestampsFromRemovedAnchors || source[i].type == CommitType.ANCHOR) {
+      if (copyTimestampsFromRemovedAnchors || source[i].type == EventType.TIME) {
         timestamp = source[i].timestamp
       }
       if (!source[i].cid.equals(dest.commits[i].cid)) {
@@ -147,7 +147,7 @@ export class StateManipulator {
   }
 
   _findAnchorIndex(log: Array<LogEntry>): number {
-    return log.findIndex((logEntry) => logEntry.type == CommitType.ANCHOR)
+    return log.findIndex((logEntry) => logEntry.type == EventType.TIME)
   }
 
   /**

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -2,7 +2,7 @@ import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
 import { Memoize } from 'mapmoize'
 
-import { AnchorStatus, CommitData, CommitType, Stream, StreamUtils } from '@ceramicnetwork/common'
+import { AnchorStatus, CommitData, EventType, Stream, StreamUtils } from '@ceramicnetwork/common'
 
 import type { TileDocument } from '@ceramicnetwork/stream-tile'
 import { Dispatcher } from './dispatcher.js'
@@ -63,7 +63,7 @@ export class Utils {
     const commit = await dispatcher.retrieveCommit(cid, streamId)
     if (!commit) throw new Error(`No commit found for CID ${cid.toString()}`)
     // The default applies to all cases that do not use DagJWS for signing (e.g. CAIP-10 links)
-    const commitData: CommitData = { cid, type: CommitType.SIGNED, commit, timestamp }
+    const commitData: CommitData = { cid, type: EventType.DATA, commit, timestamp }
     if (StreamUtils.isSignedCommit(commit)) {
       const linkedCommit = await dispatcher.retrieveCommit(commit.link, streamId)
       if (!linkedCommit) throw new Error(`No commit found for CID ${commit.link.toString()}`)
@@ -71,10 +71,10 @@ export class Utils {
       commitData.envelope = commit
       commitData.capability = await this.extractCapability(commit, dispatcher)
     } else if (StreamUtils.isAnchorCommit(commit)) {
-      commitData.type = CommitType.ANCHOR
+      commitData.type = EventType.TIME
       commitData.proof = await dispatcher.retrieveFromIPFS(commit.proof)
     }
-    if (!commitData.commit.prev) commitData.type = CommitType.GENESIS
+    if (!commitData.commit.prev) commitData.type = EventType.INIT
     return commitData
   }
 

--- a/packages/http-client/src/__tests__/ceramic-http-client.test.ts
+++ b/packages/http-client/src/__tests__/ceramic-http-client.test.ts
@@ -1,7 +1,7 @@
 import { DID } from 'dids'
 import { CID } from 'multiformats/cid'
 import { jest } from '@jest/globals'
-import { fetchJson, CommitType, StreamState } from '@ceramicnetwork/common'
+import { fetchJson, EventType, StreamState } from '@ceramicnetwork/common'
 import { CeramicClient } from '../ceramic-http-client.js'
 import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { randomBytes } from '@stablelib/random'
@@ -23,7 +23,7 @@ const initial = {
   type: 0,
   log: [
     {
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       cid: FAKE_CID_1,
     },
   ],

--- a/packages/http-client/src/__tests__/document.test.ts
+++ b/packages/http-client/src/__tests__/document.test.ts
@@ -1,4 +1,4 @@
-import { CommitType, StreamState } from '@ceramicnetwork/common'
+import { EventType, StreamState } from '@ceramicnetwork/common'
 import { Document } from '../document.js'
 import { BehaviorSubject, firstValueFrom } from 'rxjs'
 import { filter } from 'rxjs/operators'
@@ -13,7 +13,7 @@ test('emit on distinct changes', async () => {
     type: 0,
     log: [
       {
-        type: CommitType.GENESIS,
+        type: eventType.INIT,
         cid: FAKE_CID_1,
       },
     ],
@@ -23,7 +23,7 @@ test('emit on distinct changes', async () => {
     log: [
       ...initial.log,
       {
-        type: CommitType.SIGNED,
+        type: EventType.DATA,
         cid: FAKE_CID_2,
       },
     ],
@@ -83,7 +83,7 @@ describe('periodic subscription', () => {
       type: 0,
       log: [
         {
-          type: CommitType.GENESIS,
+          type: eventType.INIT,
           cid: FAKE_CID_1,
         },
       ],
@@ -114,7 +114,7 @@ describe('periodic subscription', () => {
       type: 0,
       log: [
         {
-          type: CommitType.GENESIS,
+          type: eventType.INIT,
           cid: FAKE_CID_1,
         },
       ],

--- a/packages/http-client/src/__tests__/remote-index-api.test.ts
+++ b/packages/http-client/src/__tests__/remote-index-api.test.ts
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals'
 import { RemoteIndexApi } from '../remote-index-api.js'
-import { CommitType, fetchJson, Page, StreamState } from '@ceramicnetwork/common'
+import { EventType, fetchJson, Page, StreamState } from '@ceramicnetwork/common'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { CommonTestUtils as TestUtils } from '@ceramicnetwork/common-test-utils'
 
@@ -18,7 +18,7 @@ const FAUX_STREAM_STATE = {
   type: 0,
   log: [
     {
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       cid: TestUtils.randomCID(),
     },
   ],

--- a/packages/stream-caip10-link-handler/src/__tests__/caip10-link-handler.test.ts
+++ b/packages/stream-caip10-link-handler/src/__tests__/caip10-link-handler.test.ts
@@ -4,7 +4,7 @@ import cloneDeep from 'lodash.clonedeep'
 import { CID } from 'multiformats/cid'
 import { decode as decodeMultiHash } from 'multiformats/hashes/digest'
 import { Caip10Link } from '@ceramicnetwork/stream-caip10-link'
-import { CeramicApi, CommitType, Context } from '@ceramicnetwork/common'
+import { CeramicApi, EventType, Context } from '@ceramicnetwork/common'
 import sha256 from '@stablelib/sha256'
 import * as uint8arrays from 'uint8arrays'
 import { AccountId } from 'caip'
@@ -119,7 +119,7 @@ describe('Caip10LinkHandler', () => {
 
   it('throws an error if genesis commit has data', async () => {
     const commitWithData = { ...COMMITS.genesis, data: {} }
-    const genesisWithData = { cid: FAKE_CID_1, type: CommitType.GENESIS, commit: commitWithData }
+    const genesisWithData = { cid: FAKE_CID_1, type: eventType.INIT, commit: commitWithData }
     await expect(handler.applyCommit(genesisWithData, context)).rejects.toThrow(/cannot have data/)
   })
 
@@ -128,7 +128,7 @@ describe('Caip10LinkHandler', () => {
     delete commitWithoutControllers.header.controllers
     const genesisWithoutControllers = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: commitWithoutControllers,
     }
     await expect(handler.applyCommit(genesisWithoutControllers, context)).rejects.toThrow(
@@ -143,7 +143,7 @@ describe('Caip10LinkHandler', () => {
     )
     const genesisWithMultipleControllers = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: commitWithMultipleControllers,
     }
     await expect(handler.applyCommit(genesisWithMultipleControllers, context)).rejects.toThrow(
@@ -152,13 +152,13 @@ describe('Caip10LinkHandler', () => {
   })
 
   it('applies genesis commit correctly', async () => {
-    const genesisCommitData = { cid: FAKE_CID_1, type: CommitType.GENESIS, commit: COMMITS.genesis }
+    const genesisCommitData = { cid: FAKE_CID_1, type: eventType.INIT, commit: COMMITS.genesis }
     const state = await handler.applyCommit(genesisCommitData, context)
     expect(state).toMatchSnapshot()
   })
 
   it('makes update commit correctly', async () => {
-    const genesisCommitData = { cid: FAKE_CID_1, type: CommitType.GENESIS, commit: COMMITS.genesis }
+    const genesisCommitData = { cid: FAKE_CID_1, type: eventType.INIT, commit: COMMITS.genesis }
     const state = await handler.applyCommit(genesisCommitData, context)
     const state$ = TestUtils.runningState(state)
     const stream = new Caip10Link(state$, context)
@@ -171,20 +171,20 @@ describe('Caip10LinkHandler', () => {
   })
 
   it('applies signed commit correctly', async () => {
-    const genesisCommitData = { cid: FAKE_CID_1, type: CommitType.GENESIS, commit: COMMITS.genesis }
+    const genesisCommitData = { cid: FAKE_CID_1, type: eventType.INIT, commit: COMMITS.genesis }
     let state = await handler.applyCommit(genesisCommitData, context)
-    const signedCommitData = { cid: FAKE_CID_2, type: CommitType.SIGNED, commit: COMMITS.r1.commit }
+    const signedCommitData = { cid: FAKE_CID_2, type: EventType.DATA, commit: COMMITS.r1.commit }
     state = await handler.applyCommit(signedCommitData, context, state)
     expect(state).toMatchSnapshot()
   })
 
   it('throws an error of the proof is invalid', async () => {
-    const genesisCommitData = { cid: FAKE_CID_1, type: CommitType.GENESIS, commit: COMMITS.genesis }
+    const genesisCommitData = { cid: FAKE_CID_1, type: eventType.INIT, commit: COMMITS.genesis }
     const state = await handler.applyCommit(genesisCommitData, context)
     const badRecord = cloneDeep(COMMITS.r1.commit)
     badRecord.data.signature =
       '0xc6a5f50945bc7b06320b66cfe144e2b571391c88827eed0490f7f8e5e8af769c4246e27e8302348762387462387648726346877884d9cb8a9303f5d92ea4df0d1c'
-    const badCommitData = { cid: FAKE_CID_2, type: CommitType.SIGNED, commit: badRecord }
+    const badCommitData = { cid: FAKE_CID_2, type: EventType.DATA, commit: badRecord }
     await expect(handler.applyCommit(badCommitData, context, state)).rejects.toThrow(
       /Invalid proof/i
     )
@@ -195,33 +195,33 @@ describe('Caip10LinkHandler', () => {
     badAddressGenesis.header.controllers = ['0xffffffffffffffffffffffffffffffffffffffff@eip155:1']
     const badAddressGenesisData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: badAddressGenesis,
     }
     const state = await handler.applyCommit(badAddressGenesisData, context)
-    const signedCommitData = { cid: FAKE_CID_2, type: CommitType.SIGNED, commit: COMMITS.r1.commit }
+    const signedCommitData = { cid: FAKE_CID_2, type: EventType.DATA, commit: COMMITS.r1.commit }
     await expect(handler.applyCommit(signedCommitData, context, state)).rejects.toThrow(
       `Address '${COMMITS.r1.commit.data.account.toLowerCase()}' used to sign update to Caip10Link doesn't match stream controller '${badAddressGenesis.header.controllers[0].toLowerCase()}'`
     )
   })
 
   it('fails to apply commit with invalid prev link', async () => {
-    const genesisCommitData = { cid: FAKE_CID_1, type: CommitType.GENESIS, commit: COMMITS.genesis }
+    const genesisCommitData = { cid: FAKE_CID_1, type: eventType.INIT, commit: COMMITS.genesis }
     const state = await handler.applyCommit(genesisCommitData, context)
     const commit = { ...COMMITS.r1.commit }
     commit.prev = FAKE_CID_3
-    const signedCommitData = { cid: FAKE_CID_2, type: CommitType.SIGNED, commit }
+    const signedCommitData = { cid: FAKE_CID_2, type: EventType.DATA, commit }
     await expect(handler.applyCommit(signedCommitData, context, state)).rejects.toThrow(
       /Commit doesn't properly point to previous commit in log/
     )
   })
 
   it('fails to apply commit with invalid id property', async () => {
-    const genesisCommitData = { cid: FAKE_CID_1, type: CommitType.GENESIS, commit: COMMITS.genesis }
+    const genesisCommitData = { cid: FAKE_CID_1, type: eventType.INIT, commit: COMMITS.genesis }
     const state = await handler.applyCommit(genesisCommitData, context)
     const commit = { ...COMMITS.r1.commit }
     commit.id = FAKE_CID_3
-    const signedCommitData = { cid: FAKE_CID_2, type: CommitType.SIGNED, commit }
+    const signedCommitData = { cid: FAKE_CID_2, type: EventType.DATA, commit }
     await expect(handler.applyCommit(signedCommitData, context, state)).rejects.toThrow(
       /Invalid genesis CID in commit/
     )
@@ -236,15 +236,15 @@ describe('Caip10LinkHandler', () => {
     await context.ipfs.dag.put(COMMITS.proof, FAKE_CID_4)
 
     // Apply genesis
-    const genesisCommitData = { cid: FAKE_CID_1, type: CommitType.GENESIS, commit: COMMITS.genesis }
+    const genesisCommitData = { cid: FAKE_CID_1, type: eventType.INIT, commit: COMMITS.genesis }
     let state = await handler.applyCommit(genesisCommitData, context)
     // Apply signed record
-    const signedCommitData = { cid: FAKE_CID_2, type: CommitType.SIGNED, commit: COMMITS.r1.commit }
+    const signedCommitData = { cid: FAKE_CID_2, type: EventType.DATA, commit: COMMITS.r1.commit }
     state = await handler.applyCommit(signedCommitData, context, state)
     // Apply anchor record
     const anchorCommitData = {
       cid: FAKE_CID_3,
-      type: CommitType.ANCHOR,
+      type: EventType.TIME,
       commit: COMMITS.r2.commit,
       proof: COMMITS.proof.value,
       timestamp: 1666728832,
@@ -311,20 +311,20 @@ describe('Caip10LinkHandler', () => {
     await context.ipfs.dag.put(commits.r2proof, FAKE_CID_4)
     await context.ipfs.dag.put(commits.r4proof, FAKE_CID_7)
 
-    const genesisCommitData = { cid: FAKE_CID_1, type: CommitType.GENESIS, commit: commits.genesis }
+    const genesisCommitData = { cid: FAKE_CID_1, type: eventType.INIT, commit: commits.genesis }
     let state = await handler.applyCommit(genesisCommitData, context)
-    const signedCommitData_1 = { cid: FAKE_CID_2, type: CommitType.SIGNED, commit: commits.r1 }
+    const signedCommitData_1 = { cid: FAKE_CID_2, type: EventType.DATA, commit: commits.r1 }
     state = await handler.applyCommit(signedCommitData_1, context, state)
     const anchorCommitData_1 = {
       cid: FAKE_CID_3,
-      type: CommitType.ANCHOR,
+      type: EventType.TIME,
       commit: commits.r2,
       proof: commits.r2proof.value,
       timestamp: 1608116723,
     }
     state = await handler.applyCommit(anchorCommitData_1, context, state)
     expect(state.content).toEqual('did:3:testdid1')
-    const signedCommitData_2 = { cid: FAKE_CID_5, type: CommitType.SIGNED, commit: commits.r3 }
+    const signedCommitData_2 = { cid: FAKE_CID_5, type: EventType.DATA, commit: commits.r3 }
     state = await handler.applyCommit(signedCommitData_2, context, state)
 
     // create a fake update based on the r1 data to try a replay attack
@@ -333,14 +333,14 @@ describe('Caip10LinkHandler', () => {
       id: FAKE_CID_1,
       prev: FAKE_CID_5,
     }
-    const signedCommitData_3 = { cid: FAKE_CID_8, type: CommitType.SIGNED, commit: r4 }
+    const signedCommitData_3 = { cid: FAKE_CID_8, type: EventType.DATA, commit: r4 }
     await expect(handler.applyCommit(signedCommitData_3, context, state)).rejects.toThrow(
       'Invalid commit, proof timestamp too old'
     )
 
     const anchorCommitData_2 = {
       cid: FAKE_CID_6,
-      type: CommitType.ANCHOR,
+      type: EventType.TIME,
       commit: commits.r4,
       proof: commits.r4proof.value,
     }
@@ -353,7 +353,7 @@ describe('Caip10LinkHandler', () => {
       id: FAKE_CID_1,
       prev: FAKE_CID_6,
     }
-    const signedCommitData_4 = { cid: FAKE_CID_8, type: CommitType.SIGNED, commit: r5 }
+    const signedCommitData_4 = { cid: FAKE_CID_8, type: EventType.DATA, commit: r5 }
     await expect(handler.applyCommit(signedCommitData_4, context, state)).rejects.toThrow(
       'Invalid commit, proof timestamp too old'
     )

--- a/packages/stream-caip10-link-handler/src/caip10-link-handler.ts
+++ b/packages/stream-caip10-link-handler/src/caip10-link-handler.ts
@@ -3,7 +3,7 @@ import { Caip10Link } from '@ceramicnetwork/stream-caip10-link'
 import {
   AnchorStatus,
   CommitData,
-  CommitType,
+  EventType,
   SignatureStatus,
   StreamConstructor,
   StreamHandler,
@@ -75,7 +75,7 @@ export class Caip10LinkHandler implements StreamHandler<Caip10Link> {
       metadata,
       signature: SignatureStatus.GENESIS,
       anchorStatus: AnchorStatus.NOT_REQUESTED,
-      log: [{ cid: commitData.cid, type: CommitType.GENESIS }],
+      log: [{ cid: commitData.cid, type: EventType.INIT }],
     }
 
     return state
@@ -129,7 +129,7 @@ export class Caip10LinkHandler implements StreamHandler<Caip10Link> {
         `Address '${legacyAccountCaip10.toLowerCase()}' used to sign update to Caip10Link doesn't match stream controller '${legacyControllerCaip10.toLowerCase()}'`
       )
     }
-    state.log.push({ cid: commitData.cid, type: CommitType.SIGNED })
+    state.log.push({ cid: commitData.cid, type: EventType.DATA })
     return {
       ...state,
       signature: SignatureStatus.SIGNED,

--- a/packages/stream-handler-common/src/anchor-commit-utils.ts
+++ b/packages/stream-handler-common/src/anchor-commit-utils.ts
@@ -1,7 +1,7 @@
 import {
   AnchorStatus,
   CommitData,
-  CommitType,
+  EventType,
   StreamState,
   StreamUtils,
 } from '@ceramicnetwork/common'
@@ -19,7 +19,7 @@ function applyAnchorTimestampsToLog(state: StreamState): void {
   let timestamp
   for (let i = state.log.length - 1; i >= 0; i--) {
     const logEntry = state.log[i]
-    if (logEntry.type == CommitType.ANCHOR) {
+    if (logEntry.type == EventType.TIME) {
       timestamp = logEntry.timestamp
     } else {
       logEntry.timestamp = timestamp
@@ -43,7 +43,7 @@ export async function applyAnchorCommit(
   state.anchorProof = commitData.proof
   state.log.push({
     cid: commitData.cid,
-    type: CommitType.ANCHOR,
+    type: EventType.TIME,
     timestamp: commitData.timestamp,
   })
 

--- a/packages/stream-model-handler/src/__tests__/model-handler.test.ts
+++ b/packages/stream-model-handler/src/__tests__/model-handler.test.ts
@@ -5,7 +5,7 @@ import { ModelHandler } from '../model-handler.js'
 import cloneDeep from 'lodash.clonedeep'
 import { Model, ModelDefinition } from '@ceramicnetwork/stream-model'
 import {
-  CommitType,
+  EventType,
   SignedCommitContainer,
   IpfsApi,
   CeramicSigner,
@@ -234,7 +234,7 @@ describe('ModelHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -254,7 +254,7 @@ describe('ModelHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -274,7 +274,7 @@ describe('ModelHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -295,7 +295,7 @@ describe('ModelHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -322,7 +322,7 @@ describe('ModelHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -342,7 +342,7 @@ describe('ModelHandler', () => {
 
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
       timestamp: Date.now(),
@@ -365,7 +365,7 @@ describe('ModelHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -378,7 +378,7 @@ describe('ModelHandler', () => {
     await ipfs.dag.put(anchorProof, FAKE_CID_3)
     const anchorCommitData = {
       cid: FAKE_CID_4,
-      type: CommitType.ANCHOR,
+      type: EventType.TIME,
       commit: { proof: FAKE_CID_3, id: FAKE_CID_1, prev: FAKE_CID_1 },
       proof: anchorProof,
       timestamp: 1615799679,
@@ -403,7 +403,7 @@ describe('ModelHandler', () => {
     // commit is applied 1 hour before rotation
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
       timestamp: rotateDate.valueOf() / 1000 - 60 * 60,
@@ -433,7 +433,7 @@ describe('ModelHandler', () => {
     // commit is applied 1 hour after the rotation
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
       timestamp: Math.floor(rotateDate.valueOf() / 1000) + 60 * 60,

--- a/packages/stream-model-handler/src/model-handler.ts
+++ b/packages/stream-model-handler/src/model-handler.ts
@@ -2,7 +2,7 @@ import { Model } from '@ceramicnetwork/stream-model'
 import {
   AnchorStatus,
   CommitData,
-  CommitType,
+  EventType,
   SignatureStatus,
   SignatureUtils,
   StreamConstructor,
@@ -140,7 +140,7 @@ export class ModelHandler implements StreamHandler<Model> {
       metadata,
       signature: SignatureStatus.SIGNED,
       anchorStatus: AnchorStatus.NOT_REQUESTED,
-      log: [StreamUtils.commitDataToLogEntry(commitData, CommitType.GENESIS)],
+      log: [StreamUtils.commitDataToLogEntry(commitData, EventType.INIT)],
     }
 
     await this._schemaValidator.validateSchema(state.content.schema)

--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -7,7 +7,7 @@ import jsonpatch from 'fast-json-patch'
 import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
 import type { ModelDefinition } from '@ceramicnetwork/stream-model'
 import {
-  CommitType,
+  EventType,
   StreamUtils,
   SignedCommitContainer,
   IpfsApi,
@@ -539,7 +539,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -561,7 +561,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_BLOB,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -580,7 +580,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit,
     }
     await expect(handler.applyCommit(commitData, context)).rejects.toThrow(
@@ -598,7 +598,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit,
     }
     expect(commitData.commit.data).toBeNull()
@@ -621,7 +621,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -643,7 +643,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -665,7 +665,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -687,7 +687,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -712,7 +712,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -734,7 +734,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -771,7 +771,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -794,7 +794,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply signed
     const signedCommitData = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload,
       envelope: signedCommit.jws,
     }
@@ -815,7 +815,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: genesisCommit,
     }
     let state = await handler.applyCommit(genesisCommitData, context)
@@ -836,7 +836,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const signedCommitDataFail = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: payloadFail,
       envelope: signedCommitFail.jws,
     }
@@ -857,7 +857,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const signedCommitDataOK = {
       cid: FAKE_CID_3,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: payloadOK,
       envelope: signedCommitOK.jws,
     }
@@ -877,7 +877,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: genesisCommit,
     }
 
@@ -899,7 +899,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const signedCommitData = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: payload,
       envelope: signedCommit.jws,
     }
@@ -923,7 +923,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -945,7 +945,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply signed
     const signedCommitData_1 = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload1,
       envelope: signedCommit1.jws,
     }
@@ -968,7 +968,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply signed
     const signedCommitData_2 = {
       cid: FAKE_CID_3,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload2,
       envelope: signedCommit2.jws,
     }
@@ -990,7 +990,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -1021,7 +1021,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -1044,7 +1044,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply signed
     const signedCommitData = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload,
       envelope: signedCommit.jws,
     }
@@ -1066,7 +1066,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
       timestamp: Date.now(),
@@ -1091,7 +1091,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -1112,7 +1112,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply signed
     const signedCommitData = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload,
       envelope: signedCommit.jws,
     }
@@ -1135,7 +1135,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -1155,7 +1155,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply signed
     const signedCommitData = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload,
       envelope: signedCommit.jws,
     }
@@ -1178,7 +1178,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -1198,7 +1198,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply signed
     const signedCommitData = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload,
       envelope: signedCommit.jws,
     }
@@ -1221,7 +1221,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -1244,7 +1244,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply signed
     const signedCommitData = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload,
       envelope: signedCommit.jws,
     }
@@ -1257,7 +1257,7 @@ describe('ModelInstanceDocumentHandler', () => {
     await ipfs.dag.put(anchorProof, FAKE_CID_3)
     const anchorCommitData = {
       cid: FAKE_CID_4,
-      type: CommitType.ANCHOR,
+      type: EventType.TIME,
       commit: { proof: FAKE_CID_3, id: FAKE_CID_1, prev: FAKE_CID_2 },
       proof: anchorProof,
       timestamp: 1615799679,
@@ -1282,7 +1282,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // genesis commit applied one hour before rotation
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
       timestamp: rotateDate.valueOf() / 1000 - 60 * 60,
@@ -1307,7 +1307,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const signedCommitData = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload,
       envelope: signedCommit.jws,
       // 24 hours after rotation
@@ -1336,7 +1336,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // commit is applied 1 hour before rotation
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
       timestamp: rotateDate.valueOf() / 1000 - 60 * 60,
@@ -1364,7 +1364,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // commit is applied 1 hour after the rotation
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
       timestamp: Math.floor(rotateDate.valueOf() / 1000) + 60 * 60,
@@ -1389,7 +1389,7 @@ describe('ModelInstanceDocumentHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -1412,7 +1412,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -1435,7 +1435,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -1456,7 +1456,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -1477,7 +1477,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -1498,7 +1498,7 @@ describe('ModelInstanceDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -7,7 +7,7 @@ import {
 import {
   AnchorStatus,
   CommitData,
-  CommitType,
+  EventType,
   SignatureStatus,
   SignatureUtils,
   StreamConstructor,
@@ -129,7 +129,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
       metadata,
       signature: SignatureStatus.SIGNED,
       anchorStatus: AnchorStatus.NOT_REQUESTED,
-      log: [StreamUtils.commitDataToLogEntry(commitData, CommitType.GENESIS)],
+      log: [StreamUtils.commitDataToLogEntry(commitData, EventType.INIT)],
     }
   }
 
@@ -183,7 +183,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     state.signature = SignatureStatus.SIGNED
     state.anchorStatus = AnchorStatus.NOT_REQUESTED
     state.content = newContent
-    state.log.push(StreamUtils.commitDataToLogEntry(commitData, CommitType.SIGNED))
+    state.log.push(StreamUtils.commitDataToLogEntry(commitData, EventType.DATA))
 
     return state
   }

--- a/packages/stream-tests/src/__tests__/deterministic-model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/deterministic-model-instance-document.test.ts
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals'
 import getPort from 'get-port'
-import { AnchorStatus, CommitType, IpfsApi } from '@ceramicnetwork/common'
+import { AnchorStatus, EventType, IpfsApi } from '@ceramicnetwork/common'
 import { CommonTestUtils as TestUtils } from '@ceramicnetwork/common-test-utils'
 import { createIPFS, swarmConnect } from '@ceramicnetwork/ipfs-daemon'
 import {
@@ -111,7 +111,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
       model: midMetadata.model,
     })
     expect(doc.state.log.length).toEqual(1)
-    expect(doc.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(doc.state.log[0].type).toEqual(eventType.INIT)
     expect(doc.state.anchorStatus).toEqual(AnchorStatus.NOT_REQUESTED)
     expect(doc.metadata.model.toString()).toEqual(model.id.toString())
     await expect(TestUtils.isPinned(ceramic.admin, doc.id)).resolves.toBeTruthy()
@@ -123,8 +123,8 @@ describe('ModelInstanceDocument API http-client tests', () => {
     await doc.replace(CONTENT0)
     expect(doc.content).toEqual(CONTENT0)
     expect(doc.state.log.length).toEqual(2)
-    expect(doc.state.log[0].type).toEqual(CommitType.GENESIS)
-    expect(doc.state.log[1].type).toEqual(CommitType.SIGNED)
+    expect(doc.state.log[0].type).toEqual(eventType.INIT)
+    expect(doc.state.log[1].type).toEqual(EventType.DATA)
     expect(doc.state.anchorStatus).toEqual(AnchorStatus.PENDING)
   })
 
@@ -136,8 +136,8 @@ describe('ModelInstanceDocument API http-client tests', () => {
     await doc.replace(CONTENT0)
     expect(doc.content).toEqual(CONTENT0)
     expect(doc.state.log.length).toEqual(2)
-    expect(doc.state.log[0].type).toEqual(CommitType.GENESIS)
-    expect(doc.state.log[1].type).toEqual(CommitType.SIGNED)
+    expect(doc.state.log[0].type).toEqual(eventType.INIT)
+    expect(doc.state.log[1].type).toEqual(EventType.DATA)
     expect(doc.state.anchorStatus).toEqual(AnchorStatus.PENDING)
   })
 

--- a/packages/stream-tests/src/__tests__/model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/model-instance-document.test.ts
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals'
 import getPort from 'get-port'
-import { AnchorStatus, CommitType, IpfsApi } from '@ceramicnetwork/common'
+import { AnchorStatus, EventType, IpfsApi } from '@ceramicnetwork/common'
 import { Utils as CoreUtils } from '@ceramicnetwork/core'
 import { createIPFS, swarmConnect } from '@ceramicnetwork/ipfs-daemon'
 import {
@@ -161,7 +161,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
     expect(doc.metadata.model.equals(midMetadata.model)).toBe(true)
     expect(doc.metadata.unique).toBeInstanceOf(Uint8Array)
     expect(doc.state.log.length).toEqual(1)
-    expect(doc.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(doc.state.log[0].type).toEqual(eventType.INIT)
     expect(doc.state.anchorStatus).toEqual(AnchorStatus.PENDING)
     expect(doc.metadata.model.toString()).toEqual(model.id.toString())
     await expect(TestUtils.isPinned(ceramic.admin, doc.id)).resolves.toBeTruthy()
@@ -179,7 +179,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
     expect(docWithRelation.metadata.model.equals(midRelationMetadata.model)).toBe(true)
     expect(docWithRelation.metadata.unique).toBeInstanceOf(Uint8Array)
     expect(docWithRelation.state.log.length).toEqual(1)
-    expect(docWithRelation.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(docWithRelation.state.log[0].type).toEqual(eventType.INIT)
     expect(docWithRelation.state.anchorStatus).toEqual(AnchorStatus.PENDING)
     expect(docWithRelation.metadata.model.toString()).toEqual(modelWithRelation.id.toString())
     await expect(TestUtils.isPinned(ceramic.admin, docWithRelation.id)).resolves.toBeTruthy()
@@ -196,8 +196,8 @@ describe('ModelInstanceDocument API http-client tests', () => {
 
     expect(doc.content).toEqual(CONTENT1)
     expect(doc.state.log.length).toEqual(2)
-    expect(doc.state.log[0].type).toEqual(CommitType.GENESIS)
-    expect(doc.state.log[1].type).toEqual(CommitType.SIGNED)
+    expect(doc.state.log[0].type).toEqual(eventType.INIT)
+    expect(doc.state.log[1].type).toEqual(EventType.DATA)
   })
 
   test(`Cannot create document with relation that isn't a valid streamid`, async () => {
@@ -257,8 +257,8 @@ describe('ModelInstanceDocument API http-client tests', () => {
 
     expect(doc.state.anchorStatus).toEqual(AnchorStatus.ANCHORED)
     expect(doc.state.log.length).toEqual(2)
-    expect(doc.state.log[0].type).toEqual(CommitType.GENESIS)
-    expect(doc.state.log[1].type).toEqual(CommitType.ANCHOR)
+    expect(doc.state.log[0].type).toEqual(eventType.INIT)
+    expect(doc.state.log[1].type).toEqual(EventType.TIME)
     expect(doc.content).toEqual(CONTENT0)
   })
 
@@ -273,9 +273,9 @@ describe('ModelInstanceDocument API http-client tests', () => {
 
     expect(doc.state.anchorStatus).toEqual(AnchorStatus.ANCHORED)
     expect(doc.state.log.length).toEqual(3)
-    expect(doc.state.log[0].type).toEqual(CommitType.GENESIS)
-    expect(doc.state.log[1].type).toEqual(CommitType.SIGNED)
-    expect(doc.state.log[2].type).toEqual(CommitType.ANCHOR)
+    expect(doc.state.log[0].type).toEqual(eventType.INIT)
+    expect(doc.state.log[1].type).toEqual(EventType.DATA)
+    expect(doc.state.log[2].type).toEqual(EventType.TIME)
     expect(doc.content).toEqual(CONTENT1)
   })
 
@@ -294,12 +294,12 @@ describe('ModelInstanceDocument API http-client tests', () => {
 
     expect(doc.state.anchorStatus).toEqual(AnchorStatus.ANCHORED)
     expect(doc.state.log.length).toEqual(6)
-    expect(doc.state.log[0].type).toEqual(CommitType.GENESIS)
-    expect(doc.state.log[1].type).toEqual(CommitType.SIGNED)
-    expect(doc.state.log[2].type).toEqual(CommitType.ANCHOR)
-    expect(doc.state.log[3].type).toEqual(CommitType.SIGNED)
-    expect(doc.state.log[4].type).toEqual(CommitType.SIGNED)
-    expect(doc.state.log[5].type).toEqual(CommitType.ANCHOR)
+    expect(doc.state.log[0].type).toEqual(eventType.INIT)
+    expect(doc.state.log[1].type).toEqual(EventType.DATA)
+    expect(doc.state.log[2].type).toEqual(EventType.TIME)
+    expect(doc.state.log[3].type).toEqual(EventType.DATA)
+    expect(doc.state.log[4].type).toEqual(EventType.DATA)
+    expect(doc.state.log[5].type).toEqual(EventType.TIME)
     expect(doc.content).toEqual(CONTENT3)
   })
 

--- a/packages/stream-tests/src/__tests__/model.test.ts
+++ b/packages/stream-tests/src/__tests__/model.test.ts
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals'
 import getPort from 'get-port'
-import { AnchorStatus, CommitType, IpfsApi } from '@ceramicnetwork/common'
+import { AnchorStatus, EventType, IpfsApi } from '@ceramicnetwork/common'
 import { Utils as CoreUtils } from '@ceramicnetwork/core'
 import { createIPFS, swarmConnect } from '@ceramicnetwork/ipfs-daemon'
 import { Model, ModelDefinition, parseModelVersion } from '@ceramicnetwork/stream-model'
@@ -129,7 +129,7 @@ describe('Model API http-client tests', () => {
     expect(model.content).toEqual(MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
     expect(model.id.toString()).toEqual(MODEL_STREAM_ID)
   })
@@ -142,7 +142,7 @@ describe('Model API http-client tests', () => {
       expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
-      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.log[0].type).toEqual(eventType.INIT)
       expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -163,7 +163,7 @@ describe('Model API http-client tests', () => {
       expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
-      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.log[0].type).toEqual(eventType.INIT)
       expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -186,7 +186,7 @@ describe('Model API http-client tests', () => {
       expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
-      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.log[0].type).toEqual(eventType.INIT)
       expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -212,7 +212,7 @@ describe('Model API http-client tests', () => {
       expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
-      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.log[0].type).toEqual(eventType.INIT)
       expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
       await expect(
@@ -236,7 +236,7 @@ describe('Model API http-client tests', () => {
       expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
-      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.log[0].type).toEqual(eventType.INIT)
       expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -264,7 +264,7 @@ describe('Model API http-client tests', () => {
       expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
-      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.log[0].type).toEqual(eventType.INIT)
       expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -300,7 +300,7 @@ describe('Model API http-client tests', () => {
       expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
-      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.log[0].type).toEqual(eventType.INIT)
       expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -336,7 +336,7 @@ describe('Model API http-client tests', () => {
       expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
-      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.log[0].type).toEqual(eventType.INIT)
       expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -380,7 +380,7 @@ describe('Model API http-client tests', () => {
       expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
-      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.log[0].type).toEqual(eventType.INIT)
       expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -427,7 +427,7 @@ describe('Model API http-client tests', () => {
       expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
-      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.log[0].type).toEqual(eventType.INIT)
       expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -468,7 +468,7 @@ describe('Model API http-client tests', () => {
       expect(model.content).toEqual(SINGLE_INDEXED_MODEL_DEFINITION)
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
-      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.log[0].type).toEqual(eventType.INIT)
       expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -489,7 +489,7 @@ describe('Model API http-client tests', () => {
       expect(model.content).toEqual(SINGLE_INDEXED_MODEL_DEFINITION)
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
-      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.log[0].type).toEqual(eventType.INIT)
       expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -515,7 +515,7 @@ describe('Model API http-client tests', () => {
       expect(model.content).toEqual(SINGLE_INDEXED_MODEL_DEFINITION)
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
-      expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+      expect(model.state.log[0].type).toEqual(eventType.INIT)
       expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -547,7 +547,7 @@ describe('Model API http-client tests', () => {
     expect(model.content).toEqual(MODEL_DEFINITION_WITH_RELATION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
   })
 
@@ -560,8 +560,8 @@ describe('Model API http-client tests', () => {
 
     expect(model.state.anchorStatus).toEqual(AnchorStatus.ANCHORED)
     expect(model.state.log.length).toEqual(2)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
-    expect(model.state.log[1].type).toEqual(CommitType.ANCHOR)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
+    expect(model.state.log[1].type).toEqual(EventType.TIME)
     expect(model.content).toEqual(MODEL_DEFINITION)
   })
 

--- a/packages/stream-tests/src/__tests__/pg-model-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/pg-model-indexing.test.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals'
-import { AnchorStatus, CommitType, IpfsApi } from '@ceramicnetwork/common'
+import { AnchorStatus, EventType, IpfsApi } from '@ceramicnetwork/common'
 import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
 import { Model, ModelDefinition } from '@ceramicnetwork/stream-model'
 import { createCeramic } from '../create-ceramic.js'
@@ -91,7 +91,7 @@ describe('Postgres Model indexing tests', () => {
     expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -112,7 +112,7 @@ describe('Postgres Model indexing tests', () => {
     expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -135,7 +135,7 @@ describe('Postgres Model indexing tests', () => {
     expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -161,7 +161,7 @@ describe('Postgres Model indexing tests', () => {
     expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await expect(
@@ -185,7 +185,7 @@ describe('Postgres Model indexing tests', () => {
     expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -213,7 +213,7 @@ describe('Postgres Model indexing tests', () => {
     expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -249,7 +249,7 @@ describe('Postgres Model indexing tests', () => {
     expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -285,7 +285,7 @@ describe('Postgres Model indexing tests', () => {
     expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -330,7 +330,7 @@ describe('Postgres Model indexing tests', () => {
     expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -377,7 +377,7 @@ describe('Postgres Model indexing tests', () => {
     expect(model.content).toEqual(INDEXED_MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -418,7 +418,7 @@ describe('Postgres Model indexing tests', () => {
     expect(model.content).toEqual(SINGLE_INDEXED_MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -439,7 +439,7 @@ describe('Postgres Model indexing tests', () => {
     expect(model.content).toEqual(SINGLE_INDEXED_MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
@@ -465,7 +465,7 @@ describe('Postgres Model indexing tests', () => {
     expect(model.content).toEqual(SINGLE_INDEXED_MODEL_DEFINITION)
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
-    expect(model.state.log[0].type).toEqual(CommitType.GENESIS)
+    expect(model.state.log[0].type).toEqual(eventType.INIT)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()

--- a/packages/stream-tile-handler/src/__tests__/three-id.test.ts
+++ b/packages/stream-tile-handler/src/__tests__/three-id.test.ts
@@ -4,7 +4,7 @@ import * as dagCBOR from '@ipld/dag-cbor'
 import {
   CeramicSigner,
   CommitData,
-  CommitType,
+  EventType,
   IpfsApi,
   SignedCommitContainer,
   StreamReaderWriter,
@@ -213,7 +213,7 @@ describe('TileDocument with 3ID', () => {
 
     const signedCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -228,7 +228,7 @@ describe('TileDocument with 3ID', () => {
 
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: COMMITS.genesisGenerated.linkedBlock,
       envelope: COMMITS.genesisGenerated.jws,
     }
@@ -263,7 +263,7 @@ describe('TileDocument with 3ID', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -284,7 +284,7 @@ describe('TileDocument with 3ID', () => {
     // apply signed
     const signedCommitData = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload,
       envelope: signedCommit.jws,
     }
@@ -306,7 +306,7 @@ describe('TileDocument with 3ID', () => {
 
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -329,7 +329,7 @@ describe('TileDocument with 3ID', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -350,7 +350,7 @@ describe('TileDocument with 3ID', () => {
     // apply signed
     const signedCommitData = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload,
       envelope: signedCommit.jws,
     }
@@ -360,7 +360,7 @@ describe('TileDocument with 3ID', () => {
     // apply anchor
     const anchorCommitData = {
       cid: FAKE_CID_3,
-      type: CommitType.ANCHOR,
+      type: EventType.TIME,
       commit: COMMITS.r2.commit,
       proof: COMMITS.proof,
       timestamp: 1615799679,

--- a/packages/stream-tile-handler/src/__tests__/tile-document-handler.test.ts
+++ b/packages/stream-tile-handler/src/__tests__/tile-document-handler.test.ts
@@ -7,7 +7,7 @@ import { TileDocument } from '@ceramicnetwork/stream-tile'
 import {
   CeramicSigner,
   CommitData,
-  CommitType,
+  EventType,
   GenesisCommit,
   IpfsApi,
   SignedCommitContainer,
@@ -231,7 +231,7 @@ describe('TileDocumentHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: commit.jws,
     }
@@ -249,7 +249,7 @@ describe('TileDocumentHandler', () => {
 
     const commitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: COMMITS.genesisGenerated.linkedBlock,
       envelope: COMMITS.genesisGenerated.jws,
     }
@@ -286,7 +286,7 @@ describe('TileDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -307,7 +307,7 @@ describe('TileDocumentHandler', () => {
     // apply signed
     const signedCommitData = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload,
       envelope: signedCommit.jws,
     }
@@ -330,7 +330,7 @@ describe('TileDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -349,7 +349,7 @@ describe('TileDocumentHandler', () => {
     // apply signed
     const signedCommitData_1 = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload1,
       envelope: signedCommit1.jws,
     }
@@ -373,7 +373,7 @@ describe('TileDocumentHandler', () => {
     // apply signed
     const signedCommitData_2 = {
       cid: FAKE_CID_3,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload2,
       envelope: signedCommit2.jws,
     }
@@ -400,7 +400,7 @@ describe('TileDocumentHandler', () => {
 
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
       timestamp: Date.now(),
@@ -423,7 +423,7 @@ describe('TileDocumentHandler', () => {
 
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -448,7 +448,7 @@ describe('TileDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -473,7 +473,7 @@ describe('TileDocumentHandler', () => {
       // apply signed
       const signedCommitData_1 = {
         cid: FAKE_CID_2,
-        type: CommitType.SIGNED,
+        type: EventType.DATA,
         commit: sPayload,
         envelope: signedCommit.jws,
       }
@@ -496,7 +496,7 @@ describe('TileDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -521,7 +521,7 @@ describe('TileDocumentHandler', () => {
       // apply signed
       const signedCommitData_1 = {
         cid: FAKE_CID_2,
-        type: CommitType.SIGNED,
+        type: EventType.DATA,
         commit: sPayload,
         envelope: signedCommit.jws,
       }
@@ -544,7 +544,7 @@ describe('TileDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -569,7 +569,7 @@ describe('TileDocumentHandler', () => {
       // apply signed
       const signedCommitData_1 = {
         cid: FAKE_CID_2,
-        type: CommitType.SIGNED,
+        type: EventType.DATA,
         commit: sPayload,
         envelope: signedCommit.jws,
       }
@@ -594,7 +594,7 @@ describe('TileDocumentHandler', () => {
     // apply genesis
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
     }
@@ -615,7 +615,7 @@ describe('TileDocumentHandler', () => {
     // apply signed
     const signedCommitData = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload,
       envelope: signedCommit.jws,
     }
@@ -625,7 +625,7 @@ describe('TileDocumentHandler', () => {
     // apply anchor
     const anchorCommitData = {
       cid: FAKE_CID_3,
-      type: CommitType.ANCHOR,
+      type: EventType.TIME,
       commit: COMMITS.r2.commit,
       proof: COMMITS.proof,
       timestamp: 1615799679,
@@ -653,7 +653,7 @@ describe('TileDocumentHandler', () => {
     // genesis commit applied one hour before rotation
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
       timestamp: rotateDate.valueOf() / 1000 - 60 * 60,
@@ -678,7 +678,7 @@ describe('TileDocumentHandler', () => {
 
     const signedCommitData = {
       cid: FAKE_CID_2,
-      type: CommitType.SIGNED,
+      type: EventType.DATA,
       commit: sPayload,
       envelope: signedCommit.jws,
       // 24 hours after rotation
@@ -709,7 +709,7 @@ describe('TileDocumentHandler', () => {
     // commit is applied 1 hour before rotation
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
       timestamp: rotateDate.valueOf() / 1000 - 60 * 60,
@@ -741,7 +741,7 @@ describe('TileDocumentHandler', () => {
     // commit is applied 1 hour after the rotation
     const genesisCommitData = {
       cid: FAKE_CID_1,
-      type: CommitType.GENESIS,
+      type: eventType.INIT,
       commit: payload,
       envelope: genesisCommit.jws,
       timestamp: Math.floor(rotateDate.valueOf() / 1000) + 60 * 60,

--- a/packages/stream-tile-handler/src/tile-document-handler.ts
+++ b/packages/stream-tile-handler/src/tile-document-handler.ts
@@ -5,7 +5,7 @@ import { TileDocument } from '@ceramicnetwork/stream-tile'
 import {
   AnchorStatus,
   CommitData,
-  CommitType,
+  EventType,
   SignatureStatus,
   SignatureUtils,
   StreamConstructor,
@@ -112,7 +112,7 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
       metadata: payload.header,
       signature: isSigned ? SignatureStatus.SIGNED : SignatureStatus.GENESIS,
       anchorStatus: AnchorStatus.NOT_REQUESTED,
-      log: [StreamUtils.commitDataToLogEntry(commitData, CommitType.GENESIS)],
+      log: [StreamUtils.commitDataToLogEntry(commitData, EventType.INIT)],
     }
 
     if (state.metadata.schema) {
@@ -183,7 +183,7 @@ export class TileDocumentHandler implements StreamHandler<TileDocument> {
     state.signature = SignatureStatus.SIGNED
     state.anchorStatus = AnchorStatus.NOT_REQUESTED
 
-    state.log.push(StreamUtils.commitDataToLogEntry(commitData, CommitType.SIGNED))
+    state.log.push(StreamUtils.commitDataToLogEntry(commitData, EventType.DATA))
 
     const oldContent = state.next?.content ?? cloneDeep(state.content)
     const oldMetadata = state.next?.metadata ?? state.metadata


### PR DESCRIPTION
## Description
if we're going to start having users consume the CommitType enum publicly more, we should probably update the names of the types within it to match the standard names in the protocol spec. So GENESIS->INIT, SIGNED->DATA, and ANCHOR->TIME. Also rename CommitType->EventType.