### PR TITLE
chore: use ubuntu 22 version of ceramic-one

### DIFF
--- a/ci-scripts/install-rust-ceramic.sh
+++ b/ci-scripts/install-rust-ceramic.sh
@@ -3,7 +3,7 @@
 REPO=ceramicnetwork/rust-ceramic/releases
 ARCH=x86_64
 OS=unknown-linux-gnu
-OS_VERSION=ubuntu-22
+OS_VERSION=ubuntu-22.04
 TARGET=$ARCH-$OS
 
 if [ -z ${1+x} ] || [ "$1" == "latest" ]; then

--- a/ci-scripts/install-rust-ceramic.sh
+++ b/ci-scripts/install-rust-ceramic.sh
@@ -3,6 +3,7 @@
 REPO=ceramicnetwork/rust-ceramic/releases
 ARCH=x86_64
 OS=unknown-linux-gnu
+OS_VERSION=ubuntu-22
 TARGET=$ARCH-$OS
 
 if [ -z ${1+x} ] || [ "$1" == "latest" ]; then
@@ -17,7 +18,7 @@ else
   VERSION="v"$1
 fi
 NAME=ceramic-one
-TAR_NAME=${NAME}_$TARGET.tar.gz
+TAR_NAME=${NAME}_${TARGET}-${OS_VERSION}.tar.gz
 DEB_NAME=${NAME}.deb
 OUTPUT_FILE=$NAME.tar.gz
 DOWNLOAD_URL=https://github.com/$REPO/download/$VERSION/$TAR_NAME


### PR DESCRIPTION
CI is failing because latest ceramic-one uses Ubuntu 24. CI here still uses Ubuntu 22, this change explicitly installs the ubuntu 22 version. https://github.com/ceramicnetwork/rust-ceramic/pull/634 