### PR TITLE
feat: recon resubscribes to interests on startup

### DIFF
--- a/packages/core/src/__tests__/create-dispatcher.ts
+++ b/packages/core/src/__tests__/create-dispatcher.ts
@@ -32,6 +32,7 @@ export async function createDispatcher(ipfs: IpfsApi, pubsubTopic: string): Prom
   } as unknown as AnchorRequestStore
   const index = {
     init: () => Promise.resolve(),
+    indexedModels: () => [],
   } as unknown as IndexApi
   repository.setDeps({
     pinStore,

--- a/packages/core/src/__tests__/recon.test.ts
+++ b/packages/core/src/__tests__/recon.test.ts
@@ -5,6 +5,7 @@ import { jest } from '@jest/globals'
 import { CARFactory, type CAR } from 'cartonne'
 import { toArray, take, lastValueFrom, firstValueFrom, race, timer } from 'rxjs'
 import { CommonTestUtils } from '@ceramicnetwork/common-test-utils'
+import { BaseTestUtils as TestUtils } from '@ceramicnetwork/base-test-utils'
 
 const RECON_URL = 'http://example.com'
 const LOGGER = new LoggerProvider().getDiagnosticsLogger()
@@ -79,6 +80,22 @@ describe('ReconApi', () => {
       await reconApi.init()
       await firstValueFrom(race(reconApi, timer(1000)))
       expect(mockSendRequest).toHaveBeenCalledTimes(1)
+    })
+
+    test('should register interests on init', async () => {
+      const mockSendRequest = jest.fn(() => Promise.resolve())
+      const reconApi = new ReconApi(
+        { enabled: true, url: RECON_URL, feedEnabled: false },
+        LOGGER,
+        mockSendRequest
+      )
+      const fakeInterest0 = TestUtils.randomStreamID()
+      const fakeInterest1 = TestUtils.randomStreamID()
+      await reconApi.init('testInitialCursor', [fakeInterest0, fakeInterest1])
+      expect(mockSendRequest).toHaveBeenCalledTimes(3)
+      expect(mockSendRequest.mock.calls[1][0]).toContain(fakeInterest0.toString())
+      expect(mockSendRequest.mock.calls[2][0]).toContain(fakeInterest1.toString())
+      reconApi.stop()
     })
   })
 

--- a/packages/core/src/recon.ts
+++ b/packages/core/src/recon.ts
@@ -56,7 +56,7 @@ export interface ReconEventFeedResponse {
  * Recon API Interface
  */
 export interface IReconApi extends Observable<ReconEventFeedResponse> {
-  init(initialCursor?: string): Promise<void>
+  init(initialCursor?: string, initialInterests?: Array<StreamID>): Promise<void>
   registerInterest(model: StreamID): Promise<void>
   put(car: CAR, opts?: AbortOptions): Promise<void>
   enabled: boolean
@@ -96,7 +96,7 @@ export class ReconApi extends Observable<ReconEventFeedResponse> implements IRec
    * @param initialCursor
    * @returns
    */
-  async init(initialCursor = ''): Promise<void> {
+  async init(initialCursor = '', initialInterests: Array<StreamID> = []): Promise<void> {
     if (this.#initialized) {
       return
     }
@@ -109,6 +109,10 @@ export class ReconApi extends Observable<ReconEventFeedResponse> implements IRec
 
     this.#url = await this.#config.url
     await this.registerInterest(Model.MODEL)
+
+    for (const interest of initialInterests) {
+      await this.registerInterest(interest)
+    }
 
     if (this.#config.feedEnabled) {
       this.#eventsSubscription = this.createSubscription(initialCursor).subscribe(this.#feed$)

--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -186,7 +186,9 @@ export class Repository {
     const cursor = (await reconStore.exists(RECON_STORE_CURSOR_KEY))
       ? await reconStore.get(RECON_STORE_CURSOR_KEY)
       : '0'
-    await this.recon.init(cursor)
+
+    const interests = this.index.indexedModels().map((modelData) => modelData.streamID)
+    await this.recon.init(cursor, interests)
     this.reconEventFeedSubscription = this.recon
       .pipe(concatMap(this.handleReconEvents.bind(this)))
       .subscribe()


### PR DESCRIPTION
## Description

current: does not resubscribe
desired: resubscribed 

added unit test and stream-test (for restarting node) 

