### PR TITLE
Added WebAuthN support to SignatureUtils for Passkey support

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -46,6 +46,7 @@
     "@ceramicnetwork/observability": "^1.4.4",
     "@ceramicnetwork/streamid": "^5.0.0",
     "@didtools/cacao": "^3.0.0",
+    "@didtools/key-webauthn": "^2.0.1",
     "@didtools/pkh-ethereum": "^0.2.0",
     "@didtools/pkh-solana": "^0.2.0",
     "@didtools/pkh-stacks": "^0.2.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -46,7 +46,7 @@
     "@ceramicnetwork/observability": "^1.4.4",
     "@ceramicnetwork/streamid": "^5.0.0",
     "@didtools/cacao": "^3.0.0",
-    "@didtools/key-webauthn": "^2.0.1",
+    "@didtools/key-webauthn": "^2.0.2",
     "@didtools/pkh-ethereum": "^0.2.0",
     "@didtools/pkh-solana": "^0.2.0",
     "@didtools/pkh-stacks": "^0.2.0",

--- a/packages/common/src/utils/signature_utils.ts
+++ b/packages/common/src/utils/signature_utils.ts
@@ -5,6 +5,8 @@ import { getEIP191Verifier } from '@didtools/pkh-ethereum'
 import { getSolanaVerifier } from '@didtools/pkh-solana'
 import { getStacksVerifier } from '@didtools/pkh-stacks'
 import { getTezosVerifier } from '@didtools/pkh-tezos'
+import { WebauthnAuth } from '@didtools/key-webauthn'
+
 import { CeramicSigner } from '../ceramic-signer.js'
 import { StreamUtils } from './stream-utils.js'
 import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
@@ -19,6 +21,8 @@ const verifiersCACAO = {
   ...getSolanaVerifier(),
   ...getStacksVerifier(),
   ...getTezosVerifier(),
+  ...WebauthnAuth.getVerifier(),
+  // Add Webauthn verifier
 }
 
 /**

--- a/packages/common/src/utils/signature_utils.ts
+++ b/packages/common/src/utils/signature_utils.ts
@@ -22,7 +22,6 @@ const verifiersCACAO = {
   ...getStacksVerifier(),
   ...getTezosVerifier(),
   ...WebauthnAuth.getVerifier(),
-  // Add Webauthn verifier
 }
 
 /**


### PR DESCRIPTION
## Description

This work was requested as an improvement from the Ceramic developers (Joel Thorstensson) in conjunction with Snickerdoodle Labs. It adds WebAuthN support for DID verification, which will enable Passkey support for DIDs. It just adds the Ceramic authored @didtools/key-webauthn package and wires it into SignatureUtils.

## How Has This Been Tested?

Was not able to test on my local; the test scripts do not seem to work on a Windows machine. CI should catch any problems per devs.

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation