### PR TITLE
feat: Update ajv-threads package to version with worker pool

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,7 +71,7 @@
     "@stablelib/random": "^1.0.1",
     "@stablelib/sha256": "^1.0.1",
     "@stablelib/uuid": "^1.0.1",
-    "ajv-threads": "^1.0.3",
+    "ajv-threads": "^1.0.4",
     "await-semaphore": "^0.1.3",
     "cartonne": "^3.0.1",
     "codeco": "^1.1.0",

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -247,7 +247,7 @@ export class Ceramic implements StreamReaderWriter, StreamStateLoader {
     const numCores = os.cpus().length
     // Use number of threads equal to half the available cores for schema validation. Leave the
     // other half for signature validation.
-    this._schemaValidator = new SchemaValidation(Math.floor(numCores / 2))
+    this._schemaValidator = new SchemaValidation(Math.max(1, Math.ceil(numCores / 2)))
     this._streamHandlers = HandlersMap.makeWithDefaultHandlers(this._logger, this._schemaValidator)
 
     // This initialization block below has to be redone.
@@ -487,6 +487,7 @@ export class Ceramic implements StreamReaderWriter, StreamStateLoader {
         this._logger.warn(`Starting in read-only mode. All write operations will fail`)
       }
 
+      await this._schemaValidator.init()
       await this.repository.init()
       await this.dispatcher.init()
 

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -244,7 +244,10 @@ export class Ceramic implements StreamReaderWriter, StreamStateLoader {
 
     this._ipfs = modules.ipfs
 
-    this._schemaValidator = new SchemaValidation()
+    const numCores = os.cpus().length
+    // Use number of threads equal to half the available cores for schema validation. Leave the
+    // other half for signature validation.
+    this._schemaValidator = new SchemaValidation(Math.floor(numCores / 2))
     this._streamHandlers = HandlersMap.makeWithDefaultHandlers(this._logger, this._schemaValidator)
 
     // This initialization block below has to be redone.

--- a/packages/core/src/stream-loading/__tests__/state-manipulator.test.ts
+++ b/packages/core/src/stream-loading/__tests__/state-manipulator.test.ts
@@ -62,7 +62,8 @@ describeIfV3('StateManipulator test', () => {
     const logger = new LoggerProvider().getDiagnosticsLogger()
     logSyncer = new LogSyncer(dispatcher)
 
-    schemaValidator = new SchemaValidation()
+    schemaValidator = new SchemaValidation(1)
+    await schemaValidator.init()
     const handlers = HandlersMap.makeWithDefaultHandlers(logger, schemaValidator)
     stateManipulator = new StateManipulator(logger, handlers, logSyncer, ceramic)
 

--- a/packages/core/src/stream-loading/__tests__/stream-loader.test.ts
+++ b/packages/core/src/stream-loading/__tests__/stream-loader.test.ts
@@ -85,7 +85,8 @@ describeIfV3('Streamloader', () => {
         ceramic.anchorService.validator
       )
 
-      schemaValidator = new SchemaValidation()
+      schemaValidator = new SchemaValidation(1)
+      await schemaValidator.init()
       const handlers = HandlersMap.makeWithDefaultHandlers(logger, schemaValidator)
       const stateManipulator = new StateManipulator(logger, handlers, logSyncer, ceramic)
       streamLoader = new StreamLoader(

--- a/packages/stream-model-instance-handler/package.json
+++ b/packages/stream-model-instance-handler/package.json
@@ -42,7 +42,7 @@
     "@ceramicnetwork/stream-handler-common": "^4.1.0",
     "@ceramicnetwork/stream-model-instance": "^4.2.0",
     "@ceramicnetwork/streamid": "^5.0.0",
-    "ajv-threads": "^1.0.3",
+    "ajv-threads": "^1.0.4",
     "fast-json-patch": "^3.1.0",
     "least-recent": "^1.0.3",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -423,7 +423,8 @@ describe('ModelInstanceDocumentHandler', () => {
   let ipfs: IpfsApi
 
   beforeAll(async () => {
-    schemaValidator = new SchemaValidation()
+    schemaValidator = new SchemaValidation(1)
+    await schemaValidator.init()
     const recs: Record<string, any> = {}
     ipfs = {
       dag: {


### PR DESCRIPTION
This will make js-ceramic actually use multiple worker threads for schema validation.  When this merges is when we should be able to observe real improvements to js-ceramic throughput.