### PR TITLE
feat: send js-ceramic and ceramic-one versions to CAS when creating requests

### DIFF
--- a/packages/cli/src/__tests__/ceramic-error.test.ts
+++ b/packages/cli/src/__tests__/ceramic-error.test.ts
@@ -2,7 +2,7 @@ import getPort from 'get-port'
 import { IpfsApi, LogLevel } from '@ceramicnetwork/common'
 import * as tmp from 'tmp-promise'
 import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
-import { Ceramic } from '@ceramicnetwork/core'
+import { Ceramic, VersionInfo } from '@ceramicnetwork/core'
 import * as random from '@stablelib/random'
 import { CeramicDaemon, makeCeramicConfig } from '../ceramic-daemon.js'
 import { CeramicClient } from '@ceramicnetwork/http-client'
@@ -58,7 +58,7 @@ beforeAll(async () => {
 
   const ceramicConfig = makeCeramicConfig(daemonConfig)
   ceramicConfig.enableAnchorPollingLoop = false
-  core = await Ceramic.create(ipfs, ceramicConfig)
+  core = await Ceramic.create(ipfs, ceramicConfig, {} as VersionInfo)
   daemon = new CeramicDaemon(core, daemonConfig)
   await daemon.listen()
   const apiUrl = `http://localhost:${daemonPort}`

--- a/packages/cli/src/__tests__/ceramic-multi-daemon.test.ts
+++ b/packages/cli/src/__tests__/ceramic-multi-daemon.test.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals'
-import { Ceramic } from '@ceramicnetwork/core'
+import { Ceramic, VersionInfo } from '@ceramicnetwork/core'
 import { CeramicClient } from '@ceramicnetwork/http-client'
 import * as tmp from 'tmp-promise'
 import { CeramicDaemon } from '../ceramic-daemon.js'
@@ -16,16 +16,20 @@ const seed = 'SEED'
 const TOPIC = '/ceramic'
 
 const makeCeramicCore = async (ipfs: IpfsApi, stateStoreDirectory: string): Promise<Ceramic> => {
-  const core = await Ceramic.create(ipfs, {
-    pubsubTopic: TOPIC,
-    stateStoreDirectory,
-    anchorOnRequest: false,
-    indexing: {
-      db: `sqlite://${stateStoreDirectory}/ceramic.sqlite`,
-      disableComposedb: false,
+  const core = await Ceramic.create(
+    ipfs,
+    {
+      pubsubTopic: TOPIC,
+      stateStoreDirectory,
+      anchorOnRequest: false,
+      indexing: {
+        db: `sqlite://${stateStoreDirectory}/ceramic.sqlite`,
+        disableComposedb: false,
+      },
+      anchorLoopMinDurationMs: 0,
     },
-    anchorLoopMinDurationMs: 0,
-  })
+    {} as VersionInfo
+  )
 
   const handler = new TileDocumentHandler()
   handler.verifyJWS = (): Promise<void> => {

--- a/packages/cli/src/__tests__/make-ceramic-core.ts
+++ b/packages/cli/src/__tests__/make-ceramic-core.ts
@@ -1,23 +1,27 @@
 import { IpfsApi } from '@ceramicnetwork/common'
-import { Ceramic } from '@ceramicnetwork/core'
+import { Ceramic, VersionInfo } from '@ceramicnetwork/core'
 import { TileDocumentHandler } from '@ceramicnetwork/stream-tile-handler'
 
 export async function makeCeramicCore(
   ipfs: IpfsApi,
   stateStoreDirectory: string
 ): Promise<Ceramic> {
-  const core = await Ceramic.create(ipfs, {
-    pubsubTopic: '/ceramic',
-    stateStoreDirectory,
-    anchorOnRequest: false,
-    indexing: {
-      db: `sqlite://${stateStoreDirectory}/ceramic.sqlite`,
-      allowQueriesBeforeHistoricalSync: true,
-      disableComposedb: false,
-      enableHistoricalSync: false,
+  const core = await Ceramic.create(
+    ipfs,
+    {
+      pubsubTopic: '/ceramic',
+      stateStoreDirectory,
+      anchorOnRequest: false,
+      indexing: {
+        db: `sqlite://${stateStoreDirectory}/ceramic.sqlite`,
+        allowQueriesBeforeHistoricalSync: true,
+        disableComposedb: false,
+        enableHistoricalSync: false,
+      },
+      anchorLoopMinDurationMs: 0,
     },
-    anchorLoopMinDurationMs: 0,
-  })
+    {} as VersionInfo
+  )
 
   const handler = new TileDocumentHandler()
   ;(handler as any).verifyJWS = (): Promise<void> => {

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -282,9 +282,14 @@ export class CeramicDaemon {
       ceramicConfig.loggerProvider.getDiagnosticsLogger(),
       opts.ipfs?.host
     )
+    const ipfsId = await ipfs.id()
 
-    const [modules, params] = Ceramic._processConfig(ipfs, ceramicConfig)
-    params.versionInfo = { cliPackageVersion: version, gitHash: commitHash }
+    const versionInfo = {
+      cliPackageVersion: version,
+      gitHash: commitHash,
+      ceramicOneVersion: ipfsId.agentVersion,
+    }
+    const [modules, params] = Ceramic._processConfig(ipfs, ceramicConfig, versionInfo)
     const diagnosticsLogger = modules.loggerProvider.getDiagnosticsLogger()
     diagnosticsLogger.imp(
       `Starting Ceramic Daemon with @ceramicnetwork/cli package version ${version}, with js-ceramic repo git hash ${commitHash}, and with config: \n${JSON.stringify(
@@ -293,7 +298,6 @@ export class CeramicDaemon {
         2
       )}`
     )
-    const ipfsId = await ipfs.id()
     diagnosticsLogger.imp(
       `Connecting to IPFS node with version "${ipfsId.agentVersion}" available as ${ipfsId.addresses
         .map(String)

--- a/packages/core/src/__tests__/ceramic-pinning.test.ts
+++ b/packages/core/src/__tests__/ceramic-pinning.test.ts
@@ -1,5 +1,5 @@
 import { jest, describe, expect, beforeEach, afterEach } from '@jest/globals'
-import { Ceramic } from '../ceramic.js'
+import { Ceramic, VersionInfo } from '../ceramic.js'
 import { Ed25519Provider } from 'key-did-provider-ed25519'
 import tmp from 'tmp-promise'
 import { IpfsApi, SyncOptions } from '@ceramicnetwork/common'
@@ -47,18 +47,22 @@ const createCeramic = async (
 
   const databaseFolder = await tmp.dir({ unsafeCleanup: true })
   const connectionString = new URL(`sqlite://${databaseFolder.path}/ceramic.sqlite`)
-  const ceramic = await Ceramic.create(ipfs, {
-    stateStoreDirectory,
-    anchorOnRequest,
-    indexing: {
-      db: connectionString.href,
-      allowQueriesBeforeHistoricalSync: true,
-      disableComposedb: true,
-      enableHistoricalSync: false,
+  const ceramic = await Ceramic.create(
+    ipfs,
+    {
+      stateStoreDirectory,
+      anchorOnRequest,
+      indexing: {
+        db: connectionString.href,
+        allowQueriesBeforeHistoricalSync: true,
+        disableComposedb: true,
+        enableHistoricalSync: false,
+      },
+      pubsubTopic: '/ceramic/inmemory/test', // necessary so Ceramic instances can talk to each other
+      anchorLoopMinDurationMs: 0,
     },
-    pubsubTopic: '/ceramic/inmemory/test', // necessary so Ceramic instances can talk to each other
-    anchorLoopMinDurationMs: 0,
-  })
+    {} as VersionInfo
+  )
   ceramic.did = makeDID(seed, ceramic)
   await ceramic.did.authenticate()
 

--- a/packages/core/src/__tests__/create-ceramic.ts
+++ b/packages/core/src/__tests__/create-ceramic.ts
@@ -9,6 +9,8 @@ import * as KeyDidResolver from 'key-did-resolver'
 import { Resolver } from 'did-resolver'
 import { DID } from 'dids'
 
+const VERSION_INFO = { cliPackageVersion: '', gitHash: '', ceramicOneVersion: '' }
+
 export async function createCeramic(
   ipfs: IpfsApi,
   config?: CeramicConfig & {
@@ -33,7 +35,7 @@ export async function createCeramic(
     anchorLoopMinDurationMs: 0,
     ...config,
   }
-  const ceramic = await Ceramic.create(ipfs, appliedConfig)
+  const ceramic = await Ceramic.create(ipfs, appliedConfig, VERSION_INFO)
   const seed = sha256.hash(uint8arrays.fromString(appliedConfig.seed || 'SEED'))
   const provider = new Ed25519Provider(seed)
   const keyDidResolver = KeyDidResolver.getResolver()

--- a/packages/core/src/__tests__/initialization.test.ts
+++ b/packages/core/src/__tests__/initialization.test.ts
@@ -6,6 +6,8 @@ import { Networks } from '@ceramicnetwork/common'
 import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
 import { InMemoryAnchorService } from '../anchor/memory/in-memory-anchor-service.js'
 
+const VERSION_INFO = { cliPackageVersion: '', gitHash: '', ceramicOneVersion: '' }
+
 describe('Ceramic integration', () => {
   jest.setTimeout(60000)
   let ipfs1: IpfsApi
@@ -21,11 +23,15 @@ describe('Ceramic integration', () => {
   it('can create Ceramic instance on default network', async () => {
     const stateStoreDirectory = await tmp.tmpName()
     const databaseConnectionString = new URL(`sqlite://${stateStoreDirectory}/ceramic.sqlite`)
-    const ceramic = await Ceramic.create(ipfs1, {
-      stateStoreDirectory,
-      indexing: { db: databaseConnectionString.href, models: [] },
-      anchorLoopMinDurationMs: 0,
-    })
+    const ceramic = await Ceramic.create(
+      ipfs1,
+      {
+        stateStoreDirectory,
+        indexing: { db: databaseConnectionString.href },
+        anchorLoopMinDurationMs: 0,
+      },
+      VERSION_INFO
+    )
     const supportedChains = await ceramic.getSupportedChains()
     expect(supportedChains).toEqual(['inmemory:12345'])
     await ceramic.close()
@@ -34,12 +40,16 @@ describe('Ceramic integration', () => {
   it('can create Ceramic instance explicitly on inmemory network', async () => {
     const stateStoreDirectory = await tmp.tmpName()
     const databaseConnectionString = new URL(`sqlite://${stateStoreDirectory}/ceramic.sqlite`)
-    const ceramic = await Ceramic.create(ipfs1, {
-      networkName: 'inmemory',
-      stateStoreDirectory,
-      indexing: { db: databaseConnectionString.href, models: [] },
-      anchorLoopMinDurationMs: 0,
-    })
+    const ceramic = await Ceramic.create(
+      ipfs1,
+      {
+        networkName: 'inmemory',
+        stateStoreDirectory,
+        indexing: { db: databaseConnectionString.href },
+        anchorLoopMinDurationMs: 0,
+      },
+      VERSION_INFO
+    )
     const supportedChains = await ceramic.getSupportedChains()
     expect(supportedChains).toEqual(['inmemory:12345'])
     await ceramic.close()
@@ -48,11 +58,15 @@ describe('Ceramic integration', () => {
   it('cannot create Ceramic instance on network not supported by our anchor service', async () => {
     const tmpDirectory = await tmp.tmpName()
     const databaseConnectionString = new URL(`sqlite://${tmpDirectory}/ceramic.sqlite`)
-    const [modules, params] = Ceramic._processConfig(ipfs1, {
-      networkName: 'local',
-      indexing: { db: databaseConnectionString.href, models: [] },
-      anchorLoopMinDurationMs: 0,
-    })
+    const [modules, params] = Ceramic._processConfig(
+      ipfs1,
+      {
+        networkName: 'local',
+        indexing: { db: databaseConnectionString.href },
+        anchorLoopMinDurationMs: 0,
+      },
+      VERSION_INFO
+    )
     modules.anchorService = new InMemoryAnchorService(
       {},
       modules.loggerProvider.getDiagnosticsLogger()
@@ -67,12 +81,16 @@ describe('Ceramic integration', () => {
     const stateStoreDirectory = await tmp.tmpName()
     const databaseConnectionString = new URL(`sqlite://${stateStoreDirectory}/ceramic.sqlite`)
     await expect(
-      Ceramic.create(ipfs1, {
-        networkName: 'fakenetwork',
-        stateStoreDirectory,
-        indexing: { db: databaseConnectionString.href, models: [] },
-        anchorLoopMinDurationMs: 0,
-      })
+      Ceramic.create(
+        ipfs1,
+        {
+          networkName: 'fakenetwork',
+          stateStoreDirectory,
+          indexing: { db: databaseConnectionString.href },
+          anchorLoopMinDurationMs: 0,
+        },
+        VERSION_INFO
+      )
     ).rejects.toThrow(
       "Unrecognized Ceramic network name: 'fakenetwork'. Supported networks are: 'mainnet', 'testnet-clay', 'dev-unstable', 'local', 'inmemory'"
     )
@@ -81,12 +99,16 @@ describe('Ceramic integration', () => {
   test('init dispatcher', async () => {
     const tmpDirectory = await tmp.tmpName()
     const databaseConnectionString = new URL(`sqlite://${tmpDirectory}/ceramic.sqlite`)
-    const [modules, params] = await Ceramic._processConfig(ipfs1, {
-      networkName: Networks.INMEMORY,
-      stateStoreDirectory: tmpDirectory,
-      indexing: { db: databaseConnectionString.href, models: [] },
-      anchorLoopMinDurationMs: 0,
-    })
+    const [modules, params] = await Ceramic._processConfig(
+      ipfs1,
+      {
+        networkName: Networks.INMEMORY,
+        stateStoreDirectory: tmpDirectory,
+        indexing: { db: databaseConnectionString.href },
+        anchorLoopMinDurationMs: 0,
+      },
+      VERSION_INFO
+    )
     const dispatcher = modules.dispatcher
     const ceramic = new Ceramic(modules, params)
     const dispatcherInitSpy = jest.spyOn(dispatcher, 'init')

--- a/packages/core/src/anchor/ethereum/__tests__/authenticated-anchor-service.test.ts
+++ b/packages/core/src/anchor/ethereum/__tests__/authenticated-anchor-service.test.ts
@@ -11,8 +11,7 @@ import { createDidAnchorServiceAuth } from '../../../__tests__/create-did-anchor
 import { AuthenticatedEthereumAnchorService } from '../ethereum-anchor-service.js'
 import { AnchorRequestStore } from '../../../store/anchor-request-store.js'
 import type { AnchorLoopHandler } from '../../anchor-service.js'
-import { CARFactory, type CAR } from 'cartonne'
-import { Ceramic } from '../../../ceramic.js'
+import { Ceramic, VersionInfo } from '../../../ceramic.js'
 import { BaseTestUtils } from '@ceramicnetwork/base-test-utils'
 
 const FAUX_ANCHOR_STORE = {
@@ -28,6 +27,7 @@ const FAUX_HANDLER: AnchorLoopHandler = {
 }
 
 const diagnosticsLogger = new LoggerProvider().getDiagnosticsLogger()
+const VERSION_INFO: VersionInfo = { cliPackageVersion: '', gitHash: '', ceramicOneVersion: '' }
 
 describe('AuthenticatedEthereumAnchorServiceTest', () => {
   let ipfs: IpfsApi
@@ -53,7 +53,13 @@ describe('AuthenticatedEthereumAnchorServiceTest', () => {
 
     const auth = createDidAnchorServiceAuth(url, ceramic.signer, diagnosticsLogger, fauxFetchJson)
     const signRequestSpy = jest.spyOn(auth, 'signRequest')
-    const anchorService = new AuthenticatedEthereumAnchorService(auth, url, url, diagnosticsLogger)
+    const anchorService = new AuthenticatedEthereumAnchorService(
+      auth,
+      url,
+      url,
+      diagnosticsLogger,
+      VERSION_INFO
+    )
 
     jest.spyOn(anchorService.validator, 'init').mockImplementation(async () => {
       // Do Nothing
@@ -82,7 +88,13 @@ describe('AuthenticatedEthereumAnchorServiceTest', () => {
 
     const auth = createDidAnchorServiceAuth(url, ceramic.signer, diagnosticsLogger, fauxFetchJson)
     const signRequestSpy = jest.spyOn(auth, 'signRequest')
-    const anchorService = new AuthenticatedEthereumAnchorService(auth, url, url, diagnosticsLogger)
+    const anchorService = new AuthenticatedEthereumAnchorService(
+      auth,
+      url,
+      url,
+      diagnosticsLogger,
+      VERSION_INFO
+    )
     jest.spyOn(anchorService.validator, 'init').mockImplementation(async () => {
       // Do Nothing
     })

--- a/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
+++ b/packages/core/src/anchor/ethereum/ethereum-anchor-service.ts
@@ -18,6 +18,7 @@ import { doNotWait } from '../../ancillary/do-not-wait.js'
 import { NamedTaskQueue } from '../../state-management/named-task-queue.js'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { CID } from 'multiformats/cid'
+import { VersionInfo } from '../../ceramic.js'
 
 // BATCH_SIZE controls the number of keys fetched from the AnchorRequestStore at once.
 // It does not affect the parallelism/concurrency of actually processing the entries in those batches.
@@ -48,12 +49,13 @@ export class EthereumAnchorService implements AnchorService {
     anchorServiceUrl: string,
     ethereumRpcUrl: string | undefined,
     logger: DiagnosticsLogger,
+    versionInfo: VersionInfo,
     sendRequest: FetchRequest = fetchJson,
     enableAnchorPollingLoop = true
   ) {
     this.#logger = logger
     this.#events = new Subject()
-    this.#cas = new RemoteCAS(logger, anchorServiceUrl, sendRequest)
+    this.#cas = new RemoteCAS(logger, anchorServiceUrl, sendRequest, versionInfo)
     this.events = this.#events
     this.url = anchorServiceUrl
     this.validator = new EthereumAnchorValidator(ethereumRpcUrl, logger)
@@ -140,12 +142,14 @@ export class AuthenticatedEthereumAnchorService
     anchorServiceUrl: string,
     ethereumRpcUrl: string | undefined,
     logger: DiagnosticsLogger,
+    versionInfo: VersionInfo,
     enableAnchorPollingLoop = true
   ) {
     super(
       anchorServiceUrl,
       ethereumRpcUrl,
       logger,
+      versionInfo,
       auth.sendAuthenticatedRequest.bind(auth),
       enableAnchorPollingLoop
     )

--- a/packages/core/src/initialization/__tests__/anchoring.test.ts
+++ b/packages/core/src/initialization/__tests__/anchoring.test.ts
@@ -10,6 +10,11 @@ import {
   AuthenticatedEthereumAnchorService,
   EthereumAnchorService,
 } from '../../anchor/ethereum/ethereum-anchor-service.js'
+import { VersionInfo } from '../../ceramic.js'
+import { CeramicSigner } from '@ceramicnetwork/common'
+
+const VERSION_INFO: VersionInfo = { cliPackageVersion: '', gitHash: '', ceramicOneVersion: '' }
+const SIGNER = CeramicSigner.invalid()
 
 describe('makeAnchorServiceUrl', () => {
   const CUSTOM_URL = 'https://cas.com'
@@ -35,11 +40,25 @@ describe('makeAnchorServiceUrl', () => {
 describe('makeAnchorService', () => {
   const logger = new LoggerProvider().getDiagnosticsLogger()
   test('readOnly means null', () => {
-    const result = makeAnchorService({ readOnly: true }, '', Networks.MAINNET, logger)
+    const result = makeAnchorService(
+      { readOnly: true },
+      '',
+      Networks.MAINNET,
+      logger,
+      VERSION_INFO,
+      SIGNER
+    )
     expect(result).toBeInstanceOf(EthereumAnchorService)
   })
   test('inmemory', () => {
-    const result = makeAnchorService({ readOnly: false }, '', Networks.INMEMORY, logger)
+    const result = makeAnchorService(
+      { readOnly: false },
+      '',
+      Networks.INMEMORY,
+      logger,
+      VERSION_INFO,
+      SIGNER
+    )
     expect(result).toBeInstanceOf(InMemoryAnchorService)
   })
   test('auth', () => {
@@ -47,12 +66,21 @@ describe('makeAnchorService', () => {
       { readOnly: false, anchorServiceAuthMethod: 'auth' },
       '',
       Networks.MAINNET,
-      logger
+      logger,
+      VERSION_INFO,
+      SIGNER
     )
     expect(result).toBeInstanceOf(AuthenticatedEthereumAnchorService)
   })
   test('no auth', () => {
-    const result = makeAnchorService({ readOnly: false }, '', Networks.MAINNET, logger)
+    const result = makeAnchorService(
+      { readOnly: false },
+      '',
+      Networks.MAINNET,
+      logger,
+      VERSION_INFO,
+      SIGNER
+    )
     expect(result).toBeInstanceOf(EthereumAnchorService)
   })
 })

--- a/packages/core/src/initialization/anchoring.ts
+++ b/packages/core/src/initialization/anchoring.ts
@@ -1,6 +1,6 @@
 import { CeramicSigner, type DiagnosticsLogger, Networks } from '@ceramicnetwork/common'
 import { DIDAnchorServiceAuth } from '../anchor/auth/did-anchor-service-auth.js'
-import type { CeramicConfig } from '../ceramic.js'
+import type { CeramicConfig, VersionInfo } from '../ceramic.js'
 import { InMemoryAnchorService } from '../anchor/memory/in-memory-anchor-service.js'
 import {
   AuthenticatedEthereumAnchorService,
@@ -121,6 +121,7 @@ export function makeAnchorService(
   ethereumRpcUrl: string | undefined,
   network: Networks,
   logger: DiagnosticsLogger,
+  versionInfo: VersionInfo,
   signer: CeramicSigner
 ): AnchorService {
   if (network === Networks.INMEMORY) {
@@ -140,11 +141,12 @@ export function makeAnchorService(
         anchorServiceAuth,
         anchorServiceUrl,
         ethereumRpcUrl,
-        logger
+        logger,
+        versionInfo
       )
     }
   }
-  return new EthereumAnchorService(anchorServiceUrl, ethereumRpcUrl, logger)
+  return new EthereumAnchorService(anchorServiceUrl, ethereumRpcUrl, logger, versionInfo)
 }
 
 const DEFAULT_LOCAL_ETHEREUM_RPC = 'http://localhost:7545' // default Ganache port

--- a/packages/stream-tests/src/__tests__/ceramic_sync_disabled.test.ts
+++ b/packages/stream-tests/src/__tests__/ceramic_sync_disabled.test.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals'
-import { Ceramic } from '@ceramicnetwork/core'
+import { Ceramic, VersionInfo } from '@ceramicnetwork/core'
 import { CeramicClient } from '@ceramicnetwork/http-client'
 import * as tmp from 'tmp-promise'
 import { CeramicDaemon, DaemonConfig, makeDID } from '@ceramicnetwork/cli'
@@ -17,16 +17,20 @@ const makeCeramicCore = async (
   stateStoreDirectory: string,
   disablePeerDataSync: boolean
 ): Promise<Ceramic> => {
-  const core = await Ceramic.create(ipfs, {
-    pubsubTopic: TOPIC,
-    stateStoreDirectory,
-    anchorOnRequest: false,
-    indexing: {
-      disableComposedb: true,
+  const core = await Ceramic.create(
+    ipfs,
+    {
+      pubsubTopic: TOPIC,
+      stateStoreDirectory,
+      anchorOnRequest: false,
+      indexing: {
+        disableComposedb: true,
+      },
+      disablePeerDataSync,
+      anchorLoopMinDurationMs: 0,
     },
-    disablePeerDataSync,
-    anchorLoopMinDurationMs: 0,
-  })
+    {} as VersionInfo
+  )
 
   return core
 }

--- a/packages/stream-tests/src/create-ceramic.ts
+++ b/packages/stream-tests/src/create-ceramic.ts
@@ -5,6 +5,8 @@ import tmp from 'tmp-promise'
 import { createDid } from './create_did.js'
 import type { ProvidersCache } from '@ceramicnetwork/core'
 
+const VERSION_INFO = { cliPackageVersion: '', gitHash: '', ceramicOneVersion: '' }
+
 export async function createCeramic(
   ipfs: IpfsApi,
   config: CeramicConfig & { seed?: string } = { networkName: Networks.INMEMORY },
@@ -29,7 +31,7 @@ export async function createCeramic(
     config
   )
 
-  const [modules, params] = Ceramic._processConfig(ipfs, appliedConfig)
+  const [modules, params] = Ceramic._processConfig(ipfs, appliedConfig, VERSION_INFO)
   if (providersCache) {
     modules.providersCache = providersCache
   }


### PR DESCRIPTION
js-ceramic half corresponding to https://github.com/ceramicnetwork/ceramic-anchor-service/pull/1232

Builds on https://github.com/ceramicnetwork/js-ceramic/pull/3245