### PR TITLE
chore(stream-model,stream-model-handler): bump version

### DIFF
--- a/packages/stream-model-handler/package.json
+++ b/packages/stream-model-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramicnetwork/stream-model-handler",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Ceramic Model stream handler",
   "keywords": [
     "ceramic",

--- a/packages/stream-model/package.json
+++ b/packages/stream-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramicnetwork/stream-model",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Ceramic Model stream type",
   "keywords": [
     "ceramic",


### PR DESCRIPTION
No sure how Lerna and/or the nightly releases script works but it seems the last 2 commits for these packages didn't get released to the nightly channel, maybe it's because they didn't use the conventional commit format?
If so, hopefully this commit will help having the changes detected and released.