### PR TITLE
test pinning http-request-mock to 1.8.17

### DIFF
--- a/packages/3id-did-resolver/package.json
+++ b/packages/3id-did-resolver/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@ceramicnetwork/http-client": "^5.6.0-rc.0",
     "did-resolver": "^4.0.1",
-    "http-request-mock": "^1.8.17"
+    "http-request-mock": "^1.8.18"
   },
   "gitHead": "56e646e82ee6e9cdb0b762bbbf77b8432edce367"
 }

--- a/packages/blockchain-utils-validation/package.json
+++ b/packages/blockchain-utils-validation/package.json
@@ -64,7 +64,7 @@
     "@taquito/signer": "^11.2.0",
     "eth-sig-util": "^3.0.1",
     "ganache-core": "^2.13.2",
-    "http-request-mock": "^1.8.17",
+    "http-request-mock": "^1.8.18",
     "near-api-js": "^0.44.2"
   },
   "gitHead": "56e646e82ee6e9cdb0b762bbbf77b8432edce367"

--- a/packages/pinning-crust-backend/package.json
+++ b/packages/pinning-crust-backend/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@ceramicnetwork/common": "^5.5.0-rc.0",
-    "http-request-mock": "^1.8.17",
+    "http-request-mock": "^1.8.18",
     "multiformats": "^13.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
Just testing as a backup if this affects failing tests (may not be a good test if we are also downgrading node at same time)