### PR TITLE
chore: add logging for leveldb

### DIFF
--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -162,7 +162,7 @@ export class Repository {
     })
     this.updates$ = this.updates$.bind(this)
     this.streamState = this.streamState.bind(this)
-    this.feedAggregationStore = new FeedAggregationStore()
+    this.feedAggregationStore = new FeedAggregationStore(this.logger)
     this.feed = new Feed(this.feedAggregationStore, this.logger, this.streamState)
   }
 

--- a/packages/core/src/store/__tests__/feed-aggregation-store.test.ts
+++ b/packages/core/src/store/__tests__/feed-aggregation-store.test.ts
@@ -27,7 +27,7 @@ let feedAggregationStore: FeedAggregationStore
 beforeAll(async () => {
   tmpFolder = await tmp.dir({ unsafeCleanup: true })
   kvFactory = new LevelKVFactory(tmpFolder.path, `fake-${Math.random()}`, logger)
-  feedAggregationStore = new FeedAggregationStore()
+  feedAggregationStore = new FeedAggregationStore(logger)
   const open = async (name: string): Promise<IKVStore> => {
     feedKVStore = await kvFactory.open(name)
     return feedKVStore
@@ -123,7 +123,7 @@ describe('periodic clean up', () => {
   })
 
   test('every cleanupInterval', async () => {
-    const store = new FeedAggregationStore(10, 100)
+    const store = new FeedAggregationStore(logger, 10, 100)
     const tasks = store.tasks
     let addCalledTimes = 0
     const addCalledMax = 3

--- a/packages/core/src/store/feed-aggregation-store.ts
+++ b/packages/core/src/store/feed-aggregation-store.ts
@@ -3,6 +3,7 @@ import { StreamID } from '@ceramicnetwork/streamid'
 import type { IKVFactory, IKVStoreFindResult, StoreSearchParams } from './ikv-store.js'
 import { TaskQueue } from '../ancillary/task-queue.js'
 import { Observable, firstValueFrom, Subject } from 'rxjs'
+import type { DiagnosticsLogger } from '@ceramicnetwork/common'
 import * as process from 'node:process'
 
 function serializeStreamID(streamID: StreamID): string {
@@ -57,6 +58,7 @@ export class FeedAggregationStore extends ObjectStore<string, StreamID> {
   private readonly onWrite: Subject<void>
 
   constructor(
+    private readonly logger: DiagnosticsLogger,
     staleDuration: number = DEFAULT_STALE_DURATION,
     cleanupInterval: number | null = DEFAULT_CLEANUP_INTERVAL
   ) {
@@ -96,6 +98,7 @@ export class FeedAggregationStore extends ObjectStore<string, StreamID> {
 
   async put(streamId: StreamID, key: string = this.#keyGenerator.next()): Promise<void> {
     await this.save(key, streamId)
+    this.logger.verbose(`Inserting this streamId from LevelDB ${streamId} at ${Date.now()}`)
     this.onWrite.next()
   }
 
@@ -113,7 +116,7 @@ export class FeedAggregationStore extends ObjectStore<string, StreamID> {
   }
 
   streamIDs(gt?: string): ReadableStream<AggregationStoreEntry> {
-    const source = new StreamIDFeedSource(this.find, this.onWrite.asObservable(), gt)
+    const source = new StreamIDFeedSource(this.find, this.onWrite.asObservable(), gt, this.logger)
     return new ReadableStream(source)
   }
 
@@ -133,7 +136,8 @@ class StreamIDFeedSource implements UnderlyingSource<AggregationStoreEntry> {
   constructor(
     private readonly find: FeedAggregationStore['find'],
     private readonly onWrite: Observable<void>,
-    token: string = new MonotonicKey().next()
+    token: string = new MonotonicKey().next(),
+    private readonly logger: DiagnosticsLogger,
   ) {
     this.token = token
   }
@@ -145,6 +149,7 @@ class StreamIDFeedSource implements UnderlyingSource<AggregationStoreEntry> {
       return this.pull(controller)
     }
     for (const entry of entries) {
+      this.logger.verbose(`Sending this streamId from LevelDB ${entry.value} at ${Date.now()}`)
       controller.enqueue({
         resumeToken: entry.key,
         streamID: entry.value,

--- a/packages/core/src/store/feed-aggregation-store.ts
+++ b/packages/core/src/store/feed-aggregation-store.ts
@@ -137,7 +137,7 @@ class StreamIDFeedSource implements UnderlyingSource<AggregationStoreEntry> {
     private readonly find: FeedAggregationStore['find'],
     private readonly onWrite: Observable<void>,
     token: string = new MonotonicKey().next(),
-    private readonly logger: DiagnosticsLogger,
+    private readonly logger: DiagnosticsLogger
   ) {
     this.token = token
   }

--- a/packages/core/src/store/feed-aggregation-store.ts
+++ b/packages/core/src/store/feed-aggregation-store.ts
@@ -116,7 +116,7 @@ export class FeedAggregationStore extends ObjectStore<string, StreamID> {
   }
 
   streamIDs(gt?: string): ReadableStream<AggregationStoreEntry> {
-    const source = new StreamIDFeedSource(this.find, this.onWrite.asObservable(), gt, this.logger)
+    const source = new StreamIDFeedSource(this.find, this.onWrite.asObservable(), this.logger, gt)
     return new ReadableStream(source)
   }
 
@@ -136,8 +136,8 @@ class StreamIDFeedSource implements UnderlyingSource<AggregationStoreEntry> {
   constructor(
     private readonly find: FeedAggregationStore['find'],
     private readonly onWrite: Observable<void>,
-    token: string = new MonotonicKey().next(),
-    private readonly logger: DiagnosticsLogger
+    private readonly logger: DiagnosticsLogger,
+    token: string = new MonotonicKey().next()
   ) {
     this.token = token
   }


### PR DESCRIPTION
## Description
In order to verify if events are not being emitted by the data feed we'll add logging for the events being dispatched from js-ceramic. The way we'll do it is by showing the timestamps of when events were written and read from Level.