### PR TITLE
chore: change ipfs default to remote mode and remove bundled ceramic-one

### DIFF
--- a/Dockerfile.daemon
+++ b/Dockerfile.daemon
@@ -2,10 +2,6 @@ FROM node:20 as ceramic
 
 RUN apt-get update && apt-get install -y netcat-traditional gettext-base jq
 
-COPY ci-scripts/install-rust-ceramic.sh ./
-
-ARG RUST_CERAMIC_VERSION=latest
-RUN ./install-rust-ceramic.sh ${RUST_CERAMIC_VERSION}
 
 WORKDIR /js-ceramic
 
@@ -25,8 +21,6 @@ ARG GIT_COMMIT_HASH=docker
 
 RUN lerna run build
 
-ENV CERAMIC_ONE_PATH=/usr/local/bin/ceramic-one CERAMIC_ONE_STORE_DIR=~/.ceramic-one
-
 EXPOSE 7007
 
 ENTRYPOINT ["./packages/cli/bin/ceramic.js", "daemon"]
@@ -34,5 +28,4 @@ ENTRYPOINT ["./packages/cli/bin/ceramic.js", "daemon"]
 FROM ceramic as composedb
 
 ARG COMPOSEDB_VERSION=latest
-ENV CERAMIC_ONE_PATH=/usr/local/bin/ceramic-one CERAMIC_ONE_STORE_DIR=~/.ceramic-one
 RUN npm install --location=global @composedb/cli@${COMPOSEDB_VERSION}

--- a/packages/cli/src/ceramic-cli-utils.ts
+++ b/packages/cli/src/ceramic-cli-utils.ts
@@ -47,7 +47,7 @@ const generateDefaultDaemonConfig = () => {
       'auth-method': AnchorServiceAuthMethods.DID,
     },
     'http-api': { 'cors-allowed-origins': [new RegExp('.*')], 'admin-dids': [] },
-    ipfs: { mode: IpfsMode.BUNDLED },
+    ipfs: { mode: IpfsMode.REMOTE, host: 'http://localhost:5101' },
     logger: { 'log-level': LogLevel.important, 'log-to-files': false },
     metrics: {
       'metrics-exporter-enabled': false,

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -258,7 +258,7 @@ export class CeramicDaemon {
       ipfsId = await ipfs.id()
     } catch (err) {
       throw new Error(
-        `Error connecting to p2p node. Make sure ceramic-one is running or use --ipfs-api modify the expected http location (currently ${opts.ipfs?.host}): ${err}`
+        `Error connecting to p2p node. Make sure ceramic-one is running or use --ipfs-api to modify the expected http location (currently ${opts.ipfs?.host}): ${err}`
       )
     }
 

--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -253,7 +253,14 @@ export class CeramicDaemon {
       ceramicConfig.loggerProvider.getDiagnosticsLogger(),
       opts.ipfs?.host
     )
-    const ipfsId = await ipfs.id()
+    let ipfsId
+    try {
+      ipfsId = await ipfs.id()
+    } catch (err) {
+      throw new Error(
+        `Error connecting to p2p node. Make sure ceramic-one is running or use --ipfs-api modify the expected http location (currently ${opts.ipfs?.host}): ${err}`
+      )
+    }
 
     // we need to change the values before processing the config, so we keep track to log the warning after we have logging set up
     const desiredIpfsClient = EnvironmentUtils.useRustCeramic() ? 'ceramic-one' : 'kubo'

--- a/packages/cli/src/ipfs-connection-factory.ts
+++ b/packages/cli/src/ipfs-connection-factory.ts
@@ -36,7 +36,7 @@ export class IpfsConnectionFactory {
     } else {
       if (EnvironmentUtils.useRustCeramic()) {
         throw new Error(
-          `Rust Ceramic does not support running in bundled mode. Pass --ipfs-api to connect to an external ceramic-one node.`
+          `Running ceramic-one in bundled mode is not supported. Pass --ipfs-api to connect to an external ceramic-one node.`
         )
       } else {
         return this.createGoIPFS()

--- a/packages/cli/src/ipfs-connection-factory.ts
+++ b/packages/cli/src/ipfs-connection-factory.ts
@@ -35,11 +35,8 @@ export class IpfsConnectionFactory {
       return ipfsApi
     } else {
       if (EnvironmentUtils.useRustCeramic()) {
-        return ipfs.createIPFS(
-          {
-            rust: ipfs.RustIpfs.defaultOptions(network),
-          },
-          false
+        throw new Error(
+          `Rust Ceramic does not support running in bundled mode. Pass --ipfs-api to connect to an external ceramic-one node.`
         )
       } else {
         return this.createGoIPFS()

--- a/packages/ipfs-daemon/src/index.ts
+++ b/packages/ipfs-daemon/src/index.ts
@@ -1,4 +1,3 @@
 export * from './create-ipfs.js'
 export * from './ipfs-daemon.js'
 export * from './healthcheck-server.js'
-export * from './rust-ipfs.js'


### PR DESCRIPTION
## Description

The default IPFS mode is now remote with localhost:5101 (ceramic-one). We no longer support starting the ceramic-one binary automatically in bundled mode outside of tests. It didn't provide a super elegant startup as we don't have a good cross platform install method for node so couldn't guarantee the defaults and it isn't how we want people to run things anyway. It also had some issues stopping, especially when errors occur during start up and rather than rework that handling, we're moving away from the option.

This changes the default config options to remote ceramic one, so it doesn't "just work" if you run `node ceramic.js daemon` like it would before. If you previously had bundled mode in your config, you will get an error saying it's not supported and you should pass a url.

## Note

The local CI still passes as we're starting in bundled mode for the tests, however, the daemon is no longer able to do that so the verifyImage task fails. It will require validating and merging the changes in [pipeline-tools](https://github.com/3box/pipeline-tools/pull/65) first before this is fully green.

## How Has This Been Tested?

Ran daemon locally and CI.

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
