### PR TITLE
fix(indexing): don't index empty deterministic streams

### DIFF
--- a/packages/indexing/src/__tests__/database-index-api.test.ts
+++ b/packages/indexing/src/__tests__/database-index-api.test.ts
@@ -793,9 +793,7 @@ describe('postgres', () => {
     test('new stream with null content', async () => {
       await indexApi.indexStream({ ...STREAM_CONTENT_A, streamContent: null })
       const result: Array<any> = await dbConnection.from(`${MODELS_TO_INDEX[0]}`).select('*')
-      expect(result.length).toEqual(1)
-      const raw = result[0]
-      expect(raw.stream_content).toEqual({})
+      expect(result.length).toEqual(0)
     })
 
     test('override stream', async () => {
@@ -1653,9 +1651,7 @@ describe('sqlite', () => {
     test('new stream with null content', async () => {
       await indexApi.indexStream({ ...STREAM_CONTENT, streamContent: null })
       const result: Array<any> = await dbConnection.from(`${MODELS_TO_INDEX[0]}`).select('*')
-      expect(result.length).toEqual(1)
-      const raw = result[0]
-      expect(raw.stream_content).toEqual('{}')
+      expect(result.length).toEqual(0)
     })
 
     test('override stream', async () => {

--- a/packages/indexing/src/database-index-api.ts
+++ b/packages/indexing/src/database-index-api.ts
@@ -216,15 +216,15 @@ export abstract class DatabaseIndexApi<DateType = Date | number> {
   async indexStream(
     indexingArgs: IndexStreamArgs & { createdAt?: Date; updatedAt?: Date }
   ): Promise<void> {
-    if (indexingArgs.streamContent == null) {
-      // Don't index streams with no content (deterministic streams created from genesis)
-      return
-    }
     const tableName = asTableName(indexingArgs.model)
     if (indexingArgs.shouldIndex === false) {
       await this.dbConnection(tableName)
         .where('stream_id', indexingArgs.streamID.toString())
         .delete()
+      return
+    }
+    if (indexingArgs.streamContent == null) {
+      // Don't index streams with no content (deterministic streams created from genesis)
       return
     }
     const indexedData = this.getIndexedData(indexingArgs) as Record<string, unknown>

--- a/packages/indexing/src/database-index-api.ts
+++ b/packages/indexing/src/database-index-api.ts
@@ -216,6 +216,10 @@ export abstract class DatabaseIndexApi<DateType = Date | number> {
   async indexStream(
     indexingArgs: IndexStreamArgs & { createdAt?: Date; updatedAt?: Date }
   ): Promise<void> {
+    if (indexingArgs.streamContent == null) {
+      // Don't index streams with no content (deterministic streams created from genesis)
+      return
+    }
     const tableName = asTableName(indexingArgs.model)
     if (indexingArgs.shouldIndex === false) {
       await this.dbConnection(tableName)

--- a/packages/stream-tests/src/__tests__/deterministic-indexing.test.ts
+++ b/packages/stream-tests/src/__tests__/deterministic-indexing.test.ts
@@ -1,0 +1,110 @@
+import { jest } from '@jest/globals'
+import type { BaseQuery, IpfsApi } from '@ceramicnetwork/common'
+import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
+import {
+  ModelInstanceDocument,
+  type ModelInstanceDocumentMetadataArgs,
+} from '@ceramicnetwork/stream-model-instance'
+import { createCeramic } from '../create-ceramic.js'
+import { Ceramic } from '@ceramicnetwork/core'
+import { Model, ModelDefinition } from '@ceramicnetwork/stream-model'
+
+const MODEL_DEFINITION_SET: ModelDefinition = {
+  name: 'MyModel',
+  version: '2.0',
+  interface: false,
+  implements: [],
+  accountRelation: { type: 'set', fields: ['unique'] },
+  schema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      unique: {
+        type: 'string',
+        minLength: 3,
+      },
+      other: {
+        type: 'string',
+        minLength: 3,
+      },
+    },
+    required: ['unique'],
+  },
+}
+
+type SetContent = { unique: string; other?: string }
+
+describe('Deterministic ModelInstanceDocument indexing', () => {
+  jest.setTimeout(1000 * 30)
+
+  let ipfs: IpfsApi
+  let ceramic: Ceramic
+  let model: Model
+  let midMetadata: ModelInstanceDocumentMetadataArgs
+
+  beforeAll(async () => {
+    ipfs = await createIPFS()
+  }, 12000)
+
+  beforeEach(async () => {
+    ceramic = await createCeramic(ipfs)
+    model = await Model.create(ceramic, MODEL_DEFINITION_SET)
+    await ceramic.admin.startIndexingModels([model.id])
+    midMetadata = { model: model.id }
+  }, 12000)
+
+  afterEach(async () => {
+    await ceramic.close()
+  })
+
+  afterAll(async () => {
+    await ipfs.stop()
+  })
+
+  async function count(query: Partial<BaseQuery> = {}): Promise<number> {
+    return await ceramic.index.count({ models: [model.id], ...query })
+  }
+
+  async function loadContent(unique: string): Promise<ModelInstanceDocument<SetContent | null>> {
+    return await ModelInstanceDocument.set<SetContent>(ceramic, midMetadata, [unique])
+  }
+
+  async function setContent(content: SetContent): Promise<ModelInstanceDocument<SetContent>> {
+    const doc = await ModelInstanceDocument.set<SetContent>(ceramic, midMetadata, [content.unique])
+    await doc.replace(content)
+    return doc
+  }
+
+  test('looking up documents should not add them to the index', async () => {
+    await expect(count()).resolves.toBe(0)
+    // Loading streams should not cause them to get indexed
+    await Promise.all([loadContent('one'), loadContent('two')])
+    await expect(count()).resolves.toBe(0)
+    // Setting the stream content should cause it to get indexed
+    await setContent({ unique: 'one' })
+    await expect(count()).resolves.toBe(1)
+  })
+
+  test('index queries should filter as expected', async () => {
+    const docs = await Promise.all([
+      setContent({ unique: 'one', other: 'test' }),
+      setContent({ unique: 'two', other: 'hello' }),
+      setContent({ unique: 'three' }),
+      setContent({ unique: 'four', other: 'test' }),
+      setContent({ unique: 'five', other: 'hello' }),
+      setContent({ unique: 'six', other: 'hello' }),
+      setContent({ unique: 'seven' }),
+      setContent({ unique: 'height', other: 'hello' }),
+      setContent({ unique: 'nine', other: 'goodbye' }),
+      setContent({ unique: 'ten', other: 'goodbye' }),
+    ])
+    await expect(count()).resolves.toBe(10)
+
+    const filterHello = { where: { other: { equalTo: 'hello' } } }
+    await expect(count({ queryFilters: filterHello })).resolves.toBe(4)
+    await Promise.all([docs[1].shouldIndex(false), docs[4].shouldIndex(false)])
+    // Unindexed streams should not be returned
+    await expect(count({ queryFilters: filterHello })).resolves.toBe(2)
+  })
+})


### PR DESCRIPTION
Simply looking up a deterministic stream causes it to be indexed, which causes the indexer queries to return results with empty contents that don't match the expected behavior.
This PR updates the logic to ignore streams with no content when indexing.