### PR TITLE
use interval publishing metrics for anchor polling loop delay

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
     "@ceramicnetwork/indexing": "^3.1.0",
     "@ceramicnetwork/ipfs-daemon": "^4.1.0",
     "@ceramicnetwork/logger": "^4.1.0",
-    "@ceramicnetwork/observability": "^1.4.1",
+    "@ceramicnetwork/observability": "^1.4.4",
     "@ceramicnetwork/stream-tile": "^4.1.0",
     "@ceramicnetwork/streamid": "^4.1.0",
     "@stablelib/random": "^1.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "@ceramicnetwork/indexing": "^3.1.0",
     "@ceramicnetwork/ipfs-topology": "^4.1.0",
     "@ceramicnetwork/job-queue": "^3.1.0",
-    "@ceramicnetwork/observability": "^1.4.1",
+    "@ceramicnetwork/observability": "^1.4.4",
     "@ceramicnetwork/pinning-aggregation": "^4.1.0",
     "@ceramicnetwork/pinning-ipfs-backend": "^4.1.0",
     "@ceramicnetwork/stream-caip10-link": "^4.1.0",

--- a/packages/core/src/anchor/anchor-processing-loop.ts
+++ b/packages/core/src/anchor/anchor-processing-loop.ts
@@ -8,7 +8,7 @@ import type { NamedTaskQueue } from '../state-management/named-task-queue.js'
 import type { StreamID } from '@ceramicnetwork/streamid'
 import { TimeableMetric, SinceField } from '@ceramicnetwork/observability'
 
-const METRICS_REPORTING_INTERVAL_MS = 10000  // 10 second reporting interval
+const METRICS_REPORTING_INTERVAL_MS = 10000 // 10 second reporting interval
 
 /**
  * Get anchor request entries from AnchorRequestStore one by one. For each entry, get CAS response,
@@ -34,7 +34,11 @@ export class AnchorProcessingLoop {
     anchorStoreQueue: NamedTaskQueue
   ) {
     this.#anchorStoreQueue = anchorStoreQueue
-    this.#anchorPollingMetrics = new TimeableMetric(SinceField.TIMESTAMP, 'anchorPollingDelay', METRICS_REPORTING_INTERVAL_MS)
+    this.#anchorPollingMetrics = new TimeableMetric(
+      SinceField.TIMESTAMP,
+      'anchorPollingDelay',
+      METRICS_REPORTING_INTERVAL_MS
+    )
     this.#loop = new ProcessingLoop(logger, store.infiniteList(batchSize), async (streamId) => {
       try {
         logger.verbose(

--- a/packages/core/src/anchor/anchor-processing-loop.ts
+++ b/packages/core/src/anchor/anchor-processing-loop.ts
@@ -36,7 +36,7 @@ export class AnchorProcessingLoop {
     this.#anchorStoreQueue = anchorStoreQueue
     this.#anchorPollingMetrics = new TimeableMetric(
       SinceField.TIMESTAMP,
-      'anchorPollingDelay',
+      'anchorRequestAge',
       METRICS_REPORTING_INTERVAL_MS
     )
     this.#loop = new ProcessingLoop(logger, store.infiniteList(batchSize), async (streamId) => {

--- a/packages/core/src/anchor/anchor-processing-loop.ts
+++ b/packages/core/src/anchor/anchor-processing-loop.ts
@@ -6,6 +6,9 @@ import type { AnchorLoopHandler } from './anchor-service.js'
 import type { DiagnosticsLogger } from '@ceramicnetwork/common'
 import type { NamedTaskQueue } from '../state-management/named-task-queue.js'
 import type { StreamID } from '@ceramicnetwork/streamid'
+import { TimeableMetric, SinceField } from '@ceramicnetwork/observability'
+
+const METRICS_REPORTING_INTERVAL_MS = 10000  // 10 second reporting interval
 
 /**
  * Get anchor request entries from AnchorRequestStore one by one. For each entry, get CAS response,
@@ -20,6 +23,7 @@ export class AnchorProcessingLoop {
    * Linearizes requests to AnchorRequestStore by stream id. Shared with the AnchorService.
    */
   readonly #anchorStoreQueue: NamedTaskQueue
