### PR TITLE
feat: default node metrics publishing to on and add docs

### DIFF
--- a/docs-dev/ADVANCED_CONFIG.md
+++ b/docs-dev/ADVANCED_CONFIG.md
@@ -41,6 +41,7 @@ Do NOT copy the following code it is for reference only.
     "metrics": {
          "collector-host": STRING               // hostname of OTLP collector when push exporter enabled
          "metrics-exporter-enabled": BOOLEAN    // whether push exporting is enabled, default false
+         "metrics-publisher-enabled": BOOLEAN   // publish node metrics as streams, default true
          "prometheus-exporter-enabled": BOOLEAN // whether prometheus-compatible endpoint enalbed, default false
          "prometheus-exporter-port": NUMBER     // port for scraping prometheus metrics if enabled
     },

--- a/docs-dev/NODE_METRICS.md
+++ b/docs-dev/NODE_METRICS.md
@@ -1,0 +1,41 @@
+# Node Metrics
+
+By default, Ceramic Nodes publish some limited metrics about their state publicly to a model on the Ceramic Network.
+
+## Metric Data Published
+
+The data published is defined in the [@ceramicnetwork/node-metrics](https://www.npmjs.com/package/@ceramicnetwork/node-metrics) package.
+
+Currently, this includes the following about the Ceramic node:
+
+  - DID used to log into the Ceramic Anchor Service
+  - IP address, if known
+  - Peer ID
+  - js-ceramic version
+  - ceramic-one version, or IPFS version if still using IPFS.
+
+As well as the following dynamic metrics published periodically (by default once per minute):
+
+  - total Pinned streams
+  - total Indexed models
+  - current number of pending requests to CAS
+  - mean pending Anchor request age
+  - max pending Anchor request age
+  - number of writes in the last window
+  - number of completed requests in the last window
+  - number of errors in the last window
+  - a sample of recent errors encountered
+
+These metrics are very helpful for measuring the health of the network and addressing problems early.
+
+## Disabling Node Metrics
+
+However, if you would like to *disable* metrics from your node, you can easily do so!
+
+Edit your ceramic daemon config file and set
+
+` "metrics-publisher-enabled": false `
+
+in the `metrics` section.  For more information about editing the ceramic daemon config see [ADVANCED_CONFIG](./ADVANCED_CONFIG.md)
+
+  

--- a/docs-dev/NODE_METRICS.md
+++ b/docs-dev/NODE_METRICS.md
@@ -21,8 +21,7 @@ As well as the following dynamic metrics published periodically (by default once
   - current number of pending requests to CAS
   - mean pending Anchor request age
   - max pending Anchor request age
-  - number of writes in the last window
-  - number of completed requests in the last window
+  - number of completed anchor requests in the last window
   - number of errors in the last window
   - a sample of recent errors encountered
 

--- a/packages/cli/src/__tests__/daemon-config.test.ts
+++ b/packages/cli/src/__tests__/daemon-config.test.ts
@@ -10,6 +10,9 @@ const mockNodeConfig = {
   'private-seed-url':
     'inplace:ed25519#85704d3f4712d11be488bff0590eead8d4971b2c16b32ea23d6a00d53f3e7dad',
 }
+const mockMetricsPublishOff = {
+  'metrics-publisher-enabled': false,
+}
 
 describe('reading from file', () => {
   let folder: tmp.DirectoryResult
@@ -41,6 +44,19 @@ describe('reading from file', () => {
     await writeFile(configFilepath, JSON.stringify(config))
     const daemonConfig = await DaemonConfig.fromFile(configFilepath)
     expect(daemonConfig.node.sensitive_privateSeedUrl()).toEqual(mockNodeConfig['private-seed-url'])
+  })
+  test('publish metrics on by default', async () => {
+    const config = { metrics: {} }
+    await writeFile(configFilepath, JSON.stringify(config))
+    const daemonConfig = await DaemonConfig.fromFile(configFilepath)
+    expect(daemonConfig.metrics?.metricsPublisherEnabled).toBeTruthy()
+  })
+  test('setting publish metrics to false overrides default', async () => {
+    console.log('in publish metrics')
+    const config = { metrics: mockMetricsPublishOff }
+    await writeFile(configFilepath, JSON.stringify(config))
+    const daemonConfig = await DaemonConfig.fromFile(configFilepath)
+    expect(daemonConfig.metrics.metricsPublisherEnabled).toBeFalsy()
   })
   test('expand relative path', async () => {
     const config = {

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -361,7 +361,7 @@ export class CeramicDaemon {
         logger: diagnosticsLogger,
       })
       diagnosticsLogger.imp(
-        `Publishing Node Metrics to the Ceramic Network.  To learn more, including how to disable publishing, please see the NODE_METRICS.md file for your branch, e.g. https://github.com/ceramicnetwork/js-ceramic/blob/develop/docs-dev/NODE_METRICS.md`
+        `Publishing Node Metrics publicly to the Ceramic Network.  To learn more, including how to disable publishing, please see the NODE_METRICS.md file for your branch, e.g. https://github.com/ceramicnetwork/js-ceramic/blob/develop/docs-dev/NODE_METRICS.md`
       )
     }
 

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -322,7 +322,7 @@ export class CeramicDaemon {
     if (provider) {
       await did.authenticate()
       diagnosticsLogger.imp(
-        `Node DID set to '${did.id}. This DID will be used to authenticate to the anchor service'`
+        `Node DID set to '${did.id}'. This DID will be used to authenticate to the anchor service`
       )
     }
     ceramic.did = did
@@ -344,7 +344,8 @@ export class CeramicDaemon {
     await daemon.listen()
 
     // Now that ceramic node is set up we can start publishing metrics
-    if (opts.metrics?.metricsPublisherEnabled) {
+    // publishing metrics is enabled by default, even if no metrics config
+    if (! opts.metrics || opts.metrics?.metricsPublisherEnabled) {
       const ipfsVersion = await ipfs.version()
       NodeMetrics.start({
         ceramic: ceramic,
@@ -359,6 +360,9 @@ export class CeramicDaemon {
         nodePeerId: ipfsId.publicKey,
         logger: diagnosticsLogger,
       })
+      diagnosticsLogger.imp(
+        `Publishing Node Metrics to the Ceramic Network.  To learn more, including how to disable publishing, please see the NODE_METRICS.md file for your branch, e.g. https://github.com/ceramicnetwork/js-ceramic/blob/develop/docs-dev/NODE_METRICS.md`
+      )
     }
 
     return daemon

--- a/packages/cli/src/daemon-config.ts
+++ b/packages/cli/src/daemon-config.ts
@@ -400,13 +400,14 @@ export class DaemonMetricsConfig {
    * Controls whether we publish metrics periodically on the Ceramic Network
    */
   @jsonMember(Boolean, { name: 'metrics-publisher-enabled' })
-  metricsPublisherEnabled?: boolean
+  metricsPublisherEnabled?: boolean = true
 
   /**
    * If metrics publishing enabled, publish interval in milliseconds
    */
   @jsonMember(Number, { name: 'metrics-publish-interval-ms' })
   metricsPublishIntervalMS?: number
+
 }
 
 /**


### PR DESCRIPTION
## Description

As we move towards more decentralization, publishing metrics on the ceramic network becomes more important - so defaulting it to on.  Will notify folks in an announcement and post.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x] run locally
- [x] unit tests

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [ x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
