### PR TITLE
fix: rate limit how fast anchor polling loops on small data sets

### DIFF
--- a/packages/cli/src/__tests__/ceramic-error.test.ts
+++ b/packages/cli/src/__tests__/ceramic-error.test.ts
@@ -53,6 +53,7 @@ beforeAll(async () => {
     indexing: {
       db: `sqlite://${stateStoreDirectory}/ceramic.sqlite`,
     },
+    anchorLoopMinDurationMs: 0,
   })
 
   const ceramicConfig = makeCeramicConfig(daemonConfig)

--- a/packages/cli/src/__tests__/ceramic-multi-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-multi-daemon.test.ts
@@ -24,6 +24,7 @@ const makeCeramicCore = async (ipfs: IpfsApi, stateStoreDirectory: string): Prom
       db: `sqlite://${stateStoreDirectory}/ceramic.sqlite`,
       disableComposedb: false,
     },
+    anchorLoopMinDurationMs: 0,
   })
 
   const handler = new TileDocumentHandler()

--- a/packages/cli/src/__tests__/make-ceramic-core.ts
+++ b/packages/cli/src/__tests__/make-ceramic-core.ts
@@ -16,6 +16,7 @@ export async function makeCeramicCore(
       disableComposedb: false,
       enableHistoricalSync: false,
     },
+    anchorLoopMinDurationMs: 0,
   })
 
   const handler = new TileDocumentHandler()

--- a/packages/core/src/__tests__/ceramic-pinning.test.ts
+++ b/packages/core/src/__tests__/ceramic-pinning.test.ts
@@ -57,6 +57,7 @@ const createCeramic = async (
       enableHistoricalSync: false,
     },
     pubsubTopic: '/ceramic/inmemory/test', // necessary so Ceramic instances can talk to each other
+    anchorLoopMinDurationMs: 0,
   })
   ceramic.did = makeDID(seed, ceramic)
   await ceramic.did.authenticate()

--- a/packages/core/src/__tests__/create-ceramic.ts
+++ b/packages/core/src/__tests__/create-ceramic.ts
@@ -30,6 +30,7 @@ export async function createCeramic(
       disableComposedb: false,
       enableHistoricalSync: false,
     },
+    anchorLoopMinDurationMs: 0,
     ...config,
   }
   const ceramic = await Ceramic.create(ipfs, appliedConfig)

