### PR TITLE
feat: turn on cross-node sync test

### DIFF
--- a/packages/common-test-utils/src/index.ts
+++ b/packages/common-test-utils/src/index.ts
@@ -13,6 +13,8 @@ import {
 import first from 'it-first'
 import { BaseTestUtils } from '@ceramicnetwork/base-test-utils'
 
+export const testIfV3 = process.env['CERAMIC_RECON_MODE'] ? test.skip : test
+
 class FakeRunningState extends BehaviorSubject<StreamState> implements RunningStateLike {
   readonly id: StreamID
   readonly state: StreamState

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -893,6 +893,7 @@ export class Repository {
   ): Promise<RunningState> {
     this.anchorService.assertCASAccessible()
 
+    // TODO: WS1-1494 validate genesis commit before storing
     const genesisCid = await this.dispatcher.storeInitEvent(genesis)
     const streamId = new StreamID(type, genesisCid)
     const state$ = await this.load(streamId, opts)


### PR DESCRIPTION
I moved `testIfV3` to common test utils and used it in this test suite because one of the tests in this test suite ACTUALLY cannot work in V'. 

We cannot skip publishing in V'