### PR TITLE
feat: dont log depth in anchor-utils, just return it

### DIFF
--- a/packages/anchor-utils/src/merkle/merkle-tree-factory.ts
+++ b/packages/anchor-utils/src/merkle/merkle-tree-factory.ts
@@ -73,9 +73,8 @@ export class MerkleTreeFactory<TData, TLeaf extends TData, TMetadata>
     const root = await this.buildLevel(nodes, 0, metadata)
 
     const depth = this.getTreeDepth(root)
-    console.log(`Merkle tree generated with depth: ${depth}`)
 
-    return new MerkleTree<TData, TLeaf, TMetadata>(this.mergeFn, root, nodes, metadata)
+    return new MerkleTree<TData, TLeaf, TMetadata>(this.mergeFn, root, nodes, metadata, depth)
   }
 
   private getTreeDepth(node: Node<TData>): number {

--- a/packages/anchor-utils/src/merkle/merkle-tree.ts
+++ b/packages/anchor-utils/src/merkle/merkle-tree.ts
@@ -74,7 +74,11 @@ export class MerkleTree<TData, TLeaf extends TData, TMetadata>
     /**
      * Tree metadata
      */
-    readonly metadata: TMetadata | null
+    readonly metadata: TMetadata | null,
+    /**
+     * Tree depth
+     */
+    readonly depth: number
   ) {}
 
   /**


### PR DESCRIPTION
Instead of logging the depth in the library, return it so the caller can log or make a metric.