### PR TITLE
feat: add metrics to track queue sizes and add operations - #AES-361

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -133,3 +133,4 @@ $ npm run publish:hotfix                  # create and publish the release
 The main step here is `npm run publish:hotfix`, which creates a full release on NPM by bumping the patch version (e.g. `2.1.9` => `2.1.10`). It also creates a git commit with updated package versions as well as their corresponding git tags on github. Make sure to set the [GH_TOKEN](https://github.com/lerna/lerna/tree/master/commands/version#--create-release-type) environment variable and log into npm before you run this command.
 
 After the release, don't forget to make a post in the #releases channel of the Ceramic discord to notify the community about the new release!
+

--- a/packages/cli/src/s3-store.ts
+++ b/packages/cli/src/s3-store.ts
@@ -13,6 +13,7 @@ import PQueue from 'p-queue'
 import AWSSDK from 'aws-sdk'
 import { Mutex } from 'await-semaphore'
 import type { DeepNonNullable } from 'ts-essentials'
+import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
 
 /**
  * **Remove** `undefined` fields from an S3 Level search params.
@@ -185,6 +186,8 @@ class S3KVStore implements IKVStore {
   }
 
   get(key: string): Promise<any> {
+    Metrics.count(LOAD_S3_QUEUE_ADD, 1)
+    Metrics.observe(LOAD_S3_SIZE, this.#loadingLimit.size)
     return this.#loadingLimit.add(async () => {
       const value = await this.level.get(key)
       return JSON.parse(value)

--- a/packages/cli/src/s3-store.ts
+++ b/packages/cli/src/s3-store.ts
@@ -31,6 +31,9 @@ function definiteSearchParams<T extends Partial<StoreSearchParams>>(obj: T): Dee
  */
 const MAX_LOAD_RPS = 4000
 
+const LOAD_S3_QUEUE_ADD = 'load_s3_queue_add'
+const LOAD_S3_QUEUE_SIZE = 'load_s3_queue_size'
+
 export class S3KVFactory implements IKVFactory {
   readonly #networkName: string
   readonly #bucketName: string
@@ -187,7 +190,7 @@ class S3KVStore implements IKVStore {
 
   get(key: string): Promise<any> {
     Metrics.count(LOAD_S3_QUEUE_ADD, 1)
-    Metrics.observe(LOAD_S3_SIZE, this.#loadingLimit.size)
+    Metrics.observe(LOAD_S3_QUEUE_SIZE, this.#loadingLimit.size)
     return this.#loadingLimit.add(async () => {
       const value = await this.level.get(key)
       return JSON.parse(value)

--- a/packages/core/src/ancillary/task-queue.ts
+++ b/packages/core/src/ancillary/task-queue.ts
@@ -1,4 +1,8 @@
 import PQueue from 'p-queue'
+import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
+
+const TASK_QUEUE_SIZE = 'task_queue_size'
+const TASK_QUEUE_SIZE_PENDING = 'task_queue_size_pending'
 
 export const noop = () => {
   // Do Nothing
@@ -52,6 +56,8 @@ export class TaskQueue implements TaskQueueLike {
    * Size of the queue. Counts both deferred and currently running tasks.
    */
   get size(): number {
+    Metrics.observe(TASK_QUEUE_SIZE, this.#pq.size)
+    Metrics.observe(TASK_QUEUE_SIZE_PENDING, this.#pq.pending)
     return this.#pq.size + this.#pq.pending
   }
 

--- a/packages/core/src/ancillary/task-queue.ts
+++ b/packages/core/src/ancillary/task-queue.ts
@@ -1,8 +1,4 @@
 import PQueue from 'p-queue'
-import { ServiceMetrics as Metrics } from '@ceramicnetwork/observability'
-
-const TASK_QUEUE_SIZE = 'task_queue_size'
-const TASK_QUEUE_SIZE_PENDING = 'task_queue_size_pending'
 
 export const noop = () => {
   // Do Nothing
@@ -56,8 +52,6 @@ export class TaskQueue implements TaskQueueLike {
    * Size of the queue. Counts both deferred and currently running tasks.
    */
   get size(): number {
-    Metrics.observe(TASK_QUEUE_SIZE, this.#pq.size)
-    Metrics.observe(TASK_QUEUE_SIZE_PENDING, this.#pq.pending)
     return this.#pq.size + this.#pq.pending
   }
 

--- a/packages/core/src/state-management/named-task-queue.ts
+++ b/packages/core/src/state-management/named-task-queue.ts
@@ -54,8 +54,8 @@ export class NamedTaskQueue {
    */
   run<A>(name: string, task: () => Promise<A>): Promise<A> {
     const queue = this.queue(name)
-    Metrics.observe(NAMED_TASK_QUEUE_SIZE, queue.size, {'name': name})
-    Metrics.count(NAMED_TASK_QUEUE_RUN, 1, {'name': name})
+    Metrics.observe(NAMED_TASK_QUEUE_SIZE, queue.size, { name: name })
+    Metrics.count(NAMED_TASK_QUEUE_RUN, 1, { name: name })
     return queue.run(task).finally(() => {
       this.remove(name)
     })
@@ -69,8 +69,8 @@ export class NamedTaskQueue {
    */
   add(name: string, task: () => Promise<void>): void {
     const queue = this.queue(name)
-    Metrics.observe(NAMED_TASK_QUEUE_SIZE, queue.size, {'name': name})
-    Metrics.count(NAMED_TASK_QUEUE_ADD, 1, {'name': name})
+    Metrics.observe(NAMED_TASK_QUEUE_SIZE, queue.size, { name: name })
+    Metrics.count(NAMED_TASK_QUEUE_ADD, 1, { name: name })
     queue.add(
       () => task(),
       () => this.remove(name)


### PR DESCRIPTION
## Description

From the datadog analysis, it looks like the gitcoin out of memory errors are related to queue growth specifically with the p-queue library.

This adds metrics to all instances of PQueue to track the size and add operations.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [x] Unit tests

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
