### PR TITLE
feat: Keep ProcessingLoop full up to the concurrency limit

### DIFF
--- a/packages/core/src/anchor/__tests__/anchor-processing-loop.test.ts
+++ b/packages/core/src/anchor/__tests__/anchor-processing-loop.test.ts
@@ -151,6 +151,8 @@ test('Dont process the same entry multiple times concurrently', async () => {
   // Will regenerate the same entries until they get processed.
   async function* overEntries(): AsyncGenerator<number> {
     do {
+      // Need this sleep or else the Node runtime might never switch back to the "process" function.
+      await CommonTestUtils.delay(1)
       for (const e of entries) yield e
     } while (true)
   }

--- a/packages/core/src/anchor/processing-loop.ts
+++ b/packages/core/src/anchor/processing-loop.ts
@@ -145,7 +145,7 @@ export class ProcessingLoop<T> {
           }
         })
         if (this.#taskQueue.size >= this.#taskQueue.concurrency) {
-          await this.#taskQueue.onIdle() // Wait till we process the batch
+          await this.#taskQueue.onEmpty() // Wait for the queue to have room to take on more tasks
         }
       } while (!isDone)
       await this.#taskQueue.onIdle()

--- a/packages/core/src/ancillary/task-queue.ts
+++ b/packages/core/src/ancillary/task-queue.ts
@@ -90,6 +90,14 @@ export class TaskQueue implements TaskQueueLike {
   }
 
   /**
+   * Returns a Promise that resolves when the underlying PQueue is empty. This means it has no more
+   * tasks waiting to start, though there may still be up to `concurrency` tasks still running.
+   */
+  onEmpty(): Promise<void> {
+    return this.#pq.onEmpty()
+  }
+
+  /**
    * Clear the queue.
    */
   clear() {


### PR DESCRIPTION
https://github.com/ceramicnetwork/js-ceramic/pull/3163 was a really nice code cleanup, and addressed the issue of the multiple tasks being generated and run concurrently for the same logical unit of work.  It however brought back a slight performance regression by returning us to the behavior of processing work in batches, waiting for every task in the batch to finish before starting on the next task.  This PR returns us to the behavior of always keeping ourselves busy with up to the concurrency limit number of tasks running at once, and as soon as one task finishes letting the next one in immediately.