### PR TITLE
chore: turn off ecs deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,6 @@ jobs:
         if: ${{ env.PUBLISH == 'true' }}
         run: dagger do push -w "actions:push:\"${{ env.AWS_REGION }}\":\"${{ env.ENV_TAG }}\":\"${{ env.BRANCH }}\":\"${{ env.SHA }}\":\"${{ env.SHA_TAG }}\":\"${{ env.VERSION }}\":_" -p ${{ env.DAGGER_PLAN }}
       -
-        name: Create deployment job
-        if: ${{ env.PUBLISH == 'true' }}
-        run: dagger do -l error deploy -w "actions:deploy:\"${{ env.AWS_REGION }}\":\"${{ env.ENV_TAG }}\":latest:\"${{ env.SHA_TAG }}\":_" -p ${{ env.DAGGER_PLAN }}
-      -
         name: Set commit status "success"
         run: dagger do success -p ${{ env.STATUS_PLAN }}
       -


### PR DESCRIPTION
This PR turns off ECS deployment simply by not creating a CD Manager deployment. A subsequent PR will add the code for deploying to k8s, and deprecate/remove the image verification workflow entirely.