### PR TITLE
Update model-handler.ts

### DIFF
--- a/packages/stream-model-handler/src/model-handler.ts
+++ b/packages/stream-model-handler/src/model-handler.ts
@@ -30,6 +30,7 @@ const ALLOWED_CONTENT_KEYS = new Set([
   'views',
   'interface',
   'implements',
+  'immutableFields',
 ])
 
 /**


### PR DESCRIPTION
## Description
This is something that should have been done with the #3111 
Part of the work for immutable fields on composeDB its failing because the `assertNoExtraKeys` functions didnt have the immutableFields option, and throws.