### PR TITLE
fix: make convertCommitToSignedCommitContainer use offline mode

### DIFF
--- a/packages/common/src/utils/stream-utils.ts
+++ b/packages/common/src/utils/stream-utils.ts
@@ -280,7 +280,10 @@ export class StreamUtils {
     ipfs: IpfsApi
   ): Promise<CeramicCommit> {
     if (StreamUtils.isSignedCommit(commit)) {
-      const block = await ipfs.block.get(toCID((commit as DagJWS).link))
+      const block = await ipfs.block.get(toCID((commit as DagJWS).link), {
+        // @ts-ignore
+        offline: process.env.CERAMIC_RECON_MODE == 'true',
+      })
       return {
         jws: commit as DagJWS,
         linkedBlock: block,


### PR DESCRIPTION
The code paths needed for creating a new composedb model called the convertCommitToSignedCommitContainer function. However the function would always use online mode and fails in Recon mode. We should not need online mode as the commits will have just been stored locally. This changes the code to use offline mode when in recon mode.

## How Has This Been Tested?

Created a model using the composedb CLI, prior to this change it errors. With this change it no longer errors.
