### PR TITLE
feat: Flag to fully disable pubsub and all cross-node syncing

### DIFF
--- a/packages/cli/src/ceramic-daemon.ts
+++ b/packages/cli/src/ceramic-daemon.ts
@@ -90,7 +90,8 @@ export function makeCeramicConfig(opts: DaemonConfig): CeramicConfig {
     syncOverride: SYNC_OPTIONS_MAP[opts.node.syncOverride],
     streamCacheLimit: opts.node.streamCacheLimit,
     indexing: opts.indexing,
-    disablePeerDataSync: opts.ipfs.disablePeerDataSync,
+    disablePeerDataSync:
+      opts.ipfs.disablePeerDataSync || process.env.CERAMIC_DISABLE_PEER_DATA_SYNC == 'true',
     metrics: opts.metrics,
   }
   if (opts.stateStore?.mode == StateStoreMode.FS) {

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -497,7 +497,7 @@ export class Dispatcher {
    * @param tip - Commit CID
    */
   publishTip(streamId: StreamID, tip: CID, model?: StreamID): Subscription {
-    if (process.env.CERAMIC_DISABLE_PUBSUB_UPDATES == 'true' || !this.enableSync) {
+    if (!this.enableSync) {
       return empty().subscribe()
     }
 

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -140,7 +140,7 @@ export class Dispatcher {
     const rustCeramic = EnvironmentUtils.useRustCeramic()
     this.enableSync = rustCeramic ? false : enableSync
 
-    if (!rustCeramic) {
+    if (this.enableSync) {
       const pubsub = new Pubsub(
         _ipfs,
         topic,
@@ -178,10 +178,9 @@ export class Dispatcher {
   }
 
   async init() {
-    if (EnvironmentUtils.useRustCeramic()) {
-      return
+    if (this.enableSync) {
+      this.messageBus.subscribe(this.handleMessage.bind(this))
     }
-    this.messageBus.subscribe(this.handleMessage.bind(this))
   }
 
   get shutdownSignal(): ShutdownSignal {
@@ -498,7 +497,7 @@ export class Dispatcher {
    * @param tip - Commit CID
    */
   publishTip(streamId: StreamID, tip: CID, model?: StreamID): Subscription {
-    if (process.env.CERAMIC_DISABLE_PUBSUB_UPDATES == 'true' || EnvironmentUtils.useRustCeramic()) {
+    if (process.env.CERAMIC_DISABLE_PUBSUB_UPDATES == 'true' || !this.enableSync) {
       return empty().subscribe()
     }
 
@@ -621,7 +620,7 @@ export class Dispatcher {
    * Gracefully closes the Dispatcher.
    */
   async close(): Promise<void> {
-    if (!EnvironmentUtils.useRustCeramic()) {
+    if (this.enableSync) {
       this.messageBus.unsubscribe()
     }
     await this.tasks.onIdle()


### PR DESCRIPTION
Flag can be enabled by setting `ipfs.disablePeerDataSync` in the config file, or with the new `CERAMIC_DISABLE_PEER_DATA_SYNC` env var.

turning on this flag does 3 things:
1. Fully disable pubsub.  The node will not subscribe to the ceramic pubsub topic, and will not publish or receive any pubsub messages
2. Turns down the timeout when getting blocks from ipfs from 30 seconds to 1 second
3. Uses the "offline" flag whenever loading blocks form ipfs so that the request will fail immediately if the block is not found in the ipfs node's local blockstore.  IPFS will never try to load the block via bitswap.

Blocks published to ipfs with this flag enabled should still be fetchable by other ipfs nodes over bitswap.