### PR TITLE
wip: fix: enable offline mode when fetching blocks while anchoring

### DIFF
--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -207,7 +207,7 @@ export class Dispatcher {
       Metrics.count(IPFS_CACHE_MISS, 1)
       const bytes = await this._shutdownSignal.abortable((signal) => {
         // @ts-expect-error
-        return this._ipfs.block.get(cid, { signal, offline: !this.enableSync })
+        return this._ipfs.block.get(cid, { signal, offline: !this.enableSync || this.recon.enabled})
       })
       this.ipldCache.setBlock(cid, bytes)
       return new CarBlock(cid, bytes)


### PR DESCRIPTION
## Description

Anchoring we do blockGet which uses IPFS in online mode. With recon enabled we should maybe move this to offline mode
IPFS 
