### PR TITLE
fix: correctly use controller when registering interest and correctly use node's ID when publishing metrics.

### DIFF
--- a/packages/core/src/__tests__/recon.test.ts
+++ b/packages/core/src/__tests__/recon.test.ts
@@ -94,14 +94,16 @@ describe('ReconApi', () => {
       const fakeInterest1 = TestUtils.randomStreamID()
       await reconApi.init('testInitialCursor', [fakeInterest0, fakeInterest1])
       expect(mockSendRequest).toHaveBeenCalledTimes(4)
-      expect(mockSendRequest).toHaveBeenCalledWith(
-        `${RECON_URL}/ceramic/interests`,
-        { method: 'POST', body: { sep: "model", sepValue: fakeInterest0.toString() }, headers: { 'Content-Type': 'application/json' } }
-      )
-      expect(mockSendRequest).toHaveBeenCalledWith(
-        `${RECON_URL}/ceramic/interests`,
-        { method: 'POST', body: { sep: "model", sepValue: fakeInterest1.toString() }, headers: { 'Content-Type': 'application/json' } }
-      )
+      expect(mockSendRequest).toHaveBeenCalledWith(`${RECON_URL}/ceramic/interests`, {
+        method: 'POST',
+        body: { sep: 'model', sepValue: fakeInterest0.toString() },
+        headers: { 'Content-Type': 'application/json' },
+      })
+      expect(mockSendRequest).toHaveBeenCalledWith(`${RECON_URL}/ceramic/interests`, {
+        method: 'POST',
+        body: { sep: 'model', sepValue: fakeInterest1.toString() },
+        headers: { 'Content-Type': 'application/json' },
+      })
       reconApi.stop()
     })
   })
@@ -120,10 +122,11 @@ describe('ReconApi', () => {
 
     test('should be able to register interest in a model', async () => {
       await reconApi.registerInterest(MODEL)
-      expect(mockSendRequest).toHaveBeenCalledWith(
-        `${RECON_URL}/ceramic/interests`,
-        { method: 'POST', body: { sep: "model", sepValue: MODEL.toString() }, headers: { 'Content-Type': 'application/json' } }
-      )
+      expect(mockSendRequest).toHaveBeenCalledWith(`${RECON_URL}/ceramic/interests`, {
+        method: 'POST',
+        body: { sep: 'model', sepValue: MODEL.toString() },
+        headers: { 'Content-Type': 'application/json' },
+      })
     })
   })
 

--- a/packages/core/src/__tests__/recon.test.ts
+++ b/packages/core/src/__tests__/recon.test.ts
@@ -94,8 +94,14 @@ describe('ReconApi', () => {
       const fakeInterest1 = TestUtils.randomStreamID()
       await reconApi.init('testInitialCursor', [fakeInterest0, fakeInterest1])
       expect(mockSendRequest).toHaveBeenCalledTimes(4)
-      expect(mockSendRequest.mock.calls[2][0]).toContain(fakeInterest0.toString())
-      expect(mockSendRequest.mock.calls[3][0]).toContain(fakeInterest1.toString())
+      expect(mockSendRequest).toHaveBeenCalledWith(
+        `${RECON_URL}/ceramic/interests`,
+        { method: 'POST', body: { sep: "model", sepValue: fakeInterest0.toString() }, headers: { 'Content-Type': 'application/json' } }
+      )
+      expect(mockSendRequest).toHaveBeenCalledWith(
+        `${RECON_URL}/ceramic/interests`,
+        { method: 'POST', body: { sep: "model", sepValue: fakeInterest1.toString() }, headers: { 'Content-Type': 'application/json' } }
+      )
       reconApi.stop()
     })
   })
