### PR TITLE
chore: pin node.js version in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
           name: Install rust-ceramic
           command: sudo bash ci-scripts/install-rust-ceramic.sh
       - node/install:
-          node-version: '20'
+          node-version: '20.11.1'
       - node/install-packages
       - run: npm run build
       - run: npm run lint


### PR DESCRIPTION
This PR pins the version of Node.js used for running unit tests in CircleCI to the last version that worked (`20.11.1`). A newer version of Node.js (`20.12.0`) is causing (currently) unexplained errors such as the following:
```
> @ceramicnetwork/stream-model-instance@4.5.0-rc.0 test
> exit 0

 PASS  src/__tests__/tezos.test.ts
 FAIL  src/__tests__/near.test.ts
  ● Test suite failed to run

    TypeError: Cannot assign to read only property 'fetch' of object '[object global]'

      at Object.<anonymous> (../../node_modules/near-api-js/lib/connect.js:35:14)
      at Object.<anonymous> (../../node_modules/near-api-js/lib/index.js:28:14)


ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/__tests__/near.test.ts.
```