### PR TITLE
feat: update how we check immutability

### DIFF
--- a/packages/stream-model-instance-handler/src/__tests__/__snapshots__/model-instance-document-handler.test.ts.snap
+++ b/packages/stream-model-instance-handler/src/__tests__/__snapshots__/model-instance-document-handler.test.ts.snap
@@ -6,6 +6,7 @@ exports[`ModelInstanceDocumentHandler MIDs with SET account relation validate si
   "content": {
     "myData": 2,
     "one": "foo",
+    "three": "three",
     "two": "bar",
   },
   "log": [

--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -850,7 +850,7 @@ describe('ModelInstanceDocumentHandler', () => {
     expect(state).toMatchSnapshot()
   })
 
-  it('MIDs with SET account relation validate signed commit fields', async () => {
+  it.only('MIDs with SET account relation validate signed commit fields', async () => {
     const genesisCommit = (await ModelInstanceDocument.makeGenesis(
       context.signer,
       null,
@@ -890,12 +890,12 @@ describe('ModelInstanceDocumentHandler', () => {
     await expect(handler.applyCommit(signedCommitDataFail, context, state)).rejects.toThrow(
       'Unique content fields value does not match metadata. If you are trying to change the value of these fields, this is causing this error: these fields values are not mutable.'
     )
-
+    console.log('voy')
     const signedCommitOK = (await ModelInstanceDocument.makeUpdateCommit(
       context.signer,
       doc.commitId,
       doc.content,
-      { one: 'foo', two: 'bar', myData: 2 }
+      { one: 'foo', two: 'bar', three: 'three', myData: 2 }
     )) as SignedCommitContainer
     await ipfs.dag.put(signedCommitOK, FAKE_CID_3)
 
@@ -917,7 +917,7 @@ describe('ModelInstanceDocumentHandler', () => {
       context.signer,
       null,
       { ...DETERMINISTIC_METADATA, model: FAKE_MODEL_SET_ID },
-      ['a', 'b', 'c']
+      ['a', 'b']
     )) as GenesisCommit
     await ipfs.dag.put(genesisCommit, FAKE_CID_1)
 

--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -890,7 +890,7 @@ describe('ModelInstanceDocumentHandler', () => {
     await expect(handler.applyCommit(signedCommitDataFail, context, state)).rejects.toThrow(
       'Unique content fields value does not match metadata. If you are trying to change the value of these fields, this is causing this error: these fields values are not mutable.'
     )
-    console.log('voy')
+
     const signedCommitOK = (await ModelInstanceDocument.makeUpdateCommit(
       context.signer,
       doc.commitId,

--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -189,6 +189,7 @@ const MODEL_DEFINITION_SET: ModelDefinition = {
     properties: {
       one: { type: 'string', minLength: 2 },
       two: { type: 'string', minLength: 2 },
+      three: { type: 'string', minLength: 2 },
       myData: {
         type: 'integer',
         maximum: 100,
@@ -197,6 +198,7 @@ const MODEL_DEFINITION_SET: ModelDefinition = {
     },
     required: ['myData'],
   },
+  immutableFields: ['three'],
 }
 
 const MODEL_DEFINITION_BLOB: ModelDefinition = {
@@ -915,7 +917,7 @@ describe('ModelInstanceDocumentHandler', () => {
       context.signer,
       null,
       { ...DETERMINISTIC_METADATA, model: FAKE_MODEL_SET_ID },
-      ['a', 'b']
+      ['a', 'b', 'c']
     )) as GenesisCommit
     await ipfs.dag.put(genesisCommit, FAKE_CID_1)
 
@@ -926,7 +928,7 @@ describe('ModelInstanceDocumentHandler', () => {
       commit: genesisCommit,
     }
 
-    // The deterministic genesis creation works independently of content validation as determinitic commits have no content
+    // The deterministic genesis creation works independently of content validation as deterministic commits have no content
     const state = await handler.applyCommit(genesisCommitData, context)
     const state$ = TestUtils.runningState(state)
     const doc = new ModelInstanceDocument(state$, context)

--- a/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
+++ b/packages/stream-model-instance-handler/src/__tests__/model-instance-document-handler.test.ts
@@ -850,7 +850,7 @@ describe('ModelInstanceDocumentHandler', () => {
     expect(state).toMatchSnapshot()
   })
 
-  it.only('MIDs with SET account relation validate signed commit fields', async () => {
+  it('MIDs with SET account relation validate signed commit fields', async () => {
     const genesisCommit = (await ModelInstanceDocument.makeGenesis(
       context.signer,
       null,

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -197,9 +197,16 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     const newContent = jsonpatch.applyPatch(oldContent, payload.data, undefined, false).newDocument
     const modelStream = await context.loadStream<Model>(metadata.model)
     const isSetType = modelStream.content.accountRelation.type === 'set'
-    const isFirstDataCommit = !state.log.some(c => c.type === EventType.DATA)
+    const isFirstDataCommit = !state.log.some((c) => c.type === EventType.DATA)
 
-    await this._validateContent(context, modelStream, newContent, false, payload, isSetType && isFirstDataCommit)
+    await this._validateContent(
+      context,
+      modelStream,
+      newContent,
+      false,
+      payload,
+      isSetType && isFirstDataCommit
+    )
     await this._validateUnique(
       modelStream,
       metadata as unknown as ModelInstanceDocumentMetadata,
@@ -361,10 +368,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
   /**
    *  Helper function to validate if immutable fields are being mutated
    */
-  async _validateLockedFieldsUpdate(
-    model: Model,
-    payload: Payload
-  ): Promise<void> {
+  async _validateLockedFieldsUpdate(model: Model, payload: Payload): Promise<void> {
     if (!ModelDefinitionV2.is(model.content)) return
     const immutableFields = model.content.immutableFields
     const hasImmutableFields = immutableFields && immutableFields.length > 0

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -24,7 +24,6 @@ import { SchemaValidation } from './schema-utils.js'
 import { Model, ModelDefinitionV2 } from '@ceramicnetwork/stream-model'
 import { applyAnchorCommit } from '@ceramicnetwork/stream-handler-common'
 import { toString } from 'uint8arrays'
-import _ from 'lodash'
 
 // Hardcoding the model streamtype id to avoid introducing a dependency on the stream-model package
 const MODEL_STREAM_TYPE_ID = 2

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -269,7 +269,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
 
     // Now validate the relations
     await this._validateRelationsContent(ceramic, model, content)
-    if (!genesis && payload) {
+    if (!genesis && payload && Object.keys(oldContent).length > 0) {
       await this._validateLockedFieldsUpdate(model, payload, oldContent)
     }
   }
@@ -366,7 +366,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     if (!ModelDefinitionV2.is(model.content)) return
     const immutableFields = model.content.immutableFields
     const hasImmutableFields = immutableFields && immutableFields.length > 0
-    if (!hasImmutableFields || Object.keys(oldContent).length === 0) return
+    if (!hasImmutableFields) return
 
     const newContent = jsonpatch.applyPatch(
       oldContent,

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -251,7 +251,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
    * @param model - The model that this ModelInstanceDocument belongs to
    * @param content - Content to validate
    * @param genesis - Whether the commit being applied is a genesis commit
-   * @param enforceImmutableFields - Whether the incoming commit is the first data commit for a model with deterministic creation (Optional)
+   * @param skipImmutableFieldsCheck - Whether the incoming commit is the first data commit for a model with deterministic creation (Optional)
    * @private
    */
   async _validateContent(
@@ -260,7 +260,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     content: any,
     genesis: boolean,
     payload?: Payload,
-    enforceImmutableFields?: boolean
+    skipImmutableFieldsCheck?: boolean
   ): Promise<void> {
     if (
       genesis &&
@@ -281,7 +281,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
 
     // Now validate the relations
     await this._validateRelationsContent(ceramic, model, content)
-    if (!genesis && payload && !enforceImmutableFields) {
+    if (!genesis && payload && !skipImmutableFieldsCheck) {
       await this._validateLockedFieldsUpdate(model, payload)
     }
   }

--- a/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
+++ b/packages/stream-model-instance-handler/src/model-instance-document-handler.ts
@@ -366,7 +366,7 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
     if (!ModelDefinitionV2.is(model.content)) return
     const immutableFields = model.content.immutableFields
     const hasImmutableFields = immutableFields && immutableFields.length > 0
-    if (!hasImmutableFields) return
+    if (!hasImmutableFields || Object.keys(oldContent).length === 0) return
 
     const newContent = jsonpatch.applyPatch(
       oldContent,
@@ -374,10 +374,10 @@ export class ModelInstanceDocumentHandler implements StreamHandler<ModelInstance
       undefined,
       false
     ).newDocument
+
     for (const lockedField of immutableFields) {
       const mutated =
         JSON.stringify(newContent[lockedField]) !== JSON.stringify(oldContent[lockedField])
-
       if (mutated) {
         throw new Error(`Immutable field "${lockedField}" cannot be updated`)
       }


### PR DESCRIPTION
## Description
We used the payload data to determine if an immutable field was being altered, but this caused 2 problems:
- Not optimal developer experience when running a mutation including an immutable field but not mutating it.
- Databases built on top of js-ceramic using an `upsert` command will always throw if creating a new record for a model with an immutable field. e.g. ComposeDB