@@ -115,8 +121,8 @@ describe('ReconApi', () => {
     test('should be able to register interest in a model', async () => {
       await reconApi.registerInterest(MODEL)
       expect(mockSendRequest).toHaveBeenCalledWith(
-        `${RECON_URL}/ceramic/interests/model/${MODEL.toString()}`,
-        { method: 'POST', body: {}, headers: { 'Content-Type': 'application/json' } }
+        `${RECON_URL}/ceramic/interests`,
+        { method: 'POST', body: { sep: "model", sepValue: MODEL.toString() }, headers: { 'Content-Type': 'application/json' } }
       )
     })
   })

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -662,11 +662,11 @@ export class Ceramic implements StreamReaderWriter, StreamStateLoader {
       ceramicVersion: this._versionInfo.cliPackageVersion,
       ipfsVersion: ipfsVersion.version,
       intervalMS: this._metricsConfig?.metricsPublishIntervalMS || DEFAULT_PUBLISH_INTERVAL_MS,
-      nodeId: ipfsId.publicKey, // what makes the best ID for the node?
+      nodeId: ipfsId.id.toString(),
       nodeName: '', // daemon.hostname is not useful
       nodeAuthDID: this.did.id,
       nodeIPAddr: '', // daemon.hostname is not the external name
-      nodePeerId: ipfsId.publicKey,
+      nodePeerId: ipfsId.id.toString(),
       logger: this._logger,
     })
     this._logger.imp(

--- a/packages/core/src/recon.ts
+++ b/packages/core/src/recon.ts
@@ -171,11 +171,10 @@ export class ReconApi extends Observable<ReconEventFeedResponse> implements IRec
     }
     try {
       const headers = { 'Content-Type': 'application/json' }
-      const body = { ...(controller && { controller }) }
-      await this.#sendRequest(this.#url + `/ceramic/interests/model/${model.toString()}`, {
+      const query = controller ? `controller=${controller}` : ''
+      await this.#sendRequest(this.#url + `/ceramic/interests/model/${model.toString()}?${query}`, {
         method: 'POST',
         headers,
-        body,
       })
       this.#logger.debug(`Recon: added interest for model ${model.toString()}`)
     } catch (err) {

--- a/packages/core/src/recon.ts
+++ b/packages/core/src/recon.ts
@@ -171,10 +171,11 @@ export class ReconApi extends Observable<ReconEventFeedResponse> implements IRec
     }
     try {
       const headers = { 'Content-Type': 'application/json' }
-      const query = controller ? `controller=${controller}` : ''
-      await this.#sendRequest(this.#url + `/ceramic/interests/model/${model.toString()}?${query}`, {
+      const body = { sep: "model", sepValue: model.toString(), ...(controller && { controller }) }
+      await this.#sendRequest(this.#url + `/ceramic/interests`, {
         method: 'POST',
         headers,
+        body,
       })
       this.#logger.debug(`Recon: added interest for model ${model.toString()}`)
     } catch (err) {

--- a/packages/core/src/recon.ts
+++ b/packages/core/src/recon.ts
@@ -171,7 +171,7 @@ export class ReconApi extends Observable<ReconEventFeedResponse> implements IRec
     }
     try {
       const headers = { 'Content-Type': 'application/json' }
-      const body = { sep: "model", sepValue: model.toString(), ...(controller && { controller }) }
+      const body = { sep: 'model', sepValue: model.toString(), ...(controller && { controller }) }
       await this.#sendRequest(this.#url + `/ceramic/interests`, {
         method: 'POST',
         headers,


### PR DESCRIPTION

## Description
In testing the node metrics publish I found two bugs:

1. Metrics interest was for all peers not just itself.
2. The node id was empty causing the published data to fail validation.

This fixes both issues.

The controller needs to be a query parameter not a POST body object.

The `ipfsId.publicKey` was empty I do not know why, however the `ipfsId.id` field was set correctly and works as expected.


## How Has This Been Tested?

Manually tested, starting a node. Previously the node saw errors everytime it tried to publish metrics. Additionally I directly inspected the interest and was able to see it was for all controllers not just itself. I have manually verified the interest is now for the specific controller.

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
