### PR TITLE
chore: cleanup related to starting/stopping ceramic-one from daemon

### DIFF
--- a/packages/cli/src/ipfs-connection-factory.ts
+++ b/packages/cli/src/ipfs-connection-factory.ts
@@ -1,6 +1,6 @@
 import mergeOpts from 'merge-options'
 import * as ipfsClient from 'ipfs-http-client'
-import { DiagnosticsLogger, EnvironmentUtils, IpfsApi, Networks } from '@ceramicnetwork/common'
+import { DiagnosticsLogger, EnvironmentUtils, IpfsApi } from '@ceramicnetwork/common'
 import { IpfsMode } from './daemon-config.js'
 import * as http from 'http'
 import * as https from 'https'
@@ -30,6 +30,12 @@ export class IpfsConnectionFactory {
           return ipfsEndpoint
         }
         return ''
+      }
+      // I need to figure out why the proxy overriding this in RemoteRunningIpfs isn't working
+      if (EnvironmentUtils.useRustCeramic()) {
+        ipfsApi.stop = async () => {
+          // no op
+        }
       }
 
       return ipfsApi

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -950,6 +950,10 @@ export class Ceramic implements StreamReaderWriter, StreamStateLoader {
     await this.dispatcher.close()
     await this.repository.close()
     this._ipfsTopology.stop()
+    if (EnvironmentUtils.useRustCeramic()) {
+      // this is a no-op for remote c1 nodes and will shutdown the binary if we started it
+      await this.ipfs.stop()
+    }
     await this._kvFactory.close()
     this._logger.imp('Ceramic instance closed successfully')
   }

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -603,6 +603,9 @@ export class Dispatcher {
   async close(): Promise<void> {
     if (!EnvironmentUtils.useRustCeramic()) {
       this.messageBus.unsubscribe()
+    } else {
+      // this is a no-op for remote c1 nodes and will shutdown the binary if we started it
+      this._ipfs.stop()
     }
     await this.tasks.onIdle()
   }

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -603,9 +603,6 @@ export class Dispatcher {
   async close(): Promise<void> {
     if (!EnvironmentUtils.useRustCeramic()) {
       this.messageBus.unsubscribe()
-    } else {
-      // this is a no-op for remote c1 nodes and will shutdown the binary if we started it
-      this._ipfs.stop()
     }
     await this.tasks.onIdle()
   }

--- a/packages/ipfs-topology/src/ipfs-topology.ts
+++ b/packages/ipfs-topology/src/ipfs-topology.ts
@@ -132,6 +132,10 @@ export class IpfsTopology {
     if (this.intervalId) {
       clearInterval(this.intervalId)
     }
+    if (EnvironmentUtils.useRustCeramic()) {
+      // this is a no-op for remote c1 nodes and will shutdown the binary if we started it
+      this.ipfs.stop()
+    }
   }
 
   private async _forceBootstrapConnection(

--- a/packages/ipfs-topology/src/ipfs-topology.ts
+++ b/packages/ipfs-topology/src/ipfs-topology.ts
@@ -57,28 +57,28 @@ const BOOTSTRAP_LIST = (ceramicNetwork: Networks): Array<Multiaddr> | null => {
       case Networks.MAINNET:
         return [
           multiaddr(
-            '/dns4/bootstrap-mainnet-rust-ceramic-1.3box.io/tcp/4101/p2p/12D3KooWJC1yR4KiCnocV9kuAEwtsMNh7Xmu2vzqpBvk2o3MrYd6',
+            '/dns4/bootstrap-mainnet-rust-ceramic-1.3box.io/tcp/4101/p2p/12D3KooWJC1yR4KiCnocV9kuAEwtsMNh7Xmu2vzqpBvk2o3MrYd6'
           ),
           multiaddr(
-            '/dns4/bootstrap-mainnet-rust-ceramic-2.3box.io/tcp/4101/p2p/12D3KooWCuS388c1im7KkmdrpsLMziihF8mbcv2w6HPCp4Qmww6m',
+            '/dns4/bootstrap-mainnet-rust-ceramic-2.3box.io/tcp/4101/p2p/12D3KooWCuS388c1im7KkmdrpsLMziihF8mbcv2w6HPCp4Qmww6m'
           ),
         ]
       case Networks.TESTNET_CLAY:
         return [
           multiaddr(
-            '/dns4/bootstrap-tnet-rust-ceramic-1.3box.io/tcp/4101/p2p/12D3KooWMqCFj5bnwuNi6D6KLhYiK4C8Eh9xSUKv2E6Jozs4nWEE',
+            '/dns4/bootstrap-tnet-rust-ceramic-1.3box.io/tcp/4101/p2p/12D3KooWMqCFj5bnwuNi6D6KLhYiK4C8Eh9xSUKv2E6Jozs4nWEE'
           ),
           multiaddr(
-            '/dns4/bootstrap-tnet-rust-ceramic-2.3box.io/tcp/4101/p2p/12D3KooWPFGbRHWfDaWt5MFFeqAHBBq3v5BqeJ4X7pmn2V1t6uNs',
+            '/dns4/bootstrap-tnet-rust-ceramic-2.3box.io/tcp/4101/p2p/12D3KooWPFGbRHWfDaWt5MFFeqAHBBq3v5BqeJ4X7pmn2V1t6uNs'
           ),
         ]
       case Networks.DEV_UNSTABLE:
         return [
           multiaddr(
-            '/dns4/bootstrap-devqa-rust-ceramic-1.3box.io/tcp/4101/p2p/12D3KooWJmYPnXgst4gW5GoyAYzRB3upLgLVR1oDVGwjiS9Ce7sA',
+            '/dns4/bootstrap-devqa-rust-ceramic-1.3box.io/tcp/4101/p2p/12D3KooWJmYPnXgst4gW5GoyAYzRB3upLgLVR1oDVGwjiS9Ce7sA'
           ),
           multiaddr(
-            '/dns4/bootstrap-devqa-rust-ceramic-2.3box.io/tcp/4101/p2p/12D3KooWFCf7sKeW8NHoT35EutjJX5vCpPekYqa4hB4tTUpYrcam',
+            '/dns4/bootstrap-devqa-rust-ceramic-2.3box.io/tcp/4101/p2p/12D3KooWFCf7sKeW8NHoT35EutjJX5vCpPekYqa4hB4tTUpYrcam'
           ),
         ]
       case Networks.LOCAL:
@@ -106,7 +106,7 @@ export class IpfsTopology {
     readonly ceramicNetwork: string,
     readonly logger: DiagnosticsLogger,
     readonly period: number = DEFAULT_BOOTSTRAP_CONNECTION_PERIOD
-  ) { }
+  ) {}
 
   async forceConnection(): Promise<void> {
     const bootstrapList: Multiaddr[] = BOOTSTRAP_LIST(this.ceramicNetwork as Networks) || []

--- a/packages/ipfs-topology/src/ipfs-topology.ts
+++ b/packages/ipfs-topology/src/ipfs-topology.ts
@@ -132,10 +132,6 @@ export class IpfsTopology {
     if (this.intervalId) {
       clearInterval(this.intervalId)
     }
-    if (EnvironmentUtils.useRustCeramic()) {
-      // this is a no-op for remote c1 nodes and will shutdown the binary if we started it
-      this.ipfs.stop()
-    }
   }
 
   private async _forceBootstrapConnection(


### PR DESCRIPTION
## Description

- We now call ipfs.stop() for rust ceramic to make sure it gets shutdown when something goes wrong during setup. This required adjusting the override for the remote IPFS client as there is no shutdown endpoint on ceramic-one like kubo.
- We now default to a standard (not hidden) folder called `ceramic-one` in the local directory as the default store-dir. 
- We now force shutdown ipfs/c1 if we fail to send SIGTERM. The messaging around binary shutdown errors were adjusted as well. The acutal issue re-binding ports was due to ceramic-one shutdown and should be fixed in [rust-ceramic #440](https://github.com/ceramicnetwork/rust-ceramic/pull/440).

## How Has This Been Tested?

Local testing with [rust-ceramic #440](https://github.com/ceramicnetwork/rust-ceramic/pull/440) and CI.

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
