### PR TITLE
feat: metrics for counting state of cas requests

### DIFF
--- a/packages/core/src/anchor/ethereum/remote-cas.ts
+++ b/packages/core/src/anchor/ethereum/remote-cas.ts
@@ -29,7 +29,7 @@ function parseResponse(streamId: StreamID, tip: CID, json: unknown): AnchorEvent
   }
   const parsed = validation.right
   if (ErrorResponse.is(parsed)) {
-    Metrics.count('cas_request_failed', 1, )
+    Metrics.count('cas_request_failed', 1)
     return {
       status: AnchorRequestStatusName.FAILED,
       streamId: streamId,

--- a/packages/core/src/anchor/ethereum/remote-cas.ts
+++ b/packages/core/src/anchor/ethereum/remote-cas.ts
@@ -38,7 +38,7 @@ function parseResponse(streamId: StreamID, tip: CID, json: unknown): AnchorEvent
     }
   } else {
     if (parsed.status === AnchorRequestStatusName.COMPLETED) {
-      Metrics.count('cas_request_success', 1)
+      Metrics.count('cas_request_completed', 1)
       return {
         status: parsed.status,
         streamId: parsed.streamId,
@@ -46,9 +46,6 @@ function parseResponse(streamId: StreamID, tip: CID, json: unknown): AnchorEvent
         message: parsed.message,
         witnessCar: parsed.witnessCar,
       }
-    }
-    if (parsed.status === AnchorRequestStatusName.PENDING) {
-      Metrics.count('cas_request_pending', 1)
     }
     return {
       status: parsed.status,


### PR DESCRIPTION
## Description

We need metrics for keeping track of how many streams have been anchored/errored or are in pending state. This is done in order to track performance of anchoring. 

## How Has This Been Tested?

Tested locally by creating a ceramic node with config where prometheus exporter was turned on.

- [x] Created streams and checked if the metrics were being reported accurately on url http://localhost:9464/metrics : Result : # HELP js_ceramic_cas_request_success_total description missing
# TYPE js_ceramic_cas_request_success_total counter
js_ceramic_cas_request_success_total 7513

## PR checklist

Before submitting this PR, please make sure:

- [Yes ] I have tagged the relevant reviewers and interested parties
- [ Not needed] I have updated the READMEs of affected packages
- [Not needed ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
