### PR TITLE
Feat/reduce all fetch timeouts

### DIFF
--- a/packages/cli/src/ipfs-connection-factory.ts
+++ b/packages/cli/src/ipfs-connection-factory.ts
@@ -6,7 +6,7 @@ import * as http from 'http'
 import * as https from 'https'
 import * as ipfs from '@ceramicnetwork/ipfs-daemon'
 
-const IPFS_GET_TIMEOUT = 60000 // 1 minute
+const IPFS_GET_TIMEOUT = 10000 // 10 seconds
 
 const mergeOptions = mergeOpts.bind({ ignoreUndefined: true })
 

--- a/packages/common/src/utils/fetch-json.ts
+++ b/packages/common/src/utils/fetch-json.ts
@@ -1,6 +1,6 @@
 import { mergeAbortSignals, TimedAbortSignal, abortable } from './abort-signal-utils.js'
 
-const DEFAULT_FETCH_TIMEOUT = 60 * 1000 * 3 // 3 minutes
+const DEFAULT_FETCH_TIMEOUT = 10 * 1000 // 10 seconds
 
 export type FetchOpts = Partial<{
   body: any

--- a/packages/core/src/ceramic.ts
+++ b/packages/core/src/ceramic.ts
@@ -67,7 +67,7 @@ import { LevelKVFactory } from './store/level-kv-factory.js'
 const METRICS_CALLER_NAME = 'js-ceramic'
 const DEFAULT_CACHE_LIMIT = 500 // number of streams stored in the cache
 const DEFAULT_QPS_LIMIT = 10 // Max number of pubsub query messages that can be published per second without rate limiting
-const DEFAULT_MULTIQUERY_TIMEOUT_MS = 30 * 1000
+const DEFAULT_MULTIQUERY_TIMEOUT_MS = 3 * 1000
 const DEFAULT_MIN_ANCHOR_LOOP_DURATION_MS = 60 * 1000 // 1 minute
 const TESTING = process.env.NODE_ENV == 'test'
 

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -36,7 +36,7 @@ import { IReconApi } from './recon.js'
 import { NodeMetrics } from '@ceramicnetwork/node-metrics'
 
 const IPFS_GET_RETRIES = 3
-const DEFAULT_IPFS_GET_SYNC_TIMEOUT = 30000 // 30 seconds per retry, 3 retries = 90 seconds total timeout
+const DEFAULT_IPFS_GET_SYNC_TIMEOUT =  2000 // 2 seconds per retry, 3 retries = 6 seconds total timeout
 const DEFAULT_IPFS_GET_LOCAL_TIMEOUT = 1000 // 1 second to get data from local ipfs store
 const IPFS_MAX_COMMIT_SIZE = 256000 // 256 KB
 const IPFS_RESUBSCRIBE_INTERVAL_DELAY = 1000 * 15 // 15 sec


### PR DESCRIPTION
## Description

See https://github.com/ceramicnetwork/js-ceramic/pull/3284

Fundamentally, 30 or 90 second timeouts are not compatible with operation at scale and under conditions of load will lead to OOM errors, which we are seeing.

## How Has This Been Tested?

Describe the tests that you ran to verify your changes. Provide instructions for reproduction.

- [ ] Test A (e.g. Test A - New test that ... ran in local, docker, and dev unstable.)
- [ ] Test B

## PR checklist

Before submitting this PR, please make sure:

- [ ] I have tagged the relevant reviewers and interested parties
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
