### PR TITLE
chore: make TestUtils.waitForConditionOrTimeout throw on failure

### DIFF
--- a/packages/base-test-utils/src/__tests__/index.test.ts
+++ b/packages/base-test-utils/src/__tests__/index.test.ts
@@ -1,7 +1,29 @@
-import { BaseTestUtils } from '../index.ts'
+import { BaseTestUtils } from '../index.js'
 
 describe('BaseTestUtils', () => {
   it('should generate a random CID', () => {
     expect(BaseTestUtils.randomCID().version).toEqual(1)
+  })
+})
+
+describe('waitForConditionOrTimeout errmsg generation', () => {
+  const failPredicate = () => Promise.resolve(false)
+
+  it('default errmsg', async () => {
+    await expect(BaseTestUtils.waitForConditionOrTimeout(failPredicate, 1)).rejects.toThrow(
+      'timed out after 1ms waiting for condition to be true'
+    )
+  })
+
+  it('specific errmsg', async () => {
+    await expect(
+      BaseTestUtils.waitForConditionOrTimeout(failPredicate, 1, 'custom errmsg')
+    ).rejects.toThrow('timed out after 1ms waiting for condition to be true: custom errmsg')
+  })
+
+  it('generated errmsg', async () => {
+    await expect(
+      BaseTestUtils.waitForConditionOrTimeout(failPredicate, 1, () => 'generated errmsg')
+    ).rejects.toThrow('timed out after 1ms waiting for condition to be true: generated errmsg')
   })
 })

--- a/packages/common-test-utils/src/index.ts
+++ b/packages/common-test-utils/src/index.ts
@@ -32,11 +32,15 @@ export class CommonTestUtils {
     return BaseTestUtils.randomCID(version, codec, hasher)
   }
 
+  /**
+   * See comments for BaseTestUtils.waitForConditionOrTimeout
+   */
   static async waitForConditionOrTimeout(
     predicate: () => Promise<boolean>,
-    timeoutMs = 1000 * 30
-  ): Promise<boolean> {
-    return BaseTestUtils.waitForConditionOrTimeout(predicate, timeoutMs)
+    timeoutMs = 1000 * 30,
+    errMsgGenerator?: string | (() => string)
+  ): Promise<void> {
+    return BaseTestUtils.waitForConditionOrTimeout(predicate, timeoutMs, errMsgGenerator)
   }
 
   static async delay(ms: number, signal?: AbortSignal): Promise<void> {

--- a/packages/stream-tests/src/__tests__/history-sync.test.ts
+++ b/packages/stream-tests/src/__tests__/history-sync.test.ts
@@ -204,7 +204,7 @@ const extractDocuments = (
 const waitForMidsToBeIndexed = async (
   ceramic: Ceramic,
   docs: ModelInstanceDocument[]
-): Promise<boolean> => {
+): Promise<void> => {
   // TODO: Once we support subscriptions, use a subscription to wait for the stream to show up
   // in the index, instead of this polling-based approach.
   return TestUtils.waitForConditionOrTimeout(async () => {
@@ -400,8 +400,7 @@ describeIfV3('Sync tests', () => {
 
     await provider.mineBlocks([merkleTree1.root, merkleTree2.root, merkleTree3.root])
 
-    const success = await waitForMidsToBeIndexed(syncingCeramic, [mid, mid2, mid3])
-    expect(success).toEqual(true)
+    await waitForMidsToBeIndexed(syncingCeramic, [mid, mid2, mid3])
   })
 
   test('Can perform sync for the first time starting from the model`s anchored block', async () => {
@@ -435,8 +434,7 @@ describeIfV3('Sync tests', () => {
 
     await syncingCeramic.admin.startIndexingModels([MODEL_STREAM_ID])
 
-    const success = await waitForMidsToBeIndexed(syncingCeramic, [mid, mid2])
-    expect(success).toEqual(true)
+    await waitForMidsToBeIndexed(syncingCeramic, [mid, mid2])
 
     const jobData = addSyncJobSpy.mock.calls[0][1] as any
     expect(jobData.fromBlock).toBeGreaterThan(DEFAULT_START_BLOCK)
@@ -471,8 +469,7 @@ describeIfV3('Sync tests', () => {
 
     await syncingCeramic.admin.startIndexingModels([MODEL_STREAM_ID])
 
-    const success = await waitForMidsToBeIndexed(syncingCeramic, [mid, mid2])
-    expect(success).toEqual(true)
+    await waitForMidsToBeIndexed(syncingCeramic, [mid, mid2])
 
     const jobData = addSyncJobSpy.mock.calls[0][1] as any
     expect(jobData.fromBlock).toEqual(DEFAULT_START_BLOCK)
@@ -498,7 +495,6 @@ describeIfV3('Sync tests', () => {
 
     syncingCeramic = await createSyncingCeramic()
     await syncingCeramic.admin.startIndexingModels([MODEL_STREAM_ID])
-    const success = await waitForMidsToBeIndexed(syncingCeramic, [mid])
-    expect(success).toEqual(true)
+    await waitForMidsToBeIndexed(syncingCeramic, [mid])
   })
 })


### PR DESCRIPTION
Currently it returns false if it fails, which is error prone as it means the test author needs to remember to check the return value or re-check the condition after calling it.  Making it throw on error makes the behavior more obvious and harder to mis-use, at the cost of possibly getting less useful error messages in some cases.