### PR TITLE
chore: enable linting of commit messages

### DIFF
--- a/.github/workflows/pr-semantic-message.yml
+++ b/.github/workflows/pr-semantic-message.yml
@@ -1,0 +1,15 @@
+---
+name: "Conventional PR and Commit Messages"
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+jobs:
+  semantic:
+    uses: influxdata/validate-semantic-github-messages/.github/workflows/semantic.yml@main
+    with:
+      # When true:
+      #   If there is one commit, only validate its commit message (and not the PR title).
+      #   Else validate PR title only (and skip commit messages).
+      CHECK_PR_TITLE_OR_ONE_COMMIT: true


### PR DESCRIPTION
The PR title or single commit message will be linted against conventional commit message standard. If you have multiple commits in a PR only the PR title will be linted.
