### PR TITLE
fix: Disable event-validation in C1 in unit tests

### DIFF
--- a/packages/ipfs-daemon/src/rust-ipfs.ts
+++ b/packages/ipfs-daemon/src/rust-ipfs.ts
@@ -115,6 +115,8 @@ async function binary(
     // nodes that should not be in the same network will never discover each other
     '--local-network-id',
     networkId.toString(),
+    '--event-validation',
+    false,
   ].concat(testExtras)
 
   const proc = spawn(binary_path, parameters, {


### PR DESCRIPTION
to unbreak js-ceramic CI