### PR TITLE
fix: address multiquery long timeouts causing excessive queue growth …

### DIFF
--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -67,7 +67,7 @@ import { LevelKVFactory } from './store/level-kv-factory.js'
 const METRICS_CALLER_NAME = 'js-ceramic'
 const DEFAULT_CACHE_LIMIT = 500 // number of streams stored in the cache
 const DEFAULT_QPS_LIMIT = 10 // Max number of pubsub query messages that can be published per second without rate limiting
-const DEFAULT_MULTIQUERY_TIMEOUT_MS = 30 * 1000
+const DEFAULT_MULTIQUERY_TIMEOUT_MS = 3 * 1000
 const DEFAULT_MIN_ANCHOR_LOOP_DURATION_MS = 60 * 1000 // 1 minute
 const TESTING = process.env.NODE_ENV == 'test'
 


### PR DESCRIPTION


During a period of heavy traffic and possible IPFS overload or failures, many errors of the following form occurred:

```Error loading stream kjzl6kcym7
w8y6ppdchg8sfi0dnlcoixh4j5liiqhloal1dlz8yndht0nxxdafp at time undefined as part of a multiQuery request: Error: Timeout after 30000ms
```

Approximately 292K in one day.  

We also have been seeing dramatic queue size growth and p-queue memory usage during these periods of intense load.  This could be related to the large number of streams waiting for the 90 sec timeout, which still eventually fails.  It would be better to fail sooner and not increase the load further.

Include relevant motivation, context, brief description and impact of the change(s). List follow-up tasks here.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Test A (e.g. Test A - New test that ... ran in local, docker, and dev unstable.)
- [ ] Test B

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
