### PR TITLE
feat: enforce immutability constraints when working with interfaces

### DIFF
--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -147,7 +147,8 @@ export class CeramicCliUtils {
     if (process.env.CERAMIC_PROMETHEUS_EXPORTER_PORT)
       config.metrics.prometheusExporterPort = Number(process.env.CERAMIC_PROMETHEUS_EXPORTER_PORT)
     if (process.env.CERAMIC_PROMETHEUS_EXPORTER_ENABLED)
-      config.metrics.prometheusExporterEnabled = process.env.CERAMIC_PROMETHEUS_EXPORTER_ENABLED == 'true'
+      config.metrics.prometheusExporterEnabled =
+        process.env.CERAMIC_PROMETHEUS_EXPORTER_ENABLED == 'true'
     if (process.env.CERAMIC_NODE_PRIVATE_SEED_URL)
       config.node.privateSeedUrl = process.env.CERAMIC_NODE_PRIVATE_SEED_URL
     if (process.env.CERAMIC_DISABLE_IPFS_PEER_DATA_SYNC == 'true')

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -426,10 +426,7 @@ export class Dispatcher {
    * @param tip - Commit CID
    */
   publishTip(streamId: StreamID, tip: CID, model?: StreamID): Subscription {
-    if (
-      process.env.CERAMIC_DISABLE_PUBSUB_UPDATES == 'true' ||
-      process.env.CERAMIC_RECON_MODE
-    ) {
+    if (process.env.CERAMIC_DISABLE_PUBSUB_UPDATES == 'true' || process.env.CERAMIC_RECON_MODE) {
       return empty().subscribe()
     }
 

--- a/packages/stream-model-handler/src/__tests__/interfaces-utils.test.ts
+++ b/packages/stream-model-handler/src/__tests__/interfaces-utils.test.ts
@@ -762,6 +762,7 @@ describe('interfaces validation', () => {
       views: {
         bar: { type: 'documentAccount' },
       },
+      immutableFields: ['foo'],
     }
 
     const loadStream = jest.fn(() => ({ content: interfaceModel }))
@@ -779,11 +780,23 @@ describe('interfaces validation', () => {
             type: 'object',
             properties: { foo: { type: 'string' } },
           },
+          immutableFields: [],
         },
         context
       )
     } catch (error) {
       expect(error.errors).toHaveLength(2)
+      const model1Errors = error.errors[0].errors
+      expect(model1Errors).toHaveLength(3)
+      expect(model1Errors[0].toString()).toBe(
+        `Error: Invalid relations implementation of interface ${MODEL_ID_1}`
+      )
+      expect(model1Errors[1].toString()).toBe(
+        `Error: Invalid views implementation of interface ${MODEL_ID_1}`
+      )
+      expect(model1Errors[2].toString()).toBe(
+        `Error: Invalid immutable fields implementation of interface ${MODEL_ID_1}`
+      )
     }
     expect(loadStream).toHaveBeenCalledTimes(2)
 
@@ -805,6 +818,7 @@ describe('interfaces validation', () => {
           views: {
             bar: { type: 'documentAccount' },
           },
+          immutableFields: ['foo'],
         },
         context
       )

--- a/packages/stream-model-handler/src/interfaces-utils.ts
+++ b/packages/stream-model-handler/src/interfaces-utils.ts
@@ -695,15 +695,22 @@ export function isValidImmutabilityImplementation(
   expected: ModelDefinition,
   implemented: ModelDefinition
 ): boolean {
-  if (expected.version === '2.0') {
-    const expectedModelV2 = expected as ModelDefinitionV2
-    const implementedModelV2 = implemented as ModelDefinitionV2
-    // No immutable fields
-    if (!expectedModelV2.immutableFields && !implementedModelV2.immutableFields) return true
-
-    const implementedSet = new Set(implementedModelV2.immutableFields ?? [])
-    return (expectedModelV2.immutableFields ?? []).every((item) => implementedSet.has(item))
-  } else {
+  if (
+    expected.version === '1.0' ||
+    expected.immutableFields == null ||
+    expected.immutableFields.length === 0
+  ) {
+    // No immutable field expected
     return true
   }
+  if (
+    implemented.version === '1.0' ||
+    implemented.immutableFields == null ||
+    implemented.immutableFields.length === 0
+  ) {
+    // No immutable field implemented
+    return false
+  }
+  // Check all expected fields are implemented
+  return expected.immutableFields.every((field) => implemented.immutableFields.includes(field))
 }

--- a/packages/stream-model-handler/src/interfaces-utils.ts
+++ b/packages/stream-model-handler/src/interfaces-utils.ts
@@ -690,11 +690,16 @@ export async function validateImplementedInterfaces(
     throw new AggregateError(errors, `Interfaces validation failed for model ${model.name}`)
   }
 }
-function isValidImmutabilityImplementation(
+
+export function isValidImmutabilityImplementation(
   expected: ModelDefinition,
   implemented: ModelDefinition
 ): boolean {
-  if (implemented.version == '1.0') return true
-  const implementedSet = new Set(implemented.immutableFields)
-  return (expected as ModelDefinitionV2).immutableFields.every((item) => implementedSet.has(item))
+  const expectedModelV2 = expected as ModelDefinitionV2
+  const implementedModelV2 = implemented as ModelDefinitionV2
+  // No immutable fields
+  if (!expectedModelV2.immutableFields && !implementedModelV2.immutableFields) return true
+
+  const implementedSet = new Set(implementedModelV2.immutableFields ?? [])
+  return (expectedModelV2.immutableFields ?? []).every((item) => implementedSet.has(item))
 }

--- a/packages/stream-model-handler/src/interfaces-utils.ts
+++ b/packages/stream-model-handler/src/interfaces-utils.ts
@@ -661,6 +661,9 @@ export function validateInterfaceImplementation(
   if (!isValidViewsImplementation(expected.views, implemented.views)) {
     errors.push(new Error(`Invalid views implementation of interface ${interfaceID}`))
   }
+  if (!isValidImmutabilityImplementation(expected, implemented)) {
+    errors.push(new Error(`Invalid immutable fields implementation of interface ${interfaceID}`))
+  }
 
   if (errors.length) {
     throw new AggregateError(errors, `Invalid implementation of interface ${interfaceID}`)
@@ -686,4 +689,12 @@ export async function validateImplementedInterfaces(
   if (errors.length) {
     throw new AggregateError(errors, `Interfaces validation failed for model ${model.name}`)
   }
+}
+function isValidImmutabilityImplementation(
+  expected: ModelDefinition,
+  implemented: ModelDefinition
+): boolean {
+  if (implemented.version == '1.0') return true
+  const implementedSet = new Set(implemented.immutableFields)
+  return (expected as ModelDefinitionV2).immutableFields.every((item) => implementedSet.has(item))
 }

--- a/packages/stream-model-handler/src/interfaces-utils.ts
+++ b/packages/stream-model-handler/src/interfaces-utils.ts
@@ -695,11 +695,15 @@ export function isValidImmutabilityImplementation(
   expected: ModelDefinition,
   implemented: ModelDefinition
 ): boolean {
-  const expectedModelV2 = expected as ModelDefinitionV2
-  const implementedModelV2 = implemented as ModelDefinitionV2
-  // No immutable fields
-  if (!expectedModelV2.immutableFields && !implementedModelV2.immutableFields) return true
+  if (expected.version === '2.0') {
+    const expectedModelV2 = expected as ModelDefinitionV2
+    const implementedModelV2 = implemented as ModelDefinitionV2
+    // No immutable fields
+    if (!expectedModelV2.immutableFields && !implementedModelV2.immutableFields) return true
 
-  const implementedSet = new Set(implementedModelV2.immutableFields ?? [])
-  return (expectedModelV2.immutableFields ?? []).every((item) => implementedSet.has(item))
+    const implementedSet = new Set(implementedModelV2.immutableFields ?? [])
+    return (expectedModelV2.immutableFields ?? []).every((item) => implementedSet.has(item))
+  } else {
+    return true
+  }
 }


### PR DESCRIPTION
## Description
Currently js-composedb enforces that if an interface being implemented has an immutable fields this constraint should be kept by the implementer. This PR adds the enforcement on the server side.