### PR TITLE
fix: disable recon feed in test where it is causing flaky behavior

### DIFF
--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -382,7 +382,6 @@ describe('Ceramic API', () => {
       const NUM_INDEX_CALLS_PER_STREAM_CREATE = process.env.CERAMIC_RECON_MODE ? 1 : 2
 
       expect(addIndexSpy).toBeCalledTimes(NUM_INDEX_CALLS_PER_STREAM_CREATE)
-      console.log('AFTER MODEL CREATE CHECK')
       const midMetadata = { model: model.id }
       const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata, {
         anchor: false,

--- a/packages/core/src/__tests__/ceramic-api.test.ts
+++ b/packages/core/src/__tests__/ceramic-api.test.ts
@@ -108,6 +108,7 @@ describe('Ceramic API', () => {
       tmpFolder = await tmp.dir({ unsafeCleanup: true })
       ceramic = await createCeramic(ipfs, {
         stateStoreDirectory: tmpFolder.path,
+        reconFeedEnabled: false,
       })
     })
 
@@ -373,28 +374,25 @@ describe('Ceramic API', () => {
       handleAnchorEventSpy.mockImplementation(() => Promise.resolve(false))
 
       const model = await Model.create(ceramic, MODEL_DEFINITION_BLOB)
-      await CommonTestUtils.delay(1000)
 
       // In v3 mode we call into update the state store and index twice as part of creating a
       // Stream. Once from loading the genesis commit, a second from applying the handling the
       // create. In v4 mode and going forward, there is only 1 call into the index since we don't
       // update persisted state on stream loads.
-      const NUM_INDEX_CALLS_PER_STREAM_CREATE = 2
+      const NUM_INDEX_CALLS_PER_STREAM_CREATE = process.env.CERAMIC_RECON_MODE ? 1 : 2
 
       expect(addIndexSpy).toBeCalledTimes(NUM_INDEX_CALLS_PER_STREAM_CREATE)
+      console.log('AFTER MODEL CREATE CHECK')
       const midMetadata = { model: model.id }
       const doc = await ModelInstanceDocument.create(ceramic, CONTENT0, midMetadata, {
         anchor: false,
         pin: false,
       })
-      await CommonTestUtils.delay(1000)
       expect(doc.content).toEqual(CONTENT0)
       expect(addIndexSpy).toBeCalledTimes(NUM_INDEX_CALLS_PER_STREAM_CREATE * 2)
       await doc.patch(CONTENT1, { anchor: false })
-      await CommonTestUtils.delay(1000)
       expect(doc.content).toEqual({ myData: 'abcdefgh' })
-      const reconCorrection = process.env.CERAMIC_RECON_MODE ? 0 : -1
-      expect(addIndexSpy).toBeCalledTimes(NUM_INDEX_CALLS_PER_STREAM_CREATE * 3 + reconCorrection)
+      expect(addIndexSpy).toBeCalledTimes(NUM_INDEX_CALLS_PER_STREAM_CREATE * 2 + 1)
       addIndexSpy.mockRestore()
     })
 


### PR DESCRIPTION
## Description

The flaky behavior was caused by the node receiving the updates created by itself via recon and applying them. This caused the mock calls to include calls outside of functions we were testing for. I disabled recon in these tests as it does not test updates between nodes anyways. 