### PR TITLE
feat: Disable anchoring when CERAMIC_RECON_MODE env var is set

### DIFF
--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -585,6 +585,11 @@ export class Repository {
       return
     }
 
+    if (process.env.CERAMIC_RECON_MODE) {
+      // TODO(WS1-1471): Enable anchoring when in Recon (Prime) mode.
+      return
+    }
+
     const carFile = await this.#deps.anchorRequestCarBuilder.build(state$.id, state$.tip)
     const anchorEvent = await this.anchorService.requestAnchor(carFile)
     // Don't wait on handling the anchor event, let that happen in the background.

--- a/packages/stream-tests/src/__tests__/deterministic-model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/deterministic-model-instance-document.test.ts
@@ -59,6 +59,9 @@ const MODEL_DEFINITION_SET: ModelDefinition = {
   },
 }
 
+// TODO(WS1-1471): These tests should be enabled once anchoring works in Recon mode
+const testIfV3ShouldPassWithAnchoring = process.env.CERAMIC_RECON_MODE ? test.skip : test
+
 describe('ModelInstanceDocument API http-client tests', () => {
   jest.setTimeout(1000 * 30)
 
@@ -118,7 +121,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
     await expect(TestUtils.isPinned(ceramic.admin, doc.metadata.model)).resolves.toBeTruthy()
   })
 
