### PR TITLE
feat: warn-cacao-near-exp

### DIFF
--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -1,6 +1,7 @@
 import cloneDeep from 'lodash.clonedeep'
 import * as uint8arrays from 'uint8arrays'
 import { toCID } from './cid-utils.js'
+import type { DiagnosticsLogger } from '@ceramicnetwork/common'
 import * as dagCBOR from '@ipld/dag-cbor'
 import {
   AnchorCommit,
@@ -354,7 +355,7 @@ export class StreamUtils {
   /**
    * Takes a StreamState and validates that none of the commits in its log are based on expired CACAOs.
    */
-  static checkForCacaoExpiration(state: StreamState): void {
+  static checkForCacaoExpiration(state: StreamState, logger: DiagnosticsLogger): void {
     const now = Math.floor(Date.now() / 1000) // convert millis to seconds
     for (const logEntry of state.log) {
       const timestamp = logEntry.timestamp ?? now
@@ -365,6 +366,12 @@ export class StreamUtils {
           ).toString()} has a CACAO that expired at ${
             logEntry.expirationTime
           }. Loading the stream with 'sync: SyncOptions.ALWAYS_SYNC' will restore the stream to a usable state, by discarding the invalid commits (this means losing the data from those invalid writes!)`
+        )
+      } else if (logEntry.expirationTime && logEntry.expirationTime - timestamp < 12 * 60 * 60) {
+        logger.warn(
+          `CACAO anchored with less then 12 hours left. ${logEntry.cid.toString()} of ${StreamUtils.streamIdFromState(
+            state
+          ).toString()}: anchorTime=${logEntry.timestamp} expirationTime=${logEntry.expirationTime}`
         )
       }
     }

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -301,7 +301,7 @@ export class Repository {
     })
 
     if (checkCacaoExpiration) {
-      StreamUtils.checkForCacaoExpiration(state$.state)
+      StreamUtils.checkForCacaoExpiration(state$.state, this.logger)
     }
 
     if (syncStatus != SyncStatus.ALREADY_SYNCED) {
@@ -485,7 +485,7 @@ export class Repository {
       const stateAtCommit = await this.streamLoader.stateAtCommit(existingState$.state, commitId)
 
       // Since we skipped CACAO expiration checking earlier we need to make sure to do it here.
-      StreamUtils.checkForCacaoExpiration(stateAtCommit)
+      StreamUtils.checkForCacaoExpiration(stateAtCommit, this.logger)
 
       // If the provided CommitID is ahead of what we have in the cache and state store, then we
       // should update them to include it.

--- a/packages/core/src/stream-loading/state-manipulator.ts
+++ b/packages/core/src/stream-loading/state-manipulator.ts
@@ -324,7 +324,7 @@ export class StateManipulator {
     // The initial state may have included commits that were valid previously but have since had
     // their CACAOs expire.  Before returning the state back to the caller we should double-check
     // that it is based all on valid commits without expired CACAOs.
-    StreamUtils.checkForCacaoExpiration(state)
+    StreamUtils.checkForCacaoExpiration(state, this.logger)
 
     return state
   }


### PR DESCRIPTION
log a warning when a cacao is verified with an expiration within 12h of the covering time event.

## Description

Include a summary of the change or link to the issue it addresses.

Include relevant motivation, context, brief description and impact of the change(s). List follow-up tasks here.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Test A (e.g. Test A - New test that ... ran in local, docker, and dev unstable.)
- [ ] Test B

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
