### PR TITLE
fix: adjust tests for failure to start due to network mismatch

### DIFF
--- a/packages/core/src/__tests__/initialization.test.ts
+++ b/packages/core/src/__tests__/initialization.test.ts
@@ -74,7 +74,7 @@ describe('Ceramic integration', () => {
     const ceramic = new Ceramic(modules, params)
     if (EnvironmentUtils.useRustCeramic()) {
       await expect(ceramic._init(false)).rejects.toThrow(
-        "Recon: failed to verify network as js-ceramic is using local but ceramic-one is on inmemory. Pass --network to the js-ceramic or ceramic-one daemon to make them match."
+        'Recon: failed to verify network as js-ceramic is using local but ceramic-one is on inmemory. Pass --network to the js-ceramic or ceramic-one daemon to make them match.'
       )
     } else {
       await expect(ceramic._init(false)).rejects.toThrow(

--- a/packages/core/src/__tests__/initialization.test.ts
+++ b/packages/core/src/__tests__/initialization.test.ts
@@ -2,7 +2,7 @@ import { expect, jest, describe, test, it, beforeEach, afterEach } from '@jest/g
 import { Ceramic } from '../ceramic.js'
 import tmp from 'tmp-promise'
 import type { IpfsApi } from '@ceramicnetwork/common'
-import { Networks } from '@ceramicnetwork/common'
+import { EnvironmentUtils, Networks } from '@ceramicnetwork/common'
 import { createIPFS } from '@ceramicnetwork/ipfs-daemon'
 import { InMemoryAnchorService } from '../anchor/memory/in-memory-anchor-service.js'
 
@@ -55,7 +55,7 @@ describe('Ceramic integration', () => {
     await ceramic.close()
   })
 
-  it('cannot create Ceramic instance on network not supported by our anchor service', async () => {
+  it('cannot create Ceramic instance on network different from ceramic one or cas', async () => {
     const tmpDirectory = await tmp.tmpName()
     const databaseConnectionString = new URL(`sqlite://${tmpDirectory}/ceramic.sqlite`)
     const [modules, params] = Ceramic._processConfig(
@@ -72,9 +72,15 @@ describe('Ceramic integration', () => {
       modules.loggerProvider.getDiagnosticsLogger()
     )
     const ceramic = new Ceramic(modules, params)
-    await expect(ceramic._init(false)).rejects.toThrow(
-      "No usable chainId for anchoring was found.  The ceramic network 'local' supports the chains: ['eip155:1337'], but the configured anchor service '<inmemory>' only supports the chains: ['inmemory:12345']"
-    )
+    if (EnvironmentUtils.useRustCeramic()) {
+      await expect(ceramic._init(false)).rejects.toThrow(
+        "Recon: failed to verify network as js-ceramic is using local but ceramic-one is on inmemory. Pass --network to the js-ceramic or ceramic-one daemon to make them match."
+      )
+    } else {
+      await expect(ceramic._init(false)).rejects.toThrow(
+        "No usable chainId for anchoring was found.  The ceramic network 'local' supports the chains: ['eip155:1337'], but the configured anchor service '<inmemory>' only supports the chains: ['inmemory:12345']"
+      )
+    }
   })
 
   it('cannot create Ceramic instance on invalid network', async () => {

--- a/packages/core/src/anchor/memory/in-memory-anchor-service.ts
+++ b/packages/core/src/anchor/memory/in-memory-anchor-service.ts
@@ -146,7 +146,7 @@ export class InMemoryAnchorService implements AnchorService {
 
   async close(): Promise<void> {
     await this.#cas.close()
-    await this.#store.close()
-    await this.#loop.stop()
+    await this.#store?.close()
+    await this.#loop?.stop()
   }
 }

--- a/packages/core/src/recon.ts
+++ b/packages/core/src/recon.ts
@@ -146,8 +146,10 @@ export class ReconApi extends Observable<ReconEventFeedResponse> implements IRec
       // in the network, or don't use it at all and just rely on c1, we're okay ignoring that piece
       if (!response.name.includes(this.#config.network)) {
         throw new Error(
-          `Recon: failed to verify network as js-ceramic is using ${this.#config.network
-          } but ceramic-one is on ${response.name
+          `Recon: failed to verify network as js-ceramic is using ${
+            this.#config.network
+          } but ceramic-one is on ${
+            response.name
           }. Pass --network to the js-ceramic or ceramic-one daemon to make them match.`
         )
       }
@@ -268,7 +270,8 @@ export class ReconApi extends Observable<ReconEventFeedResponse> implements IRec
               retry({
                 delay: (err) => {
                   this.#logger.warn(
-                    `Recon: event feed failed, due to error ${err}; attempting to retry in ${this.#pollInterval
+                    `Recon: event feed failed, due to error ${err}; attempting to retry in ${
+                      this.#pollInterval
                     }ms`
                   )
                   return timer(this.#pollInterval)


### PR DESCRIPTION
## Description

Related to the new network startup check for ceramic one. That error happens earlier than the cas error was, so we get a different error. On kubo, we get the old error. We also check a few fields are not null when cleaning up in case we somehow didn't manage to call init() due to an error in `ceramic._init()` but we still try to stop everything.

- [x] Ran tests locally with c1

## PR checklist

Before submitting this PR, please make sure:

- [x] I have tagged the relevant reviewers and interested parties
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
