### PR TITLE
feat: Add concurrency to ProcessingLoop

### DIFF
--- a/packages/core/src/anchor/__tests__/anchor-processing-loop.test.ts
+++ b/packages/core/src/anchor/__tests__/anchor-processing-loop.test.ts
@@ -1,12 +1,10 @@
 import { test, jest, expect, describe } from '@jest/globals'
 import { ProcessingLoop, Deferred } from '../processing-loop.js'
 import { LoggerProvider } from '@ceramicnetwork/common'
-import { CommonTestUtils } from '@ceramicnetwork/common-test-utils'
 
 async function* infiniteIntegers() {
   let n = 0
   while (true) {
-    await CommonTestUtils.delay(1)
     yield n++
   }
 }
@@ -83,35 +81,31 @@ test('stop generator', async () => {
   expect(returnSpy).toBeCalled()
 })
 
-test(
-  'Errors are swallowed',
-  async () => {
-    const isDone = new Deferred()
-    const max = 2
-    const errorAfter = 1
+test('Errors are swallowed', async () => {
+  const isDone = new Deferred()
+  const max = 2
+  const errorAfter = 1
 
-    async function* finiteIntegers() {
-      let n = 0
-      while (n < max) {
-        yield n++
-      }
-      isDone.resolve()
+  async function* finiteIntegers() {
+    let n = 0
+    while (n < max) {
+      yield n++
     }
-    const source = finiteIntegers()
-    const returnSpy = jest.spyOn(source, 'return')
-    const noop = jest.fn().mockImplementation((n: number) => {
-      if (n >= errorAfter) {
-        throw new Error(`Valhalla welcomes you`)
-      }
-    })
-    const loop = new ProcessingLoop(logger, 1, source, noop)
-    const whenComplete = loop.start()
-    await isDone
-    await whenComplete
-    expect(noop).toHaveBeenCalledTimes(max)
-    expect(returnSpy).not.toBeCalled()
-    await loop.stop()
-    expect(returnSpy).toBeCalled()
-  },
-  1000 * 1000 // todo remove
-)
+    isDone.resolve()
+  }
+  const source = finiteIntegers()
+  const returnSpy = jest.spyOn(source, 'return')
+  const noop = jest.fn().mockImplementation((n: number) => {
+    if (n >= errorAfter) {
+      throw new Error(`Valhalla welcomes you`)
+    }
+  })
+  const loop = new ProcessingLoop(logger, 1, source, noop)
+  const whenComplete = loop.start()
+  await isDone
+  await whenComplete
+  expect(noop).toHaveBeenCalledTimes(max)
+  expect(returnSpy).not.toBeCalled()
+  await loop.stop()
+  expect(returnSpy).toBeCalled()
+})

--- a/packages/core/src/anchor/anchor-processing-loop.ts
+++ b/packages/core/src/anchor/anchor-processing-loop.ts
@@ -10,6 +10,8 @@ import { TimeableMetric, SinceField } from '@ceramicnetwork/observability'
 
 const METRICS_REPORTING_INTERVAL_MS = 10000 // 10 second reporting interval
 
+const DEFAULT_CONCURRENCY = 10
+
 /**
  * Get anchor request entries from AnchorRequestStore one by one. For each entry, get CAS response,
  * and handle the response via `eventHandler.handle`.
@@ -39,46 +41,54 @@ export class AnchorProcessingLoop {
       'anchorRequestAge',
       METRICS_REPORTING_INTERVAL_MS
     )
-    this.#loop = new ProcessingLoop(logger, store.infiniteList(batchSize), async (streamId) => {
-      try {
-        logger.verbose(
-          `Loading pending anchor metadata for Stream ${streamId} from AnchorRequestStore`
-        )
-        const entry = await store.load(streamId)
-        const event = await cas.getStatusForRequest(streamId, entry.cid).catch(async (error) => {
-          logger.warn(`No request present on CAS for ${entry.cid} of ${streamId}: ${error}`)
-          const requestCAR = await eventHandler.buildRequestCar(streamId, entry.cid)
-          return cas.create(new AnchorRequestCarFileReader(requestCAR))
-        })
-        const isTerminal = await eventHandler.handle(event)
-        logger.verbose(
-          `Anchor event with status ${event.status} for commit CID ${entry.cid} of Stream ${streamId} handled successfully`
-        )
-        if (isTerminal) {
-          // Record the latency of how long this particular anchor request existed in the
-          // AnchorRequestStore.  The "record" function will compare the current time to the
-          // "timestamp" field from "entry", which was set as the current time when the request was
-          // first written into the AnchorRequestStore.
-          this.#anchorPollingMetrics.record(entry)
-          // Remove iff tip stored equals to the tip we processed
-          // Sort of Compare-and-Swap.
-          await this.#anchorStoreQueue.run(streamId.toString(), async () => {
-            const loaded = await store.load(streamId)
-            if (loaded.cid.equals(entry.cid)) {
-              await store.remove(streamId)
-            }
-          })
+
+    const concurrency =
+      Number(process.env.CERAMIC_ANCHOR_POLLING_CONCURRENCY) || DEFAULT_CONCURRENCY
+    this.#loop = new ProcessingLoop(
+      logger,
+      concurrency,
+      store.infiniteList(batchSize),
+      async (streamId) => {
+        try {
           logger.verbose(
-            `Entry from AnchorRequestStore for Stream ${streamId} removed successfully`
+            `Loading pending anchor metadata for Stream ${streamId} from AnchorRequestStore`
           )
+          const entry = await store.load(streamId)
+          const event = await cas.getStatusForRequest(streamId, entry.cid).catch(async (error) => {
+            logger.warn(`No request present on CAS for ${entry.cid} of ${streamId}: ${error}`)
+            const requestCAR = await eventHandler.buildRequestCar(streamId, entry.cid)
+            return cas.create(new AnchorRequestCarFileReader(requestCAR))
+          })
+          const isTerminal = await eventHandler.handle(event)
+          logger.verbose(
+            `Anchor event with status ${event.status} for commit CID ${entry.cid} of Stream ${streamId} handled successfully`
+          )
+          if (isTerminal) {
+            // Record the latency of how long this particular anchor request existed in the
+            // AnchorRequestStore.  The "record" function will compare the current time to the
+            // "timestamp" field from "entry", which was set as the current time when the request was
+            // first written into the AnchorRequestStore.
+            this.#anchorPollingMetrics.record(entry)
+            // Remove iff tip stored equals to the tip we processed
+            // Sort of Compare-and-Swap.
+            await this.#anchorStoreQueue.run(streamId.toString(), async () => {
+              const loaded = await store.load(streamId)
+              if (loaded.cid.equals(entry.cid)) {
+                await store.remove(streamId)
+              }
+            })
+            logger.verbose(
+              `Entry from AnchorRequestStore for Stream ${streamId} removed successfully`
+            )
+          }
+        } catch (err) {
+          logger.err(
+            `Error while processing entry from the AnchorRequestStore for StreamID ${streamId}: ${err}`
+          )
+          // Swallow the error and leave the entry in the store, it will get retries the next time through the loop.
         }
-      } catch (err) {
-        logger.err(
-          `Error while processing entry from the AnchorRequestStore for StreamID ${streamId}: ${err}`
-        )
-        // Swallow the error and leave the entry in the store, it will get retries the next time through the loop.
       }
-    })
+    )
   }
 
   /**

--- a/packages/core/src/anchor/anchor-processing-loop.ts
+++ b/packages/core/src/anchor/anchor-processing-loop.ts
@@ -10,7 +10,7 @@ import { TimeableMetric, SinceField } from '@ceramicnetwork/observability'
 
 const METRICS_REPORTING_INTERVAL_MS = 10000 // 10 second reporting interval
 
-const DEFAULT_CONCURRENCY = 10
+const DEFAULT_CONCURRENCY = 25
 
 /**
  * Get anchor request entries from AnchorRequestStore one by one. For each entry, get CAS response,
@@ -96,7 +96,7 @@ export class AnchorProcessingLoop {
    */
   start(): void {
     this.#anchorPollingMetrics.startPublishingStats()
-    this.#loop.start()
+    void this.#loop.start()
   }
 
   /**

--- a/packages/core/src/anchor/processing-loop.ts
+++ b/packages/core/src/anchor/processing-loop.ts
@@ -95,6 +95,9 @@ export class ProcessingLoop<T> {
     this.#runningTasks = new Map()
   }
 
+  /**
+   * Start the loop processing.  Returns a promise that resolves when the loop completes.
+   */
   start(): Promise<void> {
     const rejectOnAbortSignal = new Promise<IteratorResult<T>>((resolve) => {
       if (this.#abortController.signal.aborted) {

--- a/packages/core/src/anchor/processing-loop.ts
+++ b/packages/core/src/anchor/processing-loop.ts
@@ -135,7 +135,9 @@ export class ProcessingLoop<T> {
             .finally(() => {
               this.#runningTasks.delete(curTaskId)
             })
-          this.#runningTasks.set(taskId++, task)
+          this.#runningTasks.set(taskId, task)
+          // Mod by MAX_SAFE_INTEGER just in case taskId gets really large and needs to wrap around
+          taskId = (taskId + 1) % Number.MAX_SAFE_INTEGER
         } catch (e) {
           this.#logger.err(`Error in ProcessingLoop: ${e}`)
         }

--- a/packages/core/src/store/anchor-request-store.ts
+++ b/packages/core/src/store/anchor-request-store.ts
@@ -115,7 +115,7 @@ export class AnchorRequestStore extends ObjectStore<StreamID, AnchorRequestData>
             resolve(null)
           }, this.#infiniteListBatchTimeoutMs)
         })
-        this.#logger.verbose(`Fetching batch from AnchorRequestStore starting at key ${gt}`)
+        this.#logger.debug(`Fetching batch from AnchorRequestStore starting at key ${gt}`)
         const batchPromise = this.store.find({
           limit: batchSize,
           useCaseName: this.useCaseName,


### PR DESCRIPTION
An alternative approach to https://github.com/ceramicnetwork/js-ceramic/pull/3152 that addresses the concerns raised in my comment there.

This changes the ProcessingLoop to swallow errors instead of returning an encountered error when the loop shuts down as it did before.  This is because now that multiple tasks are running concurrently, it's possible to get multiple errors at once, and it isn't clear what error should be returned by the loop.  Given that nothing outside of tests was actually doing anything with the returned error other than logging it anyway, just logging it and otherwise swallowing errors seems fine.