### PR TITLE
chore: Update DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,7 +34,7 @@ $ npm test
 ```
 If you only want to test a specific package just `cd` into the specific package folder and run the same command as above.
 
-If you want to run the tests in recon mode, you must specify the ceramic-one path, the ipfs flavor as `rust`, and indicate that ceramic will run in recon mode on:
+If you want to run the tests in recon mode, you must specify the ceramic-one path, the IPFS flavor as `rust`, and indicate that ceramic will run in recon mode on:
 ```
 CERAMIC_ONE_PATH=<PATH> CERAMIC_RECON_MODE=true IPFS_FLAVOR=rust npm test
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,6 +34,11 @@ $ npm test
 ```
 If you only want to test a specific package just `cd` into the specific package folder and run the same command as above.
 
+If you want to run the tests in recon mode, you must specify the ceramic-one path, the ipfs flavor as `rust`, and indicate that ceramic will run in recon mode on:
+```
+CERAMIC_ONE_PATH=<PATH> CERAMIC_RECON_MODE=true IPFS_FLAVOR=rust npm test
+```
+
 ## Debugging and Local Development
 
 See [DEVELOPMENT_LOCAL.md](docs-dev/DEVELOPMENT_LOCAL.md)


### PR DESCRIPTION
## Description
The test currently runs with recon mode off by default, but there is no documentation regarding the necessary steps to run them in recon mode, this PR includes documentation to run the test in recon mode.

In the future, when explicit documentation is available about recon, it would be useful to modify that section by including links to the recon/ceramic-one docs.