### PR TITLE
fix: Don't remove entries from AnchorRequestStore if applying the anchor commit fails

### DIFF
--- a/packages/core/src/state-management/repository.ts
+++ b/packages/core/src/state-management/repository.ts
@@ -815,6 +815,8 @@ export class Repository {
           if (tip.equals(state$.tip)) {
             state$.next({ ...state$.value, anchorStatus: AnchorStatus.FAILED })
           }
+
+          throw error
         }
       }
     }


### PR DESCRIPTION
~Needs testing~ steph: Tested manually using both ipfs + c1, and added a unit test

This has the downside that if the reason applying the anchor failed is *not* transient, like if the TimeEvent is malformed or otherwise invalid, we will still leave the event in the store and keep retrying it.  I think that is probably fine for now since we don't expect to be getting any fundamentally invalid TimeEvents from the CAS.  Self-anchoring in C1 should be able to be more intelligent in understanding what types of failure modes are transient vs irrecoverable.