--- a/packages/core/src/__tests__/initialization.test.ts
+++ b/packages/core/src/__tests__/initialization.test.ts
@@ -24,6 +24,7 @@ describe('Ceramic integration', () => {
     const ceramic = await Ceramic.create(ipfs1, {
       stateStoreDirectory,
       indexing: { db: databaseConnectionString.href, models: [] },
+      anchorLoopMinDurationMs: 0,
     })
     const supportedChains = await ceramic.getSupportedChains()
     expect(supportedChains).toEqual(['inmemory:12345'])
@@ -37,6 +38,7 @@ describe('Ceramic integration', () => {
       networkName: 'inmemory',
       stateStoreDirectory,
       indexing: { db: databaseConnectionString.href, models: [] },
+      anchorLoopMinDurationMs: 0,
     })
     const supportedChains = await ceramic.getSupportedChains()
     expect(supportedChains).toEqual(['inmemory:12345'])
@@ -49,6 +51,7 @@ describe('Ceramic integration', () => {
     const [modules, params] = Ceramic._processConfig(ipfs1, {
       networkName: 'local',
       indexing: { db: databaseConnectionString.href, models: [] },
+      anchorLoopMinDurationMs: 0,
     })
     modules.anchorService = new InMemoryAnchorService(
       {},
@@ -68,6 +71,7 @@ describe('Ceramic integration', () => {
         networkName: 'fakenetwork',
         stateStoreDirectory,
         indexing: { db: databaseConnectionString.href, models: [] },
+        anchorLoopMinDurationMs: 0,
       })
     ).rejects.toThrow(
       "Unrecognized Ceramic network name: 'fakenetwork'. Supported networks are: 'mainnet', 'testnet-clay', 'dev-unstable', 'local', 'inmemory'"
@@ -81,6 +85,7 @@ describe('Ceramic integration', () => {
       networkName: Networks.INMEMORY,
       stateStoreDirectory: tmpDirectory,
       indexing: { db: databaseConnectionString.href, models: [] },
+      anchorLoopMinDurationMs: 0,
     })
     const dispatcher = modules.dispatcher
     const ceramic = new Ceramic(modules, params)

--- a/packages/core/src/anchor/anchor-processing-loop.ts
+++ b/packages/core/src/anchor/anchor-processing-loop.ts
@@ -7,7 +7,7 @@ import type { DiagnosticsLogger } from '@ceramicnetwork/common'
 import type { NamedTaskQueue } from '../state-management/named-task-queue.js'
 import type { StreamID } from '@ceramicnetwork/streamid'
 import { TimeableMetric, SinceField } from '@ceramicnetwork/observability'
-import { ModelMetrics, Observable, Counter } from '@ceramicnetwork/model-metrics'
+import { ModelMetrics, Counter } from '@ceramicnetwork/model-metrics'
 
 const METRICS_REPORTING_INTERVAL_MS = 10000 // 10 second reporting interval
 

--- a/packages/core/src/anchor/processing-loop.ts
+++ b/packages/core/src/anchor/processing-loop.ts
@@ -15,6 +15,7 @@
  */
 import { DiagnosticsLogger } from '@ceramicnetwork/common'
 import { TaskQueue } from '../ancillary/task-queue.js'
+import { abortSignalToPromise } from '../utils'
 
 export class Deferred<T = void> implements PromiseLike<T> {
   /**
@@ -102,16 +103,7 @@ export class ProcessingLoop<T> {
    * Start the loop processing.  Returns a promise that resolves when the loop completes.
    */
   start(): Promise<void> {
-    const waitForAbortSignal = new Promise<void>((resolve) => {
-      if (this.#abortController.signal.aborted) {
-        return resolve()
-      }
-      const done = () => {
-        this.#abortController.signal.removeEventListener('abort', done)
-        resolve()
-      }
-      this.#abortController.signal.addEventListener('abort', done)
-    })
+    const waitForAbortSignal = abortSignalToPromise(this.#abortController.signal)
     const doneOnAbortSignal = waitForAbortSignal.then(() => {
       return { done: true, value: undefined }
     })

--- a/packages/core/src/anchor/processing-loop.ts
+++ b/packages/core/src/anchor/processing-loop.ts
@@ -15,7 +15,7 @@
  */
 import { DiagnosticsLogger } from '@ceramicnetwork/common'
 import { TaskQueue } from '../ancillary/task-queue.js'
-import { abortSignalToPromise } from '../utils'
+import { abortSignalToPromise } from '../utils.js'
 
 export class Deferred<T = void> implements PromiseLike<T> {
   /**

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -270,7 +270,7 @@ export class Ceramic implements StreamReaderWriter, StreamStateLoader {
     )
     const anchorRequestStore = new AnchorRequestStore(
       this._logger,
-      params.anchorLoopMinDurationMs
+      params.anchorLoopMinDurationMs >= 0
         ? params.anchorLoopMinDurationMs
         : DEFAULT_MIN_ANCHOR_LOOP_DURATION_MS
     )
@@ -435,6 +435,7 @@ export class Ceramic implements StreamReaderWriter, StreamStateLoader {
       networkOptions,
       loadOptsOverride,
       sync: config.indexing?.enableHistoricalSync,
+      anchorLoopMinDurationMs: parseInt(config.anchorLoopMinDurationMs, 10),
     }
 
     const modules: CeramicModules = {

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -63,6 +63,7 @@ import { LevelKVFactory } from './store/level-kv-factory.js'
 const DEFAULT_CACHE_LIMIT = 500 // number of streams stored in the cache
 const DEFAULT_QPS_LIMIT = 10 // Max number of pubsub query messages that can be published per second without rate limiting
 const DEFAULT_MULTIQUERY_TIMEOUT_MS = 30 * 1000
+const DEFAULT_MIN_ANCHOR_LOOP_DURATION_MS = 60 * 1000 // 1 minute
 const TESTING = process.env.NODE_ENV == 'test'
 
 /**
@@ -161,6 +162,7 @@ export interface CeramicParameters {
   sync?: boolean
   networkOptions: CeramicNetworkOptions
   loadOptsOverride: LoadOpts
+  anchorLoopMinDurationMs?: number
 }
 
 const normalizeStreamID = (streamId: StreamID | string): StreamID => {
@@ -266,11 +268,17 @@ export class Ceramic implements StreamReaderWriter, StreamStateLoader {
       this._logger,
       params.networkOptions.name
     )
+    const anchorRequestStore = new AnchorRequestStore(
+      this._logger,
+      params.anchorLoopMinDurationMs
+        ? params.anchorLoopMinDurationMs
+        : DEFAULT_MIN_ANCHOR_LOOP_DURATION_MS
+    )
     this.repository.setDeps({
       dispatcher: this.dispatcher,
       pinStore: pinStore,
       kvFactory: this._kvFactory,
-      anchorRequestStore: new AnchorRequestStore(this._logger),
+      anchorRequestStore,
       handlers: this._streamHandlers,
       anchorService: modules.anchorService,
       indexing: localIndex,

--- a/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
+++ b/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
@@ -294,7 +294,7 @@ describe('LevelDB-backed AnchorRequestStore state store', () => {
     const sortedStreamIds = sortedParams.map((param) => param.key.toString())
 
     // Create infinite iterator over the AnchorRequestStore
-    const generator = anchorRequestStore.infiniteList(1, 10)
+    const generator = anchorRequestStore.infiniteList(1, 1)
 
     // List should repeat indefinitely
     expect((await generator.next()).value.toString()).toEqual(sortedStreamIds[0])
@@ -359,7 +359,7 @@ describe('LevelDB-backed AnchorRequestStore state store', () => {
     })
 
     // Create infinite iterator over the AnchorRequestStore
-    const generator = anchorRequestStore.infiniteList(1, 10)
+    const generator = anchorRequestStore.infiniteList(1, 1)
 
     expect((await generator.next()).value.toString()).toEqual(sortedStreamIds[0])
     expect((await generator.next()).value.toString()).toEqual(sortedStreamIds[1])

--- a/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
+++ b/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
@@ -416,7 +416,7 @@ describe('LevelDB-backed AnchorRequestStore state store', () => {
 
   test('poll at most once per loop duration', async () => {
     try {
-      const minLoopDuration = 100
+      const minLoopDuration = 300
       const kvFactory = new LevelKVFactory(tmpFolder.path, 'test', logger)
       const anchorRequestStore = new AnchorRequestStore(logger, minLoopDuration, BATCH_TIMEOUT)
       await anchorRequestStore.open(kvFactory)

--- a/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
+++ b/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
@@ -34,6 +34,7 @@ import { LevelKVFactory, ELP_NETWORK } from '../level-kv-factory.js'
 import type { Ceramic } from '../../ceramic.js'
 
 const BATCH_TIMEOUT = 100
+const MIN_LOOP_DURATION = 1
 
 const MODEL_CONTENT_1: ModelDefinition = {
   name: 'MyModel 1',
@@ -142,7 +143,7 @@ describe('LevelDB-backed AnchorRequestStore state store', () => {
   beforeEach(async () => {
     tmpFolder = await tmp.dir({ unsafeCleanup: true })
     kvFactory = new LevelKVFactory(tmpFolder.path, 'fakeNetwork', logger)
-    anchorRequestStore = new AnchorRequestStore(logger, BATCH_TIMEOUT)
+    anchorRequestStore = new AnchorRequestStore(logger, BATCH_TIMEOUT, MIN_LOOP_DURATION)
     await anchorRequestStore.open(kvFactory)
 
     // add a small delay after creating the leveldb instance before trying to use it.
@@ -294,7 +295,7 @@ describe('LevelDB-backed AnchorRequestStore state store', () => {
     const sortedStreamIds = sortedParams.map((param) => param.key.toString())
 
     // Create infinite iterator over the AnchorRequestStore
-    const generator = anchorRequestStore.infiniteList(1, 1)
+    const generator = anchorRequestStore.infiniteList(1)
 
     // List should repeat indefinitely
     expect((await generator.next()).value.toString()).toEqual(sortedStreamIds[0])
@@ -359,7 +360,7 @@ describe('LevelDB-backed AnchorRequestStore state store', () => {
     })
 
     // Create infinite iterator over the AnchorRequestStore
-    const generator = anchorRequestStore.infiniteList(1, 1)
+    const generator = anchorRequestStore.infiniteList(1)
 
     expect((await generator.next()).value.toString()).toEqual(sortedStreamIds[0])
     expect((await generator.next()).value.toString()).toEqual(sortedStreamIds[1])

--- a/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
+++ b/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
@@ -129,15 +129,13 @@ describe('LevelDB-backed AnchorRequestStore state store', () => {
       const model3 = await Model.create(ceramic, MODEL_CONTENT_3)
       streamId3 = model3.id
       genesisCommit3 = await loadGenesisCommit(ceramic, streamId3)
+
+      await ceramic.close()
+      await ipfs.stop()
     } catch (e) {
       console.error(e)
       throw e
     }
-  })
-
-  afterAll(async () => {
-    await ceramic.close()
-    await ipfs.stop()
   })
 
   beforeEach(async () => {
@@ -414,5 +412,72 @@ describe('LevelDB-backed AnchorRequestStore state store', () => {
 
     const retrievedFromMainnet = await anchorRequestStore.load(streamId1)
     expect(retrievedFromMainnet).toEqual(null)
+  })
+
+  test('poll at most once per loop duration', async () => {
+    try {
+      const minLoopDuration = 100
+      const kvFactory = new LevelKVFactory(tmpFolder.path, 'test', logger)
+      const anchorRequestStore = new AnchorRequestStore(logger, minLoopDuration, BATCH_TIMEOUT)
+      await anchorRequestStore.open(kvFactory)
+
+      // Setup data in the AnchorRequestStore
+      const anchorRequestData1: AnchorRequestData = {
+        cid: TestUtils.randomCID(),
+        timestamp: Date.now(),
+        genesis: genesisCommit1,
+      }
+      const anchorRequestData2: AnchorRequestData = {
+        cid: TestUtils.randomCID(),
+        timestamp: Date.now(),
+        genesis: genesisCommit2,
+      }
+      const anchorRequestData3: AnchorRequestData = {
+        cid: TestUtils.randomCID(),
+        timestamp: Date.now(),
+        genesis: genesisCommit3,
+      }
+      await anchorRequestStore.save(streamId1, anchorRequestData1)
+      await anchorRequestStore.save(streamId2, anchorRequestData2)
+      await anchorRequestStore.save(streamId3, anchorRequestData3)
+
+      // Get sorted list of StreamID keys in the AnchorRequestStore
+      const sortByKeyStreamId = (
+        a: AnchorRequestStoreListResult,
+        b: AnchorRequestStoreListResult
+      ) => {
+        return a.key.toString().localeCompare(b.key.toString())
+      }
+      const sortedParams = [
+        { key: streamId1, value: anchorRequestData1 },
+        { key: streamId2, value: anchorRequestData2 },
+        { key: streamId3, value: anchorRequestData3 },
+      ].sort(sortByKeyStreamId)
+      const sortedStreamIds = sortedParams.map((param) => param.key.toString())
+
+      // After the initial loop over the batch the AnchorRequestStore should wait before looping again
+      // Therefore getting 4 entries should take at least minLoopDuration ms
+      const start1 = Date.now()
+      const generator = anchorRequestStore.infiniteList(1)
+      expect((await generator.next()).value.toString()).toEqual(sortedStreamIds[0])
+      expect((await generator.next()).value.toString()).toEqual(sortedStreamIds[1])
+      expect((await generator.next()).value.toString()).toEqual(sortedStreamIds[2])
+      await generator.next()
+      const end1 = Date.now()
+      expect(end1 - start1).toBeGreaterThanOrEqual(minLoopDuration)
+
+      // iterate through the rest of the batch so when we call generator.next again we will need to wait
+      const start2 = Date.now()
+      await generator.next()
+      await generator.next()
+      // generator.next should be waiting while we close the store. Closing should cancel the wait.
+      const [_, result] = await Promise.all([anchorRequestStore.close(), generator.next()])
+      const end2 = Date.now()
+      expect(end2 - start2).toBeLessThan(minLoopDuration)
+      expect(result).toEqual({ done: true, value: undefined })
+    } finally {
+      // in case of test failure, ensure the store is closed
+      await anchorRequestStore.close()
+    }
   })
 })

--- a/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
+++ b/packages/core/src/store/__tests__/level-anchor-request-store.test.ts
@@ -34,7 +34,7 @@ import { LevelKVFactory, ELP_NETWORK } from '../level-kv-factory.js'
 import type { Ceramic } from '../../ceramic.js'
 
 const BATCH_TIMEOUT = 100
-const MIN_LOOP_DURATION = 1
+const MIN_LOOP_DURATION = 0
 
 const MODEL_CONTENT_1: ModelDefinition = {
   name: 'MyModel 1',
@@ -143,7 +143,7 @@ describe('LevelDB-backed AnchorRequestStore state store', () => {
   beforeEach(async () => {
     tmpFolder = await tmp.dir({ unsafeCleanup: true })
     kvFactory = new LevelKVFactory(tmpFolder.path, 'fakeNetwork', logger)
-    anchorRequestStore = new AnchorRequestStore(logger, BATCH_TIMEOUT, MIN_LOOP_DURATION)
+    anchorRequestStore = new AnchorRequestStore(logger, MIN_LOOP_DURATION, BATCH_TIMEOUT)
     await anchorRequestStore.open(kvFactory)
 
     // add a small delay after creating the leveldb instance before trying to use it.

--- a/packages/core/src/store/anchor-request-store.ts
+++ b/packages/core/src/store/anchor-request-store.ts
@@ -109,6 +109,7 @@ export class AnchorRequestStore extends ObjectStore<StreamID, AnchorRequestData>
     let gt: StreamID | undefined = undefined
     let numEntries = 0
     let loopStartTime = new Date()
+    const abortPromise = abortSignalToPromise(this.#abortController.signal)
     do {
       try {
         let timeout
@@ -146,7 +147,7 @@ export class AnchorRequestStore extends ObjectStore<StreamID, AnchorRequestData>
             const sleepPromise = new Promise((resolve) =>
               setTimeout(resolve, remainingLoopDuration)
             )
-            await Promise.race([sleepPromise, abortSignalToPromise(this.#abortController.signal)])
+            await Promise.race([sleepPromise, abortPromise])
           }
 
           gt = undefined

--- a/packages/core/src/store/anchor-request-store.ts
+++ b/packages/core/src/store/anchor-request-store.ts
@@ -3,7 +3,8 @@ import { ObjectStore } from './object-store.js'
 import { CID } from 'multiformats/cid'
 import { StreamUtils, type DiagnosticsLogger, type GenesisCommit } from '@ceramicnetwork/common'
 import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
-import { abortSignalToPromise } from '../utils'
+import type { StoreSearchParams } from './ikv-store.js'
+import { abortSignalToPromise } from '../utils.js'
 
 // How long to wait for the store to return a batch from a find request.
 const DEFAULT_BATCH_TIMEOUT_MS = 60 * 1000 // 1 minute

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -121,3 +121,16 @@ export const promiseTimeout = (
   })
   return Promise.race([timeout, promise])
 }
+
+export const abortSignalToPromise = (abortSignal: AbortSignal): Promise<void> => {
+  return new Promise<void>((resolve) => {
+    if (abortSignal.aborted) {
+      return resolve()
+    }
+    const done = () => {
+      abortSignal.removeEventListener('abort', done)
+      resolve()
+    }
+    abortSignal.addEventListener('abort', done)
+  })
+}

--- a/packages/stream-tests/src/__tests__/ceramic_sync_disabled.test.ts
+++ b/packages/stream-tests/src/__tests__/ceramic_sync_disabled.test.ts
@@ -25,6 +25,7 @@ const makeCeramicCore = async (
       disableComposedb: true,
     },
     disablePeerDataSync,
+    anchorLoopMinDurationMs: 0,
   })
 
   return core

--- a/packages/stream-tests/src/create-ceramic.ts
+++ b/packages/stream-tests/src/create-ceramic.ts
@@ -26,6 +26,7 @@ export async function createCeramic(
         enableHistoricalSync: false,
       },
       sync: false,
+      anchorLoopMinDurationMs: 0,
     },
     config
   )

--- a/packages/stream-tests/src/create-ceramic.ts
+++ b/packages/stream-tests/src/create-ceramic.ts
@@ -5,6 +5,8 @@ import tmp from 'tmp-promise'
 import { createDid } from './create_did.js'
 import type { ProvidersCache } from '@ceramicnetwork/core'
 
+const DEFAULT_ANCHOR_LOOP_TEST_DURATION = 10
+
 export async function createCeramic(
   ipfs: IpfsApi,
   config: CeramicConfig & { seed?: string } = { networkName: Networks.INMEMORY },
@@ -29,6 +31,9 @@ export async function createCeramic(
   )
 
   const [modules, params] = Ceramic._processConfig(ipfs, appliedConfig)
+  params.anchorLoopMinDurationMs = params.anchorLoopMinDurationMs
+    ? params.anchorLoopMinDurationMs
+    : DEFAULT_ANCHOR_LOOP_TEST_DURATION
   if (providersCache) {
     modules.providersCache = providersCache
   }

--- a/packages/stream-tests/src/create-ceramic.ts
+++ b/packages/stream-tests/src/create-ceramic.ts
@@ -24,7 +24,7 @@ export async function createCeramic(
         enableHistoricalSync: false,
       },
       sync: false,
-      anchorLoopMinDurationMs: 10,
+      anchorLoopMinDurationMs: 0,
     },
     config
   )

--- a/packages/stream-tests/src/create-ceramic.ts
+++ b/packages/stream-tests/src/create-ceramic.ts
@@ -5,8 +5,6 @@ import tmp from 'tmp-promise'
 import { createDid } from './create_did.js'
 import type { ProvidersCache } from '@ceramicnetwork/core'
 
-const DEFAULT_ANCHOR_LOOP_TEST_DURATION = 10
-
 export async function createCeramic(
   ipfs: IpfsApi,
   config: CeramicConfig & { seed?: string } = { networkName: Networks.INMEMORY },
@@ -26,15 +24,12 @@ export async function createCeramic(
         enableHistoricalSync: false,
       },
       sync: false,
-      anchorLoopMinDurationMs: 0,
+      anchorLoopMinDurationMs: 10,
     },
     config
   )
 
   const [modules, params] = Ceramic._processConfig(ipfs, appliedConfig)
-  params.anchorLoopMinDurationMs = params.anchorLoopMinDurationMs
-    ? params.anchorLoopMinDurationMs
-    : DEFAULT_ANCHOR_LOOP_TEST_DURATION
   if (providersCache) {
     modules.providersCache = providersCache
   }


### PR DESCRIPTION
With this change, when the number of pending requests is small, we will poll each of them once per minute, which is aligned with how things used to work before we switched to the new polling system.  But when the number of pending requests is large, we'll poll them as fast as possible to make sure we don't fall behind.