### PR TITLE
fix: switch package name to node-metrics / NodeMetrics from model-met…

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
     "@ceramicnetwork/indexing": "^4.15.0",
     "@ceramicnetwork/ipfs-daemon": "^5.15.0",
     "@ceramicnetwork/logger": "^5.0.0",
-    "@ceramicnetwork/model-metrics": "^1.2.5",
+    "@ceramicnetwork/node-metrics": "^1.0.1",
     "@ceramicnetwork/observability": "^1.4.4",
     "@ceramicnetwork/stream-tile": "^5.14.0",
     "@ceramicnetwork/streamid": "^5.4.0",

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -7,9 +7,9 @@ import {
 } from '@ceramicnetwork/observability'
 import {
   DEFAULT_PUBLISH_INTERVAL_MS,
-  ModelMetrics,
+  NodeMetrics,
   Observable,
-} from '@ceramicnetwork/model-metrics'
+} from '@ceramicnetwork/node-metrics'
 import { IpfsConnectionFactory } from './ipfs-connection-factory.js'
 import {
   DiagnosticsLogger,
@@ -346,7 +346,7 @@ export class CeramicDaemon {
     // Now that ceramic node is set up we can start publishing metrics
     if (opts.metrics?.metricsPublisherEnabled) {
       const ipfsVersion = await ipfs.version()
-      ModelMetrics.start({
+      NodeMetrics.start({
         ceramic: ceramic,
         network: params.networkOptions.name,
         ceramicVersion: version,
@@ -586,7 +586,7 @@ export class CeramicDaemon {
     } catch (err) {
       this.diagnosticsLogger.err(`Error running collection query: ${err}`)
       Metrics.count(ERROR_QUERYING_COLLECTION, 1)
-      ModelMetrics.recordError(ERROR_QUERYING_COLLECTION)
+      NodeMetrics.recordError(ERROR_QUERYING_COLLECTION)
       throw err
     }
   }
@@ -810,7 +810,7 @@ export class CeramicDaemon {
     }
 
     const indexedModels = await this.ceramic.admin.getIndexedModels()
-    ModelMetrics.observe(Observable.TOTAL_INDEXED_MODELS, indexedModels.length)
+    NodeMetrics.observe(Observable.TOTAL_INDEXED_MODELS, indexedModels.length)
     const body = {
       models: indexedModels.map((id) => id.toString()),
     }

--- a/packages/cli/src/daemon/error-handler.ts
+++ b/packages/cli/src/daemon/error-handler.ts
@@ -1,6 +1,6 @@
 import { ErrorRequestHandler, NextFunction, Request, Response } from 'express'
 import { DiagnosticsLogger } from '@ceramicnetwork/common'
-import { ModelMetrics } from '@ceramicnetwork/model-metrics'
+import { NodeMetrics } from '@ceramicnetwork/node-metrics'
 
 export class StartupError extends Error {}
 
@@ -29,7 +29,7 @@ export function errorHandler(logger: DiagnosticsLogger): ErrorRequestHandler {
       // 2xx indicates error has not yet been handled
       res.status(500)
     }
-    ModelMetrics.recordError(err.message)
+    NodeMetrics.recordError(err.message)
     res.send({ error: err.message })
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -43,7 +43,7 @@
     "clean": "npx rimraf ./lib"
   },
   "dependencies": {
-    "@ceramicnetwork/model-metrics": "^1.2.5",
+    "@ceramicnetwork/node-metrics": "^1.0.1",
     "@ceramicnetwork/streamid": "^5.4.0",
     "@didtools/cacao": "^3.0.0",
     "@didtools/key-webauthn": "^2.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "@ceramicnetwork/indexing": "^4.15.0",
     "@ceramicnetwork/ipfs-topology": "^5.14.0",
     "@ceramicnetwork/job-queue": "^4.15.0",
-    "@ceramicnetwork/model-metrics": "^1.2.5",
+    "@ceramicnetwork/node-metrics": "^1.0.1",
     "@ceramicnetwork/observability": "^1.4.4",
     "@ceramicnetwork/pinning-aggregation": "^5.14.0",
     "@ceramicnetwork/pinning-ipfs-backend": "^5.14.0",

--- a/packages/core/src/anchor/anchor-processing-loop.ts
+++ b/packages/core/src/anchor/anchor-processing-loop.ts
@@ -7,7 +7,7 @@ import type { DiagnosticsLogger } from '@ceramicnetwork/common'
 import type { NamedTaskQueue } from '../state-management/named-task-queue.js'
 import type { StreamID } from '@ceramicnetwork/streamid'
 import { TimeableMetric, SinceField } from '@ceramicnetwork/observability'
-import { ModelMetrics, Counter } from '@ceramicnetwork/model-metrics'
+import { NodeMetrics, Counter } from '@ceramicnetwork/node-metrics'
 
 const METRICS_REPORTING_INTERVAL_MS = 10000 // 10 second reporting interval
 
@@ -70,8 +70,8 @@ export class AnchorProcessingLoop {
             // "timestamp" field from "entry", which was set as the current time when the request was
             // first written into the AnchorRequestStore.
             this.#anchorPollingMetrics.record(entry)
-            ModelMetrics.recordAnchorRequestAgeMS(entry)
-            ModelMetrics.count(Counter.RECENT_COMPLETED_REQUESTS, 1)
+            NodeMetrics.recordAnchorRequestAgeMS(entry)
+            NodeMetrics.count(Counter.RECENT_COMPLETED_REQUESTS, 1)
 
             // Remove iff tip stored equals to the tip we processed
             // Sort of Compare-and-Swap.
@@ -88,7 +88,7 @@ export class AnchorProcessingLoop {
         } catch (err) {
           const err_msg = `Error while processing entry from the AnchorRequestStore for StreamID ${streamId}: ${err}`
           logger.err(err_msg)
-          ModelMetrics.recordError(err_msg)
+          NodeMetrics.recordError(err_msg)
 
           // Swallow the error and leave the entry in the store, it will get retries the next time through the loop.
         }

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -25,7 +25,7 @@ import {
   StreamReaderWriter,
 } from '@ceramicnetwork/common'
 import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
-import { ModelMetrics } from '@ceramicnetwork/model-metrics'
+import { NodeMetrics } from '@ceramicnetwork/node-metrics'
 
 import { DID } from 'dids'
 import { PinStoreFactory } from './store/pin-store-factory.js'
@@ -649,7 +649,7 @@ export class Ceramic implements StreamReaderWriter, StreamStateLoader {
     } catch (err) {
       this._logger.err(`Error applying commit to stream ${streamId.toString()}: ${err}`)
       Metrics.count(ERROR_APPLYING_COMMIT, 1)
-      ModelMetrics.recordError(ERROR_APPLYING_COMMIT)
+      NodeMetrics.recordError(ERROR_APPLYING_COMMIT)
       throw err
     }
   }
@@ -719,7 +719,7 @@ export class Ceramic implements StreamReaderWriter, StreamStateLoader {
       } catch (err) {
         this._logger.err(`Error loading stream ${streamId.toString()}: ${err}`)
         Metrics.count(ERROR_LOADING_STREAM, 1)
-        ModelMetrics.recordError(ERROR_LOADING_STREAM)
+        NodeMetrics.recordError(ERROR_LOADING_STREAM)
         if (opts.sync != SyncOptions.SYNC_ON_ERROR) {
           throw err
         }
@@ -807,7 +807,7 @@ export class Ceramic implements StreamReaderWriter, StreamStateLoader {
           )
         }
         Metrics.count(ERROR_LOADING_STREAM, 1)
-        ModelMetrics.recordError(ERROR_LOADING_STREAM)
+        NodeMetrics.recordError(ERROR_LOADING_STREAM)
         return Promise.resolve()
       }
       const streamRef = opts.atTime ? CommitID.make(streamId.baseID, stream.tip) : streamId

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -32,7 +32,7 @@ import { CARFactory, CarBlock, type CAR } from 'cartonne'
 import all from 'it-all'
 import { IPFS_CACHE_HIT, IPFS_CACHE_MISS, IPLDRecordsCache } from './store/ipld-records-cache.js'
 import { IReconApi } from './recon.js'
-import { ModelMetrics } from '@ceramicnetwork/model-metrics'
+import { NodeMetrics } from '@ceramicnetwork/node-metrics'
 
 const IPFS_GET_RETRIES = 3
 const DEFAULT_IPFS_GET_SYNC_TIMEOUT = 30000 // 30 seconds per retry, 3 retries = 90 seconds total timeout
@@ -301,7 +301,7 @@ export class Dispatcher {
     } catch (e) {
       this._logger.err(`Error while storing init event: ${e}`)
       Metrics.count(ERROR_STORING_COMMIT, 1)
-      ModelMetrics.recordError(ERROR_STORING_COMMIT)
+      NodeMetrics.recordError(ERROR_STORING_COMMIT)
       throw e
     }
   }
@@ -321,7 +321,7 @@ export class Dispatcher {
     } catch (e) {
       this._logger.err(`Error while storing event for stream ${streamId.toString()}: ${e}`)
       Metrics.count(ERROR_STORING_COMMIT, 1)
-      ModelMetrics.recordError(ERROR_STORING_COMMIT)
+      NodeMetrics.recordError(ERROR_STORING_COMMIT)
       throw e
     }
   }
@@ -454,7 +454,7 @@ export class Dispatcher {
             `Timeout error while loading CID ${asCid.toString()} from IPFS. ${retries} retries remain`
           )
           Metrics.count(ERROR_IPFS_TIMEOUT, 1)
-          ModelMetrics.recordError(ERROR_IPFS_TIMEOUT)
+          NodeMetrics.recordError(ERROR_IPFS_TIMEOUT)
 
           if (retries > 0) {
             continue

--- a/packages/stream-handler-common/src/signature_utils.ts
+++ b/packages/stream-handler-common/src/signature_utils.ts
@@ -6,7 +6,7 @@ import { getStacksVerifier } from '@didtools/pkh-stacks'
 import { getTezosVerifier } from '@didtools/pkh-tezos'
 import { WebauthnAuth } from '@didtools/key-webauthn'
 import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
-import { ModelMetrics } from '@ceramicnetwork/model-metrics'
+import { NodeMetrics } from '@ceramicnetwork/node-metrics'
 import { CeramicSigner, CommitData, StreamState, StreamUtils } from '@ceramicnetwork/common'
 
 const DEFAULT_CACAO_REVOCATION_PHASE_OUT_SECS = 24 * 60 * 60
@@ -59,7 +59,7 @@ export class SignatureUtils {
       if (original.includes('CACAO has expired')) {
         // TODO: string matching error messages is brittle. Can we use a stable error code instead?
         Metrics.count(CACAO_EXPIRED, 1, { source: 'new_commit' })
-        ModelMetrics.recordError(CACAO_EXPIRED + '_new_commit')
+        NodeMetrics.recordError(CACAO_EXPIRED + '_new_commit')
       }
       throw new Error(
         `Can not verify signature for commit ${commitData.cid} to stream ${streamId} which has controller DID ${controller}: ${original}`
@@ -111,7 +111,7 @@ export class SignatureUtils {
       const expirationTime = logEntry.expirationTime + DEFAULT_CACAO_REVOCATION_PHASE_OUT_SECS
       if (expirationTime < timestamp) {
         Metrics.count(CACAO_EXPIRED, 1, { source: 'existing_state' })
-        ModelMetrics.recordError(CACAO_EXPIRED + '_existing_state')
+        NodeMetrics.recordError(CACAO_EXPIRED + '_existing_state')
         throw new Error(
           `CACAO expired: Commit ${logEntry.cid.toString()} of Stream ${StreamUtils.streamIdFromState(
             state


### PR DESCRIPTION
## Description

We changed the package from @ceramicnetwork/model-metrics to @ceramicnetwork/node-metrics for clarity, and from ModelMetrics to NodeMetrics

We need to put this change in before we turn on by default so that we don't confuse people, an so the instructions are clear.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x] unit tests

(no functionality should change, only the names)

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