-  test(`Create doc and set content`, async () => {
+  testIfV3ShouldPassWithAnchoring(`Create doc and set content`, async () => {
     const doc = await ModelInstanceDocument.single(ceramic, midMetadata)
     await doc.replace(CONTENT0)
     expect(doc.content).toEqual(CONTENT0)
@@ -128,7 +131,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
     expect(doc.state.anchorStatus).toEqual(AnchorStatus.PENDING)
   })
 
-  test(`Can create deterministic doc with create method`, async () => {
+  testIfV3ShouldPassWithAnchoring(`Can create deterministic doc with create method`, async () => {
     const doc = await ModelInstanceDocument.create(ceramic, null, {
       ...midMetadata,
       deterministic: true,

--- a/packages/stream-tests/src/__tests__/deterministic-model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/deterministic-model-instance-document.test.ts
@@ -59,9 +59,6 @@ const MODEL_DEFINITION_SET: ModelDefinition = {
   },
 }
 
-// TODO(WS1-1471): These tests should be enabled once anchoring works in Recon mode
-const testIfV3ShouldPassWithAnchoring = process.env.CERAMIC_RECON_MODE ? test.skip : test
-
 describe('ModelInstanceDocument API http-client tests', () => {
   jest.setTimeout(1000 * 30)
 
@@ -121,17 +118,20 @@ describe('ModelInstanceDocument API http-client tests', () => {
     await expect(TestUtils.isPinned(ceramic.admin, doc.metadata.model)).resolves.toBeTruthy()
   })
 
-  testIfV3ShouldPassWithAnchoring(`Create doc and set content`, async () => {
+  test(`Create doc and set content`, async () => {
     const doc = await ModelInstanceDocument.single(ceramic, midMetadata)
     await doc.replace(CONTENT0)
     expect(doc.content).toEqual(CONTENT0)
     expect(doc.state.log.length).toEqual(2)
     expect(doc.state.log[0].type).toEqual(EventType.INIT)
     expect(doc.state.log[1].type).toEqual(EventType.DATA)
-    expect(doc.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(doc.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
   })
 
-  testIfV3ShouldPassWithAnchoring(`Can create deterministic doc with create method`, async () => {
+  test(`Can create deterministic doc with create method`, async () => {
     const doc = await ModelInstanceDocument.create(ceramic, null, {
       ...midMetadata,
       deterministic: true,
@@ -141,7 +141,10 @@ describe('ModelInstanceDocument API http-client tests', () => {
     expect(doc.state.log.length).toEqual(2)
     expect(doc.state.log[0].type).toEqual(EventType.INIT)
     expect(doc.state.log[1].type).toEqual(EventType.DATA)
-    expect(doc.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(doc.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
   })
 
   test(`Creating doc with SINGLE accountRelation non-deterministically should fail `, async () => {

--- a/packages/stream-tests/src/__tests__/model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/model-instance-document.test.ts
@@ -156,7 +156,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
     ).rejects.toThrow(/data must have required property 'myData'/)
   })
 
-  testIfV3ShouldPassWithAnchoring(`Create a valid doc`, async () => {
+  test(`Create a valid doc`, async () => {
     const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
     expect(doc.id.type).toEqual(ModelInstanceDocument.STREAM_TYPE_ID)
     expect(doc.content).toEqual(CONTENT0)
@@ -165,7 +165,10 @@ describe('ModelInstanceDocument API http-client tests', () => {
     expect(doc.metadata.unique).toBeInstanceOf(Uint8Array)
     expect(doc.state.log.length).toEqual(1)
     expect(doc.state.log[0].type).toEqual(EventType.INIT)
-    expect(doc.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(doc.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
     expect(doc.metadata.model.toString()).toEqual(model.id.toString())
     await expect(TestUtils.isPinned(ceramic.admin, doc.id)).resolves.toBeTruthy()
     await expect(TestUtils.isPinned(ceramic.admin, doc.metadata.model)).resolves.toBeTruthy()
@@ -183,7 +186,10 @@ describe('ModelInstanceDocument API http-client tests', () => {
     expect(docWithRelation.metadata.unique).toBeInstanceOf(Uint8Array)
     expect(docWithRelation.state.log.length).toEqual(1)
     expect(docWithRelation.state.log[0].type).toEqual(EventType.INIT)
-    expect(docWithRelation.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(docWithRelation.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
     expect(docWithRelation.metadata.model.toString()).toEqual(modelWithRelation.id.toString())
     await expect(TestUtils.isPinned(ceramic.admin, docWithRelation.id)).resolves.toBeTruthy()
     await expect(

--- a/packages/stream-tests/src/__tests__/model-instance-document.test.ts
+++ b/packages/stream-tests/src/__tests__/model-instance-document.test.ts
@@ -81,6 +81,9 @@ const MODEL_WITH_RELATION_DEFINITION: ModelDefinition = {
   },
 }
 
+// TODO(WS1-1471): These tests should be enabled once anchoring works in Recon mode
+const testIfV3ShouldPassWithAnchoring = process.env.CERAMIC_RECON_MODE ? test.skip : test
+
 describe('ModelInstanceDocument API http-client tests', () => {
   jest.setTimeout(1000 * 30)
 
@@ -153,7 +156,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
     ).rejects.toThrow(/data must have required property 'myData'/)
   })
 
-  test(`Create a valid doc`, async () => {
+  testIfV3ShouldPassWithAnchoring(`Create a valid doc`, async () => {
     const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
     expect(doc.id.type).toEqual(ModelInstanceDocument.STREAM_TYPE_ID)
     expect(doc.content).toEqual(CONTENT0)
@@ -262,7 +265,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
     expect(docWithRelation.content.optionalLinkedDoc).toBe(docID)
   })
 
-  test('Anchor genesis', async () => {
+  testIfV3ShouldPassWithAnchoring('Anchor genesis', async () => {
     const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
     expect(doc.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
@@ -276,7 +279,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
     expect(doc.content).toEqual(CONTENT0)
   })
 
-  test('Anchor after updating', async () => {
+  testIfV3ShouldPassWithAnchoring('Anchor after updating', async () => {
     const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
     expect(doc.state.anchorStatus).toEqual(AnchorStatus.PENDING)
     await doc.replace(CONTENT1)
@@ -293,7 +296,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
     expect(doc.content).toEqual(CONTENT1)
   })
 
-  test('multiple updates', async () => {
+  testIfV3ShouldPassWithAnchoring('multiple updates', async () => {
     const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
     await doc.replace(CONTENT1)
 
@@ -340,7 +343,7 @@ describe('ModelInstanceDocument API http-client tests', () => {
     ).rejects.toThrow(/Attempting to create a ModelInstanceDocument with an invalid DID string/)
   })
 
-  test('Can load a stream', async () => {
+  testIfV3ShouldPassWithAnchoring('Can load a stream', async () => {
     const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata)
     await doc.replace(CONTENT1)
     await CoreUtils.anchorUpdate(core, doc)

--- a/packages/stream-tests/src/__tests__/model.test.ts
+++ b/packages/stream-tests/src/__tests__/model.test.ts
@@ -78,9 +78,6 @@ const MODEL_DEFINITION_WITH_RELATION: ModelDefinition = {
 
 // TODO(WS1-1471): These tests should be enabled once anchoring works in Recon mode
 const testIfV3ShouldPassWithAnchoring = process.env.CERAMIC_RECON_MODE ? test.skip : test
-const describeIfV3ShouldPassWithAnchoring = process.env.CERAMIC_RECON_MODE
-  ? describe.skip
-  : describe
 
 describe('Model API http-client tests', () => {
   jest.setTimeout(1000 * 30)
@@ -128,7 +125,7 @@ describe('Model API http-client tests', () => {
     await expect(ceramic.loadStream(Model.MODEL)).rejects.toThrow(/4 is not a valid stream type/)
   })
 
-  testIfV3ShouldPassWithAnchoring('Create valid model', async () => {
+  test('Create valid model', async () => {
     const model = await Model.create(ceramic, MODEL_DEFINITION)
 
     expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
@@ -136,11 +133,15 @@ describe('Model API http-client tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
     expect(model.id.toString()).toEqual(MODEL_STREAM_ID)
   })
 
-  describeIfV3ShouldPassWithAnchoring('model indexing', () => {
+  describe('model indexing', () => {
     test('Create and index valid model', async () => {
       const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
 
@@ -149,7 +150,10 @@ describe('Model API http-client tests', () => {
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
       expect(model.state.log[0].type).toEqual(EventType.INIT)
-      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      if (!process.env.CERAMIC_RECON_MODE) {
+        // TODO (WS1-1471): Re-enable this check even in Recon mode
+        expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      }
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -170,7 +174,10 @@ describe('Model API http-client tests', () => {
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
       expect(model.state.log[0].type).toEqual(EventType.INIT)
-      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      if (!process.env.CERAMIC_RECON_MODE) {
+        // TODO (WS1-1471): Re-enable this check even in Recon mode
+        expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      }
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -193,7 +200,10 @@ describe('Model API http-client tests', () => {
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
       expect(model.state.log[0].type).toEqual(EventType.INIT)
-      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      if (!process.env.CERAMIC_RECON_MODE) {
+        // TODO (WS1-1471): Re-enable this check even in Recon mode
+        expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      }
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -219,7 +229,10 @@ describe('Model API http-client tests', () => {
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
       expect(model.state.log[0].type).toEqual(EventType.INIT)
-      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      if (!process.env.CERAMIC_RECON_MODE) {
+        // TODO (WS1-1471): Re-enable this check even in Recon mode
+        expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      }
 
       await expect(
         ceramic.admin.startIndexingModelData([
@@ -243,7 +256,10 @@ describe('Model API http-client tests', () => {
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
       expect(model.state.log[0].type).toEqual(EventType.INIT)
-      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      if (!process.env.CERAMIC_RECON_MODE) {
+        // TODO (WS1-1471): Re-enable this check even in Recon mode
+        expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      }
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -271,7 +287,10 @@ describe('Model API http-client tests', () => {
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
       expect(model.state.log[0].type).toEqual(EventType.INIT)
-      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      if (!process.env.CERAMIC_RECON_MODE) {
+        // TODO (WS1-1471): Re-enable this check even in Recon mode
+        expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      }
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -307,7 +326,10 @@ describe('Model API http-client tests', () => {
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
       expect(model.state.log[0].type).toEqual(EventType.INIT)
-      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      if (!process.env.CERAMIC_RECON_MODE) {
+        // TODO (WS1-1471): Re-enable this check even in Recon mode
+        expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      }
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -343,7 +365,10 @@ describe('Model API http-client tests', () => {
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
       expect(model.state.log[0].type).toEqual(EventType.INIT)
-      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      if (!process.env.CERAMIC_RECON_MODE) {
+        // TODO (WS1-1471): Re-enable this check even in Recon mode
+        expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      }
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -387,7 +412,10 @@ describe('Model API http-client tests', () => {
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
       expect(model.state.log[0].type).toEqual(EventType.INIT)
-      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      if (!process.env.CERAMIC_RECON_MODE) {
+        // TODO (WS1-1471): Re-enable this check even in Recon mode
+        expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      }
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -434,7 +462,10 @@ describe('Model API http-client tests', () => {
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
       expect(model.state.log[0].type).toEqual(EventType.INIT)
-      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      if (!process.env.CERAMIC_RECON_MODE) {
+        // TODO (WS1-1471): Re-enable this check even in Recon mode
+        expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      }
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -475,7 +506,10 @@ describe('Model API http-client tests', () => {
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
       expect(model.state.log[0].type).toEqual(EventType.INIT)
-      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      if (!process.env.CERAMIC_RECON_MODE) {
+        // TODO (WS1-1471): Re-enable this check even in Recon mode
+        expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      }
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -496,7 +530,10 @@ describe('Model API http-client tests', () => {
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
       expect(model.state.log[0].type).toEqual(EventType.INIT)
-      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      if (!process.env.CERAMIC_RECON_MODE) {
+        // TODO (WS1-1471): Re-enable this check even in Recon mode
+        expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      }
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -522,7 +559,10 @@ describe('Model API http-client tests', () => {
       expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
       expect(model.state.log.length).toEqual(1)
       expect(model.state.log[0].type).toEqual(EventType.INIT)
-      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      if (!process.env.CERAMIC_RECON_MODE) {
+        // TODO (WS1-1471): Re-enable this check even in Recon mode
+        expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+      }
 
       await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -546,7 +586,7 @@ describe('Model API http-client tests', () => {
     })
   })
 
-  testIfV3ShouldPassWithAnchoring('Create valid model with relation', async () => {
+  test('Create valid model with relation', async () => {
     const model = await Model.create(ceramic, MODEL_DEFINITION_WITH_RELATION)
 
     expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
@@ -554,7 +594,10 @@ describe('Model API http-client tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
   })
 
   testIfV3ShouldPassWithAnchoring('Anchor genesis', async () => {
@@ -652,7 +695,7 @@ describe('Model API http-client tests', () => {
     expect(JSON.stringify(loaded.state)).toEqual(JSON.stringify(model.state))
   })
 
-  testIfV3ShouldPassWithAnchoring('Checks interface implementation on model creation', async () => {
+  test('Checks interface implementation on model creation', async () => {
     const interfaceModel = await Model.create(ceramic, {
       version: '2.0',
       name: 'TestInterface',

--- a/packages/stream-tests/src/__tests__/model.test.ts
+++ b/packages/stream-tests/src/__tests__/model.test.ts
@@ -76,6 +76,12 @@ const MODEL_DEFINITION_WITH_RELATION: ModelDefinition = {
   relations: { linkedDoc: { type: 'document', model: MODEL_STREAM_ID } },
 }
 
+// TODO(WS1-1471): These tests should be enabled once anchoring works in Recon mode
+const testIfV3ShouldPassWithAnchoring = process.env.CERAMIC_RECON_MODE ? test.skip : test
+const describeIfV3ShouldPassWithAnchoring = process.env.CERAMIC_RECON_MODE
+  ? describe.skip
+  : describe
+
 describe('Model API http-client tests', () => {
   jest.setTimeout(1000 * 30)
 
@@ -122,7 +128,7 @@ describe('Model API http-client tests', () => {
     await expect(ceramic.loadStream(Model.MODEL)).rejects.toThrow(/4 is not a valid stream type/)
   })
 
-  test('Create valid model', async () => {
+  testIfV3ShouldPassWithAnchoring('Create valid model', async () => {
     const model = await Model.create(ceramic, MODEL_DEFINITION)
 
     expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
@@ -134,7 +140,7 @@ describe('Model API http-client tests', () => {
     expect(model.id.toString()).toEqual(MODEL_STREAM_ID)
   })
 
-  describe('model indexing', () => {
+  describeIfV3ShouldPassWithAnchoring('model indexing', () => {
     test('Create and index valid model', async () => {
       const model = await Model.create(ceramic, INDEXED_MODEL_DEFINITION)
 
@@ -540,7 +546,7 @@ describe('Model API http-client tests', () => {
     })
   })
 
-  test('Create valid model with relation', async () => {
+  testIfV3ShouldPassWithAnchoring('Create valid model with relation', async () => {
     const model = await Model.create(ceramic, MODEL_DEFINITION_WITH_RELATION)
 
     expect(model.id.type).toEqual(Model.STREAM_TYPE_ID)
@@ -551,7 +557,7 @@ describe('Model API http-client tests', () => {
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
   })
 
-  test('Anchor genesis', async () => {
+  testIfV3ShouldPassWithAnchoring('Anchor genesis', async () => {
     const model = await Model.create(ceramic, MODEL_DEFINITION)
     expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
 
@@ -634,7 +640,7 @@ describe('Model API http-client tests', () => {
     )
   })
 
-  test('Can load a complete stream', async () => {
+  testIfV3ShouldPassWithAnchoring('Can load a complete stream', async () => {
     const model = await Model.create(ceramic, MODEL_DEFINITION)
     await CoreUtils.anchorUpdate(core, model)
     await model.sync()
@@ -646,7 +652,7 @@ describe('Model API http-client tests', () => {
     expect(JSON.stringify(loaded.state)).toEqual(JSON.stringify(model.state))
   })
 
-  test('Checks interface implementation on model creation', async () => {
+  testIfV3ShouldPassWithAnchoring('Checks interface implementation on model creation', async () => {
     const interfaceModel = await Model.create(ceramic, {
       version: '2.0',
       name: 'TestInterface',

--- a/packages/stream-tests/src/__tests__/pg-model-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/pg-model-indexing.test.ts
@@ -55,7 +55,12 @@ const SINGLE_INDEXED_MODEL_DEFINITION: ModelDefinition = {
   },
 }
 
-describe('Postgres Model indexing tests', () => {
+// TODO(WS1-1471): These tests should be enabled once anchoring works in Recon mode
+const describeIfV3ShouldPassWithAnchoring = process.env.CERAMIC_RECON_MODE
+  ? describe.skip
+  : describe
+
+describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
   jest.setTimeout(1000 * 30)
 
   let ipfs: IpfsApi

--- a/packages/stream-tests/src/__tests__/pg-model-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/pg-model-indexing.test.ts
@@ -55,12 +55,7 @@ const SINGLE_INDEXED_MODEL_DEFINITION: ModelDefinition = {
   },
 }
 
-// TODO(WS1-1471): These tests should be enabled once anchoring works in Recon mode
-const describeIfV3ShouldPassWithAnchoring = process.env.CERAMIC_RECON_MODE
-  ? describe.skip
-  : describe
-
-describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
+describe('Postgres Model indexing tests', () => {
   jest.setTimeout(1000 * 30)
 
   let ipfs: IpfsApi
@@ -97,7 +92,10 @@ describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -118,7 +116,10 @@ describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -141,7 +142,10 @@ describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -167,7 +171,10 @@ describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
 
     await expect(
       ceramic.admin.startIndexingModelData([
@@ -191,7 +198,10 @@ describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -219,7 +229,10 @@ describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -255,7 +268,10 @@ describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -291,7 +307,10 @@ describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -336,7 +355,10 @@ describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -383,7 +405,10 @@ describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -424,7 +449,10 @@ describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -445,7 +473,10 @@ describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 
@@ -471,7 +502,10 @@ describeIfV3ShouldPassWithAnchoring('Postgres Model indexing tests', () => {
     expect(model.metadata).toEqual({ controller: ceramic.did.id.toString(), model: Model.MODEL })
     expect(model.state.log.length).toEqual(1)
     expect(model.state.log[0].type).toEqual(EventType.INIT)
-    expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    if (!process.env.CERAMIC_RECON_MODE) {
+      // TODO (WS1-1471): Re-enable this check even in Recon mode
+      expect(model.state.anchorStatus).toEqual(AnchorStatus.PENDING)
+    }
 
     await expect(ceramic.admin.pin.add(model.id)).resolves.not.toThrow()
 


### PR DESCRIPTION
This does reduce our test coverage of basic composedb features a good amount though.  I did this without modifying the body of any tests, just disabling any test that fails, but many of them fail just because the tests happens to check that the anchor status is PENDING in some place, without really relying on anchoring as a core part of the test.  I could, instead, use the env var inside of test bodies to selectively skip just the parts of the tests that are breaking, but leaving the bulk of many of the tests in tact.  It would just muddy up some of the tests a bit and to put them back later we'd have to grep for uses of the `CERAMIC_RECON_MODE` flag instead of just being able to search for `testIfV3ShouldPassWithAnchoring` and `describeIfV3ShouldPassWithAnchoring`.

I kind of think that would be a better way to go, but curious what others think.


EDIT: I went ahead and made the change.  You can see the two different commits in this PR if you want to compare the difference in the two approaches.