### PR TITLE
fix(ceramic-node): handle case where the admin DID is not authenticated

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -346,8 +346,9 @@ export class CeramicDaemon {
     // publishing metrics is enabled by default, even if no metrics config
     if (!opts.metrics || opts.metrics?.metricsPublisherEnabled) {
       const ipfsVersion = await ipfs.version()
+      let didId: string | null = null;
       try {
-        const didId = did.id
+        didId = did.id
       } catch (err: any) {
         diagnosticsLogger.imp(
           `Unable to publish node metrics without an authenticated DID.  If you wish your ceramic node to be able to publish metrics a privateSeedUrl is required. Error: ${err.toString()}`

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -342,11 +342,11 @@ export class CeramicDaemon {
     const daemon = new CeramicDaemon(ceramic, opts)
     await daemon.listen()
 
-    // Now that ceramic node is set up we can start publishing metrics
-    // publishing metrics is enabled by default, even if no metrics config
-    if (!opts.metrics || opts.metrics?.metricsPublisherEnabled) {
-      const ipfsVersion = await ipfs.version()
-      if (did.authenticated) {
+    if (did.authenticated) {
+      // If authenticated into the node, we can start publishing metrics
+      // publishing metrics is enabled by default, even if no metrics config
+      if (!opts.metrics || opts.metrics?.metricsPublisherEnabled) {
+        const ipfsVersion = await ipfs.version()
         NodeMetrics.start({
           ceramic: ceramic,
           network: params.networkOptions.name,
@@ -364,6 +364,11 @@ export class CeramicDaemon {
           `Publishing Node Metrics publicly to the Ceramic Network.  To learn more, including how to disable publishing, please see the NODE_METRICS.md file for your branch, e.g. https://github.com/ceramicnetwork/js-ceramic/blob/develop/docs-dev/NODE_METRICS.md`
         )
       }
+    } else {
+      // warn that the node does not have an authenticated did
+      diagnosticsLogger.imp(
+        `The ceramic daemon is running without an authenticated DID.  This means that this node cannot itself publish streams, including node metrics, and cannot use a DID as the method to authenticate with the Ceramic Anchor Service.  See https://developers.ceramic.network/docs/composedb/guides/composedb-server/access-mainnet#updating-to-did-based-authentication for instructions on how to update your node to use DID authentication.`
+      )
     }
 
     return daemon

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -344,7 +344,7 @@ export class CeramicDaemon {
 
     // Now that ceramic node is set up we can start publishing metrics
     // publishing metrics is enabled by default, even if no metrics config
-    if (! opts.metrics || opts.metrics?.metricsPublisherEnabled) {
+    if (!opts.metrics || opts.metrics?.metricsPublisherEnabled) {
       const ipfsVersion = await ipfs.version()
       try {
         const didId = did.id

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -346,15 +346,7 @@ export class CeramicDaemon {
     // publishing metrics is enabled by default, even if no metrics config
     if (!opts.metrics || opts.metrics?.metricsPublisherEnabled) {
       const ipfsVersion = await ipfs.version()
-      let didId: string | null = null;
-      try {
-        didId = did.id
-      } catch (err: any) {
-        diagnosticsLogger.imp(
-          `Unable to publish node metrics without an authenticated DID.  If you wish your ceramic node to be able to publish metrics a privateSeedUrl is required. Error: ${err.toString()}`
-        )
-      }
-      if (didId) {
+      if (did.authenticated) {
         NodeMetrics.start({
           ceramic: ceramic,
           network: params.networkOptions.name,
@@ -363,7 +355,7 @@ export class CeramicDaemon {
           intervalMS: opts.metrics?.metricsPublishIntervalMS || DEFAULT_PUBLISH_INTERVAL_MS,
           nodeId: ipfsId.publicKey, // what makes the best ID for the node?
           nodeName: '', // daemon.hostname is not useful
-          nodeAuthDID: didId,
+          nodeAuthDID: did.id,
           nodeIPAddr: '', // daemon.hostname is not the external name
           nodePeerId: ipfsId.publicKey,
           logger: diagnosticsLogger,

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -346,22 +346,31 @@ export class CeramicDaemon {
     // publishing metrics is enabled by default, even if no metrics config
     if (! opts.metrics || opts.metrics?.metricsPublisherEnabled) {
       const ipfsVersion = await ipfs.version()
-      NodeMetrics.start({
-        ceramic: ceramic,
-        network: params.networkOptions.name,
-        ceramicVersion: version,
-        ipfsVersion: ipfsVersion.version,
-        intervalMS: opts.metrics?.metricsPublishIntervalMS || DEFAULT_PUBLISH_INTERVAL_MS,
-        nodeId: ipfsId.publicKey, // what makes the best ID for the node?
-        nodeName: '', // daemon.hostname is not useful
-        nodeAuthDID: did.id,
-        nodeIPAddr: '', // daemon.hostname is not the external name
-        nodePeerId: ipfsId.publicKey,
-        logger: diagnosticsLogger,
-      })
-      diagnosticsLogger.imp(
-        `Publishing Node Metrics publicly to the Ceramic Network.  To learn more, including how to disable publishing, please see the NODE_METRICS.md file for your branch, e.g. https://github.com/ceramicnetwork/js-ceramic/blob/develop/docs-dev/NODE_METRICS.md`
-      )
+      try {
+        const didId = did.id
+      } catch (err: any) {
+        diagnosticsLogger.imp(
+          `Unable to publish node metrics without an authenticated DID.  If you wish your ceramic node to be able to publish metrics a privateSeedUrl is required. Error: ${err.toString()}`
+        )
+      }
+      if (didId) {
+        NodeMetrics.start({
+          ceramic: ceramic,
+          network: params.networkOptions.name,
+          ceramicVersion: version,
+          ipfsVersion: ipfsVersion.version,
+          intervalMS: opts.metrics?.metricsPublishIntervalMS || DEFAULT_PUBLISH_INTERVAL_MS,
+          nodeId: ipfsId.publicKey, // what makes the best ID for the node?
+          nodeName: '', // daemon.hostname is not useful
+          nodeAuthDID: didId,
+          nodeIPAddr: '', // daemon.hostname is not the external name
+          nodePeerId: ipfsId.publicKey,
+          logger: diagnosticsLogger,
+        })
+        diagnosticsLogger.imp(
+          `Publishing Node Metrics publicly to the Ceramic Network.  To learn more, including how to disable publishing, please see the NODE_METRICS.md file for your branch, e.g. https://github.com/ceramicnetwork/js-ceramic/blob/develop/docs-dev/NODE_METRICS.md`
+        )
+      }
     }
 
     return daemon


### PR DESCRIPTION
## Description

When running with simple deploy, we receive the error

```
Error: DID is not authenticated
    at get id [as id]
   ```
   
  handle this case and report the error, but do not fail to start

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x ] Unit tests

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