+  readonly #anchorPollingMetrics: TimeableMetric
 
   constructor(
     batchSize: number,
@@ -30,6 +34,7 @@ export class AnchorProcessingLoop {
     anchorStoreQueue: NamedTaskQueue
   ) {
     this.#anchorStoreQueue = anchorStoreQueue
+    this.#anchorPollingMetrics = new TimeableMetric(SinceField.TIMESTAMP, 'anchorPollingDelay', METRICS_REPORTING_INTERVAL_MS)
     this.#loop = new ProcessingLoop(logger, store.infiniteList(batchSize), async (streamId) => {
       try {
         logger.verbose(
@@ -46,6 +51,7 @@ export class AnchorProcessingLoop {
           `Anchor event with status ${event.status} for commit CID ${entry.cid} of Stream ${streamId} handled successfully`
         )
         if (isTerminal) {
+          this.#anchorPollingMetrics.record(entry)
           // Remove iff tip stored equals to the tip we processed
           // Sort of Compare-and-Swap.
           await this.#anchorStoreQueue.run(streamId.toString(), async () => {
@@ -71,6 +77,7 @@ export class AnchorProcessingLoop {
    * Start looping.
    */
   start(): void {
+    this.#anchorPollingMetrics.startPublishingStats()
     this.#loop.start()
   }
 
@@ -78,6 +85,7 @@ export class AnchorProcessingLoop {
    * Stop looping.
    */
   async stop(): Promise<void> {
+    this.#anchorPollingMetrics.stopPublishingStats()
     return this.#loop.stop()
   }
 }

--- a/packages/core/src/store/anchor-request-store.ts
+++ b/packages/core/src/store/anchor-request-store.ts
@@ -2,9 +2,11 @@ import { StreamID } from '@ceramicnetwork/streamid'
 import { ObjectStore } from './object-store.js'
 import { CID } from 'multiformats/cid'
 import { DiagnosticsLogger, GenesisCommit, StreamUtils } from '@ceramicnetwork/common'
+import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
 
 // How long to wait for the store to return a batch from a find request.
 const DEFAULT_BATCH_TIMEOUT_MS = 60 * 1000 // 1 minute
+const ANCHOR_POLLING_PROCESSED = 'anchor_polling_processed'
 
 export type AnchorRequestData = {
   cid: CID
@@ -131,6 +133,7 @@ export class AnchorRequestStore extends ObjectStore<StreamID, AnchorRequestData>
           this.#logger.debug(
             `Anchor polling loop processed ${numEntries} entries from the AnchorRequestStore. Restarting loop.`
           )
+          Metrics.observe(ANCHOR_POLLING_PROCESSED, numEntries) 
           await new Promise((resolve) => setTimeout(resolve, restartDelay))
           gt = undefined
           numEntries = 0

--- a/packages/core/src/store/anchor-request-store.ts
+++ b/packages/core/src/store/anchor-request-store.ts
@@ -133,7 +133,7 @@ export class AnchorRequestStore extends ObjectStore<StreamID, AnchorRequestData>
           this.#logger.debug(
             `Anchor polling loop processed ${numEntries} entries from the AnchorRequestStore. Restarting loop.`
           )
-          Metrics.observe(ANCHOR_POLLING_PROCESSED, numEntries) 
+          Metrics.observe(ANCHOR_POLLING_PROCESSED, numEntries)
           await new Promise((resolve) => setTimeout(resolve, restartDelay))
           gt = undefined
           numEntries = 0


### PR DESCRIPTION
## Description

We need to track the latency of the anchor requests in the polling loop

however we need to make sure not to add excessive overhead

this pr adds reporting with interval-based publishing if prometheus metrics are turned on

Under the Hood:
     calls to the TimeableMetric.count() are added to an internal counter only 
     there is a setInterval call that runs at the requested interval that then calls the observe code which creates a scrapable observation on prometheus for the average and max over the interval
      
      This mechanism is all hidden from js-ceramic.  The reason for it underneath is that we want to avoid creating load and the actual OTLP observe has a non-negligible overhead.  So we use this lighter weight calculation for every stream, and the heavier observe only once per interval.  

## How Has This Been Tested?


- [x] unit tests
- [ ] manual verification of metrics output

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [x ] I have updated the READMEs of affected packages

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
