### PR TITLE
fix: create unique package versions for nightly releases

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -306,27 +306,8 @@ jobs:
         name: Initialize and build code
         run: npm ci && npm run build
       -
-        # These steps explicitly do not push the release commit, so the specified nightly branch will not be impacted.
+        # This step explicitly does not push the release commit, so the specified nightly branch will not be impacted.
         name: Publish all packages to NPM
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          npm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
-          # First try to publish all the packages. Once a release or RC is made, all the package versions get bumped
-          # and we want to publish nightly packages for the new versions. If this fails, presumably because some
-          # packages have not changed since the last release, we'll try to publish only the packages that did change.
-          npm run publish:nightly -- --force-publish --yes
-          # If we reached here then the publish succeeded and we can exit the workflow
-          exit 0
-        continue-on-error: true
-      -
-        # Now reset the branch and try to publish only the packages that have changed since the last release
-        name: Publish updated packages to NPM
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          npm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
-          git reset --hard HEAD^
-          npm run publish:nightly -- --yes || true
+          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
+          npm run publish:nightly -- --preid "nightly.$(date +%Y%m%d%H%M%S)" --force-publish --yes

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "publish:release-candidate-followup": "npx lerna publish --dist-tag next --preid rc --no-verify-access --conventional-prerelease",
     "publish:release": "npx lerna publish --dist-tag latest --create-release github --no-verify-access --conventional-graduate bump minor",
     "publish:hotfix": "npx lerna publish --dist-tag latest --no-verify-access --conventional-graduate bump patch",
-    "publish:nightly": "npx lerna publish --dist-tag nightly --no-verify-access --conventional-prerelease --preid nightly --no-push",
+    "publish:nightly": "npx lerna publish --dist-tag nightly --no-verify-access --conventional-prerelease --no-push",
     "format": "npx prettier --write 'packages/**/src/**/*{.ts,.tsx,.js}'",
     "lint": "npx lerna run lint && npx prettier --check packages/**/src/**/*.ts",
     "clean": "npm run clean:deps && npm run clean:coverage && npm run clean:build-artifacts",


### PR DESCRIPTION
I was unnecessarily complicating the nightly releases. This PR simplifies the flow and eliminates the package versioning conflicts the workflow was running into previously.

Not having the `--preid` in the `package.json` command means that, if left unspecified when called manually, it will use the default of `beta`.

I've been able to create multiple releases using the workflow, e.g. for [stream-model](https://www.npmjs.com/package/@ceramicnetwork/stream-model?activeTab=versions), even without any changes to the package.

I was able to update the e2e tests to use the new versions and they compiled. I'm also going to run them and see if they pass after auto-updating.